### PR TITLE
Add instructions for setting up integration tests

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -26,7 +26,36 @@ pass any option to `Testem` using a configuration file.
 
 **We plan to make your test runner pluggable, so you can use your favorite runner.**
 
-#### Using ember-qunit
+#### Using ember-qunit for integrations tests
+
+All Ember Apps come with built-in [ember test helpers](http://emberjs.com/guides/testing/test-helpers/),
+which are useful for writing integration tests.
+In order to use them, you will need to import `tests/helpers/start-app.js`, which injects the required helpers.
+
+Be sure to use the injected `module` function to invoke `setup` and `teardown`.
+
+{% highlight javascript linenos %}
+import test from 'ember-qunit';
+import startApp from '../helpers/start-app';
+var App;
+module('An Integration test', {
+    setup: function() {
+        App = startApp();
+    },
+    teardown: function() {
+        Ember.run(App, App.destroy);
+    },
+});
+test("Page contents", function() {
+    expect(2);
+    visit('/foos').then(function() {
+        equal(find('.foos-list').length, 1, "Page contains list of models");
+        equal(find('.foos-list .foo-item').length, 5, "List contains expected number of models");
+    });
+});
+{% endhighlight %}
+
+#### Using ember-qunit for unit tests
 
 An Ember CLI-generated project comes pre-loaded with 
 [ember-qunit](https://github.com/rpflorence/ember-qunit) which includes


### PR DESCRIPTION
While I found the instruction for getting up and running with unit tests to be good, I could not figure out from [the documentation here](http://iamstef.net/ember-cli/#testing) on integration testing, specifically with how to access `module` and the [ember test helpers](http://emberjs.com/guides/testing/test-helpers/) that are injected when Ember is set up for testing.

I asked a [question on SO](http://stackoverflow.com/questions/24010529/setting-up-integration-tests-in-an-ember-cli-app-how-to-access-module-and-vi), and I'm adding its answer here:

---

Original question:

This page, 
[ember-cli testing](http://iamstef.net/ember-cli/#testing),
 says "The included tests demonstrate how to write both unit tests and acceptance/integration tests using the new 
[ember-testing package](http://ianpetzer.wordpress.com/2013/06/14/getting-started-with-integration-testing-ember-js-using-ember-testing-and-qunit-rails/)."

However in order to get an integration test working, I need to find `module` and `visit` or any of the [ember test helpers](http://emberjs.com/guides/testing/test-helpers/).
Where are they found, where can I import them from?

---

Details:

The closest I have found to `module` is `moduleFor`, which can be imported from `ember-qunit`. Module for is not suitable for integration testing as I am testing an entire page or series of pages within the app, rather than an individual model, route, controller, view, etc.

My best guess is that `visit` can be found within Ember itself, but I am not sure where to import it from.

Using neither `module` nor `moduleFor`, I am able to run the tests, but they error out:

> ReferenceError: visit is not defined

---
