### PR TITLE
Refactor preprocessors to work with addons.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -75,30 +75,20 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath) {
   return plugin.toTree.apply(plugin, arguments);
 };
 
-module.exports.preprocessTemplates = function(tree) {
+module.exports.preprocessTemplates = function(/* tree */) {
   var plugin = registry.load('template');
 
   if (!plugin) {
     throw new Error('Missing template processor');
   }
 
-  return requireLocal(plugin.name).call(null, tree, {
-    extensions: plugin.ext,
-    module: true
-  });
+  return plugin.toTree.apply(plugin, arguments);
 };
 
-module.exports.preprocessJs = function(tree, inputPath, outputPath, options) {
+module.exports.preprocessJs = function(/* tree, inputPath, outputPath, options */) {
   var plugin = registry.load('js');
 
-  if (!plugin) { return tree; }
+  if (!plugin) { return arguments[0]; }
 
-  if (plugin.name.indexOf('coffee') !== -1 || plugin.name.indexOf('ember-script') !== -1) {
-    options = options || {};
-    options.bare = true;
-    options.srcDir = inputPath;
-    options.destDir = outputPath;
-  }
-
-  return requireLocal(plugin.name).call(null, tree, options);
+  return plugin.toTree.apply(plugin, arguments);
 };

--- a/lib/preprocessors/javascript-plugin.js
+++ b/lib/preprocessors/javascript-plugin.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var Plugin       = require('./plugin');
+var requireLocal = require('../utilities/require-local');
+
+function JavascriptPlugin () {
+  this.type = 'js';
+  this._superConstructor.apply(this, arguments);
+}
+
+JavascriptPlugin.prototype = Object.create(Plugin.prototype);
+JavascriptPlugin.prototype.constructor = JavascriptPlugin;
+JavascriptPlugin.prototype._superConstructor = Plugin;
+
+JavascriptPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
+  if (this.name.indexOf('coffee') !== -1 || this.name.indexOf('ember-script') !== -1) {
+    options = options || {};
+    options.bare = true;
+    options.srcDir = inputPath;
+    options.destDir = outputPath;
+  }
+
+  return requireLocal(this.name).call(null, tree, options);
+};
+
+module.exports = JavascriptPlugin;

--- a/lib/preprocessors/plugin.js
+++ b/lib/preprocessors/plugin.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var path         = require('path');
+var fs           = require('fs');
+var detect       = require('lodash-node/modern/collections/find');
+
+function Plugin(name, ext, options) {
+  this.name = name;
+  this.ext = ext;
+  this.options = options || {};
+  this.registry = this.options.registry;
+  this.applicationName = this.options.applicationName;
+
+  if (this.options.toTree) {
+    this.toTree = this.options.toTree;
+  }
+}
+
+Plugin.prototype.toTree = function() {
+  throw new Error('A Plugin must implement the `toTree` method.');
+};
+
+Plugin.prototype.getExt = function(inputPath, filename) {
+  if(Array.isArray(this.ext)) {
+    return detect(this.ext, function(ext) {
+      var filenameAndExt = filename + '.' + ext;
+      return fs.existsSync(path.join('.', inputPath, filenameAndExt));
+    });
+  } else {
+    return this.ext;
+  }
+};
+
+module.exports = Plugin;

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -1,33 +1,19 @@
 'use strict';
 
-var path   = require('path');
-var fs     = require('fs');
-var detect = require('lodash-node/modern/collections/find');
-var requireLocal = require('../utilities/require-local');
-
-function Plugin(name, ext, options) {
-  this.name = name;
-  this.ext = ext;
-  this.options = options || {};
-  this.registry = this.options.registry;
-  this.applicationName = this.options.applicationName;
-
-  if (this.options.toTree) {
-    this.toTree = this.options.toTree;
-  }
-}
-
-Plugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
-  var input = path.join(inputPath, 'app.' + this.getExt(inputPath, 'app'));
-  var output = path.join(outputPath, this.applicationName + '.css');
-
-  return requireLocal(this.name).call(null, [tree], input, output, options);
-};
+var Plugin           = require('./plugin');
+var StylePlugin      = require('./style-plugin');
+var TemplatePlugin   = require('./template-plugin');
+var JavascriptPlugin = require('./javascript-plugin');
 
 function Registry(plugins, app) {
   this.registry = {};
   this.availablePlugins = plugins;
   this.app = app;
+  this.pluginTypes = {
+    'js': JavascriptPlugin,
+    'css': StylePlugin,
+    'template': TemplatePlugin
+  };
 }
 
 module.exports = Registry;
