### PR TITLE
allow undefined app.import environments

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -458,7 +458,7 @@ EmberApp.prototype.import = function(asset, options) {
     assetPath = asset;
   }
 
-  if (assetPath === null) {
+  if (assetPath == null) {
     return;
   }
 


### PR DESCRIPTION
You can pass an object of environment keys to dependency values to `app.import` currently. If you set the value of an environment to null, the import for that depdendency is ignored.

I would like to be able to leave environments completely unspecified.

``` javascript
app.import({development: 'vendor/pretender/pretender.js'});
```

But when you run `ember build --environment=production`, that currently throws:

```
You must pass a file to `app.import`.
For directories specify them to the constructor under the `trees` option.
```

I want to avoid specifying each environment I don't care about on each import statement. I would also not enjoy adding a new environment `, test: null` (or whatever) to all import statements.

This PR addresses the issue by changing the comparison from `assetPath === null` to `assetPath == null`. This allows `undefined` to match `null` for this check, allowing environments to go completely unspecified in import statements.

Does this sound acceptable?

---

_https://github.com/stefanpenner/ember-cli/issues/662 seems related._

/cc @trek
