### PR TITLE
Update testem version to fix  assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "resolve": "0.6.2",
     "rimraf": "^2.2.8",
     "rsvp": "^3.0.6",
-    "testem": "0.6.5",
+    "testem": "0.6.15",
     "through": "2.3.4",
     "tiny-lr": "0.0.5",
     "walk-sync": "0.1.2",


### PR DESCRIPTION
When looking at ember-cli, the first thing I did was see what testing was like out of the box. I started out with a simple assertion on `true` which fails.

_tests/unit/truth-test.js_

``` javascript
import { test } from 'ember-qunit';

test('true is not false', function() {
  expect(2);
  equal(1, 2, 'these numbers are not equal');
  equal(true, false, 'true is not false');
});
```

It turns out this was an [issue with testem](https://github.com/airportyh/testem/issues/354) and the default tap reporter which has [now been fixed](https://github.com/airportyh/testem/commit/05d9b66f1835db9affd0305a0c07715aec2d626e).

_(I wasn't sure how to add this type of test directly to ember-cli or I would have included it in the pull request.)_
