### PR TITLE
[BUGFIX] `ember init` fails on `NULL_PROJECT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `Router.reopen({location: 'none'});` from test helpers [#516].
 * [ENHANCEMENT] Update loom-generators-ember-appkit to `^1.1.1`.
 * [BUGFIX] Whitelist `ic-ajax` exports to prevent import validation warnings. [#533](https://github.com/stefanpenner/ember-cli/pull/533)
+* [BUGFIX] `ember init` fails on `NULL_PROJECT` ([#546](https://github.com/stefanpenner/ember-cli/pull/546))
 
 ### 0.0.25
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -17,13 +17,13 @@ module.exports = new Command({
   aliases: ['i'],
 
   run: function(environment, options) {
-    var cwd     = process.cwd();
     var ui      = this.ui;
 
     var installBlueprint = environment.tasks.installBlueprint;
     var npmInstall       = environment.tasks.npmInstall;
     var bowerInstall     = environment.tasks.bowerInstall;
-    var packageName      = environment.project ? environment.project.pkg.name : path.basename(cwd);
+    var project          = environment.project;
+    var packageName      = project.name();
     var blueprintOpts    = {
       dryRun: options.dryRun,
       blueprint: options.blueprint,

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var chalk     = require('chalk');
-var Command   = require('../command');
-var path      = require('path');
-var Blueprint = require('../blueprint');
+var chalk        = require('chalk');
+var Command      = require('../command');
+var path         = require('path');
+var Blueprint    = require('../blueprint');
+var NULL_PROJECT = require('../models/project').NULL_PROJECT;
 
 module.exports = new Command({
   description: 'Creates a new folder and runs ' + chalk.green('ember init') + ' in it.',
@@ -36,7 +37,7 @@ module.exports = new Command({
     var createAndStepIntoDirectory  = environment.tasks.createAndStepIntoDirectory;
     var init                        = environment.commands.init;
 
-    delete environment.project;
+    environment.project = NULL_PROJECT;
 
     createAndStepIntoDirectory.ui   = this.ui;
     createAndStepIntoDirectory.leek = this.leek;

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -19,7 +19,7 @@ ProjectNotFoundError.prototype = new Error();
 
 function Project(root, pkg) {
   this.root = root;
-  this.pkg = pkg;
+  this.pkg  = pkg;
 }
 
 module.exports = Project;
@@ -31,6 +31,14 @@ module.exports.NULL_PROJECT = NULL_PROJECT = new Project(undefined, undefined);
 
 NULL_PROJECT.isEmberCLIProject = function() {
   return false;
+};
+
+NULL_PROJECT.name = function() {
+  return path.basename(process.cwd());
+};
+
+Project.prototype.name = function() {
+  return this.pkg.name;
 };
 
 Project.prototype.isEmberCLIProject = function() {

--- a/tests/acceptance/init-slow.js
+++ b/tests/acceptance/init-slow.js
@@ -51,6 +51,18 @@ describe('Acceptance: ember init', function() {
     ]).then(confirmBlueprinted);
   });
 
+  it('ember init can run in created folder', function() {
+    tmp.setup('./tmp/foo');
+    process.chdir('./tmp/foo');
+
+    return ember([
+      'init',
+      '--dry-run'
+    ]).then(confirmBlueprinted).then(function() {
+      tmp.teardown('./tmp/foo');
+    });
+  });
+
   it('init an already init\'d folder', function() {
     return ember([
       'init',

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -215,7 +215,6 @@ describe('Unit: CLI', function() {
         var init = stubCommand('init');
 
         return ember([command]).then(function() {
-
           assert.equal(init.called, 1, 'expected the init command to be run');
         });
       });

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -21,7 +21,16 @@ describe('init command', function() {
   it('doesn\'t allow to create an application named `test`', function() {
     command.__set__('path', stubPath('test'));
 
-    return command.run({ tasks: {} }, {})
+    var environment = {
+      tasks: {},
+      project: {
+        name: function() {
+          return 'test';
+        }
+      }
+    };
+
+    return command.run(environment, {})
       .then(function() {
         assert.ok(false, 'should have rejected with an application name of test');
       })
@@ -32,9 +41,12 @@ describe('init command', function() {
   });
 
   it('Uses the name of the closest project to when calling installBlueprint', function() {
-
     var env = {
-      project: {pkg: { name: 'some-random-name'}},
+      project: {
+        name: function() {
+          return 'some-random-name';
+        }
+      },
       tasks: {
         installBlueprint: {
           run: function(ui, blueprintOpts) {
@@ -61,6 +73,12 @@ describe('init command', function() {
             return Promise.reject('Called run');
           }
         }
+      },
+      project: {
+        name: function() {
+          return path.basename(process.cwd());
+        },
+        pkg: { name: path.basename(process.cwd()) }
       }
     };
 


### PR DESCRIPTION
Previously, if you try to run `ember init` inside an empty directory, it will
fail because `environment.project` was not set to `NULL_PROJECT`.

Steps:

``` bash
mkdir foo && cd foo && ember init
```

thanks to @abuiles for initial spike, [#529](https://github.com/stefanpenner/ember-cli/pull/529)

Closes #540
