### PR TITLE
Add a `sassLibs` option to the options has for `new EmberApp()`.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -53,6 +53,8 @@ function EmberApp(options) {
 
   this.trees = this.options.trees;
 
+  this.sassLibs = this.options.sassLibs;
+
   this.populateLegacyFiles();
 }
 
@@ -213,6 +215,9 @@ EmberApp.prototype.styles = memoize(function() {
   });
 
   var stylesAndVendor = mergeTrees([vendor, styles]);
+  if(this.sassLibs){
+    stylesAndVendor = mergeTrees(this.sassLibs.concat(stylesAndVendor));
+  }
 
   var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets');
   var vendorStyles    = concatFiles(stylesAndVendor, {


### PR DESCRIPTION
This allows vendored sass libs to be passed into the ember-cli precompilation process.

I hope this PR can be a discussion starter for how this use case might be handled in ember-cli.  This is the simplest thing that I could get to work, and it currently has no tests.  If this approach seems OK I'm more than happy to write some tests around it, and if a different approach would be better I'd be happy to work on that.

Usage:
When creating the `EmberApp` in `Brocfile.js` you can pass a `sassLibs` option, which should be an array of paths that contain sass/scss files.

``` javascript
var app = new EmberApp({
  //...
  sassLibs: ['vendor/bootstrap-sass-official/vendor/assets/stylesheets']
});
```

This would make the bootstrap sass files available to be included in `app.scss`.

``` css
@import 'bootstrap';
```
