### PR TITLE
Do not allow periods in a project name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] Ensure that config/environment is findable and required when setting up baseURL for server. [#916](https://github.com/stefanpenner/ember-cli/pull/916)
 * [BUGFIX] Fix importing of non-JS/CSS [#915](https://github.com/stefanpenner/ember-cli/pull/915)
 * [ENHANCEMENT] Use `window.MyProjectNameENV` instead of `window.ENV`. [#922](https://github.com/stefanpenner/ember-cli/pull/922)
+* [BUGFIX] Disallow projects with periods in their name. [#927](https://github.com/stefanpenner/ember-cli/pull/927)
 
 ### 0.0.29
 

--- a/lib/utilities/valid-project-name.js
+++ b/lib/utilities/valid-project-name.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = function(name) {
-  return ['test', 'ember'].indexOf(name) === -1;
+  if (['test', 'ember'].indexOf(name) > -1) { return false; }
+  if (name.indexOf('.') > -1) { return false; }
+
+  return true;
 };

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -32,4 +32,15 @@ describe('new command', function() {
       assert.equal(command.ui.output, 'We currently do not support an application name of `ember`.');
     });
   });
+
+  it('doesn\'t allow to create an application with a period in the name', function() {
+    command = new NewCommand(
+      commandOptions()
+    ).validateAndRun(['zomg.awesome']).then(function() {
+      assert.ok(false, 'should have rejected with period in the application name');
+    })
+    .catch(function() {
+      assert.equal(command.ui.output, 'We currently do not support an application name of `zomg.awesome`.');
+    });
+  });
 });


### PR DESCRIPTION
This causes issues with the way we export information to `window` in `app/index.html`. For example (assuming a project name of `zomg.awesome`):

``` javascript
window.Zomg.Awesome = require('some-test/app')['default'].create(ENV.APP);
```

Which will obviously blow up because `Zomg` is not an object.
