### PR TITLE
Use an addon to bring in ic-ajax & ember-data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Do not remove output directory. This allows easier cross-project symlinking (previous behavior broke the link when the output path was destroyed). [#1034](https://github.com/stefanpenner/ember-cli/pull/1034)
 * [ENHANCEMENT] Keep output path (`/dist` by default) up to date with both `ember server` and `ember build`. [#1034](https://github.com/stefanpenner/ember-cli/pull/1034)
 * [ENHANCEMENT] Use the `ember-cli-ic-ajax` addon to bring in ic-ajax. [#1047](https://github.com/stefanpenner/ember-cli/issues/1047)
+* [ENHANCEMENT] Use the `ember-cli-ember-data` addon to bring in ember-data. [#1047](https://github.com/stefanpenner/ember-cli/issues/1047)
 
 ### 0.0.34
 

--- a/blueprints/app/files/Brocfile.js
+++ b/blueprints/app/files/Brocfile.js
@@ -17,13 +17,4 @@ var app = new EmberApp();
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
 
-app.import({
-  development: 'vendor/ember-data/ember-data.js',
-  production:  'vendor/ember-data/ember-data.prod.js'
-}, {
-  'ember-data': [
-    'default'
-  ]
-});
-
 module.exports = app.toTree();

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,6 @@
     "qunit": "~1.12.0",
     "ember-qunit": "~0.1.5",
     "ember": "1.5.1",
-    "ember-data": "1.0.0-beta.8",
     "ember-resolver": "~0.1.1",
     "loader": "stefanpenner/loader.js#1.0.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.2",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -24,6 +24,7 @@
     "express": "^4.1.1",
     "body-parser": "^1.2.0",
     "glob": "^3.2.9",
-    "ember-cli-ic-ajax": "0.0.2"
+    "ember-cli-ic-ajax": "0.0.2",
+    "ember-cli-ember-data": "0.0.2"
   }
 }


### PR DESCRIPTION
Uses https://github.com/rjackson/ember-cli-ic-ajax to provide ic-ajax, and https://github.com/twokul/ember-cli-ember-data to provide embe-data as addons.

There are at least a couple of benefits here:
- Adding/removing ic-ajax is now a one step operation (`npm install --save ember-cli-ic-ajax`).
- We have a logical place to put custom logic (in the future) to ensure `$.ajax` is not used (as it is not test friendly).
