### PR TITLE
Bugfix: Allow pass-in of legacyFilesToAppend via options

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -38,6 +38,7 @@ function EmberApp(options) {
     wrapInEval: !isProduction,
     loader: 'vendor/loader/loader.js',
     trees: {},
+    legacyFilesToAppend: [],
   });
 
   this.options.trees = defaults(this.options.trees, {
@@ -48,7 +49,7 @@ function EmberApp(options) {
     });
 
   this.importWhitelist     = {};
-  this.legacyFilesToAppend = [];
+  this.legacyFilesToAppend = this.options.legacyFilesToAppend;
   this.vendorStaticStyles  = [];
 
   this.trees = this.options.trees;


### PR DESCRIPTION
According to http://iamstef.net/ember-cli/#managing-dependencies, this should be possible:

```
1 var app = new EmberApp({
2   ...
3   legacyFilesToAppend: [
4     // ... existing legacy files to append
5     "moment.js" // library you wish to append
6   ],
7   //...
8 });
```

However, it looks broken on current master
