### PR TITLE
Use Project model from EmberApp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ember-cli Changelog
 
 * [BUGFIX] Ensure that vendored JS files are concatted in a safe way (to prevent issues with ASI). [#988](https://github.com/stefanpenner/ember-cli/pull/988)
+* [ENHANCEMENT] Use the `Project` model to load the project name and environment configuration (removes boilerplate from `Brocfile.js`). [#989](https://github.com/stefanpenner/ember-cli/pull/989)
 
 ### 0.0.34
 

--- a/blueprints/app/files/Brocfile.js
+++ b/blueprints/app/files/Brocfile.js
@@ -2,19 +2,7 @@
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-var app = new EmberApp({
-  name: require('./package.json').name,
-
-  // for some large projects, you may want to uncomment this (for now)
-  es3Safe: true,
-
-  minifyCSS: {
-    enabled: true,
-    options: {}
-  },
-
-  getEnvJSON: require('./config/environment')
-});
+var app = new EmberApp();
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -3,6 +3,7 @@
 
 var p = require('../preprocessors');
 
+var Project      = require('../models/project');
 var cleanBaseURL = require('../utilities/clean-base-url');
 
 var preprocessJs  = p.preprocessJs;
@@ -44,8 +45,12 @@ function mergeTrees(inputTree, options) {
 module.exports = EmberApp;
 
 function EmberApp(options) {
+  options = options || {};
+
+  this.project = options.project || Project.closestSync(process.cwd());
+
   this.env  = process.env.EMBER_ENV || 'development';
-  this.name = options.name;
+  this.name = options.name || this.project.name();
 
   this.registry = options.registry || p.setupRegistry(this);
 
@@ -77,6 +82,7 @@ function EmberApp(options) {
     },
     loader: 'vendor/loader/loader.js',
     trees: {},
+    getEnvJSON: this.project.require('./config/environment')
   });
 
   this.options.trees = defaults(this.options.trees, {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -7,6 +7,8 @@ var RSVP    = require('rsvp');
 var resolve = RSVP.denodeify(require('resolve'));
 var fs      = require('fs');
 
+var findupSync  = require('findup').sync;
+
 function Project(root, pkg) {
   this.root = root;
   this.pkg  = pkg;
@@ -52,13 +54,18 @@ Project.closest = function(pathName) {
       return new Project(result.directory, result.pkg);
     })
     .catch(function(reason) {
-      // Would be nice if findup threw error subclasses
-      if (reason && /not found/i.test(reason.message)) {
-        throw new NotFoundError('No project found at or up from: `' + pathName + '`');
-      } else {
-        throw reason;
-      }
+      handleFindupError(pathName, reason);
     });
+};
+
+Project.closestSync = function(pathName) {
+  try {
+    var directory = findupSync(pathName, 'package.json');
+
+    return new Project(directory, require(path.join(directory, 'package.json')));
+  } catch(reason) {
+    handleFindupError(pathName, reason);
+  }
 };
 
 var NULL_PROJECT = new Project(undefined, undefined);
@@ -92,6 +99,15 @@ function closestPackageJSON(pathName) {
         pkg: require(path.join(directory, 'package.json'))
       });
     });
+}
+
+function handleFindupError(pathName, reason) {
+  // Would be nice if findup threw error subclasses
+  if (reason && /not found/i.test(reason.message)) {
+    throw new NotFoundError('No project found at or up from: `' + pathName + '`');
+  } else {
+    throw reason;
+  }
 }
 
 // Export


### PR DESCRIPTION
- Add `Project.closestSync` (we cannot do async in `Brocfile.js` right now).
- Use `Project.require` and `Project.name` logic for `EmberApp`.
- Remove boilerplate/defaulted params from `Brocfile.js`.

Fixes #397.

---

Making the `EmberApp` use `Project` is the first step to adding centralized logic for discovering addons.
