### PR TITLE
Check pkg before trying to read name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Remove `Ember.setupForTesting` and
   `Router.reopen({location: 'none'});` from test helpers [#516].
 * [ENHANCEMENT] Update loom-generators-ember-appkit to `^1.1.1`.
+* [BUGFIX] On `init`, check `pkg` existence before reading name.
 
 ### 0.0.25
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -23,7 +23,7 @@ module.exports = new Command({
     var installBlueprint = environment.tasks.installBlueprint;
     var npmInstall       = environment.tasks.npmInstall;
     var bowerInstall     = environment.tasks.bowerInstall;
-    var packageName      = environment.project ? environment.project.pkg.name : path.basename(cwd);
+    var packageName      = environment.project && environment.project.pkg ? environment.project.pkg.name : path.basename(cwd);
     var blueprintOpts    = {
       dryRun: options.dryRun,
       blueprint: options.blueprint,


### PR DESCRIPTION
When trying to start a new project on a empty dir, `init` will fail, the reason is that `project` is a NULL_PROJECT which doesn't have pkg https://github.com/stefanpenner/ember-cli/blob/3e9323266e4b0922d8e519a1ac5444d796c2c98a/lib/models/project.js#L30
## Steps to reproduce

```
mkdir /tmp/foo
cd /tmp/foo
ember init
```
