### PR TITLE
Allow passing customHash in fingerprint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Allow fingerprinting to be enabled/disabled in a more custom way. [#1066](https://github.com/stefanpenner/ember-cli/pull/1066)
 * [ENHANCEMENT] Use `ember-addon` as the "addon" keyword. [#1071](https://github.com/stefanpenner/ember-cli/pull/1071)
 * [ENHANCEMENT] loader should now support CJS mode of AMD.
+* [ENHANCEMENT] Upgrade broccoli-asset-rev to 0.0.6 and allow passing a `customHash` in fingerprint options. [#1024](https://github.com/stefanpenner/ember-cli/pull/1024)
 
 ### 0.0.34
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -495,7 +495,8 @@ EmberApp.prototype.fingerprint = function(tree) {
     fingerprintExtensions: this.options.fingerprint.extensions,
     fingerprintExclude:    this.options.fingerprint.exclude,
     replaceExtensions:     this.options.fingerprint.replaceExtensions,
-    prependPath:           this.options.fingerprint.prepend
+    prependPath:           this.options.fingerprint.prepend,
+    customHash:            this.options.fingerprint.customHash
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bower": "^1.3.2",
     "bower-config": "^0.5.1",
     "broccoli": "0.12.1",
-    "broccoli-asset-rev": "0.0.5",
+    "broccoli-asset-rev": "0.0.6",
     "broccoli-clean-css": "0.1.5",
     "broccoli-concat": "0.0.6",
     "broccoli-es3-safe-recast": "0.0.7",


### PR DESCRIPTION
This adds a `customHash` option that can be passed to the fingerprint configuration:

```
var app = new EmberApp({
  fingerprint: {
    enabled: true,
    customHash: 'custom123'
  }
});
```

The result is that fingerprinted files will use the `customHash` string instead of a MD5 hash of the file. (e.g. "assets/vendor-5429f75166356b28c3e42dd401abaf36.js" becomes "assets/vendor-custom123.js").

The motivation behind this is that it's difficult to get the names of fingerprinted files if you aren't using the ember-cli generated dist/index.html file. By using `customHash`, you can set the fingerprint to be something like the current commit's SHA if you are working in a git repo or a version number from a package.json file. Those are easier to predict and setup in a non ember-cli generated index.html template elsewhere.

It relies on some new functionality released in broccoli-asset-rev 0.0.6.
