### PR TITLE
Output a newline before process exit on "q" keypress.

### DIFF
--- a/lib/ui/confirm.js
+++ b/lib/ui/confirm.js
@@ -16,6 +16,7 @@ module.exports = function confirm(question) {
     if (data === 'y') {
       return true;
     } else if (data === 'q') {
+      stdout.write('\n');
       process.exit(1);
     } else {
       return false;


### PR DESCRIPTION
There is a finally() on the promise to output a newline but this
doesn't get hit when calling process.exit(). A small annoyance, but
this ensures that on "q" the user's command prompt isn't stuck on the
last output line.
