### PR TITLE
Adds `--watch` flag to `ember build`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Ensure that non-zero exit code is used when running `ember test` with failing tests. [#1123](https://github.com/stefanpenner/ember-cli/pull/1123)
 * [BREAKING ENHANCEMENT] Change the expected interface for the `./server/index.js` file. It now receives the instantiated `express` server. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
 * [ENHANCEMENT] Allow addons to provide server side middlewares. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
+* [ENHANCEMENT] Adds the `--watch` flag to `ember build`.  [#1111](https://github.com/stefanpenner/ember-cli/pull/1111)
 
 ### 0.0.36
 

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -9,7 +9,8 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'environment', type: String, default: 'development' },
-    { name: 'output-path', type: path, default: 'dist/' }
+    { name: 'output-path', type: path, default: 'dist/' },
+    { name: 'watch', type: Boolean, default: false }
   ],
 
   run: function(commandOptions) {

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -3,10 +3,26 @@
 var chalk    = require('chalk');
 var Task     = require('../models/task');
 var Builder  = require('../models/builder');
+var Watcher  = require('../models/watcher');
 
 module.exports = Task.extend({
-  // Options: String outputPath
+  // Options:
+  // String outputPath
+  // Boolean watch
   run: function(options) {
+    this.options = options;
+    var promise  = this.build(options);
+
+    if (options.watch) {
+      promise = promise.then(function() {
+        this.watch(options);
+      }.bind(this));
+    }
+
+    return promise;
+  },
+
+  build: function(options) {
     var env = options.environment || 'development';
     process.env.EMBER_ENV = process.env.EMBER_ENV || env;
 
@@ -15,11 +31,11 @@ module.exports = Task.extend({
 
     ui.pleasantProgress.start(chalk.green('Building'), chalk.green('.'));
 
-    var builder = new Builder({
+    this.builder = new Builder({
       outputPath: options.outputPath
     });
 
-    return builder.build()
+    return this.builder.build()
       .then(function(results) {
         var totalTime = results.totalTime / 1e6;
 
@@ -57,5 +73,30 @@ module.exports = Task.extend({
         }
         ui.write(err.stack);
       });
+  },
+
+  watch: function(options) {
+    var watcher = this.watcherFor(options);
+
+    watcher.on('change', this.didChange.bind(this));
+    watcher.on('error', this.didError.bind(this));
+  },
+
+  watcherFor: function(options) {
+    return new Watcher({
+      ui: this.ui,
+      builder: this.builder,
+      analytics: this.analytics,
+      options: options
+    });
+  },
+
+  didChange: function() {
+    this.build(this.options);
+  },
+
+  didError: function(error) {
+    this.ui.write(chalk.red(error.message) + '\n');
   }
+
 });

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -355,7 +355,18 @@ describe('Unit: CLI', function() {
       var build = stubRun('build');
 
       return ember(['build']).then(function() {
+        var options = build.calledWith[0][0];
         assert.equal(build.called, 1, 'expected the build command to be run');
+        assert.equal(options.watch, false, 'expected the default watch flag to be false');
+      });
+    });
+
+    it('ember build --watch', function() {
+      var build = stubRun('build');
+
+      return ember(['build', '--watch']).then(function() {
+        var options = build.calledWith[0][0];
+        assert.equal(options.watch, true, 'expected the watch flag to be true');
       });
     });
 


### PR DESCRIPTION
`ember build --watch` - runs build initially then watches for changes and rebuilds those changes.

Watch mode is off if not specified.
