### PR TITLE
Add support for different production / development environments

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -30,7 +30,10 @@ function EmberApp(options) {
   this.env  = process.env.EMBER_ENV;
   this.name = options.name;
 
-  var isProduction = this.env === 'production';
+  this.productionEnvironments = !!options.addProductionEnvironments ? ['production'].concat(options.addProductionEnvironments) : ['production'];
+  this.developmentEnvironments = !!options.addDevelopmentEnvironments ? ['development'].concat(options.addDevelopmentEnvironments) : ['development'];
+
+  var isProduction = this.isProduction();
 
   this.tests = this.hinting = !isProduction;
 
@@ -56,10 +59,19 @@ function EmberApp(options) {
   this.populateLegacyFiles();
 }
 
+EmberApp.prototype.isProduction = function () {
+  return !!~this.productionEnvironments.indexOf(this.env);
+}
+
+EmberApp.prototype.isDevelopment = function () {
+  return !!~this.developmentEnvironments.indexOf(this.env);
+}
+
 EmberApp.prototype.populateLegacyFiles = function () {
 
   this.import('vendor/jquery/dist/jquery.js');
   this.import('vendor/handlebars/handlebars.js');
+
   this.import({
     development: 'vendor/ember/ember.js',
     production:  'vendor/ember/ember.prod.js'
@@ -167,7 +179,7 @@ EmberApp.prototype.javascript = memoize(function() {
   var applicationJs       = preprocessJs(this.appAndDependencies(), '/', this.name);
   var legacyFilesToAppend = this.legacyFilesToAppend;
 
-  if (this.env !== 'production') {
+  if (this.isDevelopment()) {
     this.import('vendor/ember-qunit/dist/named-amd/main.js', {
       'ember-qunit': [
         'globalize',
@@ -195,7 +207,7 @@ EmberApp.prototype.javascript = memoize(function() {
     legacyFilesToAppend: legacyFilesToAppend
   });
 
-  if (this.env === 'production') {
+  if (this.isProduction()) {
     return uglifyJavaScript(es6, {
       mangle: true,
       compress: true
@@ -250,7 +262,17 @@ EmberApp.prototype.testFiles = memoize(function() {
 
 EmberApp.prototype.import = function(asset, modules) {
   if (typeof asset === 'object') {
-    asset = asset[this.env];
+    if (!!path.extname(asset[this.env])) {
+      asset = asset[this.env];
+    } else {
+      if (this.isProduction()) {
+        asset = asset['production'];
+      } else if (this.isDevelopment()) {
+        asset = asset['development'];
+      } else {
+        asset = asset[this.env];
+      }
+    }
   }
 
   var extension = path.extname(asset);


### PR DESCRIPTION
This **isn't** ready to be merged in -- but would this be a helpful addition? I can spend some more time on it if so.

Basically, I have multiple 'production' environments. One for regular website, one for Phonegap.

Currently, running 

``` bash
ember build --environment=phonegap
```

Raises an error (0.0.27/master -- didn't cause error in 0.0.25) in EmberApp.prototype.import for not matching Ember development / production version in EmberApp.prototype.populateLegacyFiles.

This patch lets me add this to my Brocfile.js

``` javascript
var app = new EmberApp({
  name: require('./package.json').name,
  getEnvJSON: require('./config/environment'),
  addProductionEnvironments: ['staging'],
  addDevelopmentEnvironments: ['demo']
});
```

Where I can then build

``` bash
ember build --environment=staging
```

which inherits from production defaults, and allows me to manage custom environment differences in config/environment.js
