### PR TITLE
Use new `tmp/output` location for Testem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Integrate leek package for ember-cli usage analytics reporting. ([#448](https://github.com/stefanpenner/ember-cli/pull/448))
 * Generate current live build to `tmp/output/` when running `ember server`. This is very useful for
   debugging the current Broccoli tree without manually running `ember build`. ([#457](https://github.com/stefanpenner/ember-cli/pull/457))
+* Use `tmp/output/` directory created in [#457](https://github.com/stefanpenner/ember-cli/pull/457) for Testem setup.
+  This allows using the `testem` command to run Testem in server mode (allowing capturing multiple browsers and other goodies). [#463](https://github.com/stefanpenner/ember-cli/pull/463)
 
 ### 0.0.23
 

--- a/blueprint/testem.json
+++ b/blueprint/testem.json
@@ -1,5 +1,6 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html",
+  "cwd": "tmp/output",
   "launch_in_ci": ["PhantomJS", "Chrome"]
 }

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -12,10 +12,11 @@ module.exports = new Command({
   ],
 
   run: function(environment, options) {
+    var bind        = this;
     var build       = environment.tasks.build;
     var test        = environment.tasks.test;
-    var cwd         = quickTemp.makeOrRemake(this, '-testsDist');
-    var testOptions = assign({}, options, { cwd: cwd });
+    var cwd         = quickTemp.makeOrRemake(bind, '-testsDist');
+    var testOptions = assign({}, options);
 
     build.ui   = this.ui;
     build.leek = this.leek;
@@ -25,6 +26,9 @@ module.exports = new Command({
     return build.run({ environment: 'development', outputPath: cwd })
       .then(function() {
         return test.run(testOptions);
+      })
+      .finally(function() {
+        quickTemp.remove(bind, '-testsDist');
       });
   }
 });

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -6,7 +6,7 @@ var Promise = require('../ext/promise');
 
 module.exports = new Task({
   run: function(environment, options) {
-    var testemOptions = { cwd: options.cwd, file: options.configFile };
+    var testemOptions = { file: options.configFile };
     var mode = 'startCI';
     var testem  = new Testem();
 


### PR DESCRIPTION
This allows using the command line version of `testem` in addition to running
in CI mode (the current behavior).
