### PR TITLE
Included broccoli-asset-rev for fingerprinting in EmberApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Add support for Web Notifications for QUnit test suite with ember-qunit-notifications. [#804](https://github.com/stefanpenner/ember-cli/pull/804)
 * [BUGFIX] Ensure that files in app/ are JSHinted properly. [#832](https://github.com/stefanpenner/ember-cli/pull/832)
 * [ENHANCEMENT] Update ember-load-initializers to 0.0.2.
+* [ENHANCEMENT] Add broccoli-asset-rev for fingerprinting + source re-writing. [#814](https://github.com/stefanpenner/ember-cli/pull/814)
 
 ### 0.0.28
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -21,6 +21,7 @@ var mergeTrees  = require('broccoli-merge-trees');
 var jshintTrees = require('broccoli-jshint');
 var concatFiles = require('broccoli-concat');
 var moveFile    = require('broccoli-file-mover');
+var assetRev    = require('broccoli-asset-rev');
 
 var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
@@ -45,6 +46,12 @@ function EmberApp(options) {
     minifyCSS: {
       enabled: true,
       options: {}
+    },
+    fingerprint: {
+      exclude: [],
+      extensions: ['js', 'css', 'png', 'jpg', 'gif'],
+      prepend: '',
+      replaceExtensions: ['html', 'css', 'js']
     },
     loader: 'vendor/loader/loader.js',
     trees: {},
@@ -353,6 +360,15 @@ EmberApp.prototype.import = function(asset, modules) {
   }
 };
 
+EmberApp.prototype.fingerprint = function(tree) {
+  return assetRev(tree, {
+    fingerprintExtensions: this.options.fingerprint.extensions,
+    fingerprintExclude:    this.options.fingerprint.exclude,
+    replaceExtensions:     this.options.fingerprint.replaceExtensions,
+    prependPath:           this.options.fingerprint.prepend
+  });
+};
+
 EmberApp.prototype.toArray = function() {
   var sourceTrees = [
     this.index(),
@@ -370,9 +386,15 @@ EmberApp.prototype.toArray = function() {
 };
 
 EmberApp.prototype.toTree = memoize(function() {
-  return mergeTrees(this.toArray(), {
+  var tree = mergeTrees(this.toArray(), {
     overwrite: true
   });
+
+  if (this.env === 'production') {
+    tree = this.fingerprint(tree);
+  }
+
+  return tree;
 });
 
 function injectENVJson(fn, env, tree, files) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bower": "^1.3.2",
     "bower-config": "0.5.0",
     "broccoli": "0.12.0",
+    "broccoli-asset-rev": "0.0.5",
     "broccoli-clean-css": "0.1.5",
     "broccoli-concat": "0.0.6",
     "broccoli-env": "0.0.1",

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var tmp  = require('../helpers/tmp');
-var conf = require('../helpers/conf');
+var tmp     = require('../helpers/tmp');
+var conf    = require('../helpers/conf');
 var Promise = require('../../lib/ext/promise');
-var exec = Promise.denodeify(require('child_process').exec);
-var path = require('path');
-var rimraf = Promise.denodeify(require('rimraf'));
-var fs = require('fs');
+var exec    = Promise.denodeify(require('child_process').exec);
+var path    = require('path');
+var rimraf  = Promise.denodeify(require('rimraf'));
+var fs      = require('fs');
+var crypto  = require('crypto');
+var assert  = require('assert');
 var appName = 'some-cool-app';
 
 describe('Acceptance: smoke-test', function() {
@@ -42,6 +44,58 @@ describe('Acceptance: smoke-test', function() {
       });
     }).finally(function() {
       console.log('done!');
+    });
+  });
+
+  it('ember new foo, build production and verify fingerprint', function() {
+    console.log('    running the slow fingerprint it will take some time');
+
+    this.timeout(360000);
+
+    var appsECLIPath = path.join(appName, 'node_modules', 'ember-cli');
+    var globalPwd = null;
+
+    return exec('pwd').then(function(pwd) {
+      globalPwd = pwd;
+
+      return exec(path.join('..', 'bin', 'ember') + ' new ' + appName);
+    }).then(function() {
+      return rimraf(appsECLIPath);
+    }).then(function() {
+      fs.symlinkSync(path.join(globalPwd, '..'), appsECLIPath);
+
+      process.chdir(appName);
+
+      return exec(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember') + ' build --environment=production');
+    }).then(function() {
+      var dirPath = path.join('.', 'dist', 'assets');
+      var dir = fs.readdirSync(dirPath);
+      var files = [];
+
+      dir.forEach(function (filepath) {
+        if (filepath === '.gitkeep') {
+          return;
+        }
+
+        files.push(filepath);
+
+        var file = fs.readFileSync(path.join(dirPath, filepath), { encoding: 'utf8' });
+
+        var md5 = crypto.createHash('md5');
+        md5.update(file);
+        var hex = md5.digest('hex');
+
+        var possibleNames = [appName + '-' + hex + '.js', appName + '-' + hex + '.css', 'vendor-' + hex + '.css'];
+        assert(possibleNames.indexOf(filepath) > -1);
+      });
+
+      var indexHtml = fs.readFileSync(path.join('.', 'dist', 'index.html'), { encoding: 'utf8' });
+
+      files.forEach(function (filename) {
+        assert(indexHtml.indexOf(filename) > -1);
+      });
+    }).finally(function() {
+      console.log('done');
     });
   });
 });


### PR DESCRIPTION
I have included https://github.com/rickharrison/broccoli-asset-rev to both fingerprint files as well as replace them in the source. This will turn:

`<script src="assets/appname.js"></script>`

into

`<script src="assets/appname-ce5adb2fb916f0fdaa16c282dd074239.js"></script>`

I added an option to EmberApp to pass strings for excluding files to be fingerprinted. `EmberApp.options.fingerprint.exclude` should be an array of strings, which if any file contains any string in that array, it will not be fingerprinted. As an example, I do not fingerprint my typography.com stylesheets.

Also, there is a `prepend` option, which is an object which pairs the current env to a string to add to all of the asset filenames.

```
var app = new EmberApp({
  name: require('./package.json').name,

  minifyCSS: {
    enabled: true,
    options: {}
  },

  fingerprint: {
    exclude: ['fonts/169929'],
    prepend: 'https://subdomain.cloudfront.net/'
  },

  getEnvJSON: require('./config/environment')
});
```

If a prepend string is specified, it will be added in front of all of the fingerprinted assets. This allows for easy CDN addition to assets.

From

`background: url('/images/foo.png');`

to

`background: url('https://subdomain.cloudfront.net/images/foo-735d6c098496507e26bb40ecc8c1394d.png');`

Let me know what you think and I can improve upon it!
