### PR TITLE
Remove specifying rootURL from ENV

### DIFF
--- a/blueprint/app/router.js
+++ b/blueprint/app/router.js
@@ -1,5 +1,4 @@
 var Router = Ember.Router.extend({
-  rootURL: ENV.rootURL,
   location: 'auto'
 });
 


### PR DESCRIPTION
Specifying a rootURL should be optional and not based on the ENV rootURL, which should only be used to namespace assets in the `base href` tag. The previous functionality resulted in a bug where you would get a double url parameter if you serve your app from `/foo/index.html` and also specified a rootURL `/foo`, giving you `/foo/foo`. The router rootURL should be an opt-in configuration based on how a user decides to deploy their app.

https://github.com/stefanpenner/ember-cli/issues/417
