### PR TITLE
handle ember init inside directory without package.json

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -23,7 +23,7 @@ module.exports = new Command({
     var installBlueprint = environment.tasks.installBlueprint;
     var npmInstall       = environment.tasks.npmInstall;
     var bowerInstall     = environment.tasks.bowerInstall;
-    var packageName      = environment.project ? environment.project.pkg.name : path.basename(cwd);
+    var packageName      = environment.project && environment.project.pkg ? environment.project.pkg.name : path.basename(cwd);
     var blueprintOpts    = {
       dryRun: options.dryRun,
       blueprint: options.blueprint,

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -52,6 +52,25 @@ describe('init command', function() {
 
   });
 
+  it('Uses the name of closest project, derived from directory name if package.json is not present', function() {
+    var env = {
+      project: { pkg: undefined },
+      tasks: {
+        installBlueprint: {
+          run: function(ui, blueprintOpts) {
+            assert.equal(blueprintOpts.rawName, 'ember-cli');
+            return Promise.reject('Called run');
+          }
+        }
+      }
+    };
+
+    return command.run(env, {})
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+  });
+
   it('Uses process.cwd if no package is found when calling installBlueprint', function() {
     var env = {
       tasks: {


### PR DESCRIPTION
I found this bug after trying to run `ember init` inside an empty directory.
