### PR TITLE
Fix guide for using emblem.

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -100,5 +100,5 @@ CoffeeScript, but that support has been removed.
 For Emblem, run the following commands:
 
 {% highlight bash %}
-npm install --save-dev broccoli-emblem-compiler && bower install emblem.js --save
+npm install --save-dev broccoli-emblem-compiler
 {% endhighlight %}

--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -147,7 +147,7 @@ Your route configuration. The routes defined here correspond to routes in `app/r
 
 Contains your stylesheets, whether SASS, LESS, Stylus, Compass, or plain CSS
 (though only one type is allowed, see [Asset Compilation](asset-compilation.html)).
-These are all compiled through the into `app.css`.
+These are all compiled into `app.css`.
 
 `app/templates/`
 


### PR DESCRIPTION
'Fixes' #309. I followed the current guides on stefanpenner/ember-cli and instructions on using emblem break the `ember server` command.
