### PR TITLE
Call getEnvJSON instead of passing a bound function.

### DIFF
--- a/blueprint/Brocfile.js
+++ b/blueprint/Brocfile.js
@@ -27,7 +27,7 @@ module.exports = function (broccoli) {
 
   indexHTML = replace(indexHTML, {
     files: ['index.html'],
-    patterns: [{ match: /\{\{ENV\}\}/g, replacement: getEnvJSON.bind(env)}]
+    patterns: [{ match: /\{\{ENV\}\}/g, replacement: getEnvJSON(env)}]
   });
 
   // sourceTrees, appAndDependencies for CSS and JavaScript
@@ -119,7 +119,7 @@ module.exports = function (broccoli) {
 
     testsIndexHTML = replace(testsIndexHTML, {
       files: ['tests/index.html'],
-      patterns: [{ match: /\{\{ENV\}\}/g, replacement: getEnvJSON.bind(env)}]
+      patterns: [{ match: /\{\{ENV\}\}/g, replacement: getEnvJSON(env)}]
     });
 
     tests = preprocessTemplates(tests);


### PR DESCRIPTION
Right now, `environment.js` gets executed with environment equal to the string `{{ENV}}`. If you add development or production-specific variables to `environment.js`, it doesn't work. 
