### PR TITLE
Ensure exit code is correct for `ember test` with failing tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] Display message to user when diff cannot be applied cleanly [1091](https://github.com/stefanpenner/ember-cli/pull/1091)
 * [ENHANCEMENT] Notify when an ember-cli update is available, and add `ember update` command. [#899](https://github.com/stefanpenner/ember-cli/pull/899)
 * [BUGFIX] Ensure that build output directory is cleaned up properly. [#1122](https://github.com/stefanpenner/ember-cli/pull/1122)
+* [BUGFIX] Ensure that non-zero exit code is used when running `ember test` with failing tests. [#1123](https://github.com/stefanpenner/ember-cli/pull/1123)
 
 ### 0.0.36
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -57,7 +57,12 @@ module.exports = Command.extend({
         .then(function() {
           return test.run(testOptions);
         })
-        .finally(this.rmTmp.bind(this));
+        .finally(this.rmTmp.bind(this))
+        .then(function(exitCode) {
+          process.addListener('exit', function() {
+            process.exit(exitCode);
+          });
+        });
     }
   }
 });

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -9,8 +9,8 @@ module.exports = Task.extend({
     var testem = new Testem();
 
     return new Promise(function(resolve) {
-      testem.startCI(testemOptions, function() {
-        resolve();
+      testem.startCI(testemOptions, function(exitCode) {
+        resolve(exitCode);
       });
     });
   },


### PR DESCRIPTION
Fixes #1115.
