### PR TITLE
Fix server to allow periods in querystring

### DIFF
--- a/lib/server/middleware/history-support.js
+++ b/lib/server/middleware/history-support.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var path = require('path');
+var url = require('url');
 
 module.exports = function () {
   return function(req, res, next) {
     var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
-    var hasNoFileExtension = path.extname(req.url) === '';
+    var hasNoFileExtension = path.extname(url.parse(req.url).pathname) === '';
 
     if(req.method === 'GET' && hasHTMLHeader && hasNoFileExtension) {
       req.url = '/index.html';


### PR DESCRIPTION
The history-support middleware determines whether a static asset or a page route is requested by using `path.extname` to see if the requested path has a file extension or not. But this results in false positives for querystrings that contain periods.

I added `url.parse(req.url).pathname` to extract just the path of the url, excluding the querystring, and then using `path.extname` on that to check for a file extension.
