### PR TITLE
Root the `.jshintrc` lookup to the project root path.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -208,6 +208,7 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
 
     if (this.hinting) {
       var jshintedApp = jshintTrees(app, {
+        jshintrcRoot: this.project.root,
         description: 'JSHint - App'
       });
       var jshintedTests = jshintTrees(tests, {


### PR DESCRIPTION
Now that the `EmberApp` has access to our `Project` instance, we can simply use its `root` property to know where the correct `.jshintrc` file is.

Fixes #962.
