### PR TITLE
add es3-safe-transpile step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-cli Changelog
+
 * [BUGFIX] prevent pointless event emitter memory leak warning [#850](https://github.com/stefanpenner/ember-cli/pull/850)
+* [ENHANCEMENT] add and es3 safe transpile step: specifically promise.catch and promise.finally -> promise['catch'] & promise['finally']. In addition we cover afew more variables see: https://github.com/stefanpenner/es3-safe-recast [#823](https://github.com/stefanpenner/ember-cli/pull/823)
 * [ENHANCEMENT] Load the vendor.css in the rendered HTML. [#728](http://github.com/stefanpenner/ember-cli/pull/728)
 * [ENHANCEMENT] Allow `testem` port to be specified when running `ember test --server`. [#729](https://github.com/stefanpenner/ember-cli/pull/729)
 * [BUGFIX] Use EMBER_ENV if specified in ENV_VARIABLES `EMBER_ENV=production ember build`. [#753](https://github.com/stefanpenner/ember-cli/pull/753)

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -29,6 +29,7 @@ var memoize    = require('lodash-node/modern/functions').memoize;
 var assign     = require('lodash-node/modern/objects/assign');
 var defaults   = require('lodash-node/modern/objects/defaults');
 var path       = require('path');
+var ES3SafeFilter = require('broccoli-es3-safe-recast');
 
 module.exports = EmberApp;
 
@@ -51,11 +52,11 @@ function EmberApp(options) {
   });
 
   this.options.trees = defaults(this.options.trees, {
-      app:    'app',
-      styles: 'app/styles',
-      tests:  'tests',
-      vendor: unwatchedTree('vendor'),
-    });
+    app:    'app',
+    styles: 'app/styles',
+    tests:  'tests',
+    vendor: unwatchedTree('vendor'),
+  });
 
   this.importWhitelist     = {};
   this.legacyFilesToAppend = [];
@@ -151,7 +152,7 @@ EmberApp.prototype._processedVendorTree = memoize(function() {
 });
 
 EmberApp.prototype.appAndDependencies = memoize(function() {
-  var app    = this._processedAppTree();
+  var app    = new ES3SafeFilter(this._processedAppTree());
   var vendor = this._processedVendorTree();
 
   var appAndTemplates = preprocessTemplates(app);
@@ -159,7 +160,7 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
   var sourceTrees = [ vendor ];
 
   if (this.tests) {
-    var tests  = this._processedTestsTree();
+    var tests  = new ES3SafeFilter(this._processedTestsTree());
     var preprocessedTests = preprocessJs(tests, '/tests', this.name);
     sourceTrees.push(preprocessedTests);
 
@@ -181,11 +182,11 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
       sourceTrees.push(jshintedTests);
     }
   }
-  
+
   // js hint should be applied before preprocessing, validateES6 after
   var preprocessedApp = preprocessJs(appAndTemplates, '/', this.name);
   sourceTrees.unshift(preprocessedApp);
-  
+
   if (this.hinting) {
     var importWhitelist = this.importWhitelist;
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "testem": "0.6.15",
     "through": "2.3.4",
     "tiny-lr": "0.0.5",
-    "walk-sync": "0.1.2"
+    "walk-sync": "0.1.2",
+    "broccoli-es3-safe-recast": "0.0.4"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
currently just:

`promise.finally` -> `promise[‘finally’]`
`promise.catch`  -> `promise[‘catch’]`
`a.default`  -> `a[‘default’]`

and the object literal versions

The transpile step stuff support source maps but the rest of our pipeline doesn't quite yet.

related:
https://github.com/stefanpenner/es3-safe-recast/ 
https://github.com/stefanpenner/broccoli-es3-safe-recast/
