### PR TITLE
Allow opting out of ES3SafeFilter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-cli Changelog
 
+* Allow opting out of `ES3SafeFilter` until Recast can handle full ES6 syntax. [#966](https://github.com/stefanpenner/ember-cli/pull/966)
+
 ### 0.0.33
 
 * [BUGFIX] broccoli-sane-watcher now recovers after filters throw [#940](https://github.com/stefanpenner/ember-cli/pull/940)

--- a/blueprints/app/files/Brocfile.js
+++ b/blueprints/app/files/Brocfile.js
@@ -5,6 +5,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 var app = new EmberApp({
   name: require('./package.json').name,
 
+  // for some large projects, you may want to uncomment this (for now)
+  es3Safe: true,
+
   minifyCSS: {
     enabled: true,
     options: {}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -55,6 +55,7 @@ function EmberApp(options) {
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
 
   this.options = defaults(options, {
+    es3Safe: true,
     wrapInEval: false,
     minifyCSS: {
       enabled: true,
@@ -275,7 +276,9 @@ EmberApp.prototype.javascript = memoize(function() {
     outputFile: '/assets/' + this.name + '.js',
   });
 
-  var safeEs6 = new ES3SafeFilter(es6);
+  if (this.options.es3Safe) {
+    es6 = new ES3SafeFilter(es6);
+  }
 
   var vendor = concatFiles(applicationJs, {
     inputFiles: legacyFilesToAppend,
@@ -283,7 +286,7 @@ EmberApp.prototype.javascript = memoize(function() {
     wrapInEval: this.options.wrapInEval
   });
 
-  var vendorAndApp = mergeTrees([vendor, safeEs6]);
+  var vendorAndApp = mergeTrees([vendor, es6]);
 
   if (this.env === 'production' && this.options.minifyJS.enabled === true) {
     var options = this.options.minifyJS.options || {};


### PR DESCRIPTION
We were forced to move the `ES3SafeFilter` step to only operate on transpiled ES6 output (since it fails on some ES6 module syntax).

Sadly, this means that we are reprocessing the ENTRIE app/ tree for every rebuild.  Which is **SLOW**!!
