### PR TITLE
Default to development asset.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -442,7 +442,7 @@ EmberApp.prototype.import = function(asset, modules) {
   var assetPath;
 
   if (typeof asset === 'object') {
-    assetPath = asset[this.env];
+    assetPath = asset[this.env] || asset.development;
   } else {
     assetPath = asset;
   }


### PR DESCRIPTION
I think it makes sense to default to the development version of an asset if a version for the current env isn't specified. 

I was trying to start the server with a `test` env, but Ember and Handlebars only have versions specified for `development` and `production`, so it failed.
