### PR TITLE
Issue #66 - Create directory as specified by user input

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -23,7 +23,7 @@ module.exports.run = function run(options, ui) {
 
   var name = stringUtil.dasherize(rawName);
   var namespace = stringUtil.classify(rawName);
-  var dir = name;
+  var dir = rawName;
 
   try {
     fs.mkdirSync(dir);

--- a/tests/acceptance/new-slow.js
+++ b/tests/acceptance/new-slow.js
@@ -59,6 +59,19 @@ describe('Acceptance: ember new', function(){
     ]);
   });
 
+  it('ember new with app name creates new directory and has a dasherized package name', function() {
+    return ember([
+      'new',
+      'FooApp',
+      '--skip-npm-install'
+    ]).then(function() {
+      assert(!fs.existsSync('FooApp'));
+
+      var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      assert.equal(pkgJson.name, 'foo-app');
+    });
+  });
+
   it('Cannot run ember new, inside of ember-cli project', function() {
     return ember([
       'new',


### PR DESCRIPTION
- Behavior change
- Adds acceptance test to cover new behavior

Currently, running `ember new FooApp` will generate a folder called `foo-app`. As discussed this is a potential source of confusion for users, who will expect a directory called `FooApp` to be created.

This commit changes the behavior so that the created directory is called `FooApp`. However, it maintains the lowercase, dasherized name in the generated package.json file.
