### PR TITLE
Make EmberApp destination directory configurable.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -38,6 +38,7 @@ function EmberApp(options) {
     wrapInEval: !isProduction,
     loader: 'vendor/loader/loader.js',
     trees: {},
+    dest: '/assets'
   });
 
   this.options.trees = defaults(this.options.trees, {
@@ -52,6 +53,7 @@ function EmberApp(options) {
   this.vendorStaticStyles  = [];
 
   this.trees = this.options.trees;
+  this.dest = this.options.dest;
 
   this.populateLegacyFiles();
 }
@@ -191,7 +193,7 @@ EmberApp.prototype.javascript = memoize(function() {
       this.name + '/**/*.js'
     ],
     wrapInEval: this.options.wrapInEval,
-    outputFile: '/assets/app.js',
+    outputFile: this.dest + '/app.js',
     legacyFilesToAppend: legacyFilesToAppend
   });
 
@@ -209,10 +211,10 @@ EmberApp.prototype.styles = memoize(function() {
   var vendor = this._processedVendorTree();
   var stylesAndVendor = mergeTrees([vendor, this.trees.styles]);
 
-  var processedStyles = preprocessCss(stylesAndVendor, '/', '/assets');
+  var processedStyles = preprocessCss(stylesAndVendor, '/', this.dest);
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles,
-    outputFile: '/assets/vendor.css'
+    outputFile: this.dest + '/vendor.css'
   });
 
   return mergeTrees([processedStyles, vendorStyles]);
@@ -224,7 +226,7 @@ EmberApp.prototype.testFiles = memoize(function() {
       files: [
         'qunit.css', 'qunit.js'
       ],
-      destDir: '/assets/'
+      destDir: this.dest
     });
 
   var testemPath = path.join(__dirname, 'testem');


### PR DESCRIPTION
The new EmberApp is really great, but one thing that would be helpful for me is if the destination directory was configurable as well as the input trees.

Is this acceptable?
