### PR TITLE
Use current directory to grab testem.js.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -143,10 +143,10 @@ EmberApp.prototype.testFiles = memoize(function() {
       destDir: '/assets/'
     });
 
-  var emberCliBroccoliPath = require.resolve('ember-cli/lib/broccoli/testem.js');
-  emberCliBroccoliPath = path.dirname(emberCliBroccoliPath);
+  var testemPath = path.join(__dirname, 'testem');
+  testemPath = path.dirname(testemPath);
 
-  var testemTree = pickFiles(emberCliBroccoliPath, {
+  var testemTree = pickFiles(testemPath, {
       files: ['testem.js'],
       srcDir: '/',
       destDir: '/'


### PR DESCRIPTION
Fixes #454.
