### PR TITLE
Cleanup after `server` and `build` commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Use configuration from `config/environments.js` to pass options to `Ember.Application.create`. ([#370](https://github.com/stefanpenner/ember-cli/pull/370))
 * Adds `ic-ajax` to the list of ignored modules for tests([#378](https://github.com/stefanpenner/ember-cli/pull/378))
 * Adds per command help output ([#376](https://github.com/stefanpenner/ember-cli/pull/376))
+* Ensures that the broccoli trees are cleaned up properly. ([#444](https://github.com/stefanpenner/ember-cli/pull/444))
 
 ### 0.0.23
 

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -45,6 +45,9 @@ module.exports = new Task({
           ui.write('File: ' + err.file + '\n');
         }
         ui.write(err.stack);
+      })
+      .finally(function() {
+        builder.cleanup();
       });
   }
 });

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -20,6 +20,20 @@ module.exports = new Task({
       builder: builder
     });
 
+    process.addListener('exit', function () {
+      builder.cleanup()
+    })
+
+    // We register these so the 'exit' handler removing temp dirs is called
+    process.on('SIGINT', function () {
+      process.exit(1)
+    })
+    process.on('SIGTERM', function () {
+      process.exit(1)
+    })
+
+
+
     options = assign({}, options, { watcher: watcher });
 
     return Promise.all([


### PR DESCRIPTION
We are currently not cleanuing up our `tmp/` directories after `build` and `server` are completed. This led to a 15 minute `rm -rf tmp/` session for me...

Screenshot of current behavior:

![screenshot](http://monosnap.com/image/DOfBma6wwoD3RlwmZ9jbwmsIaiAgJK.png)

Screenshot showing new behavior:

![Screenshot](http://monosnap.com/image/RhlH4ibzWXOxT2ztMmV5f1OChm1Yjf.png)
