### PR TITLE
Remove RSVP.on('error', ...)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,17 +2,10 @@
 
 var nopt = require('nopt');
 var chalk = require('chalk');
-var RSVP = require('rsvp');
 var Insight = require('./utilities/insight');
 var merge = require('lodash-node/modern/objects/merge');
 var path = require('path');
 var pkg = require('../package.json');
-var ui = require('./ui');
-
-RSVP.on('error', function(error) {
-  ui.write(chalk.red(String(error)) + '\n');
-  throw error;
-});
 
 var types = {
   help: Boolean,


### PR DESCRIPTION
Broccoli's API returns a promise that is rejected when there is a build
error. It is perfectly acceptable to leave this rejection unhandled, as
Broccoli will merrily continue watching and serve a helpful error page
in the meantime. The rejected promise only serves as a hook for API
consumers (like ember-cli) to print out stuff or take other actions on
build errors if they wish.

---

It seems that `RSVP.on('error', ...)` is useful to put in during development to track down errors, but it shouldn't be enabled in general.
