### PR TITLE
Attempt to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: node_js
 node_js:
-  - "0.10.0"
-  - "0.10"
+  - "0.10.18"
+  - "0.10.26"
   - "0.11"
 before_script:
   - npm install -g
-matrix:
-  allow_failures:
-    - node: 0.10.0
-    fast_finish: true


### PR DESCRIPTION
From [Travis Docs](docs.travis-ci.com/user/languages/javascript-with-nodejs):

`0.10` is an alias for "the most recent 0.10.x release" and so on. Please note that using exact versions (for example, `0.10.2`) is highly discouraged because as versions change, your .travis.yml will get outdated and things will break.
