### PR TITLE
Copy other assets to output directory.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -59,6 +59,7 @@ function EmberApp(options) {
   this.importWhitelist     = {};
   this.legacyFilesToAppend = [];
   this.vendorStaticStyles  = [];
+  this.otherAssetTrees     = [];
   this._importTrees        = [];
 
   this.trees = this.options.trees;
@@ -273,6 +274,10 @@ EmberApp.prototype.testFiles = memoize(function() {
     });
 });
 
+EmberApp.prototype.otherAssets = memoize(function() {
+  return mergeTrees(this.otherAssetTrees);
+});
+
 EmberApp.prototype.import = function(asset, modules) {
   var assetPath;
 
@@ -284,6 +289,7 @@ EmberApp.prototype.import = function(asset, modules) {
 
   var directory = path.dirname(assetPath);
   var extension = path.extname(assetPath);
+  var basename  = path.basename(assetPath);
 
   if (!extension) {
     throw new Error('You must pass a file to `EmberApp::import`. For directories specify them to the constructor under the `trees` option.');
@@ -291,6 +297,7 @@ EmberApp.prototype.import = function(asset, modules) {
 
   var assetTree = pickFiles(directory, {
     srcDir: '/',
+    files: [basename],
     destDir: directory.replace(/^vendor\//, '')
   });
 
@@ -302,6 +309,8 @@ EmberApp.prototype.import = function(asset, modules) {
     this.importWhitelist = assign(this.importWhitelist, modules || {});
   } else if (extension === '.css') {
     this.vendorStaticStyles.push(assetPath);
+  } else {
+    this.otherAssetTrees.push(assetTree);
   }
 };
 
@@ -310,7 +319,8 @@ EmberApp.prototype.toArray = function() {
     this.index(),
     this.javascript(),
     this.publicFolder(),
-    this.styles()
+    this.styles(),
+    this.otherAssets()
   ];
 
   if (this.tests) {


### PR DESCRIPTION
Allows using `app.import` for things other than JS and CSS (i.e. fonts, 
images, json, etc).
