### PR TITLE
Added missing protocol for emberscript url

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -27,7 +27,7 @@ Broccoli has support for:
 * [Compass](http://compass-style.org/)
 * [Stylus](http://learnboost.github.io/stylus/)
 * [CoffeeScript](http://coffeescript.org/)
-* [EmberScript](emberscript.com/)
+* [EmberScript](http://emberscript.com/)
 * Minified JS & CSS
 
 You can find a list of available plugins [here](https://github.com/joliss/broccoli#plugins).


### PR DESCRIPTION
The link was pointing to http://iamstef.net/ember-cli/emberscript.com/ before.
