### PR TITLE
Make sure the build traps `SIGINT` and `SIGTERM` for cleanup.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -13,7 +13,7 @@ module.exports = Task.extend({
 
     process.addListener('exit', this.onExit.bind(this));
 
-    if (signalsTrapped) {
+    if (!signalsTrapped) {
       process.on('SIGINT',  this.onSIGINT.bind(this));
       process.on('SIGTERM', this.onSIGTERM.bind(this));
       signalsTrapped = true;


### PR DESCRIPTION
Exiting from `ember server` stopped cleaning up the `./tmp` directory after exit, which means the directory would expand in size until manually deleted.

**_MIGHT**_ have caused some EMFILE errors as well.  I have no proof. Though.

Traces back to a mis-refactor from https://github.com/stefanpenner/ember-cli/blob/v0.0.28/lib/utilities/build-builder.js#L16
