### PR TITLE
Do not wrap vendor in eval when `wrapInEval` is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [ENHANCEMENT] Provide `--watcher` option for switching between polling and events-based file watching. [#970](https://github.com/stefanpenner/ember-cli/pull/970)
 * [BUGFIX] Ensure that tmp/ is cleaned up after running `ember server` or `ember test --server`. [#971](https://github.com/stefanpenner/ember-cli/pull/971)
 * [BUGFIX] Fix errors with certain `generate` commands that depend on `inflection`. [f016820](https://github.com/stefanpenner/ember-cli/commit/f016820)
+* [BUGFIX] Do not wrap `vendor` assets in eval when `wrapInEval` is set. [#983](https://github.com/stefanpenner/ember-cli/pull/983)
+* [ENHANCEMENT] Use `wrapInEval` by default for application assets when running in development. [#983](https://github.com/stefanpenner/ember-cli/pull/983)
 
 ### 0.0.33
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -56,7 +56,7 @@ function EmberApp(options) {
 
   this.options = defaults(options, {
     es3Safe: true,
-    wrapInEval: false,
+    wrapInEval: !isProduction,
     minifyCSS: {
       enabled: true,
       options: {}
@@ -282,8 +282,7 @@ EmberApp.prototype.javascript = memoize(function() {
 
   var vendor = concatFiles(applicationJs, {
     inputFiles: legacyFilesToAppend,
-    outputFile: '/assets/vendor.js',
-    wrapInEval: this.options.wrapInEval
+    outputFile: '/assets/vendor.js'
   });
 
   var vendorAndApp = mergeTrees([vendor, es6]);


### PR DESCRIPTION
- Ensure that using `wrapInEval` still creates a functional application.
- Enable `wrapInEval` for app/ (aka not vendor) files while in development.

Fix #980.
