### PR TITLE
Fix JS regression in `app.import`.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -297,7 +297,6 @@ EmberApp.prototype.import = function(asset, modules) {
 
   var assetTree = pickFiles(directory, {
     srcDir: '/',
-    files: [basename],
     destDir: directory.replace(/^vendor\//, '')
   });
 
@@ -310,7 +309,13 @@ EmberApp.prototype.import = function(asset, modules) {
   } else if (extension === '.css') {
     this.vendorStaticStyles.push(assetPath);
   } else {
-    this.otherAssetTrees.push(assetTree);
+    var otherAssetTree = pickFiles(this.trees.vendor, {
+      srcDir: directory,
+      files: [basename],
+      destDir: directory
+    });
+
+    this.otherAssetTrees.push(otherAssetTree);
   }
 };
 


### PR DESCRIPTION
We are simply using `pickFiles` here to ensure that the specific directory is watched, we do not actually care about the destination files.

Without this change specifying/modifying `vendor/` and passing it into `EmberApp` would throw an error if the actual file did not exist on disk

Fixes regression added in #699.
