### PR TITLE
improve ember generate help + documentation

### DIFF
--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -2,5 +2,6 @@ module.exports = {
   help: require('./help'),
   init: require('./init'),
   build: require('./build'),
-  server: require('./server')
+  server: require('./server'),
+  generate: require('./generate')
 };

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -1,0 +1,10 @@
+var chalk = require('chalk');
+
+module.exports.run = function run(generatorName) {
+  var args = Array.prototype.slice.call(arguments);
+  require('loom')(args.join(' '));
+};
+
+module.exports.usage = function usage() {
+  return 'ember generate ' + chalk.yellow('<generator-name>') + ' <options...> ' + chalk.green('See https://github.com/cavneb/loom-generators-ember-appkit for available generators');
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "fs-extra": "~0.8.1",
     "ncp": "~0.5.0",
     "npm": "~1.4.4",
-    "inquirer": "~0.4.1"
+    "inquirer": "~0.4.1",
+    "loom-generators-ember-appkit": "~1.0.5",
+    "loom": "~3.1.2"
   },
   "devDependencies": {
     "mocha": "~1.17.1"

--- a/tests/unit/commands/generate_test.js
+++ b/tests/unit/commands/generate_test.js
@@ -1,0 +1,19 @@
+var describe = require('mocha').describe;
+var before = require('mocha').beforeEach;
+var after = require('mocha').afterEach;
+var it = require('mocha').it;
+
+var command;
+
+describe('generate command', function(){
+  before(function() {
+    command = require('../../../lib/commands/generate');
+  });
+  after(function() {
+    command = null;
+  });
+  it("generates a controller", function(){
+    command.run('controller', 'application', 'type:array');
+    //TODO: figure out how to test this more thoroughly
+  });
+});


### PR DESCRIPTION
Starts to address #43 by depending on loom and loom-generators-ember-appkit, which provides the ability to run commands like `ember generate controller foo type:array` 
- [x] Better test coverage
- [ ] `ember help generate` should give a list of available generators (not sure if loom has this ability currently)
- [x] `ember g ...` should be an alias for `ember generate ...`
- [ ] Document `ember generate init` and how to override generators/create your own  
