### PR TITLE
Trim error was thrown when linked ember-cli had detached HEAD.

### DIFF
--- a/lib/utilities/ember-cli-version.js
+++ b/lib/utilities/ember-cli-version.js
@@ -10,13 +10,20 @@ module.exports = function () {
 
   try {
     if (fs.existsSync(headFilePath)) {
+      var branchSHA;
       var headFile = fs.readFileSync(headFilePath, {encoding: 'utf8'});
       var branchName = headFile.split('/').slice(-1)[0].trim();
-      var branchPath = path.join(gitPath, headFile.split(' ')[1].trim());
+      var refPath = headFile.split(' ')[1];
+
+      if (refPath) {
+        var branchPath = path.join(gitPath, refPath.trim());
+        branchSHA  = fs.readFileSync(branchPath);
+      } else {
+        branchSHA = branchName;
+      }
 
       output.push(branchName);
 
-      var branchSHA  = fs.readFileSync(branchPath);
       output.push(branchSHA.slice(0,10));
     }
   } catch (err) {


### PR DESCRIPTION
If the contents of the ./git/HEAD file does not return a ref path,
it's a SHA value so that is what will be used.

This bug only affects people hacking on ember-cli itself.
