### PR TITLE
Tell jshint about Handlebars global variable

### DIFF
--- a/blueprint/.jshintrc
+++ b/blueprint/.jshintrc
@@ -9,7 +9,8 @@
     "DS": true,
     "$": true,
     "ENV": true,
-    "module": true
+    "module": true,
+    "Handlebars": true
   },
   "node" : false,
   "browser" : false,


### PR DESCRIPTION
This tells jshint about the Handlebars global variable.

Use case:

``` javascript
// app/helpers/render-markdown.js

export default Ember.Handlebars.makeBoundHelper(function(markdown) {
  var showdown = new Showdown.converter();
  return new Handlebars.SafeString(showdown.makeHtml(markdown));
});
```
