### PR TITLE
Add notes on testing

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -15,9 +15,17 @@ The default tests in Ember CLI use the [QUnit](http://qunitjs.com/) library.
 The included tests demonstrate how to write both unit tests and
 acceptance/integration tests using the new [ember-testing package](http://ianpetzer.wordpress.com/2013/06/14/getting-started-with-integration-testing-ember-js-using-ember-testing-and-qunit-rails/).
 
+Test filenames should be suffixed with `-test.js` in order to run.
+
 To run the tests in your browser using the QUnit interface, run `ember server`
 and navigate to `http://localhost:4200/tests`. Note that just like your app, your
 tests will auto rebuild when `ember server` is running.
+
+By default, your integration tests will run on [PhantomJS](http://phantomjs.org/).  You can install via [npm](https://www.npmjs.org/):
+
+{% highlight bash %}
+npm install -g phantomjs
+{% endhighlight %}
 
 ### CI Mode with Testem.
 

--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -223,3 +223,7 @@ We can then embed our view using the following convention:
 
 Note, that we did not namespace `UserView`. The resolver takes care of this for you.
 For more information about the default Ember resolver, check out the source [here](https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/resolver.js).
+
+### Tests
+
+Test filenames should be suffixed with `-test.js` in order to run.


### PR DESCRIPTION
I was stuck on getting my tests to run and only found what I needed by searching issues.

I've added notes to the docs to suggest including `-test.js` to the end of tests in both the testing and filenames sections.

I've also duplicated the note to install PhantomJS, as I personally missed that elsewhere and was looking for it in the testing section.

Thanks!
