### PR TITLE
Update ember-load-initializers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [BUGFIX] For `ember-init`, Use app name if specified, over package.json or cwd name. [#792](https://github.com/stefanpenner/ember-cli/pull/753)
 * [ENHANCEMENT] Add support for Web Notifications for QUnit test suite with ember-qunit-notifications. [#804](https://github.com/stefanpenner/ember-cli/pull/804)
 * [BUGFIX] Ensure that files in app/ are JSHinted properly. [#832](https://github.com/stefanpenner/ember-cli/pull/832)
+* [ENHANCEMENT] Update ember-load-initializers to 0.0.2.
 
 ### 0.0.28
 

--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -11,7 +11,7 @@
     "ic-ajax": "~1.x",
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",
-    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.1",
+    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "ember-qunit-notifications": "0.0.1"
   }
 }


### PR DESCRIPTION
Fixes issues with `app/tests/app/initializers` being loaded always.
