### PR TITLE
Changes `ember-app` helper's behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [BUGFIX] changes the behavior of an `ember-app` helper to read the name of the app from `package.json` [#856](https://github.com/stefanpenner/ember-cli/pull/856)
 * [BUGFIX] prevent pointless event emitter memory leak warning [#850](https://github.com/stefanpenner/ember-cli/pull/850)
 * [ENHANCEMENT] add and es3 safe transpile step: specifically promise.catch and promise.finally -> promise['catch'] & promise['finally']. In addition we cover afew more variables see: https://github.com/stefanpenner/es3-safe-recast [#823](https://github.com/stefanpenner/ember-cli/pull/823)
 * [ENHANCEMENT] Load the vendor.css in the rendered HTML. [#728](http://github.com/stefanpenner/ember-cli/pull/728)

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -25,6 +25,7 @@ var assetRev    = require('broccoli-asset-rev');
 
 var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
+var packageConfig    = require(process.cwd() + '/package.json');
 
 var memoize    = require('lodash-node/modern/functions').memoize;
 var assign     = require('lodash-node/modern/objects/assign');
@@ -36,7 +37,7 @@ module.exports = EmberApp;
 
 function EmberApp(options) {
   this.env  = process.env.EMBER_ENV || 'development';
-  this.name = options.name;
+  this.name = packageConfig.name;
 
   var isProduction = this.env === 'production';
 


### PR DESCRIPTION
Takes away an option to specify an app's name through `ember-app` helper.
App's name is taken from `package.json`.

Fixes #827
