### PR TITLE
Fix indentation for index.html

### DIFF
--- a/blueprint/public/index.html
+++ b/blueprint/public/index.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset='utf-8'>
-  <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-  <title>App</title>
-  <meta name='description' content=''>
-  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>App</title>
+    <meta name='description' content=''>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
 
-  <link rel='stylesheet' href='/assets/app.css'>
-  <script src='/assets/app.js'></script>
-</head>
-<body>
-  <!--[if lt IE 8]>
-    <p class='browsehappy'>
-      You are using an <strong>outdated</strong> browser. Please
-      <a href='http://browsehappy.com/'>upgrade your browser</a>
-      to improve your experience.
-    </p>
-  <![endif]-->
+    <link rel='stylesheet' href='/assets/app.css'>
+    <script src='/assets/app.js'></script>
+  </head>
+  <body>
+    <!--[if lt IE 8]>
+      <p class='browsehappy'>
+        You are using an <strong>outdated</strong> browser. Please
+        <a href='http://browsehappy.com/'>upgrade your browser</a>
+        to improve your experience.
+      </p>
+    <![endif]-->
 
-  <script>
-    window.<%= namespace %> = require('<%= modulePrefix %>/app')['default'].create();
-  </script>
-</body>
+    <script>
+      window.<%= namespace %> = require('<%= modulePrefix %>/app')['default'].create();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Nested elements should be indented once (two spaces). http://mdo.github.io/code-guide/#html-syntax

Also, I saw [this commit](https://github.com/frabrunelle/ember-cli/commit/d72da9cd9990a07c5dd652bb758b595fea2bb45d) called "quote consistency" but for HTML it's more common to have double quotes. So I would suggest having double quotes for HTML and single quotes for JavaScript.

And shouldn't the content of title be `<%= namespace %>` instead of `App`?
