### PR TITLE
Prevent an app name of `test`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-cli Changelog
 
+* Makes sure that user cannot create an application named `test`([#256](https://github.com/stefanpenner/ember-cli/pull/256))
+
 ### 0.0.21
 
 * Use `loader.js` from `bower` ([0c1e8d28](https://github.com/stefanpenner/ember-cli/commit/0c1e8d28ca4bf6d24dc28af1fa4736690394eb5a))

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var chalk = require('chalk');
+var loom  = require('loom');
 
 module.exports.run = function run(options) {
-  require('loom')(options.args.join(' '));
+  loom(options.args.join(' '));
 };
 
 module.exports.usage = function usage() {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,19 +1,22 @@
 'use strict';
 
-var Blueprint = require('../blueprint');
-var chalk = require('chalk');
+var Blueprint  = require('../blueprint');
+var chalk      = require('chalk');
 var stringUtil = require('../utilities/string');
-var path = require('path');
+var path       = require('path');
+var assert     = require('../utilities/assert');
 
 module.exports.types = {
   dryRun: [Boolean]
 };
 
 module.exports.run = function run(options, ui) {
-  var cwd = process.cwd();
+  var cwd     = process.cwd();
   var rawName = path.basename(cwd);
 
-  var name = stringUtil.dasherize(rawName);
+  assert('Due to an issue with `compileES6` an application name of `test` cannot be used.', rawName !== 'test');
+
+  var name      = stringUtil.dasherize(rawName);
   var namespace = stringUtil.classify(rawName);
 
   var blueprint = new Blueprint(Blueprint.main, ui);

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,15 +1,18 @@
 'use strict';
 
-var RSVP = require('rsvp');
-var Promise = RSVP.Promise;
-var mkdir = RSVP.denodeify(require('fs').mkdir);
-var Blueprint = require('../blueprint');
-var stringUtil = require('../utilities/string');
-var chalk = require('chalk');
+var RSVP              = require('rsvp');
+var Promise           = RSVP.Promise;
+var mkdir             = RSVP.denodeify(require('fs').mkdir);
+var Blueprint         = require('../blueprint');
+var stringUtil        = require('../utilities/string');
+var chalk             = require('chalk');
 var isEmberCliProject = require('../utilities/is-ember-cli-project');
+var assert            = require('../utilities/assert');
 
 module.exports.run = function run(options, ui) {
   var rawName = options.args[0];
+
+  assert('Due to an issue with `compileES6` an application name of `test` cannot be used.', rawName !== 'test');
 
   if (isEmberCliProject()) {
     return Promise.reject(chalk.yellow('Cannot run `ember new` inside of an ' +

--- a/lib/utilities/assert.js
+++ b/lib/utilities/assert.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function assert(errorMessage, test) {
+  if (!test) {
+    throw new Error(errorMessage);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ember": "./bin/ember"
   },
   "scripts": {
-    "test": "mocha --timeout 8000 --reporter spec tests/**/*-test.js tests/**/*-slow.js",
+    "test": "mocha --timeout 8000 --reporter spec tests/**/*-test.js tests/**/*/*-test.js tests/**/*-slow.js",
     "autotest": "mocha --watch --reporter spec tests/**/*-test.js"
   },
   "repository": {

--- a/tests/helpers/stub.js
+++ b/tests/helpers/stub.js
@@ -1,19 +1,35 @@
 'use strict';
 
-module.exports = function stub(obj, name) {
-  var original = obj[name];
+module.exports = {
+  stub: function stub(obj, name) {
+    var original = obj[name];
 
-  obj[name] = function() {
-    obj[name].called++;
-    obj[name].calledWith.push(arguments);
-  };
+    obj[name] = function() {
+      obj[name].called++;
+      obj[name].calledWith.push(arguments);
+    };
 
-  obj[name].restore = function() {
-    obj[name] = original;
-  };
+    obj[name].restore = function() {
+      obj[name] = original;
+    };
 
-  obj[name].called = 0;
-  obj[name].calledWith = [];
+    obj[name].called = 0;
+    obj[name].calledWith = [];
 
-  return obj[name];
+    return obj[name];
+  },
+  stubPath: function stubPath(path) {
+    return {
+      basename: function() {
+        return path;
+      }
+    };
+  },
+  stubBlueprint: function stubBlueprint() {
+    return function Blueprint() {
+      return {
+        install: function() { }
+      };
+    };
+  }
 };

--- a/tests/unit/blueprint-test.js
+++ b/tests/unit/blueprint-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var path = require('path');
-var assert = require('assert');
-var stub = require('../helpers/stub');
-var Blueprint = require('../../lib/blueprint');
-var basicBlueprint = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', 'basic'));
+var path              = require('path');
+var assert            = require('assert');
+var stub              = require('../helpers/stub').stub;
+var Blueprint         = require('../../lib/blueprint');
+var basicBlueprint    = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', 'basic'));
 var basicNewBlueprint = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', 'basic_2'));
-var missingBlueprint = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', '__missing__'));
+var missingBlueprint  = path.resolve(path.join(__dirname, '..', 'fixtures', 'blueprints', '__missing__'));
 
 var tmp = require('../helpers/tmp');
 var walkSync = require('walk-sync');

--- a/tests/unit/cli-test.js
+++ b/tests/unit/cli-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var assert = require('../helpers/assert');
-var stub = require('../helpers/stub');
-var MockUI = require('../helpers/mock-ui');
-var Insight = require('../../lib/utilities/insight');
-var Cli = require('../../lib/cli');
+var assert   = require('../helpers/assert');
+var stub     = require('../helpers/stub').stub;
+var MockUI   = require('../helpers/mock-ui');
+var Insight  = require('../../lib/utilities/insight');
+var Cli      = require('../../lib/cli');
 var baseArgs = ['node', 'path/to/cli'];
-var extend = require('lodash-node/compat/objects/assign');
-var brocEnv = require('broccoli-env');
+var extend   = require('lodash-node/compat/objects/assign');
+var brocEnv  = require('broccoli-env');
 
 var ui;
 var commands;

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -1,15 +1,21 @@
 'use strict';
 
-var describe = require('mocha').describe;
-var before = require('mocha').beforeEach;
-var after = require('mocha').afterEach;
-var it = require('mocha').it;
+var rewire  = require('rewire');
+var assert  = require('../../helpers/assert');
 
 var command;
+var called = false;
 
+function stubLoom() {
+  return function loom() {
+    called = true;
+  };
+}
 describe('generate command', function(){
+
   before(function() {
-    command = require('../../../lib/commands/generate');
+    command = rewire('../../../lib/commands/generate');
+    command.__set__('loom', stubLoom());
   });
 
   after(function() {
@@ -24,6 +30,7 @@ describe('generate command', function(){
         'type:array'
       ]
     });
-    //TODO: figure out how to test this more thoroughly
+
+    assert.ok(called);
   });
 });

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var command;
+var assert        = require('../../helpers/assert');
+var rewire        = require('rewire');
+var stubPath      = require('../../helpers/stub').stubPath;
+var stubBlueprint = require('../../helpers/stub').stubBlueprint;
+
+describe('init command', function(){
+  before(function() {
+    command = rewire('../../../lib/commands/init');
+    command.__set__('Blueprint', stubBlueprint());
+    command.__set__('path', stubPath('test'));
+  });
+
+  after(function() {
+    command = null;
+  });
+
+  it('doesn\'t allow to create an application named `test`', function(){
+    assert.throw(function() {
+      command.run({
+        cliOptions: {}
+      });
+    }, 'Due to an issue with `compileES6` an application name of `test` cannot be used.');
+  });
+});

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var command;
+var assert        = require('../../helpers/assert');
+var rewire        = require('rewire');
+var stubBlueprint = require('../../helpers/stub').stubBlueprint;
+
+describe('new command', function(){
+  before(function() {
+    command = rewire('../../../lib/commands/new');
+    command.__set__('Blueprint', stubBlueprint());
+  });
+
+  after(function() {
+    command = null;
+  });
+
+  it('doesn\'t allow to create an application named `test`', function(){
+    assert.throw(function() {
+      command.run({
+        args: ['test'],
+        cliOptions: {}
+      });
+    }, 'Due to an issue with `compileES6` an application name of `test` cannot be used.');
+  });
+});

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -2,8 +2,8 @@
 
 var command;
 var options;
-var assert  = require('../../helpers/assert');
-var rewire  = require('rewire');
+var assert = require('../../helpers/assert');
+var rewire = require('rewire');
 
 function stubAdapter(name, fn) {
   var result = {};
@@ -29,7 +29,7 @@ describe('server command', function(){
 
   it('has correct options', function(){
     command.run({
-      options: {
+      cliOptions: {
         port: 4000
       }
     });

--- a/tests/unit/helpers/assert-test.js
+++ b/tests/unit/helpers/assert-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var assertUtility = require('../../../lib/utilities/assert');
+var assert        = require('../../helpers/assert');
+
+describe('assert helper', function(){
+  it('throws if the condition is false', function(){
+    assert.throws(function() {
+      assertUtility('ZOMG', false);
+    }, 'ZOMG');
+  });
+
+  it('doesn\'t throw if the condition is true', function(){
+    assert.doesNotThrow(function() {
+      assertUtility('ZOMG', true);
+    }, 'ZOMG');
+  });
+});

--- a/tests/unit/insight-test.js
+++ b/tests/unit/insight-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var Insight = require('../../lib/utilities/insight');
+var Insight    = require('../../lib/utilities/insight');
 var InsightLib = require('insight');
-var assert = require('../helpers/assert');
-var stub = require('../helpers/stub');
+var assert     = require('../helpers/assert');
+var stub       = require('../helpers/stub').stub;
 
 var insight;
 var insightLib = new InsightLib({


### PR DESCRIPTION
Related to #232, initial PR by @rjackson.
- prevents the application to be named `test`
- introduces new helpers `stubPath` and `stubBlueprint`
- refacators `generate` test
- adds tests for `init` and `new` commands
- changes `npm test` command to make sure we run `unit/commands` tests
- adds an entry to CHANGELOG
