### PR TITLE
Allow test only imports.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -246,6 +246,10 @@ EmberApp.prototype.testFiles = memoize(function() {
 EmberApp.prototype.import = function(asset, modules) {
   if (typeof asset === 'object') {
     asset = asset[this.env];
+
+    if (asset.only && asset.only !== this.env) {
+      return; // if not processing the `only` environment skip
+    }
   }
 
   var extension = path.extname(asset);


### PR DESCRIPTION
Allows the following for test only imports:

``` javascript
app.import({
 only: 'development',
 development: 'vendor/qunit-bdd/lib/qunit-bdd'
});
```

Thanks to @childss for suggesting this.
