### PR TITLE
Api-stub blueprint: address two deprecation warnings

### DIFF
--- a/blueprints/api-stub/files/server/index.js
+++ b/blueprints/api-stub/files/server/index.js
@@ -12,7 +12,10 @@ var globSync   = require('glob').sync;
 var routes     = globSync('./routes/**/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(app) {
-  app.use(bodyParser());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({
+    extended: true
+  }));
 
   routes.forEach(function(route) { route(app); });
 };


### PR DESCRIPTION
This addresses two deprecation warnings thrown when the api-stub blueprint is installed and `ember serve` is called.

![warnings](https://cloud.githubusercontent.com/assets/683699/3402619/23d6e192-fd5e-11e3-8395-74079c2d45cc.png)

Cf.: https://stackoverflow.com/questions/24330014/bodyparser-is-deprecated-express-4
