### PR TITLE
Do not watch vendor/ for changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   test. A new app is generated, depedencies resolve, and the test for
   that base app are run.  [#614](https://github.com/stefanpenner/ember-cli/pull/614)
 * [ENHANCEMENT] Use handlebars-runtime in production. [#675](https://github.com/stefanpenner/ember-cli/pull/675)
+* [BUGFIX] Do not watch `vendor/` for changes (watching vendor drammatically increases CPU usage). [#693](https://github.com/stefanpenner/ember-cli/pull/693)
 
 ### 0.0.27
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -19,6 +19,7 @@ var mergeTrees  = require('broccoli-merge-trees');
 var jshintTrees = require('broccoli-jshint');
 var concatFiles = require('broccoli-concat');
 
+var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
 
 var memoize    = require('lodash-node/modern/functions').memoize;
@@ -46,12 +47,13 @@ function EmberApp(options) {
       app:    'app',
       styles: 'app/styles',
       tests:  'tests',
-      vendor: 'vendor',
+      vendor: unwatchedTree('vendor'),
     });
 
   this.importWhitelist     = {};
   this.legacyFilesToAppend = [];
   this.vendorStaticStyles  = [];
+  this._importTrees        = [];
 
   this.trees = this.options.trees;
 
@@ -123,7 +125,11 @@ EmberApp.prototype._processedAppTree = memoize(function() {
 });
 
 EmberApp.prototype._processedVendorTree = memoize(function() {
-  return pickFiles(this.trees.vendor, {
+  var mergedVendor = mergeTrees([this.trees.vendor].concat(this._importTrees), {
+    overwrite: true
+  });
+
+  return pickFiles(mergedVendor, {
     srcDir: '/',
     destDir: 'vendor/'
   });
@@ -264,11 +270,19 @@ EmberApp.prototype.import = function(asset, modules) {
     assetPath = asset;
   }
 
+  var directory = path.dirname(assetPath);
   var extension = path.extname(assetPath);
 
   if (!extension) {
     throw new Error('You must pass a file to `EmberApp::import`. For directories specify them to the constructor under the `trees` option.');
   }
+
+  var assetTree = pickFiles(directory, {
+    srcDir: '/',
+    destDir: directory.replace(/^vendor\//, '')
+  });
+
+  this._importTrees.push(assetTree);
 
   if (isType(assetPath, 'js')) {
     this.legacyFilesToAppend.push(assetPath);

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "diff": "~1.0.8",
     "broccoli-concat": "0.0.6",
     "broccoli-file-mover": "~0.3.1",
-    "connect-chain": "0.0.1"
+    "connect-chain": "0.0.1",
+    "broccoli-unwatched-tree": "~0.1.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
This fixes the polling regression that was added in #562 (broccoli-bower was doing this internally).

On my rMBP this change takes a super simple app (https://github.com/rjackson/_____ember-cli-test) from ~9% CPU usage down to ~2% (during `ember server`).
