### PR TITLE
Indicate that the build was successful after a build error.

### DIFF
--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -6,6 +6,7 @@ var expressServer    = require('./server/express-server');
 var broccoli         = require('broccoli');
 var Promise          = require('../ext/promise');
 var Watcher          = require('broccoli/lib/watcher');
+var chalk            = require('chalk');
 var Task             = require('../task');
 
 module.exports = new Task({
@@ -16,6 +17,18 @@ module.exports = new Task({
 
     var builder = new broccoli.Builder(tree);
     var watcher = new Watcher(builder);
+
+    var error = null;
+    watcher.on('change', function() {
+      if (error) {
+        environment.write(chalk.green('\n\nBuild successful.\n'));
+        error = null;
+      }
+    });
+
+    watcher.on('error', function(err) {
+      error = err;
+    });
 
     options = assign({}, options, { watcher: watcher });
 


### PR DESCRIPTION
Prior to this change if a build errored it was not possible to know from the console if that issue has been corrected. This forced us to stop && restart the server to get feedback (even though it had likely already been fixed).

This change adds a "Build successful." message when the build had previously errored (the stack was already printed to the screen), and is now built properly.

@danmcclain / @rjackson

---

Screenshot:

![screenshot](http://monosnap.com/image/PS53sco0kAgdKwdmgykVoYrRieK4eh.png)
