### PR TITLE
Log offending filename details for build command.

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -36,6 +36,14 @@ module.exports = new Task({
       .then(function() {
         ui.write(chalk.green('Built project successfully. Stored in "' +
           options.outputPath + '".\n'));
+      })
+      .catch(function(err) {
+        ui.write(chalk.red('Build failed.\n'));
+
+        if (err.file) {
+          ui.write('File: ' + err.file + '\n');
+        }
+        ui.write(err.stack);
       });
   }
 });


### PR DESCRIPTION
Screenshot of a dummy app (where I left out a comma in an object definition):

![screenshot](http://monosnap.com/image/oJTAOC5MrN7wzO3VFxcmRPTlh1lqwZ.png)

---

A few more references as to where `err.file` is coming from:

The filename is being set as `file` on the rejection value by `broccoli-filter` ([here](https://github.com/joliss/broccoli-filter/blob/7346b59b99028b1b514977d687e284b818a54711/index.js#L87)) and `broccoli-es6-concatenator` ([here](https://github.com/joliss/broccoli-es6-concatenator/blob/master/index.js#L119))

https://github.com/joliss/broccoli/pull/102 should cause this to generate nice output for both `broccoli build` and `broccoli serve` commands, but our custom `ember build` task will not take advantage of that PR.
