### PR TITLE
Loosen version constraint on ember-qunit-notifications

### DIFF
--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -12,6 +12,6 @@
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
-    "ember-qunit-notifications": "0.0.1"
+    "ember-qunit-notifications": "^0.0.1"
   }
 }


### PR DESCRIPTION
This would suck to keep updating
