### PR TITLE
Use `express.Router()` to define stub routes. Allows for easy namespacing

### DIFF
--- a/blueprints/api-stub/files/server/index.js
+++ b/blueprints/api-stub/files/server/index.js
@@ -8,11 +8,16 @@
 // };
 
 var bodyParser = require('body-parser');
+var express    = require('express');
 var globSync   = require('glob').sync;
 var routes     = globSync('./routes/**/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(app) {
   app.use(bodyParser());
 
-  routes.forEach(function(route) { route(app); });
+  var stubRoutes = express.Router();
+  routes.forEach(function(route) { route(stubRoutes); });
+
+  // A custom route prefix can be added here
+  app.use('/', stubRoutes);
 };


### PR DESCRIPTION
**_Pull for thought.**_  The same thing could probably be accomplished with documentation.  

https://github.com/stefanpenner/ember-cli/pull/1097 breaks [express-namespace](https://github.com/visionmedia/express-namespace) because it initializes the express() before namespace can be required (I think).  But apparently, Express 4.0 [killed express-namespace](https://github.com/visionmedia/express-namespace/issues/44) so I threw together an example of what I gather to be the current best practice.  It also allows for namespacing out of the box without adding any additional dependencies.  

Might make sense to make `/api` the default namespace and add it to the adapter blueprint as well?
