### PR TITLE
[fixes ] update es3 filter to v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ember-cli Changelog
 
-* [Bugfix] upgrade broccoli-sane-watcher to include better error messages when attempting to watch non-existent files
+* [BUGFIX] broccoli-es6-safe-recast now once again has one-at-a-time semantics for incremental rebuilds
+* [BUGFIX] upgrade broccoli-sane-watcher to include better error messages when attempting to watch non-existent files
 * Allow opting out of `ES3SafeFilter` until Recast can handle full ES6 syntax. [#966](https://github.com/stefanpenner/ember-cli/pull/966)
 * [ENHANCEMENT] Provide `--watcher` option for switching between polling and events-based file watching. [#970](https://github.com/stefanpenner/ember-cli/pull/970)
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -184,6 +184,10 @@ EmberApp.prototype._processedVendorTree = memoize(function() {
 
 EmberApp.prototype.appAndDependencies = memoize(function() {
   var app    = this._processedAppTree();
+  if (this.options.es3Safe) {
+    app= new ES3SafeFilter(app);
+  }
+
   var vendor = this._processedVendorTree();
 
   var appAndTemplates = preprocessTemplates(app);
@@ -275,10 +279,6 @@ EmberApp.prototype.javascript = memoize(function() {
     wrapInEval: this.options.wrapInEval,
     outputFile: '/assets/' + this.name + '.js',
   });
-
-  if (this.options.es3Safe) {
-    es6 = new ES3SafeFilter(es6);
-  }
 
   var vendor = concatFiles(applicationJs, {
     inputFiles: legacyFilesToAppend,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "broccoli-asset-rev": "0.0.5",
     "broccoli-clean-css": "0.1.5",
     "broccoli-concat": "0.0.6",
-    "broccoli-es3-safe-recast": "0.0.5",
+    "broccoli-es3-safe-recast": "0.0.7",
     "broccoli-es6-concatenator": "~0.1.6",
     "broccoli-export-tree": "0.3.2",
     "broccoli-file-mover": "~0.3.5",


### PR DESCRIPTION
- it now uses the same esprima as the module transpiler, so it should
  work on all versions of esprima that it does.
- due to ^^ we can now re-introduce one at a time semantics for this
  transpile step (faster incremental builds)

Signed-off-by: Stefan Penner stefan.penner@gmail.com
