### PR TITLE
Use project.root for ember generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-cli Changelog
 
+* [BUGFIX] Ensure `ember generate` always operate in relation to project root. [#1165](https://github.com/stefanpenner/ember-cli/pull/1165)
+
 ### 0.0.37
 
 * [BUGFIX] ensure the CLI exits with the correct status, fixes hanging tests and some non-graceful exit cleanups [#1150](https://github.com/stefanpenner/ember-cli/pull/1150)

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -21,14 +21,6 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions, rawArgs) {
-    if (commandOptions.list) {
-      return this.list();
-    } else {
-      return this.install(commandOptions, rawArgs);
-    }
-  },
-
-  install: function(commandOptions, rawArgs) {
     var ui            = this.ui;
     var blueprintName = rawArgs[0];
     var entityName    = rawArgs[1];
@@ -70,13 +62,14 @@ module.exports = Command.extend({
 
     ui.write('\n  Available blueprints:\n');
 
-    Blueprint.list().forEach(function(collection) {
-      if (collection.blueprints.length) {
-        ui.write('    ' + collection.source + ':\n');
-        collection.blueprints.forEach(function(blueprint) {
-          ui.write('      ' + chalk.yellow(blueprint) + '\n');
-        });
-      }
-    });
+    Blueprint.list({ paths: [this.project.blueprintsPath()] })
+      .forEach(function(collection) {
+        if (collection.blueprints.length) {
+          ui.write('    ' + collection.source + ':\n');
+          collection.blueprints.forEach(function(blueprint) {
+            ui.write('      ' + chalk.yellow(blueprint) + '\n');
+          });
+        }
+      });
   }
 });

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -21,6 +21,7 @@ module.exports = Blueprint;
 /*
   @class Blueprint
   @extends CoreObject
+  @param {String} [blueprintPath]
 
   A `Blueprint` is a bundle of template files with optional
   install logic. Ember CLI uses blueprints to generate new
@@ -154,12 +155,9 @@ module.exports = Blueprint;
   See the built-in `resource` blueprint for an example of this.
 
 */
-function Blueprint(options) {
-  this.ui        = options.ui;
-  this.analytics = options.analytics;
-  this.project   = options.project;
-  this.path      = options.path;
-  this.name      = path.basename(this.path);
+function Blueprint(blueprintPath) {
+  this.path = blueprintPath;
+  this.name = path.basename(blueprintPath);
 }
 
 Blueprint.__proto__ = require('./core-object');
@@ -190,7 +188,7 @@ Blueprint.prototype.srcPath = function(file) {
   @return {Promise}
 */
 Blueprint.prototype.install = function(options) {
-  var ui      = this.ui;
+  var ui      = this.ui = options.ui;
   var intoDir = options.target;
   var dryRun  = options.dryRun;
   var locals  = this._locals(options);
@@ -328,7 +326,7 @@ Blueprint.prototype.mapFile = function(file, locals) {
   @return {Object}
 */
 Blueprint.prototype._locals = function(options) {
-  var packageName = this.project.name();
+  var packageName = options.project.name();
   var moduleName = options.entity && options.entity.name || packageName;
 
   var standardLocals = {
@@ -348,8 +346,10 @@ Blueprint.prototype._locals = function(options) {
   @static
   @method lookup
   @namespace Blueprint
-  @param {String} name
-  @param {Object} options
+  @param {String} [name]
+  @param {Object} [options]
+  @param {Array} [options.paths] Extra paths to search for blueprints
+  @param {Object} [options.properties] Properties
   @return {Blueprint}
 */
 Blueprint.lookup = function(name, options) {
@@ -377,12 +377,7 @@ Blueprint.lookup = function(name, options) {
       Constructor = Blueprint;
     }
 
-    return new Constructor({
-        ui: options.ui,
-        analytics: options.analytics,
-        project: options.project,
-        path: blueprintPath
-      });
+    return new Constructor(blueprintPath);
   }
 
   throw new Error('Unknown blueprint: ' + name);
@@ -392,11 +387,14 @@ Blueprint.lookup = function(name, options) {
   @static
   @method list
   @namespace Blueprint
-  @param {Array} lookupPaths
+  @param {Object} [options]
+  @param {Array} [options.paths] Extra paths to search for blueprints
   @return {Blueprint}
 */
-Blueprint.list = function(lookupPaths) {
-  lookupPaths = generateLookupPaths(lookupPaths);
+Blueprint.list = function(options) {
+  options = options || {};
+
+  var lookupPaths = generateLookupPaths(options.paths);
 
   return lookupPaths.map(function(lookupPath) {
     var source = path.basename(path.join(lookupPath, '..'));
@@ -435,7 +433,6 @@ Blueprint.ignoredFiles = [
 */
 Blueprint.defaultLookupPaths = function() {
   return [
-    path.resolve(process.cwd(), 'blueprints'),
     path.resolve(__dirname, '..', '..', 'blueprints')
   ];
 };

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -104,6 +104,10 @@ Project.prototype.initializeAddons = function() {
   });
 };
 
+Project.prototype.blueprintsPath = function() {
+  return path.join(this.root, 'blueprints');
+};
+
 Project.closest = function(pathName) {
   return closestPackageJSON(pathName)
     .then(function(result) {

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -9,17 +9,20 @@ var parseOptions = require('../utilities/parse-options');
 module.exports = Task.extend({
   run: function(options) {
     var blueprint = Blueprint.lookup(options.args[0], {
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project
+      paths: [this.project.blueprintsPath()]
     });
 
+    var entity = {
+      name: options.args[1],
+      options: parseOptions(options.args.slice(2))
+    };
+
     var installOptions = {
-      entity: {
-        name: options.args[1],
-        options: parseOptions(options.args.slice(2))
-      },
-      target: process.cwd(),
+      target: this.project.root,
+      entity: entity,
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project,
       dryRun: options.dryRun,
       verbose: options.verbose
     };

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -9,18 +9,15 @@ module.exports = Task.extend({
     var name          = options.rawName;
     var blueprintName = options.blueprint || 'app';
 
-    var blueprint = Blueprint.lookup(blueprintName, {
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project
-    });
+    var blueprint = Blueprint.lookup(blueprintName);
 
     var installOptions = {
       target: cwd,
-      dryRun: options.dryRun,
-      entity: {
-        name: name
-      }
+      entity: { name: name },
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project,
+      dryRun: options.dryRun
     };
 
     return blueprint.install(installOptions);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -509,4 +509,29 @@ describe('Acceptance: ember generate', function() {
       assertFileEquals('tests/acceptance/foo-test.js', expected);
     });
   });
+
+  it('correctly identifies the root of the project', function() {
+    return initApp()
+      .then(function() {
+        return outputFile(
+          'blueprints/controller/files/app/controllers/__name__.js',
+          "import Ember from 'ember';\n\n" +
+          "export default Ember.Controller.extend({ custom: true });\n"
+        );
+      })
+      .then(function() {
+        process.chdir(path.join(tmpdir, 'app'));
+      })
+      .then(function() {
+        return ember(['generate', 'controller', 'foo']);
+      })
+      .then(function() {
+        process.chdir(tmpdir);
+      })
+      .then(function() {
+        assertFile('app/controllers/foo.js', {
+          contains: 'custom: true'
+        });
+      });
+  });
 });


### PR DESCRIPTION
Addresses #1153

Refactors Blueprint. Here are the details:

Refactor Blueprint Lookup:

The only default lookup path is ember-cli’s own blueprints directory.
Any other lookup paths must be passed explicitly.

```
Blueprint.lookup('foo', { paths: [project.blueprintsPath()] });
```

Refactor Blueprint Construction:

The constructor takes only the path to the blueprint directory. The
options `ui`, `analytics` and `project` should now be passed to
`install`.

```
var blueprint = new Blueprint('my/cool/blueprint');

blueprint.install({
  target: this.project.root,
  entity: { name: 'foo' },
  ui: this.ui,
  analytics: this.analytics,
  project: this.project
});
```
