### PR TITLE
Incorporate addons into EmberApp.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1,7 +1,8 @@
 /* global require, module */
 'use strict';
 
-var p = require('../preprocessors');
+var fs = require('fs');
+var p  = require('../preprocessors');
 
 var Project      = require('../models/project');
 var cleanBaseURL = require('../utilities/clean-base-url');
@@ -101,10 +102,34 @@ function EmberApp(options) {
   this.trees = this.options.trees;
 
   this.populateLegacyFiles();
+  this._notifyAddonIncluded();
 }
 
-EmberApp.prototype.populateLegacyFiles = function () {
+EmberApp.prototype._notifyAddonIncluded = function() {
+  this.project.initializeAddons();
+  this.project.addons.forEach(function(addon) {
+    if (typeof addon.included !== 'function') {
+      throw new Error('The `' + addon.constructor.name + '` addon must implement the `included` hook.');
+    }
+    addon.included(this);
+  }, this);
+};
 
+EmberApp.prototype.addonTreesFor = function(type) {
+  var addonTrees = this.project.addons.map(function(addon) {
+    if (typeof addon.treeFor !== 'function') {
+      throw new Error('The `' + addon.constructor.name + '` addon must implement the `treeFor` hook.');
+    }
+
+    return addon.treeFor(type);
+  }, this);
+
+  return addonTrees.filter(function(tree) {
+    return !!tree;
+  });
+};
+
+EmberApp.prototype.populateLegacyFiles = function () {
   this.import('vendor/loader/loader.js');
 
   this.import('vendor/jquery/dist/jquery.js');
@@ -163,7 +188,13 @@ EmberApp.prototype.publicFolder = function() {
 };
 
 EmberApp.prototype._processedAppTree = memoize(function() {
-  return pickFiles(this.trees.app, {
+  var addonTrees = this.addonTreesFor('app');
+  var mergedApp  = mergeTrees(addonTrees.concat(this.trees.app), {
+    overwrite: true,
+    description: 'TreeMerger (app)'
+  });
+
+  return pickFiles(mergedApp, {
     srcDir: '/',
     destDir: this.name
   });
@@ -177,7 +208,8 @@ EmberApp.prototype._processedTestsTree = memoize(function() {
 });
 
 EmberApp.prototype._processedVendorTree = memoize(function() {
-  var mergedVendor = mergeTrees([this.trees.vendor].concat(this._importTrees), {
+  var addonTrees   = this.addonTreesFor('vendor');
+  var mergedVendor = mergeTrees(this._importTrees.concat(addonTrees, this.trees.vendor), {
     overwrite: true,
     description: 'TreeMerger (vendor)'
   });
@@ -304,16 +336,18 @@ EmberApp.prototype.javascript = memoize(function() {
 });
 
 EmberApp.prototype.styles = memoize(function() {
+  var addonTrees = this.addonTreesFor('styles');
   var vendor = this._processedVendorTree();
   var styles = pickFiles(this.trees.styles, {
     srcDir: '/',
     destDir: '/app/styles'
   });
 
-  var stylesAndVendor = mergeTrees([
-    vendor,
-    styles
-  ], {
+  var trees = [vendor];
+  trees.concat(addonTrees);
+  trees.push(styles);
+
+  var stylesAndVendor = mergeTrees(trees, {
     description: 'TreeMerger (stylesAndVendor)'
   });
 
@@ -426,12 +460,14 @@ EmberApp.prototype.import = function(asset, modules) {
     throw new Error('You must pass a file to `app.import`. For directories specify them to the constructor under the `trees` option.');
   }
 
-  var assetTree = pickFiles(directory, {
-    srcDir: '/',
-    destDir: subdirectory
-  });
+  if (fs.existsSync(directory)) {
+    var assetTree = pickFiles(directory, {
+      srcDir: '/',
+      destDir: subdirectory
+    });
 
-  this._importTrees.push(assetTree);
+    this._importTrees.push(assetTree);
+  }
 
   if (isType(assetPath, 'js')) {
     this.legacyFilesToAppend.push(assetPath);

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -50,7 +50,7 @@ Project.prototype.require = function(file) {
 };
 
 Project.prototype.dependencies = function() {
-  return assign(this.pkg['devDependencies'], this.pkg['dependencies']);
+  return assign({}, this.pkg['devDependencies'], this.pkg['dependencies']);
 };
 
 Project.prototype.availableAddons = function() {
@@ -66,8 +66,8 @@ Project.prototype.availableAddons = function() {
   }, this);
 };
 
-Project.prototype.addons = function() {
-  return this.availableAddons().map(function(name) {
+Project.prototype.initializeAddons = function() {
+  this.addons = this.availableAddons().map(function(name) {
     var Addon = require(path.join(this.root, 'node_modules', name));
 
     return new Addon(this);

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
@@ -1,6 +1,27 @@
+'use strict';
+
+var path = require('path');
+var fs   = require('fs');
+
 function EmberRandomAddon(project) {
   this.project = project;
   this.name = 'Ember Random Addon';
 }
+
+function unwatchedTree(dir){
+  return {read: function() { return dir; }};
+}
+
+EmberRandomAddon.prototype.treeFor = function treeFor(name) {
+  var treePath = path.join(__dirname, name);
+
+  if (fs.existsSync(treePath)) {
+    return unwatchedTree(treePath);
+  }
+};
+
+EmberRandomAddon.prototype.included = function included(app) {
+  this.app = app;
+};
 
 module.exports = EmberRandomAddon;

--- a/tests/unit/broccoli/addon-hooks-test.js
+++ b/tests/unit/broccoli/addon-hooks-test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+var path     = require('path');
+var Project  = require('../../../lib/models/project');
+var EmberApp = require('../../../lib/broccoli/ember-app');
+var assert   = require('assert');
+var stub     = require('../../helpers/stub').stub;
+
+describe('broccoli/ember-app', function() {
+  var project, projectPath, emberApp, addonTreesForStub, addon;
+
+  describe('addons', function() {
+    beforeEach(function() {
+      projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+      project.require = function() {
+        return function() {};
+      };
+      project.initializeAddons = function() {
+        this.addons = [];
+      };
+    });
+
+    describe('included hook', function() {
+      it('included hook is called properly on instantiation', function() {
+        var called = false;
+        var passedApp;
+
+        addon = {
+          included: function(app) { called = true; passedApp = app; },
+          treeFor: function() { }
+        };
+
+        project.initializeAddons = function() {
+          this.addons = [ addon ];
+        };
+
+        emberApp = new EmberApp({
+          project: project
+        });
+
+        assert.ok(called);
+        assert.equal(passedApp, emberApp);
+      });
+
+      it('throws an error if the addon does not implement `included`', function() {
+        delete addon.included;
+
+        project.initializeAddons = function() {
+          this.addons = [ addon ];
+        };
+
+        assert.throws(
+          function() {
+            emberApp = new EmberApp({
+              project: project
+            });
+          },
+          /addon must implement the `included`/
+        );
+      });
+    });
+
+    describe('addonTreesFor', function() {
+      beforeEach(function() {
+        addon = {
+          included: function() { },
+          treeFor: function() { }
+        };
+
+        project.initializeAddons = function() {
+          this.addons = [ addon ];
+        };
+
+      });
+
+      it('addonTreesFor returns an empty array if no addons return a tree', function() {
+        emberApp = new EmberApp({
+          project: project
+        });
+
+        assert.deepEqual(emberApp.addonTreesFor('blah'), []);
+      });
+
+      it('addonTreesFor calls treesFor on the addon', function() {
+        emberApp = new EmberApp({
+          project: project
+        });
+
+        var sampleAddon = project.addons[0];
+        var actualTreeName;
+
+        sampleAddon.treeFor = function(name) {
+          actualTreeName = name;
+
+          return 'blazorz';
+        };
+
+        assert.deepEqual(emberApp.addonTreesFor('blah'), ['blazorz']);
+        assert.equal(actualTreeName, 'blah');
+      });
+
+      it('addonTreesFor throws an error if treeFor is not defined', function() {
+        delete addon.treeFor;
+
+        emberApp = new EmberApp({
+          project: project
+        });
+
+        assert.throws(
+          function() {
+            emberApp.addonTreesFor('blah');
+          },
+          /addon must implement the `treeFor`/
+        );
+      });
+
+      describe('addonTreesFor is called properly', function() {
+        beforeEach(function() {
+          emberApp = new EmberApp({
+            project: project
+          });
+
+          addonTreesForStub = stub(emberApp, 'addonTreesFor', []);
+        });
+
+        it('_processedVendorTree calls addonTreesFor', function() {
+          emberApp._processedVendorTree();
+
+          assert.equal(addonTreesForStub.calledWith[0][0], 'vendor');
+        });
+
+        it('_processedAppTree calls addonTreesFor', function() {
+          emberApp._processedAppTree();
+
+          assert.equal(addonTreesForStub.calledWith[0][0], 'app');
+        });
+
+        it('styles calls addonTreesFor', function() {
+          emberApp.styles();
+
+          assert.equal(addonTreesForStub.calledWith[0][0], 'styles');
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -14,11 +14,6 @@ describe('models/project.js', function() {
     projectPath = process.cwd() + '/tmp/test-app';
 
     before(function() {
-      Project.prototype.require = function() {
-        called = true;
-        return function() {};
-      };
-
       tmp.setup(projectPath);
 
       touch(projectPath + '/config/environment.js', {
@@ -26,6 +21,11 @@ describe('models/project.js', function() {
       });
 
       project = new Project(projectPath, { });
+      project.require = function() {
+        called = true;
+        return function() {};
+      };
+
     });
 
     after(function() {
@@ -44,6 +44,7 @@ describe('models/project.js', function() {
       var packageContents = require(path.join(projectPath, 'package.json'));
 
       project = new Project(projectPath, packageContents);
+      project.initializeAddons();
     });
 
     it('returns a listing of all dependencies in the projects package.json', function() {
@@ -64,13 +65,13 @@ describe('models/project.js', function() {
     });
 
     it('returns an instance of the addon', function() {
-      var addons = project.addons();
+      var addons = project.addons;
 
       assert.equal(addons[0].name, 'Ember Random Addon');
     });
 
     it('addons get passed the project instance', function() {
-      var addons = project.addons();
+      var addons = project.addons;
 
       assert.equal(addons[0].project, project);
     });


### PR DESCRIPTION
Incorporate the `Project` models, recent addon support into `EmberApp`.

Uses the following hooks/functions that are called on each addon (if the method exists):
- `included` -- Called at the end of the `EmberApp` constructor.
- `treesFor` -- Called at various points in the building up of the final dist tree. Receives the name of the step that is being processed. The return value is expected to be a Broccoli tree.  The following steps are available with this PR:
  - `app`
  - `styles`
  - `vendor`

---

For a sample addon please take a look at: [ember-cli-pretender](https://github.com/rjackson/ember-cli-pretender/blob/master/index.js)

`ember-cli-pretender` can be used (with these changes) via the following steps:

``` bash
npm install -g ember-cli
ember new some-awesome-app
cd some-awesome-app
npm install --save-dev ember-cli-pretender
ember server
```

No modifications are needed to the `Brocfile.js` at all.
