### PR TITLE
mention the jekyll-server port (4000) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ getting started
 bundle install
 ./run.sh
 ```
+
+you can now view the result at http://localhost:4000/


### PR DESCRIPTION
adds the server port (4000) to README.md so devs do not have to google "jekyll port" first. :)
