### PR TITLE
Adding optional Autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] If both EMBER_ENV and --environment are specified, use EMBER_ENV. [#753](https://github.com/stefanpenner/ember-cli/pull/753)
 * [ENHANCEMENT] Update broccoli-jshint to 0.5.0 (more efficient caching for faster rebuilds). [#758](https://github.com/stefanpenner/ember-cli/pull/758)
 * [ENHANCEMENT] Ensure that the `app/templates/components` directory is created automatically. [#761](https://github.com/stefanpenner/ember-cli/pull/761)
+* [FEATURE] If installed, Autoprefixer automatically adds the needed vendor-prefixes to your styles. [#771](https://github.com/stefanpenner/ember-cli/pull/771)
 
 ### 0.0.28
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -12,6 +12,7 @@ var isType        = p.isType;
 var preprocessTemplates = p.preprocessTemplates;
 
 var preprocessMinifyCss = p.preprocessMinifyCss;
+var postprocessPrefixCss = p.postprocessPrefixCss;
 
 var replace     = require('broccoli-replace');
 var compileES6  = require('broccoli-es6-concatenator');
@@ -43,6 +44,9 @@ function EmberApp(options) {
     wrapInEval: !isProduction,
     minifyCSS: {
       enabled: true,
+      options: {}
+    },
+    prefixCSS: {
       options: {}
     },
     loader: 'vendor/loader/loader.js',
@@ -235,6 +239,10 @@ EmberApp.prototype.styles = memoize(function() {
   var stylesAndVendor = mergeTrees([vendor, styles]);
 
   var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets');
+
+  var prefixOptions = this.options.prefixCSS.options || {};
+  processedStyles = postprocessPrefixCss(processedStyles, prefixOptions);
+
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles,
     outputFile: '/assets/vendor.css'

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -14,6 +14,7 @@ registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
 registry.add('css', 'broccoli-less-single', 'less');
 registry.add('css', 'broccoli-stylus-single', 'styl');
 
+registry.add('prefix-css', 'broccoli-autoprefixer', null);
 registry.add('minify-css', 'broccoli-csso', null);
 
 registry.add('js', 'broccoli-coffee', 'coffee');
@@ -74,6 +75,16 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
   var input = path.join(inputPath, 'app.' + plugin.getExt(inputPath, 'app'));
   var output = path.join(outputPath, pkg.name + '.css');
   return requireLocal(plugin.name).call(null, [tree], input, output, options);
+};
+
+module.exports.postprocessPrefixCss = function(tree, options) {
+  var plugin = registry.load('prefix-css');
+
+  if (!plugin) {
+    return tree;
+  }
+
+  return requireLocal(plugin.name).call(null, tree, options);
 };
 
 module.exports.preprocessTemplates = function(tree) {


### PR DESCRIPTION
This PR adds optional prefixing of css-properties with [Autoprefixer](https://github.com/ai/autoprefixer) through [`broccoli-autoprefixer`](https://github.com/sindresorhus/broccoli-autoprefixer), as mentioned in #718 and elsewhere.
### How to use

Run `npm install --save-dev broccoli-autoprefixer`, and it should be picked up automatically. If you don't have it, nothing happens.
#### Options

You can pass in options for Autoprefixer by passing them in to `EmberApp` in your `Brocfile.js` like so:

``` js
var app = new EmberApp({
  ...
  prefixCSS: {
    options: {
      browsers: ['options', 'in', 'an', 'array']
    }
  }
});
```
### Testing

I'm not sure how I could go about adding tests for this - if someone could chip in on that, that would be great.

---

I'm not convinced this is a good way of adding things like this in the long run, but feel like that is a separate discussion. Let's have that discussion, though.
