### PR TITLE
Add ES6 Import Validation

### DIFF
--- a/blueprint/Brocfile.js
+++ b/blueprint/Brocfile.js
@@ -3,6 +3,7 @@
 var uglifyJavaScript = require('broccoli-uglify-js');
 var replace = require('broccoli-replace');
 var compileES6 = require('broccoli-es6-concatenator');
+var validateES6 = require('broccoli-es6-import-validate');
 var pickFiles = require('broccoli-static-compiler');
 var mergeTrees = require('broccoli-merge-trees');
 
@@ -131,6 +132,20 @@ module.exports = function (broccoli) {
 
     var testsJs = preprocessJs(appAndDependencies, '/', prefix);
 
+    var validatedJs = validateES6(mergeTrees([app, tests]), {
+      whitelist: {
+        'ember/resolver': ['default'],
+        'ember-qunit': [
+          'globalize',
+          'moduleFor',
+          'moduleForComponent',
+          'moduleForModel',
+          'test',
+          'setResolver'
+        ]
+      }
+    });
+
     var legacyTestFiles = [
       'qunit/qunit/qunit.js',
       'qunit-shim.js',
@@ -156,7 +171,7 @@ module.exports = function (broccoli) {
       outputFile: '/assets/tests.js'
     });
 
-    var testsTrees = [qunitStyles, testsIndexHTML, testsJs];
+    var testsTrees = [qunitStyles, testsIndexHTML, validatedJs, testsJs];
     outputTrees = outputTrees.concat(testsTrees);
   }
 

--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -30,6 +30,7 @@
     "broccoli-merge-trees": "0.1.3",
     "broccoli": "0.7.2",
     "broccoli-static-compiler": "0.1.4",
+    "broccoli-es6-import-validate": "0.1.0",
     "broccoli-template": "0.1.0",
     "broccoli-uglify-js": "0.1.1",
     "broccoli-env": "0.0.1",


### PR DESCRIPTION
Progress on #36
- Add dependency broccoli-es6-import-validate
- Add validateJs tree (only when env !== 'production')

Wanted to get this up for review.  I've tested by running locally with `npm link`, creating a new project with `ember new ember-test` then `ember build` and `ember server` in the new project.

I tried to test out importing from a non existent module like `import Blah from 'ember-test/something/missing'` but something is failing with an ENOENT because that file doesn't exist that is being imported from.  But, when I tested by adding an extra named import like

```
import {
  test,
  moduleFor,
  blah // <-- doesn't exist
} from 'ember-qunit';
```

I get a proper warning from the validationJs tree.
