### PR TITLE
Update ember-cli-test-loader & fix load ordering.

### DIFF
--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -13,6 +13,6 @@
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "ember-qunit-notifications": "^0.0.1",
-    "ember-cli-test-loader": "rjackson/ember-cli-test-loader#0.0.1"
+    "ember-cli-test-loader": "rjackson/ember-cli-test-loader#0.0.2"
   }
 }

--- a/blueprint/tests/index.html
+++ b/blueprint/tests/index.html
@@ -40,9 +40,9 @@
     <script src="assets/qunit-notifications.js"></script>
     <script src="assets/<%= name %>.js"></script>
     <script src="testem.js"></script>
-    <script src="assets/test-loader.js"></script>
     <script>
       require('<%= modulePrefix %>/tests/test-helper');
     </script>
+    <script src="assets/test-loader.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Previously, the modules were required before our test-helper was loaded. This causes errors in ember-qunit (as it expects the resolver to be set).

Also, ember-cli-test-loader fixed an issue that caused all modules to be required once one was.
