### PR TITLE
Breaking change tag info contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ explain a standard use case to us.
 7. Update the Changelog. Please prefix your change with one of the
 following tags inside brackets: BUGFIX, FEATURE/ENHANCEMENT, INTERNAL. If a
 change requires a user to change their configuration, `bower.json`, `package.json`,
-or `Brocfile.js` also add a BREAKING tag.
+or `Brocfile.js` also add a BREAKING tag within the brackets before any other tags (example [BREAKING BUGFIX]).
 
     - FEATURES and ENHANCEMENT is something that users are interested in (no super technical, concise changes + description).
     - BUGFIX is a link to a bug + a link to a patch.


### PR DESCRIPTION
Helps to document the BREAKING tag in the contributing.md file.

This helps solve #651 for now and promote use of the BREAKING tag.
