### PR TITLE
Update broccoli-jshint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "broccoli-es6-import-validate": "0.1.0",
     "broccoli-export-tree": "0.3.1",
     "broccoli-file-mover": "~0.3.1",
-    "broccoli-jshint": "0.4.0",
+    "broccoli-jshint": "0.5.0",
     "broccoli-merge-trees": "0.1.3",
     "broccoli-replace": "0.1.6",
     "broccoli-static-compiler": "0.1.4",


### PR DESCRIPTION
0.5.0 now inherits from broccoli-filter which allows much more efficient 
caching between reloads (i.e. only calls JSHint on individual files that have
changed).
