### PR TITLE
Update broccoli-jshint.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -151,7 +151,7 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
       });
       sourceTrees.push(jshintedApp);
       var jshintedTests = jshintTrees(tests, {
-        jshintrcRoot: 'tests/',
+        jshintrcRoot: this.name + '/tests/',
         destFile: this.name + '/tests/tests-jshint-test.js'
       });
       sourceTrees.push(jshintedTests);

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "broccoli-es6-import-validate": "0.1.0",
     "readline2": "0.1.0",
     "broccoli-export-tree": "0.3.0",
-    "broccoli-jshint": "0.3.3",
+    "broccoli-jshint": "0.4.0",
     "diff": "~1.0.8",
     "broccoli-concat": "0.0.6"
   },


### PR DESCRIPTION
Updated version looks into the root of the input tree for the jshintrc.

Fixes #613.
