### PR TITLE
Add middleware concept for addons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [ENHANCEMENT] Notify when an ember-cli update is available, and add `ember update` command. [#899](https://github.com/stefanpenner/ember-cli/pull/899)
 * [BUGFIX] Ensure that build output directory is cleaned up properly. [#1122](https://github.com/stefanpenner/ember-cli/pull/1122)
 * [BUGFIX] Ensure that non-zero exit code is used when running `ember test` with failing tests. [#1123](https://github.com/stefanpenner/ember-cli/pull/1123)
+* [BREAKING ENHANCEMENT] Change the expected interface for the `./server/index.js` file. It now receives the instantiated `express` server. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
+* [ENHANCEMENT] Allow addons to provide server side middlewares. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
 
 ### 0.0.36
 

--- a/blueprints/api-stub/files/server/index.js
+++ b/blueprints/api-stub/files/server/index.js
@@ -7,17 +7,12 @@
 //   });
 // };
 
-var express    = require('express');
 var bodyParser = require('body-parser');
 var globSync   = require('glob').sync;
 var routes     = globSync('./routes/**/*.js', { cwd: __dirname }).map(require);
 
-module.exports = function(emberCLIMiddleware) {
-  var app = express();
+module.exports = function(app) {
   app.use(bodyParser());
 
   routes.forEach(function(route) { route(app); });
-  app.use(emberCLIMiddleware);
-
-  return app;
 };

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var http    = require('http');
 var Promise = require('../../ext/promise');
 var proxy   = require('proxy-middleware');
 var url     = require('url');
@@ -12,11 +13,39 @@ var livereloadMiddleware = require('connect-livereload');
 var serveFilesMiddleware = require('./middleware/serve-files');
 
 module.exports = Task.extend({
+  setupHttpServer: function() {
+    this.httpServer = http.createServer(this.app);
+  },
+
+  listen: function(port, host) {
+    var server = this.httpServer;
+    var listen = Promise.denodeify(server.listen.bind(server));
+    return listen(port, host);
+  },
+
+  processAddonMiddlewares: function(options) {
+    this.project.initializeAddons();
+    this.project.addons.forEach(function(addon) {
+      if (addon.serverMiddleware) {
+        addon.serverMiddleware({
+          app: this.app,
+          options: options
+        });
+      }
+    }, this);
+  },
+
+  processAppMiddlewares: function() {
+    if (this.project.has('./server')) {
+      this.project.require('./server')(this.app);
+    }
+  },
+
   start: function(options) {
     var ui      = this.ui;
-    var project = this.project;
     var watcher = this.watcher;
     var middleware = chain();
+    var app = this.app = express();
 
     if (options.liveReload === true) {
       middleware = chain(middleware, livereloadMiddleware({
@@ -36,16 +65,13 @@ module.exports = Task.extend({
       middleware = chain(middleware, proxy(urlopts));
     }
 
-    var server;
-    if (project.has('./server')) {
-      server = project.require('./server')(middleware);
-    } else {
-      server = express();
-      server.use(middleware);
-    }
+    this.processAddonMiddlewares(options);
+    this.processAppMiddlewares();
 
-    var listen = Promise.denodeify(server.listen.bind(server));
-    return listen(options.port, options.host)
+    app.use(middleware);
+
+    this.setupHttpServer();
+    return this.listen(options.port, options.host)
       .then(function() {
         ui.write('Serving on http://' + options.host + ':' + options.port + '\n');
       });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -437,19 +437,14 @@ describe('Acceptance: ember generate', function() {
   it('api-stub foo/bar', function() {
     return generate(['api-stub', '/foo/bar']).then(function() {
       assertFile('server/index.js', {
-        contains: "var express    = require('express');\n" +
-                  "var bodyParser = require('body-parser');\n" +
+        contains: "var bodyParser = require('body-parser');\n" +
                   "var globSync   = require('glob').sync;\n" +
                   "var routes     = globSync('./routes/**/*.js', { cwd: __dirname }).map(require);\n" +
                   "\n" +
-                  "module.exports = function(emberCLIMiddleware) {\n" +
-                  "  var app = express();\n" +
+                  "module.exports = function(app) {\n" +
                   "  app.use(bodyParser());\n" +
                   "\n" +
                   "  routes.forEach(function(route) { route(app); });\n" +
-                  "  app.use(emberCLIMiddleware);\n" +
-                  "\n" +
-                  "  return app;\n" +
                   "};"
       });
       assertFile('server/routes/foo/bar.js', {

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -30,4 +30,8 @@ MockProject.prototype.name = function() {
   return 'mock-project';
 };
 
+MockProject.prototype.initializeAddons = function() {
+  this.addons = [];
+};
+
 module.exports = MockProject;

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -18,6 +18,10 @@ describe('express-server', function() {
     });
   });
 
+  afterEach(function() {
+    return subject.httpServer.close();
+  });
+
   describe('output', function() {
     it('with proxy', function() {
       return subject.start({
@@ -58,6 +62,49 @@ describe('express-server', function() {
       it('proxies PUT',    function() { });
       it('proxies POST',   function() { });
       it('proxies DELETE', function() { });
+    });
+
+    describe('addons', function() {
+      it('calls processAddonMiddlewares upon start', function() {
+        var called = false;
+
+        subject.processAddonMiddlewares = function() {
+          called = true;
+        };
+
+        return subject.start({
+          host:  '0.0.0.0',
+          port: '1337'
+        }).then(function() {
+          assert(called);
+        });
+      });
+
+      it('calls serverMiddleware on the addons', function() {
+        var firstCalled  = false;
+        var secondCalled = false;
+
+        project.initializeAddons = function() { };
+        project.addons = [{
+            serverMiddleware: function() {
+              firstCalled = true;
+            }
+          }, {
+            serverMiddleware: function() {
+              secondCalled = true;
+            }
+          }, {
+            doesntGoBoom: null
+          }];
+
+        return subject.start({
+          host:  '0.0.0.0',
+          port: '1337'
+        }).then(function() {
+          assert(firstCalled);
+          assert(secondCalled);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
- Refactors express server to explicitly start the http server. This was
  what it does naturally, but we need access to the raw server to be
  able to teardown the server between tests.
- Refactor express server to make it a bit more testable.
- Add `addon.serverMiddleware` callback function.  The addon is called
  with the instance of the express app.
- Refactor `api-stub` blueprint (and expected API) so that the express
  app is started in a consistent way. Prior to this, if you had a
  `./server/` folder, your code would create the `express` app add the
  `ember-cli` middleware.

Closes #1086.
