### PR TITLE
Don't pass hardcoded input path to preprocessCss.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -282,7 +282,7 @@ EmberApp.prototype.styles = memoize(function() {
     description: 'TreeMerger (stylesAndVendor)'
   });
 
-  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets');
+  var processedStyles = preprocessCss(stylesAndVendor, this.trees.styles, '/assets');
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles,
     outputFile: '/assets/vendor.css',


### PR DESCRIPTION
[This line](https://github.com/stefanpenner/ember-cli/blob/fb32e33dbb6fff5b3aa0abdd7793dc32e87e103c/lib/preprocessors.js#L74) in preprocessors.js doesn't work if you're using a plugin with multiple extensions (e.g., broccoli-ruby-sass) and a passing a custom `trees.styles` path to EmberApp.

The hardcoded string `'/app/styles'` is passed to preprocessCss as `inputPath` by EmberApp#styles, but that path might not actually exist on the filesystem.
