### PR TITLE
Allow addons to preserve `main` entry point.

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -68,7 +68,13 @@ Project.prototype.availableAddons = function() {
 
 Project.prototype.initializeAddons = function() {
   this.addons = this.availableAddons().map(function(name) {
-    var Addon = require(path.join(this.root, 'node_modules', name));
+    var addonPkg = require(path.join(this.root, 'node_modules', name, 'package.json'));
+    var Addon;
+    if (addonPkg['ember-addon-main']) {
+      Addon = require(path.join(this.root, 'node_modules', name, addonPkg['ember-addon-main']));
+    } else {
+      Addon = require(path.join(this.root, 'node_modules', name));
+    }
 
     return new Addon(this);
   }, this);

--- a/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/ember-index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/ember-index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var path = require('path');
+var fs   = require('fs');
+
+function EmberNonRootAddon(project) {
+  this.project = project;
+  this.name = 'Ember Non Root Addon';
+}
+
+function unwatchedTree(dir){
+  return {read: function() { return dir; }};
+}
+
+EmberNonRootAddon.prototype.treeFor = function treeFor(name) {
+  var treePath = path.join(__dirname, name);
+
+  if (fs.existsSync(treePath)) {
+    return unwatchedTree(treePath);
+  }
+};
+
+EmberNonRootAddon.prototype.included = function included(app) {
+  this.app = app;
+};
+
+module.exports = EmberNonRootAddon;

--- a/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ember-random-addon",
+  "main": "index.js",
+  "ember-addon-main": "ember-index.js",
+  "private": true,
+  "keywords": [
+    "ember-cli-addon"
+  ]
+}
+

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "ember-cli": "latest",
     "ember-random-addon": "latest",
+    "ember-non-root-addon": "latest",
     "non-ember-thingy": "latest"
   }
 }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -51,6 +51,7 @@ describe('models/project.js', function() {
       var expected = {
         'ember-cli': 'latest',
         'ember-random-addon': 'latest',
+        'ember-non-root-addon': 'latest',
         'non-ember-thingy': 'latest',
         'something-else': 'latest'
       };
@@ -59,7 +60,7 @@ describe('models/project.js', function() {
     });
 
     it('returns a listing of all ember-cli-addons', function() {
-      var expected = [ 'ember-random-addon' ];
+      var expected = [ 'ember-random-addon', 'ember-non-root-addon' ];
 
       assert.deepEqual(project.availableAddons(), expected);
     });
@@ -74,6 +75,12 @@ describe('models/project.js', function() {
       var addons = project.addons;
 
       assert.equal(addons[0].project, project);
+    });
+
+    it('returns an instance of an addon that uses `ember-addon-main`', function() {
+      var addons = project.addons;
+
+      assert.equal(addons[1].name, 'Ember Non Root Addon');
     });
   });
 });


### PR DESCRIPTION
This allows packages to support both standard NPM usage (where the `main` entry point is to the actual library) AND Ember CLI usage by using the `ember-addon-main` property if it is present.

Packages like `ic-ajax` and `emberfire` can use this to support both types of consumers.
