### PR TITLE
Fix LESS and Stylus support with broccoli-less-single and broccoli-stylus-single

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npm run-script autotest
 LESS, Sass, or Stylus
 ---------------------
 
-You can use [LESS](http://lesscss.org/), [Sass](http://sass-lang.com/) *(scss only)*, or [Stylus](http://learnboost.github.io/stylus/) by installing the corresponding Broccoli package (`broccoli-sass`, `broccoli-less-single` or `broccoli-stylus`).
+You can use [LESS](http://lesscss.org/), [Sass](http://sass-lang.com/) *(scss only)*, or [Stylus](http://learnboost.github.io/stylus/) by installing the corresponding Broccoli package (`broccoli-sass`, `broccoli-less-single` or `broccoli-stylus-single`).
 
 For example, to enable SCSS compilation:
 

--- a/lib/preprocessors/css.js
+++ b/lib/preprocessors/css.js
@@ -7,7 +7,7 @@ var requireLocal = require('../utilities/require-local');
 module.exports.supportedPlugins = {
   'sass': 'broccoli-sass',
   'less': 'broccoli-less-single',
-  'stylus': 'broccoli-stylus'
+  'stylus': 'broccoli-stylus-single'
 };
 
 module.exports.fallback = 'css';
@@ -23,8 +23,8 @@ module.exports.less = function(trees, inputPath, outputPath, options) {
 };
 
 module.exports.stylus = function(trees, inputPath, outputPath, options) {
-  var compiler = requireLocal('broccoli-stylus');
-  return compiler(trees, options);
+  var compiler = requireLocal('broccoli-stylus-single');
+  return compiler(trees, path.join(inputPath, 'app.styl'), path.join(outputPath, 'app.css'), options);
 };
 
 module.exports.css = function(trees, inputPath, outputPath) {


### PR DESCRIPTION
The problem in #135 seems to be that the LESS and Stylus Broccoli plugins are fundamentally different from Sass plugin. The Sass plugin compiles a single, primary input file into a single output file, and takes a tree of dependencies (for imported files). The LESS plugin, on the other hand, just compiles each `.less` file into a `.css` file, one-to-one. It doesn't support imports, or multi-file dependencies.

I've just created a [new LESS plugin](https://github.com/gabrielgrant/broccoli-less-single), based on the Sass version's (imo) correct n-to-one semantics. This branch sets up ember-cli to use that plugin for (functioning!) LESS, when it's installed.

Fixes #136
