### PR TITLE
<head> updates in _includes/head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,11 @@
 <head>
   <meta charset='utf-8' />
-  <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/assets/styles/bootstrap.css">
   <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/assets/styles/ecli.css">
   <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/assets/styles/syntax.css">
 
-  <title>Ember CLI | Ember command line utility for the ambitions web applications</title>
+  <title>Ember CLI | A command line utility for creating ambitious web applications</title>
 </head>


### PR DESCRIPTION
Removing "chrome=1" from "X-UA-Compatible" meta tag. 
See https://developers.google.com/chrome/chrome-frame/

-Updated `<title>` to fix the typos; Also tweaked to better align with the Ember slogan.
