### PR TITLE
Make Project aware of addons.

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -6,6 +6,7 @@ var findup  = Promise.denodeify(require('findup'));
 var RSVP    = require('rsvp');
 var resolve = RSVP.denodeify(require('resolve'));
 var fs      = require('fs');
+var assign  = require('lodash-node/modern/objects/assign');
 
 var findupSync  = require('findup').sync;
 
@@ -46,6 +47,31 @@ Project.prototype.require = function(file) {
   } else {
     return require(path.join(this.root, 'node_modules', file));
   }
+};
+
+Project.prototype.dependencies = function() {
+  return assign(this.pkg['devDependencies'], this.pkg['dependencies']);
+};
+
+Project.prototype.availableAddons = function() {
+  return Object.keys(this.dependencies()).filter(function(name) {
+    if (name === 'ember-cli') { return false; }
+
+    var addonPkg = require(path.join(this.root, 'node_modules', name, 'package.json'));
+
+    if ((addonPkg.keywords || []).indexOf('ember-cli-addon') > -1) {
+      return true;
+    }
+
+  }, this);
+};
+
+Project.prototype.addons = function() {
+  return this.availableAddons().map(function(name) {
+    var Addon = require(path.join(this.root, 'node_modules', name));
+
+    return new Addon(this);
+  }, this);
 };
 
 Project.closest = function(pathName) {

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var assign       = require('lodash-node/modern/objects/assign');
-var pkg          = require(process.cwd() + '/package');
-var deps         = assign(pkg['devDependencies'], pkg['dependencies']);
 var path         = require('path');
 var Registry     = require('./preprocessors/registry');
 var requireLocal = require('./utilities/require-local');
@@ -10,7 +7,7 @@ var requireLocal = require('./utilities/require-local');
 var registry;
 
 module.exports.setupRegistry = function(app) {
-  registry = new Registry(deps, app);
+  registry = new Registry(app.project.dependencies(), app);
 
   registry.add('css', 'broccoli-sass', 'scss');
   registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
@@ -1,0 +1,6 @@
+function EmberRandomAddon(project) {
+  this.project = project;
+  this.name = 'Ember Random Addon';
+}
+
+module.exports = EmberRandomAddon;

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ember-random-addon",
+  "private": true,
+  "keywords": [
+    "ember-cli-addon"
+  ]
+}
+

--- a/tests/fixtures/addon/simple/node_modules/non-ember-thingy/package.json
+++ b/tests/fixtures/addon/simple/node_modules/non-ember-thingy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "non-ember-thingy",
+  "private": true,
+  "keywords": [ ]
+}

--- a/tests/fixtures/addon/simple/node_modules/something-else/package.json
+++ b/tests/fixtures/addon/simple/node_modules/something-else/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "something-else",
+  "private": true
+}
+

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+    "something-else": "latest"
+  },
+  "devDependencies": {
+    "ember-cli": "latest",
+    "ember-random-addon": "latest",
+    "non-ember-thingy": "latest"
+  }
+}
+


### PR DESCRIPTION
- Add `Project.prototype.dependencies` as a list of all dependencies & devDependencies in the projects `package.json`.
- Add `Project.prototype.availableAddons` as a list of all dependencies that contain the `ember-cli-addon` keyword.
- Add `Project.prototype.addons` as an array of instances of each addon found.
  - The addon package is required and a new instance is created.
  - The current project instance will be passed to the addons
    constructor.
- Update preprocessors to use the project's dependencies.
