### PR TITLE
Allow disabling Insight module via setting an ENV variable

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -62,11 +62,15 @@ Cli.run = function run (argv, ui, insight) {
 
   var cli = new Cli(argv, commands, ui, insight);
 
-  permission = insight.askPermission();
-
-  return permission.then(function() {
+  if( process.env.EMBER_INSIGHT == 'off'){
     return cli.run();
-  });
+  } else {
+    permission = insight.askPermission();
+
+    return permission.then(function() {
+      return cli.run();
+    });
+  }
 };
 
 function collectArgs(args, options) {


### PR DESCRIPTION
`EMBER_INSIGHT=off`

See stefanpenner/ember-cli#238 _'Insight: how to disable / opt out automatically under test'_

This is going to work for now for me. I know there is ongoing discussion about config, just hacked this together and submitting back in case it's useful. 

Not suggesting that ENV is the way to go for this particular variable, a config file with defaults probably better however I do think that a good thing to keep in mind would be allowing build overrides from the command line for some things
