### PR TITLE
More detailed docs on using non-AMD assets with ember-cli

### DIFF
--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -5,7 +5,7 @@ permalink: managing-dependencies
 github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-08-managing-dependencies.md"
 ---
 
-Ember CLI uses [Bower](http://bower.io/) for dependency management.
+Ember CLI uses [Bower](http://bower.io/) for dependency management. In this context, dependency management typically means downloading third-party javascript and/or CSS libraries like moment.js or Twitter Bootstrap for use in your application.
 
 ### Bower Configuration
 
@@ -27,32 +27,114 @@ install new dependencies via `bower install --save <dependencies>`.
 Further documentation about Bower is available at their
 [official documentation page](http://bower.io/).
 
-### Temporary Recommendations for Using Bower Assets in Your Ember App
-We are actively working on a new & improved way to handle dependencies in your 
-Ember app with ember-cli.  The new method will leverage the [ES6 Module 
-Transpiler](https://github.com/square/es6-module-transpiler) to allow a simple 
-`import` statement in your javascript file to automatically manage both AMD and 
-non-AMD dependencies (learn more about [handling depenencies in javascript](http://addyosmani.com/writing-modular-js/)).  In the meantime, if you wish to begin developing with ember-cli immediately, use
- these guidelines as a temporary workaround.
+### Recommendations for Using Bower Assets in Your Ember App
 
-You may opt to continue using these temporary methods to handle dependencies in 
-your app even after we've released the ES6 import functionality.
+Ideally, all dependencies downloaded via Bower would adhere to the ES6 module syntax, however this standard is still evolving.  In reality, dependencies will either be (listed in order of how we prefer to import them): 
 
-In your `Brocfile.js` specify a dependency before calling `app.toTree()`. The 
-following example scenarios  illustrate how this works.
+1. Compatible with the ES6 module syntax, or
+2. Compatible with the [Asynchronous Module Definition](http://requirejs.org/docs/whyamd.html) (AMD) format often used with [Require.js](http://requirejs.org/), or
+3. Compatible with the [CommonJS Format](http://requirejs.org/docs/commonjs.html), or
+4. Compatible with none of the above and therefore written to add variables to the global namespace, now considered a "legacy" approach to writing Javascript modules.
 
-#### Javascript Assets
+Learn more about [Handling Dependencies in Javascript](http://addyosmani.com/writing-modular-js/).
 
-##### Standard Non-AMD Asset
+#### Begin Using ES6 Modules Soon
+Where possible, you should use ES6-compatible libraries, and import them into your project using ES6 syntax.  
 
-Provide the asset path as the first and only argument:
+Officially, the ES6 module syntax is still [under development](http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts) by the Ecma TC39 committee.  However, it is unlikely that the `import` syntax used to import dependencies into a script will change.  Note that ES6 `import` functionality in ember-cli is still under development and not yet ready for use with importing dependencies.  
 
-{% highlight javascript linenos %}
-app.import('vendor/momentjs/moment.js');
-{% endhighlight %}
+Nevertheless, we recommend you plan on using the ES6 `import` syntax when possible. Ember-cli leverages the [ES6 Module Transpiler](https://github.com/square/es6-module-transpiler) to allow ES6-style `import` statements to be used natively on modern browsers and be "transpiled" into older javascript supported by older browsers.  Use of the transpiler also enables the ES6 `import` syntax to be used with javascript modules that are compatible with ES6, AMD, or non-AMD (CommonJS or global legacy).
 
-##### Standard Non-AMD Asset Example
-For example, to add a third-party library like moment.js from scratch, first type:
+##### ES6 Module Example
+
+At this time, ES6-style `import` is used for Ember libraries, but is not yet implemented for non-Ember libraries.
+
+#### Importing AMD Modules
+
+AMD modules are javascript libraries that are written to be used by any AMD-compliant script loader such as [Require.js](http://requirejs.org/).  Authors of AMD-compliant modules adhere to a [very simple standard](http://requirejs.org/docs/whyamd.html#amd) that AMD-compliant script loaders expect. Ember-cli includes its own script loader, so use of Require.js is not necessary. 
+
+
+
+##### AMD Module Example #1: Official Method (Coming Soon)
+
+*NOTE: This method will work soon, but support is still under development.*
+
+To import an AMD module like [d3.js](http://d3js.org/) using ember-cli, first tell Bower to import this library and add an entry to your `bower.json` file:
+
+```
+bower install --save d3
+```
+
+Bower will download the necessary files to your `/vendor/d3` directory.  
+
+Next, we tell Broccoli to add the relevant javascript files to the `/assets/your-app-name.js` file (PENDING: this will soon be `/assets/vendor.js`), which is explicitly referenced from your `index.html` page. Broccoli compiles 
+this file every time you run either `ember serve` or `ember build`.  In your `Brocfile.js`, add this before calling `app.toTree()`:
+
+```javascript
+app.import('vendor/d3/d3.js');
+```
+
+Note that you need not reference the `d3.min.js` file because Broccoli will minify this file for us when using `ember build --environment production` (assuming default settings in your `Brocfile.js`.
+
+Any variables or functions defined in the `d3.js` library are now available for `import` in an Ember-managed javascript file.  Open the EmberJS file where you will be using the `d3.js` library (say `views/my-page.js`), and access the `d3.js` library directly.  
+
+For example:
+
+```javascript
+import d3 from 'd3';
+
+var MyPageView = Ember.View.extend({
+    didInsertElement: function() {
+        console.log( d3.version );
+    }
+});
+```
+
+##### AMD Module Example #2: Temporary Method Using Shims
+
+Once the method described in AMD Module Example #1 is released, this method will be deprecated.  In the meantime, use this for immediate compatibility with an easy option for upgrading to the official method when available.
+
+Follow AMD Module Example #1 until the `import` step.  
+
+**TODO:** Add Info on Using Shims.
+
+
+For example:
+
+```javascript
+import d3 from 'd3';
+
+var MyPageView = Ember.View.extend({
+    didInsertElement: function() {
+        console.log( d3.version );
+    }
+});
+```
+
+##### AMD Module Example #3: Temporary Method Using Globals
+
+The whole point of using AMD modules is to avoid defining variables in the global namespace.  Nevertheless, because AMD imports using ember-cli is still under development, you may use the method described under **Non-AMD Module Example** in the meantime.  This will support easy upgrading to proper use of AMD modules (using either one of the above examples, or a variation thereof) in the future.
+
+
+#### Import CommonJS Libraries
+
+CommonJS modules are javascript libraries that are generally intended for use with server-side javascript (e.g. using nodejs).  These libraries are frequently useful for client-side (i.e in the browser) javascript as well.
+
+##### CommonJS Module Example
+
+**TODO:** Example needed for importing CommonJS Module
+
+
+
+#### Import a Standard Non-AMD Library
+
+Many javascript libraries will be written in a non-AMD or non-CommonJS manner.  Instead, they define variables or functions in the global namespace.  This is considered a deprecated practice, so you may wish to manually update the library to make it AMD-compliant, or more likely, to just include it in your global namespace.
+
+##### Non-AMD Module Example
+
+[Moment.js](http://momentjs.com/) is a javascript library which is not natively AMD-compliant (although [documentation](http://momentjs.com/docs/#/use-it/require-js/) is available on how to make it AMD-compliant with [RequireJS](http://requirejs.org/)). 
+
+To import moment.js using ember-cli, first tell Bower to type:
 
 ```
 bower install --save moment
@@ -65,14 +147,12 @@ file which is explicitly referenced from your `index.html` page. Brocolli compil
 this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, 
 add this before calling `app.toTree()`:
 
-{% highlight javascript linenos %}
+```javascript
 app.import('vendor/momentjs/moment.js');
-{% endhighlight %}
+```
 
 Any variables or functions defined in the `moment.js` library are now in global 
-scope and available on the `window` object in any javascript file (e.g. `window.moment`).  
-But to make these available as part of the Ember environment (and therefore without 
-`.window`), we will edit the `.jshintrc` file to add the following:
+scope and available on the `window` object in any javascript file (e.g. `window.moment`).  But to make these available as part of the Ember environment (and therefore without `window`), we will edit the `.jshintrc` file to add the following:
 
 ```javascript
 {
@@ -84,8 +164,7 @@ But to make these available as part of the Ember environment (and therefore with
 ```
 
 Finally, open the EmberJS file where you will be using the `moment.js` 
-library (say `views/my-page.js`), and access the `moment.js` library directly.  
-For example:
+library (say `views/my-page.js`), and access the `moment.js` library directly. For example:
 
 ```javascript
 var MyPageView = Ember.View.extend({
@@ -95,25 +174,9 @@ var MyPageView = Ember.View.extend({
 });
 ```
 
-##### Standard AMD Asset
+##### Environment-Specific Assets
 
-Provide the asset path as the first argument, and the list of modules and exports as the second:
-
-{% highlight javascript linenos %}
-app.import('vendor/ic-ajax/dist/named-amd/main.js', {
-  'ic-ajax': [
-    'default',
-    'defineFixture',
-    'lookupFixture',
-    'raw',
-    'request',
-  ]
-});
-{% endhighlight %}
-
-##### Environment Specific Assets
-
-If you need to use different assets in different environments, specify an object as the first parameter. That objects keys should be the environment name, and the values should be the asset to use in that environment.
+If you need to use different assets (i.e. javascript, css, etc.) in different environments, specify an object as the first parameter. That objects keys should be the environment name, and the values should be the asset to use in that environment.
 
 {% highlight javascript linenos %}
 app.import({

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -27,11 +27,12 @@ install new dependencies via `bower install --save <dependencies>`.
 Further documentation about Bower is available at their
 [official documentation page](http://bower.io/).
 
-### Compiling Bower Assets
+### Temporary Recommendations for Using Bower Assets in Your Ember App
+We are actively working on a new & improved way to handle dependencies in your Ember app with ember-cli.  The new method will leverage the [ES6 Module Transpiler](https://github.com/square/es6-module-transpiler) to allow a simple `import` statement in your javascript file to automatically manage both AMD and non-AMD dependencies (learn more about [handling depenencies in javascript](http://addyosmani.com/writing-modular-js/)).  In the meantime, if you wish to begin developing with ember-cli immediately, use these guidelines as a temporary workaround.
 
-In your `Brocfile.js` specify a dependency before calling
-`app.toTree()`. The following example scenarios should illustrate how
-this works.
+You may opt to continue using these temporary methods to handle dependencies in your app even after we've released the ES6 import functionality.
+
+In your `Brocfile.js` specify a dependency before calling `app.toTree()`. The following example scenarios  illustrate how this works.
 
 #### Javascript Assets
 
@@ -42,6 +43,42 @@ Provide the asset path as the first and only argument:
 {% highlight javascript linenos %}
 app.import('vendor/momentjs/moment.js');
 {% endhighlight %}
+
+##### Standard Non-AMD Asset Example
+For example, to add a third-party library like moment.js from scratch, first type:
+
+```
+bower install --save moment
+```
+
+Bower will download the necessary files to your `/vendor/moment` directory.  
+
+Next, we tell Broccoli to add these javascript files to the `/assets/your-app-name.js` file which is explicitly referenced from your `index.html` page. Brocollio compiles this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, add this before calling `app.toTree()`:
+
+{% highlight javascript linenos %}
+app.import('vendor/momentjs/moment.js');
+{% endhighlight %}
+
+Any variables or functions defined in the `moment.js` library are now in global scope and available on the `window` object in any javascript file (e.g. `window.moment`).  But to make these available as part of the Ember environment (and therefore without `.window`), we will edit the `.jshintrc` file to add the following:
+
+```javascript
+{
+  predef: {
+    ...
+    "moment": true
+  }
+}
+```
+
+Finally, open the EmberJS file where you will be using the `moment.js` library (say `views/my-page.js`), and access the `moment.js` library directly.  For example:
+
+```javascript
+var MyPageView = Ember.View.extend({
+    didInsertElement: function() {
+        console.log( moment().format() );
+    }
+});
+```
 
 ##### Standard AMD Asset
 

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -28,11 +28,18 @@ Further documentation about Bower is available at their
 [official documentation page](http://bower.io/).
 
 ### Temporary Recommendations for Using Bower Assets in Your Ember App
-We are actively working on a new & improved way to handle dependencies in your Ember app with ember-cli.  The new method will leverage the [ES6 Module Transpiler](https://github.com/square/es6-module-transpiler) to allow a simple `import` statement in your javascript file to automatically manage both AMD and non-AMD dependencies (learn more about [handling depenencies in javascript](http://addyosmani.com/writing-modular-js/)).  In the meantime, if you wish to begin developing with ember-cli immediately, use these guidelines as a temporary workaround.
+We are actively working on a new & improved way to handle dependencies in your 
+Ember app with ember-cli.  The new method will leverage the [ES6 Module 
+Transpiler](https://github.com/square/es6-module-transpiler) to allow a simple 
+`import` statement in your javascript file to automatically manage both AMD and 
+non-AMD dependencies (learn more about [handling depenencies in javascript](http://addyosmani.com/writing-modular-js/)).  In the meantime, if you wish to begin developing with ember-cli immediately, use
+ these guidelines as a temporary workaround.
 
-You may opt to continue using these temporary methods to handle dependencies in your app even after we've released the ES6 import functionality.
+You may opt to continue using these temporary methods to handle dependencies in 
+your app even after we've released the ES6 import functionality.
 
-In your `Brocfile.js` specify a dependency before calling `app.toTree()`. The following example scenarios  illustrate how this works.
+In your `Brocfile.js` specify a dependency before calling `app.toTree()`. The 
+following example scenarios  illustrate how this works.
 
 #### Javascript Assets
 
@@ -53,13 +60,19 @@ bower install --save moment
 
 Bower will download the necessary files to your `/vendor/moment` directory.  
 
-Next, we tell Broccoli to add these javascript files to the `/assets/your-app-name.js` file which is explicitly referenced from your `index.html` page. Brocollio compiles this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, add this before calling `app.toTree()`:
+Next, we tell Broccoli to add these javascript files to the `/assets/your-app-name.js` 
+file which is explicitly referenced from your `index.html` page. Brocolli compiles 
+this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, 
+add this before calling `app.toTree()`:
 
 {% highlight javascript linenos %}
 app.import('vendor/momentjs/moment.js');
 {% endhighlight %}
 
-Any variables or functions defined in the `moment.js` library are now in global scope and available on the `window` object in any javascript file (e.g. `window.moment`).  But to make these available as part of the Ember environment (and therefore without `.window`), we will edit the `.jshintrc` file to add the following:
+Any variables or functions defined in the `moment.js` library are now in global 
+scope and available on the `window` object in any javascript file (e.g. `window.moment`).  
+But to make these available as part of the Ember environment (and therefore without 
+`.window`), we will edit the `.jshintrc` file to add the following:
 
 ```javascript
 {
@@ -70,7 +83,9 @@ Any variables or functions defined in the `moment.js` library are now in global 
 }
 ```
 
-Finally, open the EmberJS file where you will be using the `moment.js` library (say `views/my-page.js`), and access the `moment.js` library directly.  For example:
+Finally, open the EmberJS file where you will be using the `moment.js` 
+library (say `views/my-page.js`), and access the `moment.js` library directly.  
+For example:
 
 ```javascript
 var MyPageView = Ember.View.extend({

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -94,7 +94,7 @@ Once the method described in AMD Module Example #1 is released, this method will
 
 Follow AMD Module Example #1 until the `import` step.  
 
-**TODO:** Add Info on Using Shims.
+Additional documentation to be added per [GitHub Pull Request #892](https://github.com/stefanpenner/ember-cli/issues/892)
 
 For example:
 
@@ -118,7 +118,7 @@ CommonJS modules are javascript libraries that are generally intended for use wi
 
 ##### CommonJS Module Example
 
-**TODO:** Example needed for importing CommonJS Module
+Additional documentation to be added per [GitHub Pull Request #892](https://github.com/stefanpenner/ember-cli/issues/892)
 
 #### Import a Standard Non-AMD Library
 

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -29,7 +29,7 @@ Further documentation about Bower is available at their
 
 ### Recommendations for Using Bower Assets in Your Ember App
 
-Ideally, all dependencies downloaded via Bower would adhere to the ES6 module syntax, however this standard is still evolving.  In reality, dependencies will either be (listed in order of how we prefer to import them): 
+Ideally, all dependencies downloaded via Bower would adhere to the ES6 module syntax, however this standard is still evolving.  In reality, dependencies will either be (listed in order of how we prefer to import them):
 
 1. Compatible with the ES6 module syntax, or
 2. Compatible with the [Asynchronous Module Definition](http://requirejs.org/docs/whyamd.html) (AMD) format often used with [Require.js](http://requirejs.org/), or
@@ -51,7 +51,7 @@ At this time, ES6-style `import` is used for Ember libraries, but is not yet imp
 
 #### Importing AMD Modules
 
-AMD modules are javascript libraries that are written to be used by any AMD-compliant script loader such as [Require.js](http://requirejs.org/).  Authors of AMD-compliant modules adhere to a [very simple standard](http://requirejs.org/docs/whyamd.html#amd) that AMD-compliant script loaders expect. Ember-cli includes its own script loader, so use of Require.js is not necessary. 
+AMD modules are javascript libraries that are written to be used by any AMD-compliant script loader such as [Require.js](http://requirejs.org/).  Authors of AMD-compliant modules adhere to a [very simple standard](http://requirejs.org/docs/whyamd.html#amd) that AMD-compliant script loaders expect. Ember-cli includes its own script loader, so use of Require.js is not necessary.
 
 ##### AMD Module Example #1: Official Method (Coming Soon)
 
@@ -65,7 +65,7 @@ bower install --save d3
 
 Bower will download the necessary files to your `/vendor/d3` directory.  
 
-Next, we tell Broccoli to add the relevant javascript files to the `/assets/your-app-name.js` file (PENDING: this will soon be `/assets/vendor.js`), which is explicitly referenced from your `index.html` page. Broccoli compiles 
+Next, we tell Broccoli to add the relevant javascript files to the `/assets/your-app-name.js` file (PENDING: this will soon be `/assets/vendor.js`), which is explicitly referenced from your `index.html` page. Broccoli compiles
 this file every time you run either `ember serve` or `ember build`.  In your `Brocfile.js`, add this before calling `app.toTree()`:
 
 {% highlight javascript linenos %}
@@ -87,6 +87,8 @@ var MyPageView = Ember.View.extend({
     }
 });
 {% endhighlight %}
+
+*WARNING: Support is not yet complete for this feature and there may be scenarios where an AMD module's `require` is defined but not recognized by `import`.*
 
 ##### AMD Module Example #2: Temporary Method Using Shims
 
@@ -126,7 +128,7 @@ Many javascript libraries will be written in a non-AMD or non-CommonJS manner.  
 
 ##### Non-AMD Module Example
 
-[Moment.js](http://momentjs.com/) is a javascript library which is not natively AMD-compliant (although [documentation](http://momentjs.com/docs/#/use-it/require-js/) is available on how to make it AMD-compliant with [RequireJS](http://requirejs.org/)). 
+[Moment.js](http://momentjs.com/) is a javascript library which is not natively AMD-compliant (although [documentation](http://momentjs.com/docs/#/use-it/require-js/) is available on how to make it AMD-compliant with [RequireJS](http://requirejs.org/)).
 
 To import moment.js using ember-cli, first tell Bower to type:
 
@@ -136,16 +138,16 @@ bower install --save moment
 
 Bower will download the necessary files to your `/vendor/moment` directory.  
 
-Next, we tell Broccoli to add these javascript files to the `/assets/your-app-name.js` 
-file which is explicitly referenced from your `index.html` page. Brocolli compiles 
-this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, 
+Next, we tell Broccoli to add these javascript files to the `/assets/your-app-name.js`
+file which is explicitly referenced from your `index.html` page. Brocolli compiles
+this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`,
 add this before calling `app.toTree()`:
 
 {% highlight javascript linenos %}
 app.import('vendor/momentjs/moment.js');
 {% endhighlight %}
 
-Any variables or functions defined in the `moment.js` library are now in global 
+Any variables or functions defined in the `moment.js` library are now in global
 scope and available on the `window` object in any javascript file (e.g. `window.moment`).  But to make these available as part of the Ember environment (and therefore without `window`), we will edit the `.jshintrc` file to add the following:
 
 ```json
@@ -157,7 +159,7 @@ scope and available on the `window` object in any javascript file (e.g. `window.
 }
 ```
 
-Finally, open the EmberJS file where you will be using the `moment.js` 
+Finally, open the EmberJS file where you will be using the `moment.js`
 library (say `views/my-page.js`), and access the `moment.js` library directly. For example:
 
 {% highlight javascript linenos %}

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -53,8 +53,6 @@ At this time, ES6-style `import` is used for Ember libraries, but is not yet imp
 
 AMD modules are javascript libraries that are written to be used by any AMD-compliant script loader such as [Require.js](http://requirejs.org/).  Authors of AMD-compliant modules adhere to a [very simple standard](http://requirejs.org/docs/whyamd.html#amd) that AMD-compliant script loaders expect. Ember-cli includes its own script loader, so use of Require.js is not necessary. 
 
-
-
 ##### AMD Module Example #1: Official Method (Coming Soon)
 
 *NOTE: This method will work soon, but support is still under development.*
@@ -70,9 +68,9 @@ Bower will download the necessary files to your `/vendor/d3` directory.
 Next, we tell Broccoli to add the relevant javascript files to the `/assets/your-app-name.js` file (PENDING: this will soon be `/assets/vendor.js`), which is explicitly referenced from your `index.html` page. Broccoli compiles 
 this file every time you run either `ember serve` or `ember build`.  In your `Brocfile.js`, add this before calling `app.toTree()`:
 
-```javascript
+{% highlight javascript linenos %}
 app.import('vendor/d3/d3.js');
-```
+{% endhighlight %}
 
 Note that you need not reference the `d3.min.js` file because Broccoli will minify this file for us when using `ember build --environment production` (assuming default settings in your `Brocfile.js`.
 
@@ -80,7 +78,7 @@ Any variables or functions defined in the `d3.js` library are now available for 
 
 For example:
 
-```javascript
+{% highlight javascript linenos %}
 import d3 from 'd3';
 
 var MyPageView = Ember.View.extend({
@@ -88,7 +86,7 @@ var MyPageView = Ember.View.extend({
         console.log( d3.version );
     }
 });
-```
+{% endhighlight %}
 
 ##### AMD Module Example #2: Temporary Method Using Shims
 
@@ -98,10 +96,9 @@ Follow AMD Module Example #1 until the `import` step.
 
 **TODO:** Add Info on Using Shims.
 
-
 For example:
 
-```javascript
+{% highlight javascript linenos %}
 import d3 from 'd3';
 
 var MyPageView = Ember.View.extend({
@@ -109,12 +106,11 @@ var MyPageView = Ember.View.extend({
         console.log( d3.version );
     }
 });
-```
+{% endhighlight %}
 
 ##### AMD Module Example #3: Temporary Method Using Globals
 
 The whole point of using AMD modules is to avoid defining variables in the global namespace.  Nevertheless, because AMD imports using ember-cli is still under development, you may use the method described under **Non-AMD Module Example** in the meantime.  This will support easy upgrading to proper use of AMD modules (using either one of the above examples, or a variation thereof) in the future.
-
 
 #### Import CommonJS Libraries
 
@@ -123,8 +119,6 @@ CommonJS modules are javascript libraries that are generally intended for use wi
 ##### CommonJS Module Example
 
 **TODO:** Example needed for importing CommonJS Module
-
-
 
 #### Import a Standard Non-AMD Library
 
@@ -147,14 +141,14 @@ file which is explicitly referenced from your `index.html` page. Brocolli compil
 this file as part of using `ember serve` or `ember build`.  In your `Brocfile.js`, 
 add this before calling `app.toTree()`:
 
-```javascript
+{% highlight javascript linenos %}
 app.import('vendor/momentjs/moment.js');
-```
+{% endhighlight %}
 
 Any variables or functions defined in the `moment.js` library are now in global 
 scope and available on the `window` object in any javascript file (e.g. `window.moment`).  But to make these available as part of the Ember environment (and therefore without `window`), we will edit the `.jshintrc` file to add the following:
 
-```javascript
+```json
 {
   predef: {
     ...
@@ -166,13 +160,13 @@ scope and available on the `window` object in any javascript file (e.g. `window.
 Finally, open the EmberJS file where you will be using the `moment.js` 
 library (say `views/my-page.js`), and access the `moment.js` library directly. For example:
 
-```javascript
+{% highlight javascript linenos %}
 var MyPageView = Ember.View.extend({
     didInsertElement: function() {
         console.log( moment().format() );
     }
 });
-```
+{% endhighlight %}
 
 ##### Environment-Specific Assets
 

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -41,7 +41,7 @@ Learn more about [Handling Dependencies in Javascript](http://addyosmani.com/wri
 #### Begin Using ES6 Modules Soon
 Where possible, you should use ES6-compatible libraries, and import them into your project using ES6 syntax.  
 
-Officially, the ES6 module syntax is still [under development](http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts) by the Ecma TC39 committee.  However, it is unlikely that the `import` syntax used to import dependencies into a script will change.  Note that ES6 `import` functionality in ember-cli is still under development and not yet ready for use with importing dependencies.  
+Officially, the ES6 module syntax is still [under development](https://people.mozilla.org/~jorendorff/es6-draft.html) by the Ecma TC39 committee.  However, it is unlikely that the `import` syntax used to import dependencies into a script will change.  Note that ES6 `import` functionality in ember-cli is still under development and not yet ready for use with importing dependencies.  
 
 Nevertheless, we recommend you plan on using the ES6 `import` syntax when possible. Ember-cli leverages the [ES6 Module Transpiler](https://github.com/square/es6-module-transpiler) to allow ES6-style `import` statements to be used natively on modern browsers and be "transpiled" into older javascript supported by older browsers.  Use of the transpiler also enables the ES6 `import` syntax to be used with javascript modules that are compatible with ES6, AMD, or non-AMD (CommonJS or global legacy).
 
@@ -128,9 +128,9 @@ Many javascript libraries will be written in a non-AMD or non-CommonJS manner.  
 
 ##### Non-AMD Module Example
 
-[Moment.js](http://momentjs.com/) is a javascript library which is not natively AMD-compliant (although [documentation](http://momentjs.com/docs/#/use-it/require-js/) is available on how to make it AMD-compliant with [RequireJS](http://requirejs.org/)).
+[Moment.js](http://momentjs.com/) is a javascript library which can be used either as an AMD module ([See Documentation](http://momentjs.com/docs/#/use-it/require-js/)) or as a legacy global include ([See Documentation](http://momentjs.com/docs/#/use-it/browser/)).  You should always use AMD modules where possible, but for example purposes only, we will use it as a non-AMD module.  
 
-To import moment.js using ember-cli, first tell Bower to type:
+To import moment.js as a legacy global using ember-cli, first tell Bower to type:
 
 ```
 bower install --save moment


### PR DESCRIPTION
Not having worked with javascript dependencies before, I found the current ember-cli docs confusing since they spoke of the admittedly amazing ES6 imports, except that they aren't available yet!

Hopefully this will clarify for other noobs how to handle dependencies immediately.