### PR TITLE
Set loom-generators-ember-appkit in app package.

### DIFF
--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "ember-cli" : "0.0.23",
     "originate": "~0.1.5",
-    "broccoli-template": "~0.1.1"
+    "broccoli-template": "~0.1.1",
+    "loom-generators-ember-appkit": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "leek": "~0.0.4",
     "lodash-node": "~2.4.1",
     "loom": "~3.1.2",
-    "loom-generators-ember-appkit": "~1.1.0",
     "ncp": "~0.5.0",
     "quick-temp": "0.1.1",
     "nopt": "^2.1.2",


### PR DESCRIPTION
Currently `ember generate template profile` is not working, the reason seems to be that loom is searching for the generators in the app package and not the ember-cli. 

Moving the generators as a devDependency fixes the issue. 
