### PR TITLE
External links to Github, NPM and StackOverflow

### DIFF
--- a/_includes/description.html
+++ b/_includes/description.html
@@ -4,4 +4,9 @@
 </div>
 <h4 class="warning">Although potentially exciting, this is still a work in progress project, use at your own risk.</h4>
 <p class="center">Ember command line utility for ambitious web applications.</p>
+<ul class="links">
+  <li><a href="https://github.com/stefanpenner/ember-cli">Github</a></li>
+  <li><a href="https://www.npmjs.org/package/ember-cli">npm</a></li>
+  <li><a href="http://stackoverflow.com/questions/tagged/ember-cli">StackOverflow</a>
+</ul>
 <div class="npm">npm install -g ember-cli</div>

--- a/assets/styles/ecli.css
+++ b/assets/styles/ecli.css
@@ -142,6 +142,21 @@ body {
   border-color: rgb(66, 139, 202);
 }
 
+.links {
+  padding-left: 0;
+  margin-bottom: 20px;
+  font-size: 18px;
+}
+
+.links li {
+  display: inline-block;
+}
+
+.links li:not(:last-child):after {
+  content: " |";
+  color: lightgrey;
+}
+
 @media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
   .download {
     width: 100%;


### PR DESCRIPTION
A visitor currently has to google for a Github page of the project. So i added links to basic resources to page header.

You can see how it looks here to decide on merging/rejecting: http://lolmaus.github.io/ember-cli/
