### PR TITLE
Add branch and SHA to version output when running non-npm builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [BREAKING BUGFIX] No longer rely on `broccoli-bower` to automatically import vendored files. Use `app.import` to import dependencies and specify modules to whitelist. [#562](https://github.com/stefanpenner/ember-cli/pull/562)
 * [ENHANCEMENT] Removed `proxy-url` and `proxy-host` parameters and introduced `proxy` param with full proxy url. ([#567](https://github.com/stefanpenner/ember-cli/pull/567))
 * [ENHANCEMENT] Update to jQuery 1.11.1.
+* [ENHANCEMENT] When using non-NPM installed package (aka "running on master") the branch name and SHA are now printed along with the prior version number. [#634](https://github.com/stefanpenner/ember-cli/pull/634)
 
 ### 0.0.25
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -4,6 +4,8 @@ var chalk         = require('chalk');
 var lookupCommand = require('./lookup-command');
 var Promise       = require('../ext/promise');
 
+var emberCLIVersion = require('../utilities/ember-cli-version');
+
 function CLI(options) {
   this.ui   = options.ui;
   this.analytics = options.analytics;
@@ -13,7 +15,7 @@ function CLI(options) {
 module.exports = CLI;
 
 CLI.prototype.run = function(environment) {
-  this.ui.write('version: ' + require('../../package.json').version + '\n');
+  this.ui.write('version: ' + emberCLIVersion() + '\n');
 
   return Promise.hash(environment).then(function(environment) {
     var args = environment.cliArgs.slice();

--- a/lib/utilities/ember-cli-version.js
+++ b/lib/utilities/ember-cli-version.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var fs   = require('fs');
+var path = require('path');
+
+module.exports = function () {
+  var output         = [require('../../package.json').version];
+  var gitPath        = path.join(__dirname, '..','..','.git');
+  var headFilePath   = path.join(gitPath, 'HEAD');
+
+  try {
+    if (fs.existsSync(headFilePath)) {
+      var headFile = fs.readFileSync(headFilePath, {encoding: 'utf8'});
+      var branchName = headFile.split('/').slice(-1)[0].trim();
+      var branchPath = path.join(gitPath, headFile.split(' ')[1].trim());
+
+      output.push(branchName);
+
+      var branchSHA  = fs.readFileSync(branchPath);
+      output.push(branchSHA.slice(0,10));
+    }
+  } catch (err) {
+    console.error(err.stack);
+  }
+
+  return output.join('-');
+};


### PR DESCRIPTION
Looks like the following:

```
version: 0.0.26-dev-add-sha-versioning-d3680e241e
```

Interpreted as:
- The version from `package.json` is `0.0.26-dev`.
- The current branch is `add-sha-versioning`.
- The current SHA is `d3680e241e`.
