### PR TITLE
Fix module location for JSHint tests.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -162,14 +162,20 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
     sourceTrees.push(tests);
     
     if(this.hinting) {
-      var jshintedApp = jshintTrees(app, {
-        destFile: this.name + '/tests/app-jshint-test.js'
-      });
-      sourceTrees.push(jshintedApp);
+      var jshintedApp = jshintTrees(app);
       var jshintedTests = jshintTrees(tests, {
         jshintrcRoot: this.name + '/tests/',
-        destFile: this.name + '/tests/tests-jshint-test.js'
       });
+
+      jshintedApp = pickFiles(jshintedApp, {
+        srcDir: '/',
+        destDir: this.name + '/tests/'
+      });
+      jshintedTests = pickFiles(jshintedTests, {
+        srcDir: '/',
+        destDir: this.name + '/tests/'
+      });
+      sourceTrees.push(jshintedApp);
       sourceTrees.push(jshintedTests);
     }
   }


### PR DESCRIPTION
Previously, these tests were output in the same location as the original file with the `.jshint` extension added on. This causes a number of problems for anything that assumes a given module path contains certain types.  Specifically, adding an initializer would cause the build to error since every module in `my-app/initializers` is assumed to export an object.

Fixes #782.
