### PR TITLE
Allow specifying `ember test --port`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [BUGFIX] Ensure that vendored JS files are concatted in a safe way (to prevent issues with ASI). [#988](https://github.com/stefanpenner/ember-cli/pull/988)
 * [ENHANCEMENT] Use the `Project` model to load the project name and environment configuration (removes boilerplate from `Brocfile.js`). [#989](https://github.com/stefanpenner/ember-cli/pull/989)
+* [BUGFIX] Pass `--port` option through when calling `ember test --port 8987` (allows overriding the port when running concurrent `ember test` commands). [#991](https://github.com/stefanpenner/ember-cli/pull/991)
 
 ### 0.0.34
 

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -5,11 +5,16 @@ var Testem  = require('testem');
 var Promise = require('../ext/promise');
 
 module.exports = Task.extend({
-  run: function(options) {
-    var testemOptions = { file: options.configFile, cwd: 'tmp/output'};
-    var testem  = new Testem();
+  invokeTestem: function (testemOptions) {
+    var testem = new Testem();
 
     testem.startCI(testemOptions);
+  },
+
+  run: function(options) {
+    var testemOptions = { file: options.configFile, port: options.port, cwd: 'tmp/output' };
+
+    this.invokeTestem(testemOptions);
 
     return Promise.resolve();
   }

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var assert   = require('../../helpers/assert');
+var TestTask = require('../../../lib/tasks/test');
+
+describe('test', function() {
+  var subject;
+
+  it('transforms the options and invokes testem properly', function() {
+    subject = new TestTask({
+      invokeTestem: function(options) {
+        assert.equal(options.file, 'blahzorz.conf');
+        assert.equal(options.port, 123324);
+        assert.equal(options.cwd, 'tmp/output');
+      }
+    });
+
+    subject.run({
+      configFile: 'blahzorz.conf',
+      port: 123324
+    });
+  });
+});
+


### PR DESCRIPTION
Prevents errors from occuring when running `ember test` while also running `ember test --server` (possibly in separate projects).

/cc @krisselden
