### PR TITLE
Don't append qunit-notifications

### DIFF
--- a/blueprint/tests/index.html
+++ b/blueprint/tests/index.html
@@ -37,6 +37,7 @@
       window.ENV = {{ENV}};
     </script>
     <script src="assets/qunit.js"></script>
+    <script src="assets/qunit-notifications.js"></script>
     <script src="assets/<%= name %>.js"></script>
     <script src="testem.js"></script>
     <script>

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -20,6 +20,7 @@ var pickFiles   = require('broccoli-static-compiler');
 var mergeTrees  = require('broccoli-merge-trees');
 var jshintTrees = require('broccoli-jshint');
 var concatFiles = require('broccoli-concat');
+var moveFile    = require('broccoli-file-mover');
 
 var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
@@ -273,6 +274,15 @@ EmberApp.prototype.testFiles = memoize(function() {
       destDir: '/assets/'
     });
 
+  var notificationsFile = moveFile(this.trees.vendor, {
+    srcFile: '/qunit-notifications/index.js',
+    destFile: '/assets/qunit-notifications.js'
+  });
+
+  qunitFiles = mergeTrees([qunitFiles, notificationsFile], {
+    overwrite: true
+  });
+
   var testemPath = path.join(__dirname, 'testem');
   testemPath = path.dirname(testemPath);
 
@@ -281,8 +291,6 @@ EmberApp.prototype.testFiles = memoize(function() {
       srcDir: '/',
       destDir: '/'
     });
-
-  this.import({development:'vendor/qunit-notifications/index.js'});
 
   var iconsPath = 'vendor/ember-qunit-notifications';
 


### PR DESCRIPTION
This will ensure that qunit-notifications is only exposed to the test
suite. It was previously being appended and was trying to define
`QUnit.notifications` when `QUnit` did not exist.
