### PR TITLE
Subscribe to broccoli builds (watcher) from Brocfile

### DIFF
--- a/blueprint/Brocfile.js
+++ b/blueprint/Brocfile.js
@@ -20,6 +20,11 @@ module.exports = function (broccoli) {
   var qunit;
   var testsIndex;
 
+  broccoli.subscribe(function(change) {
+    // Add code here to run whenever broccoli's watcher changes
+    // /*eg.*/ change.symlinkTo('../server/public')
+  });
+
   app = pickFiles(app, {
     srcDir: '/',
     destDir: '<%= modulePrefix %>/'

--- a/lib/adapters/broccoli/build.js
+++ b/lib/adapters/broccoli/build.js
@@ -3,8 +3,10 @@
 var broccoli = require('broccoli');
 var fs = require('fs');
 var RSVP = require('rsvp');
-var ncp = require('ncp');
+var denodeify = RSVP.denodeify;
+var ncp = denodeify(require('ncp'));
 var rimraf = require('rimraf');
+var notifier = require('../../utilities/build-notifier');
 
 ncp.limit = 1;
 
@@ -14,6 +16,7 @@ function getBuilder () {
 }
 
 module.exports = function build(options) {
+  notifier.installInto(broccoli);
   return getBuilder().build()
     .then(function (dir) {
       var outputDir = options.outputPath || 'dist/';
@@ -25,9 +28,11 @@ module.exports = function build(options) {
 
       fs.mkdirSync(outputDir);
 
-      return RSVP.denodeify(ncp)(dir, outputDir, {
+      return ncp(dir, outputDir, {
         clobber: true,
         stopOnErr: true
+      }).then(function() {
+        broccoli.notify(dir);
       });
     });
 };

--- a/lib/adapters/broccoli/server.js
+++ b/lib/adapters/broccoli/server.js
@@ -4,6 +4,7 @@ var broccoli = require('broccoli');
 var Promise = require('rsvp').Promise;
 var Server = require('../../server');
 var Watcher =  require('broccoli/lib/watcher');
+var notifier = require('../../utilities/build-notifier');
 
 function getBuilder () {
   var tree = broccoli.loadBrocfile();
@@ -11,9 +12,16 @@ function getBuilder () {
 }
 
 module.exports = function server(options) {
+
+  notifier.installInto(broccoli);
+
   var watcher = new Watcher(getBuilder());
 
   options.watcher = watcher;
+
+  watcher.on('change', function(dir) {
+    broccoli.notify(dir);
+  });
 
   Server.serve(options);
   return new Promise(function(){ }); // runs for-ever

--- a/lib/models/broccoli-change.js
+++ b/lib/models/broccoli-change.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var denodeify = require('rsvp').denodeify;
+var fs = require('fs');
+var symlink = denodeify(fs.symlink);
+var path = require('path');
+var ncp = require('ncp');
+var rimraf = require('rimraf');
+
+function BroccoliChange(dir) {
+  this.dir = dir;
+}
+
+module.exports = BroccoliChange;
+
+function trySymlink(src, dest) {
+  return symlink(src, dest).catch(function(err) {
+    if(err.code === 'EEXIST') {
+      rimraf.sync(dest);
+      return symlink(src, dest);
+    }
+
+    throw err;
+  });
+}
+
+BroccoliChange.prototype.symlinkTo = function(dest) {
+  var src = this.dir;
+  return trySymlink(path.resolve(src), dest);
+};
+
+BroccoliChange.prototype.copyTo = function(dest) {
+  var src = this.dir;
+  return ncp(src, dest, {
+    clobber: true,
+    stopOnErr: true
+  });
+};

--- a/lib/utilities/build-notifier.js
+++ b/lib/utilities/build-notifier.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var BroccoliChange = require('../models/broccoli-change');
+
+var Notifier = function() {
+  this.subscribers = [];
+};
+
+Notifier.prototype.subscribe = function(subscriber) {
+  this.subscribers.push(subscriber);
+};
+
+Notifier.prototype.triggerChange = function(dir) {
+  var change = new BroccoliChange(dir);
+
+  this.subscribers.forEach(function(subscriber) {
+    subscriber(change);
+  });
+};
+
+module.exports.installInto = function(broccoli) {
+  var notifier = new Notifier();
+  broccoli.subscribe = function(fn) {
+    notifier.subscribe(fn);
+  };
+
+  broccoli.notify = function(dir) {
+    notifier.triggerChange(dir);
+  };
+};


### PR DESCRIPTION
This allows server-side integration of ember-cli by symlinking or copying the final built tmp dir to a public folder in the server-side app. I'm thinking I may eventually pull this out into its own module as a broccoli plugin, but for now I think it makes sense in here. @stefanpenner are you cool with me pulling this in?
