### PR TITLE
Disable slow tree log within `ember test --server`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Show timing and slow tree listing for each rebuild. [#860](https://github.com/stefanpenner/ember-cli/pull/860) & [#865](https://github.com/stefanpenner/ember-cli/pull/865)
 * [BUGFIX] Disable `wrapInEval` by default. [#866](//github.com/stefanpenner/ember-cli/pull/866)
 * [ENHANCEMENT] Allow passing `tests` and `hinting` to `new EmberApp()`. [#876](https://github.com/stefanpenner/ember-cli/pull/876)
+* [BUGFIX] Prevent slow tree printout during `ember test --server` from bleeding through `testem` UI.[#877](https://github.com/stefanpenner/ember-cli/pull/877)
 
 ### 0.0.28
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -39,7 +39,7 @@ module.exports = Command.extend({
       var TestServerTask = this.tasks.TestServer;
       var testServer     = new TestServerTask(options);
 
-      testOptions.watcher = new Watcher(options);
+      testOptions.watcher = new Watcher(assign(options, {verbose: false}));
 
       return testServer.run(testOptions);
     } else {

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -4,10 +4,12 @@ var chalk   = require('chalk');
 var Task    = require('./task');
 
 module.exports = Task.extend({
+  verbose: true,
+
   init: function() {
     var Watcher = require('broccoli/lib/watcher');
     this.watcher = this.watcher || new Watcher(this.builder, {
-      verbose: true
+      verbose: this.verbose
     });
 
     this.watcher.on('error', this.didError.bind(this));


### PR DESCRIPTION
The `testem` UI does not always repaint the full screen, which means that in some scenarios the slow tree log bleeds through and there is no testem command to for repaint the full screen (that I know of at least).

Fixes https://github.com/stefanpenner/ember-cli/issues/867.
