### PR TITLE
ember build, twice in a row should remove the previous dist

### DIFF
--- a/lib/adapters/broccoli/build.js
+++ b/lib/adapters/broccoli/build.js
@@ -4,6 +4,7 @@ var broccoli = require('broccoli');
 var fs = require('fs');
 var RSVP = require('rsvp');
 var ncp = require('ncp');
+var rimraf = require('rimraf');
 
 ncp.limit = 1;
 
@@ -16,6 +17,12 @@ module.exports = function build(options) {
   return getBuilder().build()
     .then(function (dir) {
       var outputDir = options.outputPath || 'dist/';
+      
+      // Cleanup dist folder before building again
+      if( fs.existsSync(outputDir) ) {
+        rimraf.sync(outputDir);
+      }
+      
       fs.mkdirSync(outputDir);
 
       return RSVP.denodeify(ncp)(dir, outputDir, {


### PR DESCRIPTION
Fixes #84 by removing the existing folder before building again
