### PR TITLE
Mention PhantomJS requirement for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,13 @@ ember server
 
 Please read the official [npm-link documentation](https://www.npmjs.org/doc/cli/npm-link.html) and the [npm-link cheatsheet](https://blog.nodejitsu.com/npm-cheatsheet/#Linking_any_npm_package_locally) for more information.
 
-#### Testing with master
+### Working with the tests
 
-The master build of ember-cli will run your project tests using [PhantomJS][] by default.  Make sure you have this installed:
+Install [PhantomJS][], if needed:
 
 ```console
 brew install phantomjs
 ```
-
-### Working with the tests
 
 Use `npm run-script autotest` to run the tests after every file change (Runs only fast tests). Use `npm test` to run them once.
 


### PR DESCRIPTION
When working with the ember-cli master branch the user needs to have phantomjs installed for testing.

This PR modifies the readme to avoid the confusion seen in #596.
