### PR TITLE
[DOCS] Fix sidebar positioning

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
             </div>
           </div>
           <div class="col-md-3">
-            <div class="sidebar affix-top">
+            <div class="sidebar">
               <ul class="nav sidenav">
                 {% for guide in site.posts %}
                   {% if guide.hidden != 'true' %}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,9 @@
 (function() {
   $('body').scrollspy({ target: '.sidebar' });
+
+  $('.sidebar').affix({
+    offset: {
+      top: $('.sidebar').offset().top - 20
+    }
+  });
 })();

--- a/assets/styles/ecli.css
+++ b/assets/styles/ecli.css
@@ -98,7 +98,10 @@ body {
 
 .sidebar {
   padding-left: 20px;
-  position: fixed;
+}
+
+.sidebar.affix {
+  top: 20px;
 }
 
 .sidenav {


### PR DESCRIPTION
The sidebar should only be fixed once it's reached the top of the page.

Currently there are issues when viewing on a smaller screen. For example, I can't see the bottom half of the sidebar when viewing on my 11" laptop.

**Current sidebar positioning on my laptop:**

![current positioning](https://dl.dropboxusercontent.com/s/b4mqftmx5wle1m2/Screen%20Shot%202014-04-17%20at%2011.29.51%20PM.png)

**New positioning after scrolling down:**

![current positioning](https://dl.dropboxusercontent.com/s/ywse2ekebthqtsj/Screen%20Shot%202014-04-17%20at%2011.30.09%20PM.png)
