### PR TITLE
Update 2014-04-01-naming-conventions.md

### DIFF
--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -33,7 +33,7 @@ export default Ember.ObjectController.extend({});
 {% endhighlight %}
 
 And if it's a nested controller, we can declare nested/child controllers
-like such: `app/controllers/test/index.js`.
+like such: `app/controllers/posts/index.js`.
 
 ##### Helpers
 


### PR DESCRIPTION
I think the example for adapter syntax is not a traditional way. It's a new syntax.

I think if it's a nested controller then we use forward slash to show hierarchy. 
