### PR TITLE
relative path fix in preprocessors.js

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -70,8 +70,8 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath) {
     }
 
     return fileMover(styles, {
-      srcFile: 'assets/app.css',
-      destFile: 'assets/' + registry.app.name + '.css'
+      srcFile: outputPath + '/app.css',
+      destFile: outputPath + '/' + registry.app.name + '.css'
     });
   }
 


### PR DESCRIPTION
I was poking through the code trying to figure out how ember-cli works its magic and I came across this. I'm guessing that this function is not supposed to be assuming the compiled css file is located in 'assets', but rather in outputPath. Sorry if I'm mistaken.
