### PR TITLE
Remove global test helpers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Always Precompile Handlebars templates. [#574](https://github.com/stefanpenner/ember-cli/pull/574)
 * [ENHANCEMENT] Update to Broccoli 0.11.0. This provides better timing information for `Watcher`. [#587](https://github.com/stefanpenner/ember-cli/pull/587)
 * [ENHANCEMENT] Track rebuild timing. [#588](https://github.com/stefanpenner/ember-cli/pull/587)
+* [ENHANCEMENT] Remove global defined helpers in favor of http://api.qunitjs.com/equal http://api.qunitjs.com/strictEqual/, etc. [#579](https://github.com/stefanpenner/ember-cli/pull/579)
 
 ### 0.0.25
 

--- a/blueprint/tests/test-helper.js
+++ b/blueprint/tests/test-helper.js
@@ -4,25 +4,3 @@ import { setResolver } from 'ember-qunit';
 setResolver(resolver);
 
 document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
-
-function exists(selector) {
-  return !!window.find(selector).length;
-}
-
-function getAssertionMessage(actual, expected, message) {
-  return message || QUnit.jsDump.parse(expected) + " expected but was " + QUnit.jsDump.parse(actual);
-}
-
-function equal(actual, expected, message) {
-  message = getAssertionMessage(actual, expected, message);
-  QUnit.equal.call(this, actual, expected, message);
-}
-
-function strictEqual(actual, expected, message) {
-  message = getAssertionMessage(actual, expected, message);
-  QUnit.strictEqual.call(this, actual, expected, message);
-}
-
-window.exists = exists;
-window.equal = equal;
-window.strictEqual = strictEqual;


### PR DESCRIPTION
Remove in favor of using  http://api.qunitjs.com/equal/ http://api.qunitjs.com/strictEqual/. I started https://github.com/abuiles/ember-test-helpers to  maintain helpers which are not attached to any testing framework and can be used across different projects.
