### PR TITLE
Allow 0.10.0 failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
-  - 0.10.0
-  - 0.10.26
-  - 0.11.11
+  - "0.10.0"
+  - "0.10"
+  - "0.11"
 before_script:
   - npm install -g
+matrix:
+  allow_failures:
+    - node: 0.10.0
+    fast_finish: true


### PR DESCRIPTION
See #534 for the 0.10.0 reasoning.

Also, I changed to use `0.10` and `0.11` instead of the specific versions as
recommended by the Travis folks. This will give use the latest version in that
series provided by the Travis VM (and is likely what we want anyways).