@@ -45,22 +31,18 @@ Registry.prototype.load = function(type) {
 
 Registry.prototype.add = function(type, name, extension, options) {
   var registered = this.registry[type] = this.registry[type] || [];
+  var plugin, PluginType;
 
-  options = options || {};
-  options.applicationName = this.app.name;
+  // plugin is being added directly do not instantiate it
+  if (typeof name === 'object') {
+    plugin = name;
+  } else {
+    PluginType = this.pluginTypes[type] || Plugin;
+    options = options || {};
+    options.applicationName = this.app.name;
 
-  var plugin = new Plugin(name, extension, options);
+    plugin = new PluginType(name, extension, options);
+  }
 
   registered.push(plugin);
-};
-
-Plugin.prototype.getExt = function(inputPath, filename) {
-  if(Array.isArray(this.ext)) {
-    return detect(this.ext, function(ext) {
-      var filenameAndExt = filename + '.' + ext;
-      return fs.existsSync(path.join('.', inputPath, filenameAndExt));
-    });
-  } else {
-    return this.ext;
-  }
 };

--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var path         = require('path');
+var Plugin       = require('./plugin');
+var requireLocal = require('../utilities/require-local');
+
+function StylePlugin () {
+  this.type = 'css';
+  this._superConstructor.apply(this, arguments);
+}
+
+StylePlugin.prototype = Object.create(Plugin.prototype);
+StylePlugin.prototype.constructor = StylePlugin;
+StylePlugin.prototype._superConstructor = Plugin;
+
+StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
+  var input = path.join(inputPath, 'app.' + this.getExt(inputPath, 'app'));
+  var output = path.join(outputPath, this.applicationName + '.css');
+
+  return requireLocal(this.name).call(null, [tree], input, output, options);
+};
+
+
+module.exports = StylePlugin;
+

--- a/lib/preprocessors/template-plugin.js
+++ b/lib/preprocessors/template-plugin.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var Plugin       = require('./plugin');
+var requireLocal = require('../utilities/require-local');
+
+function TemplatePlugin () {
+  this.type = 'template';
+  this._superConstructor.apply(this, arguments);
+}
+
+TemplatePlugin.prototype = Object.create(Plugin.prototype);
+TemplatePlugin.prototype.constructor = TemplatePlugin;
+TemplatePlugin.prototype._superConstructor = Plugin;
+
+TemplatePlugin.prototype.toTree = function(tree) {
+  return requireLocal(this.name).call(null, tree, {
+    extensions: this.ext,
+    module: true
+  });
+};
+
+
+module.exports = TemplatePlugin;
+

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -73,4 +73,13 @@ describe('Plugin Loader', function() {
     assert.equal(plugin.applicationName, 'some-application-name');
   });
 
+  it('adds a plugin directly if it is provided', function() {
+    var randomPlugin = {name: 'Awesome!'};
+
+    registry.add('js', randomPlugin);
+    var registered = registry.registry['js'];
+
+    assert.equal(registered[0], randomPlugin);
+  });
+
 });


### PR DESCRIPTION
- Create plugin subclasses to allow usage of inheritance, but still use custom `toTree` methods.
- Make `preprocessJS` defer to the plugins `toTree` method (allows plugins to require from their own node_modules folder).
- Make `preprocessTemplates` defer to the plugins `toTree` method (allows plugins to require from their own node_modules folder).

These changes allow addons to add their own preprocessors during their `included` hook.

Please review the following for implementation details on the addon side:
- [ember-cli-esnext](https://github.com/rjackson/ember-cli-esnext/blob/master/index.js)
- [sample app](https://github.com/rjackson/_____ember-cli-test/commit/4391e625f747b3d5cf9c7e8a17b8ee58db45796b)
