### PR TITLE
Pass the correct options to when calling a plugin

### DIFF
--- a/lib/preprocessors/javascript-plugin.js
+++ b/lib/preprocessors/javascript-plugin.js
@@ -14,7 +14,7 @@ JavascriptPlugin.prototype._superConstructor = Plugin;
 
 JavascriptPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
   if (this.name.indexOf('coffee') !== -1 || this.name.indexOf('ember-script') !== -1) {
-    options = options || {};
+    options = this.options || {};
     options.bare = true;
     options.srcDir = inputPath;
     options.destDir = outputPath;


### PR DESCRIPTION
We were passing the wrong options to the plugin itself, meaning that any options configued in the Brocfile were not being passed to the plugin. This fixes that problem.

@rjackson I looked at adding a test for this, but it didn't look like we were testing the `toTree` call anywhere yet. Before pulling it in, want to pair sometime this evening or tomorrow on adding a test for this?
