### PR TITLE
Update docs to mention using `podModulePrefix` in test resolver.

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -17,6 +17,8 @@ acceptance/integration tests using the new [ember-testing package](http://ianpet
 
 Test filenames should be suffixed with `-test.js` in order to run.
 
+If you are using Pods to organize your application, be sure to add your `podModulePrefix` to the [test resolver](https://github.com/stefanpenner/ember-app-kit/blob/master/tests/helpers/resolver.js) namespace.
+
 To run the tests in your browser using the QUnit interface, run `ember server`
 and navigate to `http://localhost:4200/tests`. Note that just like your app, your
 tests will auto rebuild when `ember server` is running.


### PR DESCRIPTION
Covers https://github.com/stefanpenner/ember-cli/issues/852
