### PR TITLE
If project name is app, just return styles.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -59,6 +59,12 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
       destDir: outputPath
     });
 
+    // when our application is named `app` there is no
+    // need to move the static css file.
+    if (pkg.name === 'app') {
+      return styles;
+    }
+
     return fileMover(styles, {
       srcFile: 'assets/app.css',
       destFile: 'assets/' + pkg.name + '.css'


### PR DESCRIPTION
Fixes #732.

There is no need to move `assets/app.css` to `assets/app.css` which is essentially what is happening when the project name is already `app`.
