### PR TITLE
Offset live-reload port by default

### DIFF
--- a/lib/commands/server.js
+++ b/lib/commands/server.js
@@ -31,7 +31,7 @@ module.exports.run = function run(options) {
 
   options.port = options.port || DEFAULT_PORT;
   options.host = options.host || DEFAULT_HOST;
-  options.liveReloadPort = options.liveReloadPort || LIVE_RELOAD_PORT;
+  options.liveReloadPort = options.liveReloadPort || (parseInt(options.port, 10) - 8000) + LIVE_RELOAD_PORT;
 
   return adapter.server(options);
 };


### PR DESCRIPTION
This offsets the live-reload port by default. Subtracting 8000 gives us a different live-reload port than the default one (35729), but I don't know if this is what we want. Maybe we should always subtract `DEFAULT_PORT` instead, so the default live-reload port is being used if you don't change the port (which would be the case if you don't run multiple ember-cli instances)?
