### PR TITLE
Improve CSS preprocessors situation

### DIFF
--- a/blueprint/Brocfile.js
+++ b/blueprint/Brocfile.js
@@ -88,7 +88,7 @@ module.exports = function (broccoli) {
 
   // Styles
 
-  var styles = preprocessCss(appAndDependencies, prefix + '/styles', '/assets');
+  var styles = preprocessCss(sourceTrees, prefix + '/styles', '/assets');
 
   // Ouput
 


### PR DESCRIPTION
This improves the situation with CSS preprocessors. It fixes the issues with using `broccoli-sass` and `broccoli-less-single` but it seems like `broccoli-stylus` still doesn't work.

Thanks @joliss https://github.com/stefanpenner/ember-cli/issues/265#issuecomment-39994483
