### PR TITLE
Use lodash merge instead of defaults

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -29,10 +29,11 @@ var upstreamMergeTrees  = require('broccoli-merge-trees');
 var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
 
-var memoize    = require('lodash-node/modern/functions').memoize;
-var assign     = require('lodash-node/modern/objects/assign');
-var defaults   = require('lodash-node/modern/objects/defaults');
-var path       = require('path');
+var memoize       = require('lodash-node/modern/functions').memoize;
+var assign        = require('lodash-node/modern/objects/assign');
+var defaults      = require('lodash-node/modern/objects/defaults');
+var merge         = require('lodash-node/modern/objects/merge');
+var path          = require('path');
 var ES3SafeFilter = require('broccoli-es3-safe-recast');
 
 function mergeTrees(inputTree, options) {
@@ -60,7 +61,7 @@ function EmberApp(options) {
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
 
-  this.options = defaults(options, {
+  this.options = merge(options, {
     es3Safe: true,
     wrapInEval: !isProduction,
     minifyCSS: {
@@ -84,14 +85,14 @@ function EmberApp(options) {
     loader: 'vendor/loader/loader.js',
     trees: {},
     getEnvJSON: this.project.require('./config/environment')
-  });
+  }, defaults);
 
-  this.options.trees = defaults(this.options.trees, {
+  this.options.trees = merge(this.options.trees, {
     app:    'app',
     styles: 'app/styles',
     tests:  'tests',
     vendor: unwatchedTree('vendor'),
-  });
+  }, defaults);
 
   this.importWhitelist     = {};
   this.legacyFilesToAppend = [];


### PR DESCRIPTION
Lodash defaults currently only does not do a deep merge of objects which causes an overwrite of default options in ember-app.js. I switched it to use _merge instead - http://lodash.com/docs#merge
