### PR TITLE
Update 2014-04-03-getting-started.md

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -60,7 +60,9 @@ cd my-new-app
 ember server
 {% endhighlight %}
 
-and navigate to [http://localhost:4200](http://localhost:4200) to see your new app in action.
+navigate to `http://localhost:4200` to see your new app in action.
+
+navigate to `http://localhost:4200/tests` to see your test results in action.
 
 #### Cloning an existing project
 


### PR DESCRIPTION
Removes unnecessary URL associated with http://localhost:4200 as in the rest of the document similar URLs are highlighted and not linked to anywhere. So, I think its good to be consistent. 

Adds http://localhost:4200/tests. As that URL also works out of the box from ember-cli, I think it should be exposed earlier.
