### PR TITLE
Fix the new command

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -6,14 +6,14 @@ var skeleton = require('../skeleton');
 var stringUtil = require('../utilities/string');
 var chalk = require('chalk');
 
-module.exports.run = function run(options) {
-  if (options.argv.original.length === 1) {
+module.exports.run = function run(appName) {
+  if (arguments.length == 1) {
     ui.write(chalk.yellow('The `ember new` command requires an app-name to be specified.' +
                           ' For more details, use `ember help`.\n'));
     process.exit(1);
   }
 
-  var name = stringUtil.classify(options.argv.original[1]),
+  var name = stringUtil.classify(appName),
     dir = stringUtil.dasherize(name);
 
   try {

--- a/tests/unit/cli_test.js
+++ b/tests/unit/cli_test.js
@@ -190,6 +190,7 @@ describe('Unit: CLI', function(){
     ember(['new', 'MyApp']);
 
     assert.equal(newCommand.called, 1, 'expected the new command to be run');
+    assert.equal(newCommand.calledWith[0][0], 'MyApp', 'expect first arg to be the app name');
   });
 
   it('ember <valid command>', function(){


### PR DESCRIPTION
The `new` command is failing with: `TypeError: Cannot read property 'original' of undefined`, because when using `ember new foo` the function arguments are expanded to `function run(appName, options) { ... }`
