### PR TITLE
Don't run new or init inside of a generated ember-cli project

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -4,6 +4,8 @@ var blueprint = require('../blueprint');
 var chalk = require('chalk');
 var stringUtil = require('../utilities/string');
 var path = require('path');
+var isEmberCliProject = require('../utilities/is-ember-cli-project');
+var ui = require('../ui');
 
 module.exports.types = {
   dryRun: [Boolean]
@@ -13,6 +15,12 @@ module.exports.run = function run(rawName, options) {
   if (typeof rawName === 'object') {
     options = rawName;
     rawName = path.basename(options.appRoot);
+  }
+
+  if (isEmberCliProject()) {
+    ui.write(chalk.yellow('Cannot run `ember init` inside of an existing ember-cli project.' +
+                          ' For more details, use `ember help`.\n'));
+    return;
   }
 
   var name = stringUtil.dasherize(rawName);

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -5,8 +5,15 @@ var ui = require('../ui');
 var blueprint = require('../blueprint');
 var stringUtil = require('../utilities/string');
 var chalk = require('chalk');
+var isEmberCliProject = require('../utilities/is-ember-cli-project');
 
 module.exports.run = function run(rawName) {
+  if (isEmberCliProject()) {
+    ui.write(chalk.yellow('Cannot run `ember new` inside of an existing ember-cli project.' +
+                          ' For more details, use `ember help`.\n'));
+    return;
+  }
+
   if (typeof rawName === 'object' || !rawName) {
     ui.write(chalk.yellow('The `ember new` command requires an app-name to be specified.' +
                           ' For more details, use `ember help`.\n'));
@@ -15,7 +22,6 @@ module.exports.run = function run(rawName) {
 
   var name = stringUtil.dasherize(rawName);
   var namespace = stringUtil.classify(rawName);
-
   var dir = name;
 
   try {

--- a/lib/utilities/is-ember-cli-project.js
+++ b/lib/utilities/is-ember-cli-project.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var fs = require('fs');
+
+module.exports = function isEmberCliProject() {
+  var originalCwd = process.cwd();
+  var inside = false;
+
+  while(process.cwd() !== '/') { // is it windows safe?
+    if(!fs.existsSync('package.json')) {
+      process.chdir('..');
+      continue;
+    }
+
+    var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    inside =  'ember-cli' in pkgJson.devDependencies;
+    if (inside) {
+      break;
+    } else {
+      process.chdir('..');
+    }
+  }
+
+  process.chdir(originalCwd);
+  return inside;
+};

--- a/tests/acceptance/new-slow.js
+++ b/tests/acceptance/new-slow.js
@@ -52,4 +52,12 @@ describe('Acceptance: ember new', function(){
     return ember(['new']);
   });
 
+  it('Cannot run ember new, inside of ember-cli project', function() {
+    this.timeout(1200000);
+    return ember(['new', 'foo']).then(function() {
+      return ember(['new', 'foo']).then(function() {
+        assert(!fs.existsSync('foo'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
Solves the problem of by mistake running `ember new foo` or `ember init`, inside of a ember cli project.

To identify if we are inside of a generated ember cli project, it's looked the ember-cli dependency into package.json, this is performed recursivelly so if you are inside of my_app/tests or a my_app/node_modules directory, the project isn't created.
