### PR TITLE
Show detailed rebuild timing information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] If both EMBER_ENV and --environment are specified, use EMBER_ENV. [#753](https://github.com/stefanpenner/ember-cli/pull/753)
 * [ENHANCEMENT] Update broccoli-jshint to 0.5.0 (more efficient caching for faster rebuilds). [#758](https://github.com/stefanpenner/ember-cli/pull/758)
 * [ENHANCEMENT] Ensure that the `app/templates/components` directory is created automatically. [#761](https://github.com/stefanpenner/ember-cli/pull/761)
+* [ENHANCEMENT] Show timing and slow tree listing for each rebuild. [#759](http://github.com/stefanpenner/ember-cli/pull/759)
 
 ### 0.0.28
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -25,7 +25,8 @@ module.exports = Command.extend({
     if (commandOptions.server) {
       var commonOptions = {
         ui: this.ui,
-        analytics: this.analytics
+        analytics: this.analytics,
+        verbose: false
       };
 
       var TestServerTask = this.tasks.TestServer;

--- a/lib/utilities/build-watcher.js
+++ b/lib/utilities/build-watcher.js
@@ -6,6 +6,8 @@ var buildBuilder = require('./build-builder');
 var Watcher      = require('broccoli/lib/watcher');
 var chalk        = require('chalk');
 
+var printSlowTrees = require('broccoli/lib/logging').printSlowTrees;
+
 module.exports = function(options) {
   options = options || {};
   var builder = options.builder;
@@ -13,15 +15,19 @@ module.exports = function(options) {
   if (!builder) {
     builder = buildBuilder();
   }
+
   var watcher = new Watcher(builder);
 
   watcher.on('change', function(results) {
-    if (error) {
-      options.ui.write(chalk.green('\n\nBuild successful.\n'));
-      error = null;
+    var totalTime = results.totalTime / 1e6;
+
+    // default to verbose if not specified
+    if (!options.hasOwnProperty('verbose') || options.verbose) {
+      printSlowTrees(results.graph);
     }
 
-    var totalTime = results.totalTime / 1e6;
+    options.ui.write(chalk.green('\n\nBuild successful - ' + Math.round(totalTime) + 'ms.\n'));
+
     options.analytics.track({
       name:    'ember rebuild',
       message: 'broccoli rebuild time: ' + totalTime + 'ms'


### PR DESCRIPTION
Uses the same logging as Broccoli itself. By default it logs any trees that took greater than 5% of the total build time.

Also, we now print `Built Successfully - XXXms.` for each rebuild to assist in tracking down performance issues. We may decide to remove the more verbose logging at a later time once things are better understood (and we have near constant time rebuilds).

![screenshot](http://monosnap.com/image/PPiU7NIqs4xkIAMrsVGPtXQkpKrnd4.png)
