### PR TITLE
Body-parser is not needed for ember-cli itself

### DIFF
--- a/blueprint/server/index.js
+++ b/blueprint/server/index.js
@@ -14,6 +14,9 @@ var routes     = globSync('./routes/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(emberCLIMiddleware) {
   var app = express();
+  
+  // You can include any connect enabled module here. `body-parser` is added here as an example
+  // and can safely be removed if you do not use it
   app.use(bodyParser());
 
   routes.forEach(function(route) { route(app); });


### PR DESCRIPTION
As just discussed on #ember-cli

```
[4:40pm] ssured: I just hit an issue with body-parser inclusion in Ember CLI, introduced by https://github.com/stefanpenner/ember-cli/commit/cfaa0c5b560c4526a86e0e62166d999dfc67598c#diff-57307c856b758165a32aae67277e855a. Does anybody know the rationale behind this default inclusion? It is not needed for the CLI middleware AFAIK
[4:51pm] wmeldon: ssured: I use it extensively but am apparently in the minority.  (Hence why I wrote the pull :P)
[4:53pm] ssured: mweldon: yeah I think including it on all routes is quite agressive. I use body-parser sparingly just on the routes which need it. Body parser broke on a PUT request with 5mb data
[4:53pm] ssured: Maybe we can add a hint in the file that body-parser can be removed safely?
```
