### PR TITLE
Closes #664 fallback extensions for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [ENHANCEMENT] Plugins can fall back to alternate file extensions (i.e scss, sass)
 * [BUGFIX] Fix incorrect generation of all `vendor/` assets in build output. [#645](https://github.com/stefanpenner/ember-cli/pull/645)
 * [ENHANCEMENT] Update to Broccoli 0.12. Prevents double initial rebuilds when running `ember server`. [#648](https://github.com/stefanpenner/ember-cli/pull/648)
 * [BREAKING ENHANCEMENT] The generated `app.js` and `app.css` files are now named for your application name. [#638](https://github.com/stefanpenner/ember-cli/pull/638)

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -9,7 +9,7 @@ var requireLocal = require('./utilities/require-local');
 var registry = new Registry(deps);
 
 registry.add('css', 'broccoli-sass', 'scss');
-registry.add('css', 'broccoli-ruby-sass', 'scss');
+registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
 registry.add('css', 'broccoli-less-single', 'less');
 registry.add('css', 'broccoli-stylus-single', 'styl');
 
@@ -44,7 +44,7 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
     });
   }
 
-  var input = path.join(inputPath, 'app.' + plugin.ext);
+  var input = path.join(inputPath, 'app.' + plugin.getExt(inputPath, 'app'));
   var output = path.join(outputPath, pkg.name + '.css');
   return requireLocal(plugin.name).call(null, [tree], input, output, options);
 };

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var path   = require('path');
+var fs     = require('fs');
+var detect = require('lodash-node/modern/collections/find');
+
 function Plugin(name, ext) {
   this.name = name;
   this.ext = ext;
@@ -27,4 +31,15 @@ Registry.prototype.add = function(type, name, extension) {
   var registered = this.registry[type] = this.registry[type] || [];
 
   registered.push(new Plugin(name, extension));
+};
+
+Plugin.prototype.getExt = function(inputPath, filename) {
+  if(Array.isArray(this.ext)) {
+    return detect(this.ext, function(ext) {
+      var filenameAndExt = filename + '.' + ext;
+      return fs.existsSync(path.join('.', inputPath, filenameAndExt));
+    });
+  } else {
+    return this.ext;
+  }
 };

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -15,8 +15,8 @@ describe('Plugin Loader', function() {
       }
     };
     registry = new PluginRegistry(pkg.devDependencies);
-    registry.add('css', 'broccoli-sass');
-    registry.add('css', 'broccoli-ruby-sass');
+    registry.add('css', 'broccoli-sass', 'scss');
+    registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
   });
 
   it('returns first plugin when only one', function() {
@@ -41,4 +41,17 @@ describe('Plugin Loader', function() {
     var plugin = registry.load('blah');
     assert.notOk(plugin, 'loaded a plugin that wasn\'t in dependencies');
   });
+
+  it('returns the configured extension for the plugin', function() {
+    var plugin = registry.load('css');
+    assert.equal(plugin.ext, 'scss');
+  });
+
+  it('can specify fallback extensions', function() {
+    registry.availablePlugins = { 'broccoli-ruby-sass': 'latest' };
+    var plugin = registry.load('css');
+    assert.equal(plugin.ext[0], 'scss');
+    assert.equal(plugin.ext[1], 'sass');
+  });
+
 });


### PR DESCRIPTION
Main driver for this was allowing `broccoli-ruby-sass` to use an `app.sass`
