### PR TITLE
Set base tag in template

### DIFF
--- a/blueprint/app/index.html
+++ b/blueprint/app/index.html
@@ -7,9 +7,9 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    {{BASE_TAG}}
     <script>
       window.ENV = {{ENV}};
-      document.write('<base href="' + ENV.rootURL + '" />');
     </script>
 
     <link rel="stylesheet" href="assets/app.css">

--- a/blueprint/config/environment.js
+++ b/blueprint/config/environment.js
@@ -1,6 +1,6 @@
 module.exports = function(environment) {
   var ENV = {
-    rootURL: '/',
+    baseURL: '/',
     FEATURES: {
       // Here you can enable experimental features on an ember canary build
       // e.g. 'with-controller': true
@@ -25,5 +25,5 @@ module.exports = function(environment) {
 
   }
 
-  return JSON.stringify(ENV); // Set in index.html
+  return ENV;
 };

--- a/blueprint/tests/index.html
+++ b/blueprint/tests/index.html
@@ -7,9 +7,9 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    {{BASE_TAG}}
     <script>
       window.ENV = {{ENV}};
-      document.write('<base href="' + ENV.rootURL + '" />');
     </script>
 
     <link rel="stylesheet" href="assets/app.css">

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -189,11 +189,29 @@ EmberApp.prototype.toTree = memoize(function() {
 
 function injectENVJson(fn, env, tree, files) {
   // TODO: real templating
+  var envJsonString = function(){
+    return JSON.stringify(fn(env));
+  };
+
+  var baseTag = function(){
+    var baseURL = fn(env).baseURL;
+
+    if (baseURL && baseURL !== '') {
+      return '<base href="' + baseURL + '" />';
+    } else {
+      return '';
+    }
+  };
+
   return replace(tree, {
     files: files,
     patterns: [{
       match: /\{\{ENV\}\}/g,
-      replacement: fn.bind(null, env)
+      replacement: envJsonString
+    },
+    {
+      match: /\{\{BASE_TAG\}\}/g,
+      replacement: baseTag
     }]
   });
 }


### PR DESCRIPTION
Closes #467.
Closes #417.

As discussed in #467 this cleans up the usage of `<base>` tag.
