### PR TITLE
if assetPath is null, assume the user explicitly wanted to ignore this a...

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -447,6 +447,10 @@ EmberApp.prototype.import = function(asset, modules) {
     assetPath = asset;
   }
 
+  if (assetPath === null) {
+    return;
+  }
+
   if (/[\*\,]/.test(assetPath)) {
     throw new Error('You must pass a file path (without glob pattern) to `app.import`.  path was: `' + assetPath + '`');
   }


### PR DESCRIPTION
...sset

example:

``` js
app.import({
  production: null,
  development: ‘vendor/mock-ajax/index.js’)
});
```
