### PR TITLE
Update the help functionality to get info for specific commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * upgrade broccoli to `0.9.0` [v0.9.0 brocfile changes](https://gist.github.com/joliss/15630762fa0f43976418)
 * Use configuration from `config/environments.js` to pass options to `Ember.Application.create`. ([#370](https://github.com/stefanpenner/ember-cli/pull/370))
 * Adds `ic-ajax` to the list of ignored modules for tests([#378](https://github.com/stefanpenner/ember-cli/pull/378))
+* Adds per command help output ([#376](https://github.com/stefanpenner/ember-cli/pull/376))
 
 ### 0.0.23
 

--- a/lib/cli/parse-cli-args.js
+++ b/lib/cli/parse-cli-args.js
@@ -74,6 +74,13 @@ function parseCLIArgs(ui, environment) {
     }
   }
 
+  // Make the 'help' option available.
+  command.availableOptions.push({
+    name: 'help',
+    key: 'help',
+    type: Boolean
+  });
+
   command.availableOptions.forEach(function(option) {
     knownOpts[option.name] = option.type;
   });
@@ -82,6 +89,16 @@ function parseCLIArgs(ui, environment) {
 
   if (!command.availableOptions.every(assembleAndValidateOption)) {
     return null;
+  }
+
+  // Remove the 'help' option that was added.
+  command.availableOptions.pop();
+
+  // If the help option was enabled, use the 'help' command instead of the
+  // requested one and provide the requested one in the arguments.
+  if (commandOptions.help) {
+    command = commands.help;
+    environment.cliArgs = ['help', commandName];
   }
 
   return {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var Command = require('../command');
+var chalk = require('chalk');
 
 module.exports = new Command({
-  description: 'outputs this message',
+  description: 'Outputs the usage instructions for all commands or the provided command',
   works: 'everywhere',
 
   aliases: [undefined, 'h', 'help', '-h', '--help'],
@@ -11,10 +12,40 @@ module.exports = new Command({
   run: function(ui, environment) {
     var commands = environment.commands;
 
-    ui.write('available commands:\n');
+    function displayHelpForCommand(commandName) {
+      var command = commands[commandName];
 
-    ui.write(Object.keys(commands).map(function(key) {
-      return commands[key].usageInstructions();
-    }).join('\n'));
+      // If the requested command doesn't exist, display an error message.
+      if (!command) {
+        ui.write(chalk.red('No help entry for \'' + commandName + '\'\n'));
+      } else {
+        ui.write(command.usageInstructions() + '\n');
+      }
+    }
+
+    // If any additional args were passed to the help command, attempt to look
+    // up the command for each of them.
+    var cliArgs = environment.cliArgs;
+    if (cliArgs && cliArgs.length > 1) {
+
+      ui.write('Requested ember-cli commands:\n\n');
+
+      // Iterate through each arg beyond the initial 'help' command, and try to
+      // display usage instructions.
+      environment.cliArgs.slice(1).forEach(displayHelpForCommand);
+
+    // Otherwise, display usage for all commands.
+    } else {
+      ui.write('Available commands in ember-cli:\n');
+
+      Object.keys(commands).forEach(function(key) {
+        displayHelpForCommand(key);
+      });
+    }
+  },
+  usageInstructions: function() {
+    return {
+      anonymousOptions: '<command-name (Default: all)>'
+    };
   }
 });

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -9,3 +9,7 @@ module.exports = MockUI;
 MockUI.prototype.write = function(message) {
   this.output.push(message);
 };
+
+MockUI.prototype.reset = function() {
+  this.output = [];
+};

--- a/tests/unit/cli/parse-cli-args-test.js
+++ b/tests/unit/cli/parse-cli-args-test.js
@@ -46,6 +46,10 @@ var environment = {
       works: 'everywhere',
       run: function() {},
       usageInstructions: function() {}
+    }),
+    help: new Command({
+      name: 'help',
+      run: function() {},
     })
   },
   isWithinProject: true
@@ -116,5 +120,9 @@ describe('cli/parse-cli-args.js', function() {
     expect(output.shift()).to.match(/You have to be inside an ember-cli project/);
     expect(parse({ cliArgs: ['outside-project'], isWithinProject: false })).to.be.exist;
     expect(parse({ cliArgs: ['everywhere'],      isWithinProject: false })).to.exist;
+  });
+
+  it('parseCLIArgs() should delegate commands to the help function if the help option is provided.', function() {
+    expect(parse({ cliArgs: ['s', '--help']}).command.name).to.equal('help');
   });
 });

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -3,42 +3,56 @@
 var expect  = require('chai').expect;
 var MockUI  = require('../../helpers/mock-ui');
 var rewire  = require('rewire');
-var rewire  = require('rewire');
 var Command = rewire('../../../lib/command');
 
 describe('help command', function() {
-  var ui, command, environment;
+  var ui, helpCommand, commands;
 
   before(function() {
     ui = new MockUI();
-    command = rewire('../../../lib/commands/help');
-    environment = {
-      commands: {
-        testCommand1: new Command({
-          name: 'test-command-1',
-          description: 'command-description',
-          availableOptions: [
-            { name: 'option-with-default', type: String, default: 'default-value' },
-            { name: 'required-option', type: String, required: 'true', description: 'option-descriptionnnn' }
-          ],
-          run: function() {}
-        }),
-        testCommand2: new Command({
-          name: 'test-command-2',
-          run: function() {}
-        })
-      }
+    helpCommand = rewire('../../../lib/commands/help');
+    commands = {
+      'test-command-1': new Command({
+        name: 'test-command-1',
+        description: 'command-description',
+        availableOptions: [
+          { name: 'option-with-default', type: String, default: 'default-value' },
+          { name: 'required-option', type: String, required: 'true', description: 'option-descriptionnnn' }
+        ],
+        run: function() {}
+      }),
+      'test-command-2': new Command({
+        name: 'test-command-2',
+        run: function() {}
+      })
     };
   });
 
   it('should generate complete help output', function() {
-    command.run(ui, environment);
+    ui.reset();
+
+    helpCommand.run(ui, {
+      commands: commands
+    });
+
     expect(ui.output[1]).to.include('ember test-command-1');
     expect(ui.output[1]).to.include('command-description');
     expect(ui.output[1]).to.include('option-with-default');
     expect(ui.output[1]).to.include('(Default: default-value)');
     expect(ui.output[1]).to.include('required-option');
     expect(ui.output[1]).to.include('(Required)');
-    expect(ui.output[1]).to.include('ember test-command-2');
+    expect(ui.output[2]).to.include('ember test-command-2');
+  });
+
+  it('should generate specific help output', function() {
+    ui.reset();
+
+    helpCommand.run(ui, {
+      commands: commands,
+      cliArgs: ['help', 'test-command-2']
+    });
+
+    expect(ui.output[1]).to.include('test-command-2');
+    expect(ui.output[1]).to.not.include('test-command-1');
   });
 });


### PR DESCRIPTION
Enables `ember help command1 command2 ...` as well as `ember generate --help`, like the previous pull request, but adjusted and rebased for the latest changes.
