### PR TITLE
Prevent an app name of `test`.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -13,6 +13,11 @@ module.exports.run = function run(options, ui) {
   var cwd = process.cwd();
   var rawName = path.basename(cwd);
 
+  if (rawName === 'test') {
+    return Promise.reject(chalk.yellow('Due to an issue with `compileES6` an ' +
+                                       'application name of `test` cannot be used.'));
+  }
+
   var name = stringUtil.dasherize(rawName);
   var namespace = stringUtil.classify(rawName);
 

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -21,6 +21,11 @@ module.exports.run = function run(options, ui) {
       'app-name to be specified. For more details, use `ember help`.\n'));
   }
 
+  if (rawName === 'test') {
+    return Promise.reject(chalk.yellow('Due to an issue with `compileES6` an ' +
+                                       'application name of `test` cannot be used.'));
+  }
+
   var name = stringUtil.dasherize(rawName);
   var namespace = stringUtil.classify(rawName);
   var dir = rawName;


### PR DESCRIPTION
This is to avoid the issue indicated in: https://github.com/stefanpenner/ember-cli/issues/102

---

This is likely a stop-gap measure, but this seems to keep tripping folks up (which costs both us and them valuable time). We should fix it for real at some point in the future (and #102 should stay around).
