### PR TITLE
minifyCSS noAdvanced option is more safe default

### DIFF
--- a/blueprint/Brocfile.js
+++ b/blueprint/Brocfile.js
@@ -5,9 +5,12 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 var app = new EmberApp({
   name: require('./package.json').name,
 
+  // For more options see: https://github.com/GoalSmashers/clean-css#how-to-use-clean-css-programmatically
   minifyCSS: {
     enabled: true,
-    options: {}
+    options: {
+      noAdvanced: true
+    }
   },
 
   getEnvJSON: require('./config/environment')


### PR DESCRIPTION
- `broccoli-clean-css` (minifyCSS) is using `clean-css`
- adding source where to look up for other `clean-css` options

My minified CSS wasn't working until I've set `noAdvanced` option to true. I purpose at least documenting where users can find documented options but I'm not sure if it's better to have it directly in source or on documentation site. For developers I think it's easier and faster to have it in source.
