### PR TITLE
Default to development assets if no assets match the provided env.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -456,9 +456,12 @@ EmberApp.prototype.import = function(asset, options) {
   if (typeof asset === 'object') {
     var env = this.env;
     // if the provided environment (staging?) doesn't have an asset default to dev
-    if (!asset[this.env]) {
+    if (!asset[this.env] && this.env === 'dev-server') {
+      env = 'production';
+    } else if (!asset[this.env]) {
       env = 'development';
     }
+
     assetPath = asset[env];
   } else {
     assetPath = asset;


### PR DESCRIPTION
Previously only `production` and `development` environments would work: other environment values such as `testing` or `staging` would fail with missing assets. Now it will fall back to `development` assets if nothing is found for the current environment.
