### PR TITLE
Sort blueprint package.json deps.

### DIFF
--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -22,19 +22,19 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli" : "0.0.23",
-    "loom-generators-ember-appkit": "~1.0.5",
-    "originate": "~0.1.5",
-    "loom": "~3.1.2",
     "broccoli": "0.9.0",
     "broccoli-bower": "^0.2.0",
     "broccoli-env": "0.0.1",
     "broccoli-es6-concatenator": "0.1.4",
-    "broccoli-static-compiler": "0.1.4",
-    "broccoli-uglify-js": "0.1.3",
-    "broccoli-merge-trees": "0.1.3",
     "broccoli-es6-import-validate": "0.1.0",
+    "broccoli-merge-trees": "0.1.3",
+    "broccoli-replace": "0.1.5",
+    "broccoli-static-compiler": "0.1.4",
     "broccoli-template": "0.1.1",
-    "broccoli-replace": "0.1.5"
+    "broccoli-uglify-js": "0.1.3",
+    "ember-cli" : "0.0.23",
+    "loom": "~3.1.2",
+    "loom-generators-ember-appkit": "~1.0.5",
+    "originate": "~0.1.5"
   }
 }


### PR DESCRIPTION
npm automatically sorts dependencies when you do `npm install --save-dev <pkg>`, so it'd be nice to have the dependencies already sorted in the initial package.json.
