### PR TITLE
[DOCS] Ignore bundler install log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .DS_Store
 *.swp
 node_modules
+.bundle


### PR DESCRIPTION
Ignore the `.bundle/` directory that is created after running `bundle install`.
