### PR TITLE
Fix an issue caused by setting 'window.ENV' at the wrong point

### DIFF
--- a/blueprint/app/index.html
+++ b/blueprint/app/index.html
@@ -12,9 +12,11 @@
     <link rel="stylesheet" href="assets/app.css">
   </head>
   <body>
-    <script src="assets/app.js"></script>
     <script>
       window.ENV = {{ENV}};
+    </script>
+    <script src="assets/app.js"></script>
+    <script>
       window.<%= namespace %> = require('<%= modulePrefix %>/app')['default'].create(ENV.APP);
     </script>
   </body>


### PR DESCRIPTION
Setting `window.ENV` after `app.js` is causing issues.
