### PR TITLE
Use the current package.json name value for `ember init`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   This allows using the `testem` command to run Testem in server mode (allowing capturing multiple browsers and other goodies). [#463](https://github.com/stefanpenner/ember-cli/pull/463)
 * Added `ember test --server` to run the `testem` command line server. `ember test --server` will automatically re-run your tests after a rebuild. [#474](https://github.com/stefanpenner/ember-cli/pull/474)
 * Add JSHinting for `app/` and `test/` trees when building in development. This generates console logs as well as QUnit tests (so that `ember test` shows failures). [#482](https://github.com/stefanpenner/ember-cli/pull/482)
+* Use the name specified in `package.json` while doing `ember init`. This allows you to use a different application name than your folder name. [#491](https://github.com/stefanpenner/ember-cli/pull/491)
 
 ### 0.0.23
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -18,7 +18,7 @@ CLI.prototype.run = function(environment) {
     var parsingOutput = new CommandFactory({
       ui: this.ui,
       commands: environment.commands,
-      isWithinProject: environment.isWithinProject
+      project: environment.project
     }).commandFromArgs(environment.cliArgs);
 
     if (parsingOutput) {

--- a/lib/cli/command-factory.js
+++ b/lib/cli/command-factory.js
@@ -20,7 +20,7 @@ function findCommand(commands, commandName) {
 function CommandFactory(options){
   this.ui = options.ui;
   this.commands = options.commands;
-  this.isWithinProject = options.isWithinProject;
+  this.project = options.project;
 }
 
 // Parses the cliArgs, check if all constraints for the specified command are
@@ -32,7 +32,7 @@ CommandFactory.prototype.commandFromArgs = function(cliArgs) {
   var commandName     = cliArgs[0];
   var knownOpts       = {}; // Parse options
   var commandOptions  = {}; // Set defaults and check if required options are present
-  var isWithinProject = this.isWithinProject;
+  var project         = this.project;
   var parsedOptions;
 
   // TODO: clean this up
@@ -61,7 +61,7 @@ CommandFactory.prototype.commandFromArgs = function(cliArgs) {
   }
 
   if (command.works === 'insideProject') {
-    if (!isWithinProject) {
+    if (!project.isEmberCLIProject()) {
       this.ui.write('You have to be inside an ember-cli project in order to use ' +
                'the ' + chalk.green(commandName) + ' command.\n');
       return null;
@@ -69,7 +69,7 @@ CommandFactory.prototype.commandFromArgs = function(cliArgs) {
   }
 
   if (command.works === 'outsideProject') {
-    if (isWithinProject) {
+    if (project.isEmberCLIProject()) {
       this.ui.write('You cannot use the '+  chalk.green(commandName) +
                ' command inside an ember-cli project.\n');
       return null;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -31,11 +31,21 @@ function cli(options) {
     version:      version
   });
 
+  var project = Project.closest(process.cwd())
+    .catch(function(reason) {
+      if (reason instanceof Project.ProjectNotFoundError) {
+        // no project was found
+        return null;
+      } else {
+        throw reason;
+      }
+    });
+
   var environment = {
     tasks: tasks,
     cliArgs: options.cliArgs,
     commands: commands,
-    isWithinProject: Project.isWithinProject() // TODO: this should go away once we are injecting project
+    project: project
   };
 
   return new CLI(ui, leek).run(environment);

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -18,18 +18,22 @@ module.exports = new Command({
 
   run: function(environment, options) {
     var cwd     = process.cwd();
-    var rawName = path.basename(cwd);
     var ui      = this.ui;
-
-    if (rawName === 'test') {
-      ui.write('Due to an issue with `compileES6` an application name of `test` cannot be used.');
-      throw undefined;
-    }
 
     var installBlueprint = environment.tasks.installBlueprint;
     var npmInstall       = environment.tasks.npmInstall;
     var bowerInstall     = environment.tasks.bowerInstall;
-    var blueprintOpts = { dryRun: options.dryRun, blueprint: options.blueprint };
+    var packageName      = environment.project ? environment.project.pkg.name : path.basename(cwd);
+    var blueprintOpts    = {
+      dryRun: options.dryRun,
+      blueprint: options.blueprint,
+      rawName: packageName
+    };
+
+    if (packageName === 'test') {
+      ui.write('Due to an issue with `compileES6` an application name of `test` cannot be used.');
+      throw undefined;
+    }
 
     return installBlueprint.run(ui, blueprintOpts)
       .then(function() {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -36,6 +36,8 @@ module.exports = new Command({
     var createAndStepIntoDirectory  = environment.tasks.createAndStepIntoDirectory;
     var init                        = environment.commands.init;
 
+    delete environment.project;
+
     createAndStepIntoDirectory.ui   = this.ui;
     createAndStepIntoDirectory.leek = this.leek;
     init.ui                         = this.ui;

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -23,6 +23,7 @@ function Project(root, pkg) {
 }
 
 module.exports = Project;
+module.exports.ProjectNotFoundError = ProjectNotFoundError;
 
 Project.prototype.isEmberCLIProject = function() {
   return this.pkg.devDependencies &&

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -2,14 +2,13 @@
 
 var Blueprint   = require('../blueprint');
 var stringUtil  = require('../utilities/string');
-var path        = require('path');
 var Task        = require('../task');
 
 module.exports = new Task({
   // Options: Boolean dryRun
   run: function(ui, options) {
     var cwd     = process.cwd();
-    var rawName = path.basename(cwd);
+    var rawName = options.rawName;
     var blueprintPath = options.blueprint || Blueprint.main;
 
     var name      = stringUtil.dasherize(rawName);

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -11,13 +11,18 @@ var commands;
 var argv;
 
 var isWithinProject;
+
 // helper to similate running the CLI
 function ember(args) {
   return new CLI(ui).run({
     tasks:    {},
     commands: commands,
     cliArgs:  args || [],
-    isWithinProject: isWithinProject // similate being inside or outside a project
+    project: {
+      isEmberCLIProject: function() {  // similate being inside or outside of a project
+        return isWithinProject;
+      }
+    }
   });
 }
 

--- a/tests/unit/cli/command-factory-test.js
+++ b/tests/unit/cli/command-factory-test.js
@@ -51,7 +51,11 @@ var environment = {
       run: function() {},
     })
   },
-  isWithinProject: true
+  project: {
+    isEmberCLIProject: function() {
+      return true;
+    }
+  }
 };
 
 describe('cli/command-factory.js', function() {
@@ -73,7 +77,7 @@ describe('cli/command-factory.js', function() {
     return new CommandFactory({
       ui: ui,
       commands: environment.commands,
-      isWithinProject: typeof opts.isWithinProject === 'undefined' ? environment.isWithinProject : opts.isWithinProject,
+      project: typeof opts.project === 'undefined' ? environment.project : opts.project,
     }).commandFromArgs(opts.cliArgs);
   }
 
@@ -119,9 +123,10 @@ describe('cli/command-factory.js', function() {
     expect(commandFromArgs({ cliArgs: ['everywhere']})).to.exist;
 
     // Outside project
-    expect(commandFromArgs({ cliArgs: ['inside-project'], isWithinProject: false})).to.null;
+    var nonProject = {isEmberCLIProject: function() { return false; }};
+    expect(commandFromArgs({ cliArgs: ['inside-project'], project: nonProject})).to.null;
     expect(output.shift()).to.match(/You have to be inside an ember-cli project/);
-    expect(commandFromArgs({ cliArgs: ['outside-project'], isWithinProject: false })).to.be.exist;
-    expect(commandFromArgs({ cliArgs: ['everywhere'],      isWithinProject: false })).to.exist;
+    expect(commandFromArgs({ cliArgs: ['outside-project'], project: nonProject})).to.be.exist;
+    expect(commandFromArgs({ cliArgs: ['everywhere'],      project: nonProject})).to.exist;
   });
 });

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -1,26 +1,72 @@
 'use strict';
 
+var path     = require('path');
 var assert   = require('../../helpers/assert');
 var MockUI   = require('../../helpers/mock-ui');
 var rewire   = require('rewire');
 var stubPath = require('../../helpers/stub').stubPath;
+var Promise  = require('../../../lib/ext/promise');
+
 var command;
 
 describe('init command', function() {
   var ui;
 
-  before(function() {
+  beforeEach(function() {
     ui = new MockUI();
     command = rewire('../../../lib/commands/init');
-    command.__set__('path', stubPath('test'));
+    command.ui = ui;
   });
 
   it('doesn\'t allow to create an application named `test`', function() {
-    assert.throw(function() {
-      command.ui = ui;
-      command.run();
-    }, undefined);
+    command.__set__('path', stubPath('test'));
 
-    assert.equal(ui.output, 'Due to an issue with `compileES6` an application name of `test` cannot be used.');
+    return command.run({ tasks: {} }, {})
+      .then(function() {
+        assert.ok(false, 'should have rejected with an application name of test');
+      })
+      .catch(function() {
+        assert.equal(ui.output, 'Due to an issue with `compileES6` an application name of `test` cannot be used.');
+      });
+
+  });
+
+  it('Uses the name of the closest project to when calling installBlueprint', function() {
+
+    var env = {
+      project: {pkg: { name: 'some-random-name'}},
+      tasks: {
+        installBlueprint: {
+          run: function(ui, blueprintOpts) {
+            assert.equal(blueprintOpts.rawName, 'some-random-name');
+            return Promise.reject('Called run');
+          }
+        }
+      }
+    };
+
+    return command.run(env, {})
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+
+  });
+
+  it('Uses process.cwd if no package is found when calling installBlueprint', function() {
+    var env = {
+      tasks: {
+        installBlueprint: {
+          run: function(ui, blueprintOpts) {
+            assert.equal(blueprintOpts.rawName, path.basename(process.cwd()));
+            return Promise.reject('Called run');
+          }
+        }
+      }
+    };
+
+    return command.run(env, {})
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
   });
 });


### PR DESCRIPTION
Closes #395.

---

Please note I did not add tests for this, as this code path is completely refactored (and tested) in #466.
