### PR TITLE
Use web notifications for betterifying your TDD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Update broccoli-jshint to 0.5.0 (more efficient caching for faster rebuilds). [#758](https://github.com/stefanpenner/ember-cli/pull/758)
 * [ENHANCEMENT] Ensure that the `app/templates/components` directory is created automatically. [#761](https://github.com/stefanpenner/ember-cli/pull/761)
 * [BUGFIX] For `ember-init`, Use app name if specified, over package.json or cwd name. [#792](https://github.com/stefanpenner/ember-cli/pull/753)
+* [ENHANCEMENT] Add support for Web Notifications for QUnit test suite with ember-qunit-notifications. [#804](https://github.com/stefanpenner/ember-cli/pull/804)
 
 ### 0.0.28
 

--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -11,6 +11,7 @@
     "ic-ajax": "~1.x",
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",
-    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.1"
+    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.1",
+    "ember-qunit-notifications": "0.0.1"
   }
 }

--- a/blueprint/tests/test-loader.js
+++ b/blueprint/tests/test-loader.js
@@ -6,3 +6,10 @@ Ember.keys(requirejs.entries).forEach(function(entry) {
     require(entry, null, null, true);
   }
 });
+
+QUnit.notifications({
+  icons: {
+    passed: '/assets/passed.png',
+    failed: '/assets/failed.png'
+  }
+});

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -276,7 +276,17 @@ EmberApp.prototype.testFiles = memoize(function() {
       destDir: '/'
     });
 
-  var sourceTrees = [qunitFiles, testemTree];
+  this.import({development:'vendor/qunit-notifications/index.js'});
+
+  var iconsPath = 'vendor/ember-qunit-notifications';
+
+  var iconsTree = pickFiles(iconsPath, {
+    files: ['passed.png', 'failed.png'],
+    srcDir: '/',
+    destDir: '/assets/'
+  });
+
+  var sourceTrees = [qunitFiles, testemTree, iconsTree];
 
   return mergeTrees(sourceTrees, {
       overwrite: true


### PR DESCRIPTION
If your browser supports web notifications a new `Notifications`
checkbox will appear in the toolbar menu. When checked a `Fail`
notification will show when any tests have failed and a `Pass`
notification will show when all tests are green. Tomsters added for
scale.

![screen shot 2014-05-23 at 9 35 16 pm](https://cloud.githubusercontent.com/assets/18524/3073439/3677a5de-e2ec-11e3-8a76-461e0d1151dc.png)
![screen shot 2014-05-23 at 9 35 43 pm](https://cloud.githubusercontent.com/assets/18524/3073440/3ed378e8-e2ec-11e3-98e8-1045e941730e.png)
