### PR TITLE
fix error in example syntax - use {} for named exports from ember-qunit

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -26,7 +26,7 @@ pass any option to `Testem` using a configuration file.
 
 **We plan to make your test runner pluggable, so you can use your favorite runner.**
 
-#### Using ember-qunit for integrations tests
+#### Using ember-qunit for integration tests
 
 All Ember Apps come with built-in [ember test helpers](http://emberjs.com/guides/testing/test-helpers/),
 which are useful for writing integration tests.
@@ -35,7 +35,7 @@ In order to use them, you will need to import `tests/helpers/start-app.js`, whic
 Be sure to use the injected `module` function to invoke `setup` and `teardown`.
 
 {% highlight javascript linenos %}
-import test from 'ember-qunit';
+import { test } from 'ember-qunit';
 import startApp from '../helpers/start-app';
 var App;
 module('An Integration test', {


### PR DESCRIPTION
As pointed out by @GerritWanderer and @rjackson.
See https://github.com/stefanpenner/ember-cli/pull/894#issuecomment-45203037
