### PR TITLE
Added andThen to jshint ignore list.

### DIFF
--- a/blueprint/tests/.jshintrc
+++ b/blueprint/tests/.jshintrc
@@ -39,7 +39,8 @@
     "DS",
     "keyEvent",
     "isolatedContainer",
-    "startApp"
+    "startApp",
+    "andThen"
   ],
   "node" : false,
   "browser" : false,


### PR DESCRIPTION
Looks like it was missing and causing jshint to complain when running tests.
