### PR TITLE
Do not watch node_modules/ember-cli/lib/broccoli.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BUGFIX] Ensure that files in app/ are JSHinted properly. [#832](https://github.com/stefanpenner/ember-cli/pull/832)
 * [ENHANCEMENT] Update ember-load-initializers to 0.0.2.
 * [ENHANCEMENT] Add broccoli-asset-rev for fingerprinting + source re-writing. [#814](https://github.com/stefanpenner/ember-cli/pull/814)
+* [BUGFIX] Prevent broccoli from watching `node_modules/ember-cli/lib/broccoli/`. [#857](https://github.com/stefanpenner/ember-cli/pull/857)
 
 ### 0.0.28
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -295,7 +295,7 @@ EmberApp.prototype.testFiles = memoize(function() {
   var testemPath = path.join(__dirname, 'testem');
   testemPath = path.dirname(testemPath);
 
-  var testemTree = pickFiles(testemPath, {
+  var testemTree = pickFiles(unwatchedTree(testemPath), {
       files: ['testem.js'],
       srcDir: '/',
       destDir: '/'


### PR DESCRIPTION
This change prevents changes in ember-cli/lib/broccoli/ from triggering a rebuild.
