### PR TITLE
[BUGFIX] Use trees in broccoli

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -130,7 +130,7 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
       });
       sourceTrees.push(jshintedApp);
       var jshintedTests = jshintTrees(tests, {
-        jshintrcRoot: this.tree.tests,
+        jshintrcRoot: this.trees.tests,
         destFile: this.name + '/tests/tests-jshint-test.js'
       });
       sourceTrees.push(jshintedTests);


### PR DESCRIPTION
The Brocfile allows you to pass in alternate names and locations for directories with the `trees` property. However, I was having issues with this when trying to put the `app, config, vendor, etc` directories in their own directory, like so:

```
trees: {
  app: 'ember/app',
  tests: 'ember/tests',
  vendor: 'ember/vendor',
  styles: 'ember/app/styles',
}
```

This should fix that issues by replacing hardcoded instances like `'vendor'` and `'tests'` with `this.trees.vendor` and `this.trees.tests`.
