### PR TITLE
Add LOG_MODULE_RESOLVER flag in environment.js 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [BUGFIX] ` ENV.LOG_MODULE_RESOLVER` must be set pre-1.6 to get better container logging.
 * [FEATURE] Added support for ember-scripts preprocessing.
 
 * [ENHANCEMENT] Refactor `blueprint.js` to remove unnecessary variable assignment, change double iteration to simple reduce, and remove function that only swapped arguments and called through. [#537]

--- a/blueprint/config/environment.js
+++ b/blueprint/config/environment.js
@@ -13,7 +13,9 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
+    // LOG_MODULE_RESOLVER is needed for pre-1.6.0
     ENV.LOG_MODULE_RESOLVER = true;
+
     ENV.APP.LOG_RESOLVER = true;
     ENV.APP.LOG_ACTIVE_GENERATION = true;
     ENV.APP.LOG_MODULE_RESOLVER = true;


### PR DESCRIPTION
The ENV.LOG_MODULE_RESOLVER flag needs to be set to enable the better debugging for the default resolver.  See emberjs/ember.js#4655 for more details.
