### PR TITLE
Allow addons to specify load ordering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,10 @@
 * [BUGFIX] Ensure that non-zero exit code is used when running `ember test` with failing tests. [#1123](https://github.com/stefanpenner/ember-cli/pull/1123)
 * [BREAKING ENHANCEMENT] Change the expected interface for the `./server/index.js` file. It now receives the instantiated `express` server. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
 * [ENHANCEMENT] Allow addons to provide server side middlewares. [#1097](https://github.com/stefanpenner/ember-cli/pull/1097)
-* [ENHANCEMENT] Automatically pluralize the attribute when generating a
-  model. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
-* [BUGFIX] Make sure non-dasherized model attributes are also added to
-  generated tests. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
+* [ENHANCEMENT] Automatically pluralize the attribute when generating a model. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
+* [BUGFIX] Make sure non-dasherized model attributes are also added to generated tests. [#1120](https://github.com/stefanpenner/ember-cli/pull/1120)
 * [ENHANCEMENT] Upgrade `ember-qunit-notifications` to `0.0.3`. [#1117](https://github.com/stefanpenner/ember-cli/pull/1117)
-
+* [ENHANCEMENT] Allow addons to specify load ordering. [#1132](https://github.com/stefanpenner/ember-cli/pull/1132)
 
 ### 0.0.36
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -7,6 +7,7 @@ var RSVP    = require('rsvp');
 var resolve = RSVP.denodeify(require('resolve'));
 var fs      = require('fs');
 var assign  = require('lodash-node/modern/objects/assign');
+var DAG     = require('../utilities/DAG');
 
 var findupSync  = require('findup').sync;
 
@@ -54,31 +55,53 @@ Project.prototype.dependencies = function() {
 };
 
 Project.prototype.availableAddons = function() {
-  return Object.keys(this.dependencies()).filter(function(name) {
+  var addonPackages = {};
+  Object.keys(this.dependencies()).forEach(function(name) {
     if (name === 'ember-cli') { return false; }
 
     var addonPkg = require(path.join(this.root, 'node_modules', name, 'package.json'));
     var keywords = addonPkg.keywords || [];
 
+    addonPkg['ember-addon'] = addonPkg['ember-addon'] || {};
+
     if (keywords.indexOf('ember-addon') > -1) {
-      return true;
+      addonPackages[addonPkg.name] = addonPkg;
     }
 
   }, this);
+
+  return addonPackages;
 };
 
 Project.prototype.initializeAddons = function() {
-  this.addons = this.availableAddons().map(function(name) {
-    var addonPkg = require(path.join(this.root, 'node_modules', name, 'package.json'));
+  var project         = this;
+  var graph           = new DAG();
+  var availableAddons = this.availableAddons();
+  var addon, emberAddonConfig;
+
+  for (var name in availableAddons) {
+    addon            = availableAddons[name];
+    emberAddonConfig = addon['ember-addon'];
+
+    graph.addEdges(addon.name, addon, emberAddonConfig.before, emberAddonConfig.after);
+  }
+
+  this.addons = [];
+  graph.topsort(function (vertex) {
+    var addonPkg  = vertex.value;
+    var addonPath = path.join(project.root, 'node_modules', addonPkg.name);
     var Addon;
+
     if (addonPkg['ember-addon-main']) {
-      Addon = require(path.join(this.root, 'node_modules', name, addonPkg['ember-addon-main']));
-    } else {
-      Addon = require(path.join(this.root, 'node_modules', name));
+      addonPath = path.join(addonPath, addonPkg['ember-addon-main']);
+    } else if (addonPkg['ember-addon'] && addonPkg['ember-addon'].main) {
+      addonPath = path.join(addonPath, addonPkg['ember-addon'].main);
     }
 
-    return new Addon(this);
-  }, this);
+    Addon = require(addonPath);
+
+    project.addons.push(new Addon(project));
+  });
 };
 
 Project.closest = function(pathName) {

--- a/lib/utilities/DAG.js
+++ b/lib/utilities/DAG.js
@@ -1,0 +1,110 @@
+'use strict';
+
+function visit(vertex, fn, visited, path) {
+  var name = vertex.name,
+    vertices = vertex.incoming,
+    names = vertex.incomingNames,
+    len = names.length,
+    i;
+  if (!visited) {
+    visited = {};
+  }
+  if (!path) {
+    path = [];
+  }
+  if (visited.hasOwnProperty(name)) {
+    return;
+  }
+  path.push(name);
+  visited[name] = true;
+  for (i = 0; i < len; i++) {
+    visit(vertices[names[i]], fn, visited, path);
+  }
+  fn(vertex, path);
+  path.pop();
+}
+
+function DAG() {
+  this.names = [];
+  this.vertices = {};
+}
+
+DAG.prototype.add = function(name) {
+  if (!name) { return; }
+  if (this.vertices.hasOwnProperty(name)) {
+    return this.vertices[name];
+  }
+  var vertex = {
+    name: name,
+    incoming: {},
+    incomingNames: [],
+    hasOutgoing: false,
+    value: null
+  };
+
+  this.vertices[name] = vertex;
+  this.names.push(name);
+  return vertex;
+};
+
+DAG.prototype.map = function(name, value) {
+  this.add(name).value = value;
+};
+
+DAG.prototype.addEdge = function(fromName, toName) {
+  if (!fromName || !toName || fromName === toName) {
+    return;
+  }
+  var from = this.add(fromName), to = this.add(toName);
+  if (to.incoming.hasOwnProperty(fromName)) {
+    return;
+  }
+  function checkCycle(vertex, path) {
+    if (vertex.name === toName) {
+      throw new Error('cycle detected: ' + toName + ' <- ' + path.join(' <- '));
+    }
+  }
+  visit(from, checkCycle);
+  from.hasOutgoing = true;
+  to.incoming[fromName] = from;
+  to.incomingNames.push(fromName);
+};
+
+DAG.prototype.topsort = function(fn) {
+  var visited = {},
+    vertices = this.vertices,
+    names = this.names,
+    len = names.length,
+    i, vertex;
+  for (i = 0; i < len; i++) {
+    vertex = vertices[names[i]];
+    if (!vertex.hasOutgoing) {
+      visit(vertex, fn, visited);
+    }
+  }
+};
+
+DAG.prototype.addEdges = function(name, value, before, after) {
+  var i;
+  this.map(name, value);
+  if (before) {
+    if (typeof before === 'string') {
+      this.addEdge(name, before);
+    } else {
+      for (i = 0; i < before.length; i++) {
+        this.addEdge(name, before[i]);
+      }
+    }
+  }
+  if (after) {
+    if (typeof after === 'string') {
+      this.addEdge(after, name);
+    } else {
+      for (i = 0; i < after.length; i++) {
+        this.addEdge(after[i], name);
+      }
+    }
+  }
+};
+
+module.exports = DAG;

--- a/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "ember-random-addon",
+  "name": "ember-non-root-addon",
   "main": "index.js",
-  "ember-addon-main": "ember-index.js",
+  "ember-addon": {
+    "main": "ember-index.js",
+    "before": "ember-random-addon"
+  },
   "private": true,
   "keywords": [
     "ember-addon"

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -62,13 +62,13 @@ describe('models/project.js', function() {
     it('returns a listing of all ember-cli-addons', function() {
       var expected = [ 'ember-random-addon', 'ember-non-root-addon' ];
 
-      assert.deepEqual(project.availableAddons(), expected);
+      assert.deepEqual(Object.keys(project.availableAddons()), expected);
     });
 
     it('returns an instance of the addon', function() {
       var addons = project.addons;
 
-      assert.equal(addons[0].name, 'Ember Random Addon');
+      assert.equal(addons[0].name, 'Ember Non Root Addon');
     });
 
     it('addons get passed the project instance', function() {
@@ -80,7 +80,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       var addons = project.addons;
 
-      assert.equal(addons[1].name, 'Ember Non Root Addon');
+      assert.equal(addons[1].name, 'Ember Random Addon');
     });
   });
 });


### PR DESCRIPTION
- Bring topsort algorithm from Ember (used for initializer ordering).
- Allow addons to use `ember-addon` key which resolves to an object with `main`, `before`, and `after` keys.
- Allow `ember-addon: { main: 'foo.js'}` as alternative to `ember-addon-main` in the `package.json` of the addon.
- Change `availableAddons` to return an object with the `package.json` contents of each addon (was previously being looked up twice).

Fixes #1125.
