### PR TITLE
Add testem.log to gitignore

### DIFF
--- a/blueprint/gitignore
+++ b/blueprint/gitignore
@@ -17,3 +17,4 @@
 Thumbs.db
 /coverage/*
 npm-debug.log
+testem.log


### PR DESCRIPTION
testem.log is generated if you start testem in debug mode: `testem -d`
