### PR TITLE
Print build times for `ember server`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Add broccoli-asset-rev for fingerprinting + source re-writing. [#814](https://github.com/stefanpenner/ember-cli/pull/814)
 * [BUGFIX] Prevent broccoli from watching `node_modules/ember-cli/lib/broccoli/`. [#857](https://github.com/stefanpenner/ember-cli/pull/857)
 * [BUGFIX] Prevent collision between running `ember server` and `ember test --server` simultaneously. [#862](https://github.com/stefanpenner/ember-cli/pull/862)
+* [ENHANCEMENT] Show timing and slow tree listing for each rebuild. [#860](https://github.com/stefanpenner/ember-cli/pull/860) & [#865](https://github.com/stefanpenner/ember-cli/pull/865)
 
 ### 0.0.28
 

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -12,13 +12,9 @@ module.exports = Task.extend({
 
     this.watcher.on('error', this.didError.bind(this));
     this.watcher.on('change', this.didChange.bind(this));
-
-    this._lastError = null;
   },
 
   didError: function(error) {
-    this._lastError = error;
-
     this.analytics.trackError({
       description: error && error.message
     });
@@ -29,12 +25,9 @@ module.exports = Task.extend({
   },
 
   didChange: function(results) {
-    var totalTime = results.totalTime;
+    var totalTime = results.totalTime / 1e6;
 
-    if (this._lastError) {
-      this._lastError = null;
-      this.ui.write(chalk.green('\n\nBuild successful.\n'));
-    }
+    this.ui.write(chalk.green('\nBuild successful - ' + Math.round(totalTime) + 'ms.\n'));
 
     this.analytics.track({
       name:    'ember rebuild',

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -30,7 +30,7 @@ describe('Watcher', function() {
   describe('watcher:change', function() {
     beforeEach(function() {
       watcher.emit('change', {
-        totalTime: 12344
+        totalTime: 12344000000
       });
     });
 
@@ -49,8 +49,8 @@ describe('Watcher', function() {
       }]);
     });
 
-    it('logs nothing', function() {
-      assert.equal(ui.output.length, 0);
+    it('logs that the build was successful', function() {
+      assert.equal(ui.output, '\u001b[32m\nBuild successful - 12344ms.\n\u001b[39m');
     });
   });
 
@@ -77,7 +77,7 @@ describe('Watcher', function() {
       });
 
       watcher.emit('change', {
-        totalTime: 12344
+        totalTime: 12344000000
       });
     });
 


### PR DESCRIPTION
With the slow trees being printed automatically, we need some separation between slow-tree tables. It is also nice to see the total time to put everything in the proper perspective.
### Before

![before](http://monosnap.com/image/kt6E1zfAxIexTIW1t096Pe21G3FUwp.png)
### After

![after](http://monosnap.com/image/kF4G8QxWUQeXD8kgXuKBsGaaivXPxg.png)
