### PR TITLE
Allow concurrent `ember test --server` and `ember server`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Update ember-load-initializers to 0.0.2.
 * [ENHANCEMENT] Add broccoli-asset-rev for fingerprinting + source re-writing. [#814](https://github.com/stefanpenner/ember-cli/pull/814)
 * [BUGFIX] Prevent broccoli from watching `node_modules/ember-cli/lib/broccoli/`. [#857](https://github.com/stefanpenner/ember-cli/pull/857)
+* [BUGFIX] Prevent collision between running `ember server` and `ember test --server` simultaneously. [#862](https://github.com/stefanpenner/ember-cli/pull/862)
 
 ### 0.0.28
 

--- a/blueprint/testem.json
+++ b/blueprint/testem.json
@@ -1,7 +1,6 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html",
-  "cwd": "tmp/output",
   "launch_in_ci": ["PhantomJS"],
   "launch_in_dev": ["PhantomJS", "Chrome"]
 }

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -4,6 +4,7 @@ var assign    = require('lodash-node/modern/objects/assign');
 var quickTemp = require('quick-temp');
 var Command   = require('../models/command');
 var Watcher   = require('../models/watcher');
+var Builder   = require('../models/builder');
 
 module.exports = Command.extend({
   name: 'test',
@@ -32,6 +33,9 @@ module.exports = Command.extend({
     };
 
     if (commandOptions.server) {
+      testOptions.liveOutputDir = options.liveOutputDir = this.tmp();
+      options.builder = new Builder(options);
+
       var TestServerTask = this.tasks.TestServer;
       var testServer     = new TestServerTask(options);
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -8,7 +8,7 @@ var signalsTrapped = false;
 
 module.exports = Task.extend({
   init: function() {
-    this.tree = loadBrocfile(); // TODO:
+    this.tree = loadBrocfile(this.liveOutputDir); // TODO:
     this.builder = new broccoli.Builder(this.tree);
 
     process.addListener('exit', this.onExit.bind(this));

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -3,16 +3,20 @@
 var Task    = require('../models/task');
 var Testem  = require('testem');
 var Promise = require('../ext/promise');
+var rimraf  = Promise.denodeify(require('rimraf'));
 
 module.exports = Task.extend({
   run: function(options) {
     return new Promise(function() {
-      var testemOptions = { file: options.configFile, port: options.port };
+      var testemOptions = { file: options.configFile, port: options.port, cwd: options.liveOutputDir };
 
       var watcher = options.watcher;
       var testem  = new Testem();
       testem.startDev(testemOptions, function(code) {
-        process.exit(code);
+        rimraf(options.liveOutputDir)
+          .finally(function() {
+            process.exit(code);
+          });
       });
 
       watcher.on('change', function() {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -6,11 +6,10 @@ var Promise = require('../ext/promise');
 
 module.exports = Task.extend({
   run: function(options) {
-    var testemOptions = { file: options.configFile };
-    var mode = 'startCI';
+    var testemOptions = { file: options.configFile, cwd: 'tmp/output'};
     var testem  = new Testem();
 
-    testem[mode](testemOptions);
+    testem.startCI(testemOptions);
 
     return Promise.resolve();
   }

--- a/lib/utilities/load-brocfile.js
+++ b/lib/utilities/load-brocfile.js
@@ -1,13 +1,13 @@
 'use strict';
 
-module.exports = function loadBrocfile() {
+module.exports = function loadBrocfile(liveOutputDir) {
   var broccoli   = require('broccoli');
   var mergeTrees = require('broccoli-merge-trees');
   var exportTree = require('broccoli-export-tree');
 
   var tree           = broccoli.loadBrocfile();
   var liveOutputTree = exportTree(tree, {
-    destDir: 'tmp/output'
+    destDir: liveOutputDir || 'tmp/output'
   });
 
   return mergeTrees([


### PR DESCRIPTION
Prior to this, both `ember server` and `ember test --server` attempted to write to (and clear) `tmp/output`. This allows the test task to use a custom randomly named temp dir instead (which prevents the collision).
