### PR TITLE
Include body-parser back to the express server by default.

### DIFF
--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -23,6 +23,7 @@
     "broccoli-ember-hbs-template-compiler": "^1.5.0",
     "loom-generators-ember-appkit": "^1.1.1",
     "express": "^4.1.1",
+    "body-parser": "^1.2.0",
     "glob": "^3.2.9"
   }
 }

--- a/blueprint/server/index.js
+++ b/blueprint/server/index.js
@@ -7,12 +7,14 @@
 //   });
 // };
 
-var express  = require('express');
-var globSync = require('glob').sync;
-var routes   = globSync('./routes/*.js', { cwd: __dirname }).map(require);
+var express    = require('express');
+var bodyParser = require('body-parser');
+var globSync   = require('glob').sync;
+var routes     = globSync('./routes/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(emberCLIMiddleware) {
   var app = express();
+  app.use(bodyParser());
 
   routes.forEach(function(route) { route(app); });
   app.use(emberCLIMiddleware);


### PR DESCRIPTION
As per https://github.com/stefanpenner/ember-cli/pull/683#issuecomment-42919642, without this, parsing requests (ie POST/PUT) errors out.  
