### PR TITLE
Ability to specify options for CSS preprocessor

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -234,7 +234,8 @@ EmberApp.prototype.styles = memoize(function() {
 
   var stylesAndVendor = mergeTrees([vendor, styles]);
 
-  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets');
+  var options = this.options.cssOptions;
+  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles,
     outputFile: '/assets/vendor.css'


### PR DESCRIPTION
I'd like to be able to specify the `includePaths` option for the `broccoli-sass` preprocessor, but it doesn't look like this is supported. There's an `options` argument in `preprocessCss()`, but it's not supported in `EmberApp.prototype.styles()`. This PR adds the `cssOptions` property of `this.options` to the `preprocessCss()` call.

I think it'd make more sense to have a general-purpose mechanism for passing options to broccoli plugins, such as `this.options['broccoli-css']`, but that's outside of the scope of what I'm trying to do.

Usage example is:

```
var app = new EmberApp({
  cssOptions: {
    includePaths: [
      'vendor/foundation/scss'
    ]
  }
  ...
});
```

One open question is whether this should be added to the blueprint `Brocfile.js`, I've left it out but let me know and I'll add `cssOptions: null`.

Also, I'm not really clear on how to go about writing a test for this. I'd appreciate any suggestions if you think this is worthwhile.
