### PR TITLE
Fixes local/travis tests timeout failures

### DIFF
--- a/lib/blueprint.js
+++ b/lib/blueprint.js
@@ -43,8 +43,11 @@ Blueprint.prototype.srcPath = function(file) {
 };
 
 Blueprint.prototype.install = function(intoDir, templateVariables, dryRun, skipNpmInstall) {
-
   var ui = this.ui;
+  var postInstall = this.postInstall;
+
+  this.dryRun         = dryRun;
+  this.skipNpmInstall = skipNpmInstall;
 
   var actions = {
     write: function (info) {
@@ -83,15 +86,6 @@ Blueprint.prototype.install = function(intoDir, templateVariables, dryRun, skipN
     }
   }
 
-  function postInstall() {
-    if (!dryRun && skipNpmInstall) {
-      ui.write(chalk.yellow('Skipping `npm install`..\n'));
-      return 0;
-    }
-
-    return npmInstall().then(bowerInstall);
-  }
-
   ui.write('installing\n');
 
   if (dryRun) {
@@ -100,7 +94,16 @@ Blueprint.prototype.install = function(intoDir, templateVariables, dryRun, skipN
 
   return this.processFiles(intoDir, templateVariables).
     map(commit).
-    then(postInstall);
+    then(postInstall.bind(this));
+};
+
+Blueprint.prototype.postInstall = function() {
+  if (!this.dryRun && this.skipNpmInstall) {
+    this.ui.write(chalk.yellow('Skipping `npm install`..\n'));
+    return 0;
+  }
+
+  return npmInstall().then(bowerInstall);
 };
 
 Blueprint.prototype.buildFileInfo = function(destPath, templateVariables, file) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ember": "./bin/ember"
   },
   "scripts": {
-    "test": "mocha --timeout 5000 --reporter spec tests/**/*-test.js tests/**/*-slow.js",
+    "test": "mocha --timeout 8000 --reporter spec tests/**/*-test.js tests/**/*-slow.js",
     "autotest": "mocha --watch --reporter spec tests/**/*-test.js"
   },
   "repository": {

--- a/tests/unit/blueprint-test.js
+++ b/tests/unit/blueprint-test.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var assert = require('assert');
+var stub = require('../helpers/stub');
 var Blueprint = require('../../lib/blueprint');
 var basicBlueprint = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', 'basic'));
 var basicNewBlueprint = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', 'basic_2'));
@@ -54,25 +55,27 @@ describe('Blueprint', function() {
 
   describe('basic blueprint installation', function() {
     var blueprint;
+    var postInstall;
 
     beforeEach(function() {
       tmp.setup('./tmp');
       process.chdir('./tmp');
       ui = new MockUi();
       blueprint = new Blueprint(basicBlueprint, ui);
+      postInstall = stub(blueprint, 'postInstall');
     });
 
     afterEach(function() {
       tmp.teardown('./tmp');
+      postInstall.restore();
     });
 
     it('installs basic files', function() {
       assert(blueprint);
-      return blueprint.install('.').then(function(status) {
+      return blueprint.install('.').then(function() {
         var actualFiles = walkSync('.').sort();
         var output = ui.output;
 
-        assert.equal(status, 0);
         assert.match(output.shift(), /^installing/);
         assert.match(output.shift(), /create.* foo.txt/);
         assert.match(output.shift(), /create.* test.txt/);


### PR DESCRIPTION
- `postInstall` is moved to `Blueprint` so we can stub out in tests
- changes tests accordingly
- increases mocha's timeout

/cc @joefiorini 
