### PR TITLE
document the import of non-js-css assets, as added in #699

### DIFF
--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -43,8 +43,6 @@ Provide the asset path as the first and only argument:
 app.import('vendor/momentjs/moment.js');
 {% endhighlight %}
 
-All style assets added this way will be concatenated and output as `/assets/vendor.js`.
-
 ##### Standard AMD Asset
 
 Provide the asset path as the first argument, and the list of modules and exports as the second:
@@ -151,8 +149,10 @@ The vendor trees that are provided upon instantiation are available to your dyna
 #### Other Assets
 
 All other assets like images or fonts can also be added via `import()`. They
-will be copied to `assets/` as they are.
+will be copied to `dist/` as they are.
 
 {% highlight javascript linenos %}
 app.import('vendor/font-awesome/fonts/fontawesome-webfont.ttf');
 {% endhighlight %}
+
+This example would create the font file in `dist/font-awesome/fonts/font-awesome-webfonts.ttf`.


### PR DESCRIPTION
doc for https://github.com/stefanpenner/ember-cli/pull/699
