### PR TITLE
Add Brocfile test for `wrapInEval`.

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var tmp        = require('../helpers/tmp');
+var conf       = require('../helpers/conf');
+var Promise    = require('../../lib/ext/promise');
+var path       = require('path');
+var rimraf     = Promise.denodeify(require('rimraf'));
+var fs         = require('fs');
+var ncp        = Promise.denodeify(require('ncp'));
+var runCommand = require('../helpers/run-command');
+
+var appName  = 'some-cool-app';
+
+var rootPath = process.cwd();
+
+function buildApp(appName) {
+  return runCommand(path.join('..', 'bin', 'ember'), 'new', appName, {
+    onOutput: function() {
+      return; // no output for initial application build
+    }
+  });
+}
+
+function copyFixtureFiles(sourceDir) {
+  return ncp(path.join(rootPath, 'tests', 'fixtures', 'brocfile-tests', sourceDir), '.', {
+    clobber: true,
+    stopOnErr: true
+  });
+}
+
+describe('Acceptance: brocfile-smoke-test', function() {
+  before(function() {
+    this.timeout(360000);
+
+    tmp.setup('./common-tmp');
+    process.chdir('./common-tmp');
+
+    conf.setup();
+    return buildApp(appName)
+      .then(function() {
+        return rimraf(path.join(appName, 'node_modules', 'ember-cli'));
+      });
+  });
+
+  after(function() {
+    tmp.teardown('./common-tmp');
+    conf.restore();
+  });
+
+  beforeEach(function() {
+    this.timeout(10000);
+    tmp.setup('./tmp');
+    return ncp('./common-tmp/' + appName, './tmp/' + appName, {
+      clobber: true,
+      stopOnErr: true
+    })
+    .then(function() {
+      process.chdir('./tmp');
+
+      var appsECLIPath = path.join(appName, 'node_modules', 'ember-cli');
+      var pwd = process.cwd();
+
+      fs.symlinkSync(path.join(pwd, '..'), appsECLIPath);
+
+      process.chdir(appName);
+    });
+  });
+
+  afterEach(function() {
+    tmp.teardown('./tmp');
+  });
+
+  it('using wrapInEval: true', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return copyFixtureFiles('wrap-in-eval')
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test').then(console.log);
+      });
+  });
+});
+

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/Brocfile.js
@@ -1,0 +1,13 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+var app = new EmberApp({
+  name: require('./package.json').name,
+
+  wrapInEval: true,
+
+  getEnvJSON: require('./config/environment')
+});
+
+module.exports = app.toTree();

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -1,0 +1,27 @@
+/*jshint strict:false */
+/* globals test, expect, equal, visit, andThen */
+
+import Ember from 'ember';
+import startApp    from '../helpers/start-app';
+
+var App;
+
+module('wrapInEval in-app test', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+
+test('the application boots properly with wrapInEval', function() {
+  expect(1);
+
+  visit('/');
+
+  andThen(function() {
+    equal(Ember.$('#title').text(), 'Welcome to Ember.js');
+  });
+});


### PR DESCRIPTION
This adds a structure and slow smoke test file for fleshing out `Brocfile.js` tests. 

Adds first test addressing #917.
