### PR TITLE
Add README to blueprint

### DIFF
--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -1,0 +1,25 @@
+# <%= name.substring(0,1).toUpperCase() + name.substring(1) %>
+
+This README outlines the details of collaborating on this Ember application.
+
+## Installation
+
+* `git clone` this repository
+* `npm install`
+* `bower install`
+
+## Running
+
+* `ember server`
+* Visit your app at http://localhost:4200.
+
+## Running Tests
+
+* `ember test`
+* `ember test --server`
+
+## Building
+
+* `ember build`
+
+For more information on using ember-cli, visit [http://iamstef.net/ember-cli/](http://iamstef.net/ember-cli/).


### PR DESCRIPTION
We feel having a README in a project is recognized as a good practice. Therefore, we'd like to have `ember new` generate a README.md file as part of the project.

We tried to make the README minimal and useful with basic instructions that could be added to easily.
