### PR TITLE
Ensure JS is concated safely.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-cli Changelog
 
+* [BUGFIX] Ensure that vendored JS files are concatted in a safe way (to prevent issues with ASI). [#988](https://github.com/stefanpenner/ember-cli/pull/988)
+
 ### 0.0.34
 
 * [BUGFIX] broccoli-es6-safe-recast now once again has one-at-a-time semantics this improves incremental rebuild performance

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -282,7 +282,8 @@ EmberApp.prototype.javascript = memoize(function() {
 
   var vendor = concatFiles(applicationJs, {
     inputFiles: legacyFilesToAppend,
-    outputFile: '/assets/vendor.js'
+    outputFile: '/assets/vendor.js',
+    separator: '\n;'
   });
 
   var vendorAndApp = mergeTrees([vendor, es6]);


### PR DESCRIPTION
Using app.import to include javascript files can fail depending on how the two
files end/start. Pretender 0.0.6 had this issue (has been fixed in 0.0.7).
