### PR TITLE
Make server in blueprint optional.

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var Promise = require('../../ext/promise');
+var Task    = require('../../models/task');
 var proxy   = require('proxy-middleware');
 var url     = require('url');
 var chain   = require('connect-chain');
-var Task    = require('../../models/task');
+var express = require('express');
 
 // Middleware
 var livereloadMiddleware = require('connect-livereload');
@@ -35,7 +36,16 @@ module.exports = Task.extend({
       middleware = chain(middleware, proxy(urlopts));
     }
 
-    var server = project.require('./server')(middleware);
+    var server;
+
+    try {
+      server = project.require('./server')(middleware);
+    } catch (e) {
+      if (!/^Cannot find module .+\/server'$/.test(e.message)) { throw e; }
+      server = express();
+      server.use(middleware);
+    }
+
     var listen = Promise.denodeify(server.listen.bind(server));
 
     return listen(options.port, options.host)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "connect-chain": "0.0.1",
     "connect-livereload": "0.3.2",
     "diff": "~1.0.8",
+    "express": "^4.2.0",
     "findup": "0.1.5",
     "fs-extra": "0.8.1",
     "glob": "^3.2.9",


### PR DESCRIPTION
I think it'd be good to allow the server in blueprint to be removed for projects that don't need require any API stubbing.
