### PR TITLE
Add smoke tests for default Brocfile.

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -80,5 +80,16 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test').then(console.log);
       });
   });
+
+  it('default development build tests', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return copyFixtureFiles('default-development')
+    .then(function() {
+      return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+    });
+  });
 });
 

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -1,0 +1,27 @@
+/*jshint strict:false */
+/* globals test, expect, equal, visit, andThen */
+
+import Ember from 'ember';
+import startApp    from '../helpers/start-app';
+
+var App;
+
+module('default-development - Integration', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+
+test('the application boots properly', function() {
+  expect(1);
+
+  visit('/');
+
+  andThen(function() {
+    equal(Ember.$('#title').text(), 'Welcome to Ember.js');
+  });
+});


### PR DESCRIPTION
Confirm that a blueprinted `Brocfile.js` can boot and pass tests.

Adds more coverage for #917.
