### PR TITLE
Fix loadBrocfile

### DIFF
--- a/lib/adapters/broccoli/build.js
+++ b/lib/adapters/broccoli/build.js
@@ -1,13 +1,12 @@
 var broccoli = require('broccoli'),
   fs = require('fs'),
   RSVP = require('rsvp'),
-  ncp = require('ncp'),
-  helpers = broccoli.helpers;
+  ncp = require('ncp');
 
   ncp.limit = 1;
 
 function getBuilder () {
-  var tree = helpers.loadBrocfile();
+  var tree = broccoli.loadBrocfile();
   return new broccoli.Builder(tree);
 }
 

--- a/lib/adapters/broccoli/server.js
+++ b/lib/adapters/broccoli/server.js
@@ -1,5 +1,4 @@
 var broccoli = require('broccoli'),
-  helpers = broccoli.helpers,
   Promise = require('rsvp').Promise;
 
 function getBuilder () {


### PR DESCRIPTION
The `helpers.loadBrocfile` was moved to `broccoli.loadBrocfile` since joliss/broccoli@fb2507f45bea6c06191bb62dc49723e93aacf1d2
