### PR TITLE
Fix for #723.  Use express body parser only when not proxying.

### DIFF
--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -23,7 +23,6 @@
     "broccoli-ember-hbs-template-compiler": "^1.5.0",
     "loom-generators-ember-appkit": "^1.1.1",
     "express": "^4.1.1",
-    "body-parser": "^1.2.0",
     "glob": "^3.2.9"
   }
 }

--- a/blueprint/server/index.js
+++ b/blueprint/server/index.js
@@ -8,16 +8,16 @@
 // };
 
 var express    = require('express');
-var bodyParser = require('body-parser');
 var globSync   = require('glob').sync;
 var routes     = globSync('./routes/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(emberCLIMiddleware) {
   var app = express();
-  app.use(bodyParser());
+
+  app.use(emberCLIMiddleware);
+  // Here is where you specify your own middlewares
 
   routes.forEach(function(route) { route(app); });
-  app.use(emberCLIMiddleware);
 
   return app;
 };

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var Promise = require('../../ext/promise');
-var proxy   = require('proxy-middleware');
-var url     = require('url');
-var chain   = require('connect-chain');
+var Promise    = require('../../ext/promise');
+var bodyParser = require('body-parser');
+var proxy      = require('proxy-middleware');
+var url        = require('url');
+var chain      = require('connect-chain');
 
 // Middleware
 var livereloadMiddleware = require('connect-livereload');
@@ -24,6 +25,8 @@ exports.start = function(options) {
 
     ui.write('Proxying to ' + options.proxy + '\n');
     middleware = chain(middleware, proxy(urlopts));
+  } else {
+    middleware = chain(middleware, bodyParser());
   }
 
   var server = project.require('./server')(middleware);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/stefanpenner/ember-cli/issues"
   },
   "dependencies": {
+    "body-parser": "^1.2.0",
     "bower": "^1.3.2",
     "bower-config": "0.5.0",
     "broccoli": "0.12.0",


### PR DESCRIPTION
My previous [commit](https://github.com/stefanpenner/ember-cli/commit/cfaa0c5b560c4526a86e0e62166d999dfc67598c) made killed the ability to make `POST` requests when using the API server as a proxy.  See https://github.com/stefanpenner/ember-cli/issues/723.

This put the body-parser behind the scenes with the other parts of `emberCLIMiddleware`, and it would only add the body parser if it wasn't using the proxy.

For whatever reason, `body-parser` doesn't work when included after the routes declaration.  I'm not entirely sure why, but putting it before seems to rectify this.  

Everything seems to work now, but I'm not 100% confident that it's the correct approach.
