### PR TITLE
Re-add master branch to ember-resolver in bower.json

### DIFF
--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -7,7 +7,7 @@
     "ember-qunit": "~0.1.5",
     "ember": "1.5.0",
     "ember-data": "1.0.0-beta.7",
-    "ember-resolver": "stefanpenner/ember-jj-abrams-resolver",
+    "ember-resolver": "stefanpenner/ember-jj-abrams-resolver#master",
     "ic-ajax": "~1.x",
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",


### PR DESCRIPTION
I accidentally removed the `master` specification from ember-resolver in #446 and it's required.
