### PR TITLE
Add integration-test blueprint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 node_modules/*
 blueprints/*
+tests/fixtures/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BUGFIX] Fix errors with certain `generate` commands that depend on `inflection`. [f016820](https://github.com/stefanpenner/ember-cli/commit/f016820)
 * [BUGFIX] Do not wrap `vendor` assets in eval when `wrapInEval` is set. [#983](https://github.com/stefanpenner/ember-cli/pull/983)
 * [ENHANCEMENT] Use `wrapInEval` by default for application assets when running in development. [#983](https://github.com/stefanpenner/ember-cli/pull/983)
+* [ENHANCEMENT] Add integration-test blueprint [#985](https://github.com/stefanpenner/ember-cli/pull/985)
 
 ### 0.0.33
 

--- a/blueprints/integration-test/files/tests/integration/__name__-test.js
+++ b/blueprints/integration-test/files/tests/integration/__name__-test.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+
+module('Integration - <%= classifiedModuleName %>', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /<%= dasherizedModuleName %>', function() {
+  visit('/<%= dasherizedModuleName %>');
+
+  andThen(function() {
+    equal(currentPath(), '<%= dasherizedModuleName %>');
+  });
+});

--- a/blueprints/integration-test/index.js
+++ b/blueprints/integration-test/index.js
@@ -1,0 +1,4 @@
+var Blueprint = require('../../lib/models/blueprint');
+
+module.exports = Blueprint.extend({
+});

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -2,17 +2,18 @@
 
 'use strict';
 
-var Promise    = require('../../lib/ext/promise');
-var assertFile = require('../helpers/assert-file');
-var conf       = require('../helpers/conf');
-var ember      = require('../helpers/ember');
-var fs         = require('fs-extra');
-var outputFile = Promise.denodeify(fs.outputFile);
-var path       = require('path');
-var rimraf     = require('rimraf');
-var root       = process.cwd();
-var tmp        = require('tmp-sync');
-var tmproot    = path.join(root, 'tmp');
+var Promise          = require('../../lib/ext/promise');
+var assertFile       = require('../helpers/assert-file');
+var assertFileEquals = require('../helpers/assert-file-equals');
+var conf             = require('../helpers/conf');
+var ember            = require('../helpers/ember');
+var fs               = require('fs-extra');
+var outputFile       = Promise.denodeify(fs.outputFile);
+var path             = require('path');
+var rimraf           = require('rimraf');
+var root             = process.cwd();
+var tmp              = require('tmp-sync');
+var tmproot          = path.join(root, 'tmp');
 
 describe('Acceptance: ember generate', function() {
   var tmpdir;
@@ -477,5 +478,13 @@ describe('Acceptance: ember generate', function() {
           contains: 'custom: true'
         });
       });
+  });
+
+  it('integration-test foo', function() {
+    return generate(['integration-test', 'foo']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/integration-test-expected.js');
+
+      assertFileEquals('tests/integration/foo-test.js', expected);
+    });
   });
 });

--- a/tests/fixtures/generate/integration-test-expected.js
+++ b/tests/fixtures/generate/integration-test-expected.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+
+module('Integration - Foo', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /foo', function() {
+  visit('/foo');
+
+  andThen(function() {
+    equal(currentPath(), 'foo');
+  });
+});

--- a/tests/helpers/assert-file-equals.js
+++ b/tests/helpers/assert-file-equals.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var assert = require('../helpers/assert');
+var fs     = require('fs');
+
+/*
+  Assert that a given file matches another.
+
+  @method assertFileEqual
+  @param {String} pathToActual
+  @param {String} pathToExpected
+*/
+module.exports = function assertFileEquals(pathToActual, pathToExpected) {
+  var actual = fs.readFileSync(pathToActual, { encoding: 'utf-8' });
+  var expected = fs.readFileSync(pathToExpected, { encoding: 'utf-8' });
+
+  assert.equal(actual, expected);
+};


### PR DESCRIPTION
``` sh
$ ember g integration-test foo
version: 0.0.34
installing
  create tests/integration/foo-test.js
```

``` js
import startApp from '../helpers/start-app';

var App;

module('Integration - Foo', {
  setup: function() {
    App = startApp();
  },
  teardown: function() {
    Ember.run(App, 'destroy');
  }
});

test('visiting /foo', function() {
  visit('/foo');

  andThen(function() {
    equal(currentPath(), 'foo');
  });
});
```
