### PR TITLE
Fixes CoffeeScript test files not being preprocessed

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -160,8 +160,9 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
 
   if (this.tests) {
     var tests  = this._processedTestsTree();
-    sourceTrees.push(tests);
-    
+    var preprocessedTests = preprocessJs(tests, '/tests', this.name);
+    sourceTrees.push(preprocessedTests);
+
     if(this.hinting) {
       var jshintedApp = jshintTrees(app);
       var jshintedTests = jshintTrees(tests, {


### PR DESCRIPTION
Wrote a few tests in coffeescript today and noticed that they weren't showing up in the broccoli output.  @jgwhite noticed that the files were never being run through the preprocessor, hence why they never showed up.

Not sure if this has always been an issue  or not as I'd never tried it before.  (docs say it works)
