### PR TITLE
Ensure init doesn't use command option for name

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -68,7 +68,7 @@ Command.prototype.validateAndRun = function(commandArgs) {
     name:    'ember ',
     message: this.name
   });
-  return this.run(commandOptions, commandArgs);
+  return this.run(commandOptions.options, commandOptions.args);
 };
 
 Command.prototype.parseArgs = function(commandArgs) {
@@ -117,7 +117,11 @@ Command.prototype.parseArgs = function(commandArgs) {
   if (!this.availableOptions.every(assembleAndValidateOption)) {
     return null;
   }
-  return commandOptions;
+
+  return {
+    options: commandOptions,
+    args: parsedOptions.argv.remain
+  };
 };
 
 Command.prototype.run = function(commandArgs) {

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -107,4 +107,25 @@ describe('init command', function() {
         assert.equal(reason, 'Called run');
       });
   });
+
+  it('doesn\'t use --dry-run or any other command option as the name', function() {
+    tasks.InstallBlueprint = Task.extend({
+      run: function(blueprintOpts) {
+        assert.equal(blueprintOpts.rawName, 'some-random-name');
+        return Promise.reject('Called run');
+      }
+    });
+
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { name: 'some-random-name'}),
+      tasks: tasks
+    });
+
+    return command.validateAndRun(['--dry-run'])
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+  });
 });

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -57,8 +57,11 @@ describe('models/command.js', function() {
       ui: ui,
       analytics: analytics,
       project: project
-    }).parseArgs(['--port', '80'])).to.include({
-      port: 80
+    }).parseArgs(['--port', '80'])).to.deep.equal({
+      args: [],
+      options: {
+        port: 80
+      }
     });
   });
 
@@ -67,8 +70,11 @@ describe('models/command.js', function() {
       ui: ui,
       analytics: analytics,
       project: project
-    }).parseArgs(['-p', '80'])).to.include({
-      port: 80
+    }).parseArgs(['-p', '80'])).to.deep.equal({
+      args: [],
+      options: {
+        port: 80
+      }
     });
   });
 
@@ -77,8 +83,24 @@ describe('models/command.js', function() {
       ui: ui,
       analytics: analytics,
       project: project
-    }).parseArgs([])).to.include({
-      port: 4200
+    }).parseArgs([])).to.deep.equal({
+      args: [],
+      options: {
+        port: 4200
+      }
+    });
+  });
+
+  it('parseArgs() should return args too.', function() {
+    expect(new ServeCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project
+    }).parseArgs(['foo', '--port', '80'])).to.deep.equal({
+      args: ['foo'],
+      options: {
+        port: 80
+      }
     });
   });
 


### PR DESCRIPTION
This is a follow up to #792.

`ember init --dry-run` will use `--dry-run` as the project name. This PR contains a quick-and-dirty fix.

Would it make more sense to remove commandOptions from the commandArgs array before passing them both to run?
