### PR TITLE
Wrap the tree in a MergedTree so builder can call `clean()`

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -5,6 +5,7 @@ var deps = pkg['devDependencies'];
 var path = require('path');
 var Registry = require('./preprocessors/registry');
 var requireLocal = require('./utilities/require-local');
+var broccoli = require('broccoli');
 
 var registry = new Registry(deps);
 
@@ -26,7 +27,7 @@ module.exports.preprocessCss = function(trees, inputPath, outputPath, options) {
 
   if(!plugin) {
     var compiler = requireLocal('broccoli-static-compiler');
-    return compiler(trees, {
+    return compiler(new broccoli.MergedTree(trees), {
       srcDir: inputPath,
       destDir: outputPath
     });


### PR DESCRIPTION
Right now, if you create a new app and try to `ember build`, it will fail. This fixes it. Might not be the best solution. Have 2% battery on a plane, so I'm submitting this as-is.
