### PR TITLE
Move from `ember-cli-addon` to `ember-addon`.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -24,7 +24,7 @@
     "express": "^4.1.1",
     "body-parser": "^1.2.0",
     "glob": "^3.2.9",
-    "ember-cli-ic-ajax": "0.0.2",
-    "ember-cli-ember-data": "0.0.3"
+    "ember-cli-ic-ajax": "0.0.3",
+    "ember-cli-ember-data": "0.0.4"
   }
 }

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -58,8 +58,9 @@ Project.prototype.availableAddons = function() {
     if (name === 'ember-cli') { return false; }
 
     var addonPkg = require(path.join(this.root, 'node_modules', name, 'package.json'));
+    var keywords = addonPkg.keywords || [];
 
-    if ((addonPkg.keywords || []).indexOf('ember-cli-addon') > -1) {
+    if (keywords.indexOf('ember-addon') > -1) {
       return true;
     }
 

--- a/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
@@ -4,7 +4,7 @@
   "ember-addon-main": "ember-index.js",
   "private": true,
   "keywords": [
-    "ember-cli-addon"
+    "ember-addon"
   ]
 }
 

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/package.json
@@ -2,7 +2,7 @@
   "name": "ember-random-addon",
   "private": true,
   "keywords": [
-    "ember-cli-addon"
+    "ember-addon"
   ]
 }
 


### PR DESCRIPTION
Updates `ember-cli-ic-ajax` and `ember-cli-ember-data` to their latest versions that have the proper keywords.

Closes #1064.
