### PR TITLE
Allow dry-run option in new command

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -9,6 +9,7 @@ module.exports = new Command({
   works: 'outsideProject',
 
   availableOptions: [
+    { name: 'dry-run', type: Boolean, default: false },
     { name: 'verbose', type: Boolean, default: false }
   ],
 


### PR DESCRIPTION
New options will now match init options.
