### PR TITLE
Remove redundant check for production

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -517,7 +517,7 @@ EmberApp.prototype.toTree = memoize(function() {
     description: 'TreeMerger (allTrees)'
   });
 
-  if (this.env === 'production' && this.options.fingerprint.enabled === true) {
+  if (this.options.fingerprint.enabled === true) {
     tree = this.fingerprint(tree);
   }
 


### PR DESCRIPTION
The default options for `fingerprint.enabled` is set to `true` when you are in production, so this check is redundant.

This would also make you unable to add your own conditions for enabling fingerprinting.
