### PR TITLE
Fix `ember --help` output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Do not watch `vendor/` for changes (watching vendor drammatically increases CPU usage). [#693](https://github.com/stefanpenner/ember-cli/pull/693)
 * [ENHANCEMENT] Minify CSS [#688](https://github.com/stefanpenner/ember-cli/pull/688)
 * [ENHANCEMENT] Allows using app.import for things other than JS and CSS (i.e. fonts, images, json, etc). [#699](https://github.com/stefanpenner/ember-cli/pull/699)
+* [BUGFIX] Fix `ember --help` output for test and version commands. [#701](https://github.com/stefanpenner/ember-cli/pull/701]
 
 ### 0.0.27
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,6 +7,7 @@ var Command   = require('../models/command');
 var buildWatcher = require('../utilities/build-watcher');
 
 module.exports = Command.extend({
+  name: 'test',
   aliases: ['test', 't'],
 
   availableOptions: [

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -3,6 +3,7 @@
 var Command = require('../models/command');
 
 module.exports = Command.extend({
+  name: 'version',
   description: 'outputs ember-cli version',
   works: 'everywhere',
 


### PR DESCRIPTION
Without a `name` property, these commands print `core-object`.
