### PR TITLE
Add info about CSS preprocessors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ember-cli [![Build Status](https://travis-ci.org/stefanpenner/ember-cli.png?branch=master)](https://travis-ci.org/stefanpenner/ember-cli)
 =========
 
-an ember commandline utility.
+a ember commandline utility.
 
 
 Warning
@@ -10,21 +10,33 @@ Warning
 Although potentially exciting, this is still really a WIP, use at your own risk.
 
 
+Getting Started
+===============
+
+```sh
+npm install -g ember-cli
+
+mkdir my-cool-app
+cd my-cool-app
+ember init
+ember server
+```
+
 Why?
 ====
 
-The [ember-app-kit](https://github.com/stefanpenner/ember-app-kit) project has proved to be quite useful, 
-we have learned lots, and it allowed us to iterate quickly while building real ambitious applications.
+The https://github.com/stefanpenner/ember-app-kit project has proved to be quite useful, we have learned lots, and
+it allowed us to iterate quickly while building real ambitious applications.
 
 While it's initial incarnation is useful, it has several meta problems:
 
-1. It is not "simple" and appears daunting
+1. It is not "simple" and appears daunting.
 2. Because of inline configuration, the api surface area is massive
-3. #2 does not allow users to express the "what" just the "how", this prevents EAK from doing more of the heavy lifting itself
+3. #2 does not allow users to express the "what" just the "how", this prevents EAK from doing more of the heavy lifting itself.
 4. [#2 #3] makes it quite tedious to upgrade
 
 Rationale for #3
-================
+===============
 
 If we want to upgrade or swap in a faster build pipeline it would be a major pain currently. But with #3, in theory it should be minimal pain.
 
@@ -37,17 +49,13 @@ Guidelines
   - the pipeline-related Broccoli configuration should also reside in the above mentioned library.
 
 Usage
-=====
+===========
 
-Getting Started
----------------
+Install from npm
+-------------------
 
 ```sh
-npm install -g ember-cli
-
-ember new my-cool-app
-cd my-cool-app
-ember server
+npm install ember-cli -g
 ```
 
 Current Commands
@@ -78,6 +86,19 @@ On every file change:
 ```sh
 npm run-script autotest
 ```
+
+LESS, Sass, or Stylus
+---------------------
+
+You can use [LESS](http://lesscss.org/), [Sass](http://sass-lang.com/) *(scss only)*, or [Stylus](http://learnboost.github.io/stylus/) by installing the corresponding Broccoli package (`broccoli-sass`, `broccoli-less` or `broccoli-stylus`).
+
+For example, to enable SCSS compilation:
+
+```sh
+npm install --save-dev broccoli-sass
+```
+
+Building will now compile `app/styles/app.scss` into `app.css` in your output.
 
 Ideas
 =====


### PR DESCRIPTION
It isn't entirely obvious how to enable the new CSS preprocessor support added in #109. I've included instructions for LESS and Stylus, even though support seems to not be working at the moment (see #135)
