### PR TITLE
removed stuff Ember.setupForTesting does automatically

### DIFF
--- a/blueprint/tests/helpers/start-app.js
+++ b/blueprint/tests/helpers/start-app.js
@@ -1,5 +1,4 @@
 var Application = require('<%= modulePrefix %>/app')['default'];
-var Router = require('<%= modulePrefix %>/router')['default'];
 
 export default function startApp(attrs) {
   var App;
@@ -10,10 +9,6 @@ export default function startApp(attrs) {
     LOG_ACTIVE_GENERATION:false,
     LOG_VIEW_LOOKUPS: false
   }, attrs); // but you can override;
-
-  Router.reopen({
-    location: 'none'
-  });
 
   Ember.run(function(){
     App = Application.create(attributes);

--- a/blueprint/tests/test-helper.js
+++ b/blueprint/tests/test-helper.js
@@ -1,7 +1,5 @@
 document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
 
-Ember.testing = true;
-
 import resolver from './helpers/resolver';
 require('ember-qunit').setResolver(resolver);
 


### PR DESCRIPTION
Router's location gets set to 'none' according to the documentation ( [here](http://emberjs.com/guides/testing/integration/))

`Ember.testing` gets set [here](https://github.com/emberjs/ember.js/blob/76eb6c26ab7c194701e3f4caae47f727fff20c88/packages_es6/ember-testing/lib/setup_for_testing.js#L34)
