### PR TITLE
fixed highlight flaw on the common-issues.md page

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -24,14 +24,14 @@ If you're behind a proxy, you might not be able to install because `ember-cli` &
 
 You'll probably get an error like this:
 
-```bash
+{% highlight bash %}
 npm ERR! git clone git://github.com/jgable/esprima.git Cloning into bare repository '/home/<username>/.npm/_git-remotes/git-github-com-jgable-esprima-git-d221af32'...
 npm ERR! git clone git://github.com/jgable/esprima.git 
 npm ERR! git clone git://github.com/jgable/esprima.git fatal: unable to connect to github.com:
 npm ERR! git clone git://github.com/jgable/esprima.git github.com[0: 192.30.252.129]: errno=Connection timed out
 npm ERR! Error: Command failed: fatal: unable to connect to github.com:
 npm ERR! github.com[0: 192.30.252.129]: errno=Connection timed out
-```
+{% endhighlight %}
 
 This is not a `ember-cli` issue _per se_, but here's a workaround. You can configure `git` to make the translation:
 


### PR DESCRIPTION
I've just edited the highlight type on the sample npm error to become wrapped.

Discussed here in PR [#846](https://github.com/stefanpenner/ember-cli/pull/846#issuecomment-44519089) 
