### PR TITLE
Some improvements to generator behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # ember-cli Changelog
 
 * [BUGFIX] Ensure EDITOR is set before allowing edit in ember init. [#1090](https://github.com/stefanpenner/ember-cli/pull/1090)
-* [BUGFIX] Display message to user when diff cannot be applied cleanly [1091](https://github.com/stefanpenner/ember-cli/pull/1091)
+* [BUGFIX] Display message to user when diff cannot be applied cleanly [#1091](https://github.com/stefanpenner/ember-cli/pull/1091)
 * [ENHANCEMENT] Notify when an ember-cli update is available, and add `ember update` command. [#899](https://github.com/stefanpenner/ember-cli/pull/899)
 * [BUGFIX] Ensure that build output directory is cleaned up properly. [#1122](https://github.com/stefanpenner/ember-cli/pull/1122)
 * [BUGFIX] Ensure that non-zero exit code is used when running `ember test` with failing tests. [#1123](https://github.com/stefanpenner/ember-cli/pull/1123)
 * [BREAKING ENHANCEMENT] Change the expected interface for the `./server/index.js` file. It now receives the instantiated `express` server. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
 * [ENHANCEMENT] Allow addons to provide server side middlewares. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
+* [ENHANCEMENT] Automatically pluralize the attribute when generating a
+  model. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
+* [BUGFIX] Make sure non-dasherized model attributes are also added to
+  generated tests. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
 
 ### 0.0.36
 

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -15,9 +15,14 @@ module.exports = Blueprint.extend({
       var camelizedName = stringUtils.camelize(name);
       var dasherizedType = stringUtils.dasherize(type);
 
-      attrs.push(camelizedName + ': ' + dsAttr(camelizedName, dasherizedType));
+      if (/has-many/.test(dasherizedType)) {
+        var camelizedNamePlural = inflection.pluralize(camelizedName);
+        attrs.push(camelizedNamePlural + ': ' + dsAttr(camelizedName, dasherizedType));
+      } else {
+        attrs.push(camelizedName + ': ' + dsAttr(camelizedName, dasherizedType));
+      }
 
-      if (/has-many|belongs-to/.test(type)) {
+      if (/has-many|belongs-to/.test(dasherizedType)) {
         needs.push("'model:" + dasherizedNameSingular + "'");
       }
     }

--- a/blueprints/serializer/files/tests/unit/serializers/__name__-test.js
+++ b/blueprints/serializer/files/tests/unit/serializers/__name__-test.js
@@ -2,11 +2,11 @@ import { test, moduleFor } from 'ember-qunit';
 
 moduleFor('serializer:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Serializer', {
   // Specify the other units that are required for this test.
-  // needs: ['adapter:foo']
+  // needs: ['serializer:foo']
 });
 
 // Replace this with your real tests.
 test('it exists', function() {
-  var adapter = this.subject();
-  ok(adapter);
+  var serializer = this.subject();
+  ok(serializer);
 });

--- a/blueprints/view/files/tests/unit/views/__name__-test.js
+++ b/blueprints/view/files/tests/unit/views/__name__-test.js
@@ -4,5 +4,6 @@ moduleFor('view:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>View')
 
 // Replace this with your real tests.
 test('it exists', function() {
-  ok(this.subject());
+  var view = this.subject();
+  ok(view);
 });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -139,25 +139,29 @@ describe('Acceptance: ember generate', function() {
     return generate([
       'model',
       'foo',
-      'name:string',
+      'firstName:string',
       'created_at:date',
       'is-published:boolean',
       'rating:number',
       'bars:has-many',
-      'baz:belongs-to'
+      'baz:belongs-to',
+      'echo:hasMany',
+      'bravo:belongs_to'
     ]).then(function() {
       assertFile('app/models/foo.js', {
         contains: [
-          "name: DS.attr('string')",
+          "firstName: DS.attr('string')",
           "createdAt: DS.attr('date')",
           "isPublished: DS.attr('boolean')",
           "rating: DS.attr('number')",
           "bars: DS.hasMany('bar')",
-          "baz: DS.belongsTo('baz')"
+          "baz: DS.belongsTo('baz')",
+          "echos: DS.hasMany('echo')",
+          "bravo: DS.belongsTo('bravo')"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
-        contains: "needs: ['model:bar', 'model:baz']"
+        contains: "needs: ['model:bar', 'model:baz', 'model:echo', 'model:bravo']"
       });
     });
   });


### PR DESCRIPTION
Some assorted generator improvements.
- Converting `belongsTo` and `hasMany` from more formats when generating models. (Previously it wouldn't add model to `needs` array of test unless already dasherized).
- Pluralizing attribute name when of type `hasMany`.
- Tests for the above and more.
- Adapter => Serializer in the Serializer test examples to match the other files.
- Go through a variable in the view test example like in all the others.
