### PR TITLE
Fixing an issue where env is out of scope when baseTag is called

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -294,16 +294,15 @@ EmberApp.prototype.toTree = memoize(function() {
 });
 
 function injectENVJson(fn, env, tree, files) {
-  var env = fn(env);
-
   // TODO: real templating
   var envJsonString = function(){
-    return JSON.stringify(env);
+    return JSON.stringify(fn(env));
   };
 
   var baseTag = function(){
-    var baseURL      = env.baseURL;
-    var locationType = env.locationType;
+    var envJSON      = fn(env);
+    var baseURL      = envJSON.baseURL;
+    var locationType = envJSON.locationType;
 
     if (locationType === 'hash' || locationType === 'none') {
       return '';


### PR DESCRIPTION
I've setup a broken blueprint example here: https://github.com/lpetre/ember-cli-broken

You can see I set the baseURL depending on the environment here: https://github.com/lpetre/ember-cli-broken/blob/master/config/environment.js#L3

This is the bug:

```
$ ./node_modules/.bin/ember build && cat dist/index.html | grep base
version: 0.0.27
Built project successfully. Stored in "dist/".
    <base href="/undefined" />
      window.ENV = {"baseURL":"/development","locationType":"auto","FEATURES":{},"APP":{"LOG_RESOLVER":true,"LOG_ACTIVE_GENERATION":true,"LOG_MODULE_RESOLVER":true,"LOG_VIEW_LOOKUPS":true},"LOG_MODULE_RESOLVER":true};
```
