### PR TITLE
Bump ember-cli dependency version in blueprint

### DIFF
--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli" : "^0.0.20",
+    "ember-cli" : "^0.0.21",
     "loom-generators-ember-appkit": "~1.0.5",
     "originate": "~0.1.5",
     "loom": "~3.1.2",


### PR DESCRIPTION
Updated the dependency specified in the blueprint for ember-cli to match the latest version.
