### PR TITLE
Include the styles folder in assets pipeline

### DIFF
--- a/skeleton/Brocfile.js
+++ b/skeleton/Brocfile.js
@@ -28,6 +28,11 @@ module.exports = function (broccoli) {
 
   app = preprocess(app);
 
+  var styles = pickFiles(app, {
+    srcDir: '<%= namespace %>/styles',
+    destDir: 'assets' 
+  });
+
   tests = pickFiles(tests, {
     srcDir: '/',
     destDir: '<%= namespace %>/tests'
@@ -77,6 +82,7 @@ module.exports = function (broccoli) {
 
   return [
     applicationJs,
-    publicFiles
+    publicFiles,
+    styles
   ];
 };


### PR DESCRIPTION
While playing with ember-cli I realized that the app.css included in index.html not work from the scratch. This PR fix it.
