### PR TITLE
Provide EmberApp with registry access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Bring generators in-house via blueprints. [#747](https://github.com/stefanpenner/ember-cli/pull/747)
 * [BUGFIX] Only process applicaiton code with ES3SafeFilter. [#949](https://github.com/stefanpenner/ember-cli/pull/949)
 * [ENHANCEMENT] Separate applicaiton code from vendor code. Generate `/assets/vendor.js` for vendored code. [#949](https://github.com/stefanpenner/ember-cli/pull/949)
+* [ENHANCEMENT] Provide `registry` access from `EmberApp`. [#955](https://github.com/stefanpenner/ember-cli/pull/955)
 
 ### 0.0.29
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -47,6 +47,8 @@ function EmberApp(options) {
   this.env  = process.env.EMBER_ENV || 'development';
   this.name = options.name;
 
+  this.registry = options.registry || p.setupRegistry(this);
+
   var isProduction = this.env === 'production';
 
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
@@ -305,7 +307,7 @@ EmberApp.prototype.styles = memoize(function() {
     description: 'TreeMerger (stylesAndVendor)'
   });
 
-  var processedStyles = preprocessCss(stylesAndVendor, this.trees.styles, '/assets');
+  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets');
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles,
     outputFile: '/assets/vendor.css',

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -7,23 +7,27 @@ var path         = require('path');
 var Registry     = require('./preprocessors/registry');
 var requireLocal = require('./utilities/require-local');
 
-var registry = new Registry(deps);
+var registry;
 
-registry.add('css', 'broccoli-sass', 'scss');
-registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
-registry.add('css', 'broccoli-less-single', 'less');
-registry.add('css', 'broccoli-stylus-single', 'styl');
+module.exports.setupRegistry = function(app) {
+  registry = new Registry(deps, app);
 
-registry.add('minify-css', 'broccoli-csso', null);
+  registry.add('css', 'broccoli-sass', 'scss');
+  registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
+  registry.add('css', 'broccoli-less-single', 'less');
+  registry.add('css', 'broccoli-stylus-single', 'styl');
 
-registry.add('js', 'broccoli-coffee', 'coffee');
-registry.add('js', 'broccoli-ember-script', 'em');
-registry.add('js', 'broccoli-sweetjs', 'js');
+  registry.add('minify-css', 'broccoli-csso', null);
 
-registry.add('template', 'broccoli-ember-hbs-template-compiler', ['hbs', 'handlebars']);
-registry.add('template', 'broccoli-emblem-compiler', ['embl', 'emblem']);
+  registry.add('js', 'broccoli-coffee', 'coffee');
+  registry.add('js', 'broccoli-ember-script', 'em');
+  registry.add('js', 'broccoli-sweetjs', 'js');
 
-module.exports.registerPlugin = registry.add.bind(registry);
+  registry.add('template', 'broccoli-ember-hbs-template-compiler', ['hbs', 'handlebars']);
+  registry.add('template', 'broccoli-emblem-compiler', ['embl', 'emblem']);
+
+  return registry;
+};
 
 module.exports.isType = function(file, type) {
   var plugins   = registry.registry[type] || [];
@@ -47,7 +51,7 @@ module.exports.preprocessMinifyCss = function(tree, options) {
   return requireLocal(plugin.name).call(null, tree, options);
 };
 
-module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
+module.exports.preprocessCss = function(tree, inputPath, outputPath) {
   var plugin = registry.load('css');
 
   if (!plugin) {
@@ -61,19 +65,17 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
 
     // when our application is named `app` there is no
     // need to move the static css file.
-    if (pkg.name === 'app') {
+    if (registry.app.name === 'app') {
       return styles;
     }
 
     return fileMover(styles, {
       srcFile: 'assets/app.css',
-      destFile: 'assets/' + pkg.name + '.css'
+      destFile: 'assets/' + registry.app.name + '.css'
     });
   }
 
-  var input = path.join(inputPath, 'app.' + plugin.getExt(inputPath, 'app'));
-  var output = path.join(outputPath, pkg.name + '.css');
-  return requireLocal(plugin.name).call(null, [tree], input, output, options);
+  return plugin.toTree.apply(plugin, arguments);
 };
 
 module.exports.preprocessTemplates = function(tree) {

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -3,15 +3,31 @@
 var path   = require('path');
 var fs     = require('fs');
 var detect = require('lodash-node/modern/collections/find');
+var requireLocal = require('../utilities/require-local');
 
-function Plugin(name, ext) {
+function Plugin(name, ext, options) {
   this.name = name;
   this.ext = ext;
+  this.options = options || {};
+  this.registry = this.options.registry;
+  this.applicationName = this.options.applicationName;
+
+  if (this.options.toTree) {
+    this.toTree = this.options.toTree;
+  }
 }
 
-function Registry(plugins) {
+Plugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
+  var input = path.join(inputPath, 'app.' + this.getExt(inputPath, 'app'));
+  var output = path.join(outputPath, this.applicationName + '.css');
+
+  return requireLocal(this.name).call(null, [tree], input, output, options);
+};
+
+function Registry(plugins, app) {
   this.registry = {};
   this.availablePlugins = plugins;
+  this.app = app;
 }
 
 module.exports = Registry;
@@ -27,10 +43,15 @@ Registry.prototype.load = function(type) {
 };
 
 
-Registry.prototype.add = function(type, name, extension) {
+Registry.prototype.add = function(type, name, extension, options) {
   var registered = this.registry[type] = this.registry[type] || [];
 
-  registered.push(new Plugin(name, extension));
+  options = options || {};
+  options.applicationName = this.app.name;
+
+  var plugin = new Plugin(name, extension, options);
+
+  registered.push(plugin);
 };
 
 Plugin.prototype.getExt = function(inputPath, filename) {

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -4,7 +4,7 @@ var assign         = require('lodash-node/modern/objects/assign');
 var assert         = require('../../helpers/assert');
 var PluginRegistry = require('../../../lib/preprocessors/registry');
 
-var pkg, registry;
+var pkg, registry, app;
 
 describe('Plugin Loader', function() {
 
@@ -18,7 +18,9 @@ describe('Plugin Loader', function() {
         'broccoli-coffee': 'latest'
       }
     };
-    registry = new PluginRegistry(assign(pkg.devDependencies, pkg.dependencies));
+
+    app = { name: 'some-application-name' };
+    registry = new PluginRegistry(assign(pkg.devDependencies, pkg.dependencies), app);
     registry.add('css', 'broccoli-sass', 'scss');
     registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
   });
@@ -62,6 +64,13 @@ describe('Plugin Loader', function() {
     var plugin = registry.load('css');
     assert.equal(plugin.ext[0], 'scss');
     assert.equal(plugin.ext[1], 'sass');
+  });
+
+  it('provides the application name to each plugin', function() {
+    registry.add('js', 'broccoli-coffee');
+    var plugin = registry.load('js');
+
+    assert.equal(plugin.applicationName, 'some-application-name');
   });
 
 });


### PR DESCRIPTION
- Allows customizing registry within `Brocfile.js`.
- Provides registry with `EmberApp` instance.
- Makes each `Plugin` have a `toTree` method. This will allow plugins that take a different signature to work properly (assuming they implement a custom `toTree`).
- Provides `name` property that is provided to `EmberApp` to plugin.  This allows the plugin to name the generated output file properly.

Fixes #954.
Fixes #827.
