### PR TITLE
Update ember-resolver to 0.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BUGFIX] Prevent slow tree printout during `ember test --server` from bleeding through `testem` UI.[#877](https://github.com/stefanpenner/ember-cli/pull/877)
 * [ENHANCEMENT] Remove unused `vendor/_loader.js` file. [#880](https://github.com/stefanpenner/ember-cli/pull/880)
 * [ENHANCEMENT] Allow disabling JSHint tests from within QUnit UI. [#878](https://github.com/stefanpenner/ember-cli/pull/878)
+* [ENHANCEMENT] Upgrage `ember-resolver` to `0.1.1` (and lock down version in `bower.json`). [#885](https://github.com/stefanpenner/ember-cli/pull/885)
 
 ### 0.0.28
 

--- a/blueprint/bower.json
+++ b/blueprint/bower.json
@@ -7,7 +7,7 @@
     "ember-qunit": "~0.1.5",
     "ember": "1.5.1",
     "ember-data": "1.0.0-beta.8",
-    "ember-resolver": "stefanpenner/ember-jj-abrams-resolver#master",
+    "ember-resolver": "~0.1.1",
     "ic-ajax": "~1.x",
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.1",


### PR DESCRIPTION
Major refactor of internals to split up giant functions a bit. Not a breaking change.
