### PR TITLE
Remove redundant test import from examples

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -43,7 +43,7 @@ The generic resolver that will load what you specify. The usage closely follows 
 Its use can be seen within the supplied [index-test.js](https://github.com/stefanpenner/ember-app-kit/blob/master/tests/unit/routes/index-test.js):
 
 {% highlight javascript linenos %}
-import { test, moduleFor } from 'ember-qunit';
+import { moduleFor } from 'ember-qunit';
 
 moduleFor('route:index', "Unit - IndexRoute", {
   // only neccessary if you want to load other items into the runtime
@@ -83,7 +83,7 @@ matching this signature `delegate(container, testing_context)`.
 Extends the generic `moduleFor` with custom loading for testing models:
 
 {% highlight javascript linenos %}
-import { test, moduleForModel } from 'ember-qunit';
+import { moduleForModel } from 'ember-qunit';
 
 moduleForModel('post', 'Post Model', {
   needs: ['model:comment']
@@ -124,7 +124,7 @@ will return an instance of the object.
 Extends the generic `moduleFor` with custom loading for testing components:
 
 {% highlight javascript linenos %}
-import { test, moduleForComponent } from 'ember-qunit';
+import { moduleForComponent } from 'ember-qunit';
 
 moduleForComponent('pretty-color');
 


### PR DESCRIPTION
@stefanpenner:

> You don't need to import the test helps do that for you
