### PR TITLE
Revert "Remove `/tests` from express middleware in favor of `ember test --server`."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 * Use `tmp/output/` directory created in [#457](https://github.com/stefanpenner/ember-cli/pull/457) for Testem setup.
   This allows using the `testem` command to run Testem in server mode (allowing capturing multiple browsers and other goodies). [#463](https://github.com/stefanpenner/ember-cli/pull/463)
 * Added `ember test --server` to run the `testem` command line server. `ember test --server` will automatically re-run your tests after a rebuild. [#474](https://github.com/stefanpenner/ember-cli/pull/474)
-* Remove `/tests` in favor of `ember test --server`.
 
 ### 0.0.23
 

--- a/lib/tasks/server/middleware/history-support.js
+++ b/lib/tasks/server/middleware/history-support.js
@@ -6,9 +6,10 @@ module.exports = function() {
   return function(req, res, next) {
     var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
     var hasNoFileExtension = path.extname(req.path) === '';
+    var isForTests = /^\/tests/.test(req.path);
 
     if (req.method === 'GET' && hasHTMLHeader && hasNoFileExtension) {
-      req.url = '/index.html';
+      req.url = isForTests ? '/tests/index.html' : '/index.html';
     }
 
     next();


### PR DESCRIPTION
This reverts commit 02fee9e96391ac70910b289af81fae3be0af8942.
