### PR TITLE
Updates to latest asset-rev

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -512,13 +512,7 @@ EmberApp.prototype.import = function(asset, options) {
 };
 
 EmberApp.prototype.fingerprint = function(tree) {
-  return assetRev(tree, {
-    fingerprintExtensions: this.options.fingerprint.extensions,
-    fingerprintExclude:    this.options.fingerprint.exclude,
-    replaceExtensions:     this.options.fingerprint.replaceExtensions,
-    prependPath:           this.options.fingerprint.prepend,
-    customHash:            this.options.fingerprint.customHash
-  });
+  return assetRev(tree, this.options.fingerprint);
 };
 
 EmberApp.prototype.toArray = function() {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bower": "^1.3.2",
     "bower-config": "^0.5.1",
     "broccoli": "0.12.1",
-    "broccoli-asset-rev": "0.0.6",
+    "broccoli-asset-rev": "0.0.9",
     "broccoli-clean-css": "0.1.5",
     "broccoli-concat": "0.0.6",
     "broccoli-es3-safe-recast": "0.0.7",


### PR DESCRIPTION
Latest version of asset rev now matches the fingerprint options so we
can pass the options directly instead of mutating them, which will make
it easier to support newer features.
