### PR TITLE
Setting BROCCOLI_ENV with the value from the cli arguments.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -15,6 +15,9 @@ CLI.prototype.run = function(environment) {
 
   return Promise.hash(environment).then(function(environment) {
     var parsingOutput = parseCLIArgs(this.ui, environment);
+
+    process.env.BROCCOLI_ENV = parsingOutput.commandOptions.environment || 'development';
+
     // Parse argv, returns null and writes message to ui if it fails
     // If the command was found, run it!
     if (parsingOutput) {


### PR DESCRIPTION
BROCCOLI_ENV never gets set with the value from the cli arguments and commands like build always run as in `development` env.
