### PR TITLE
Detect whether ember-cli was installed via npm or via npm link.

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -5,7 +5,7 @@ var chalk = require('chalk');
 
 process.title = 'ember';
 
-var installedViaNPM = path.basename(path.resolve(__dirname, '../../..')) === 'npm';
+var installedViaNPM = path.basename(path.resolve(__dirname, '../..')) === 'node_modules';
 
 if (installedViaNPM) {
   console.log('Detected that ember-cli was installed via npm. (Report on github if this is wrong!)');


### PR DESCRIPTION
A mechanism to detect whether ember-cli was installed via `npm install` or via `npm link`.

Idea for using this information:
- If installed via `npm install`: Use local ember-cli package if the user is in a ember-cli project
- If installed via `npm link`: Always use global ember-cli package. (Because local version would be outdated)

This is useful for https://github.com/stefanpenner/ember-cli/issues/231
