### PR TITLE
Fix ember:release alias

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,8 +40,8 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('ember:release', ['test', 'release']);
-  for(var level in ['patch', 'major', 'minor']) {
-    grunt.registerTask('ember:release:' + level, ['test', 'release:' + level]);
-  }
 
+  ['patch', 'major', 'minor'].forEach(function(level) {
+    grunt.registerTask('ember:release:' + level, ['test', 'release:' + level]);
+  });
 };


### PR DESCRIPTION
`for(var level in ['patch', 'major', 'minor'])` takes the array key instead of the value. This generate ember:release:0, ember:release:1, ember:release:2. Instead of ember:release:patch, ember:release:major, ember:release:minor. This PR fix it.
