### PR TITLE
[ENHANCEMENT] added ability to opt out of including jQuery in vendor.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ember-cli Changelog
 
 * [BUGFIX] Failed build should return non-zero exit code. [#1169](https://github.com/stefanpenner/ember-cli/pull/1169)
+* [ENHANCEMENT] Use `includeJquery: false` in the Brocfile.js to opt out of including jQuery in the vendor.js file.
 * [BUGFIX] Ensure `ember generate` always operate in relation to project root. [#1165](https://github.com/stefanpenner/ember-cli/pull/1165)
 * [ENHANCEMENT] Upgrade `ember-cli-ember-data` to `0.1.0`. [#1178](https://github.com/stefanpenner/ember-cli/pull/1178)
 * [BUGFIX] Update `ember-cli-ic-ajax` to prevent warnings. [#1180](https://github.com/stefanpenner/ember-cli/pull/1180)

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -64,6 +64,7 @@ function EmberApp(options) {
 
   this.options = merge(options, {
     es3Safe: true,
+    includeJquery: true,
     wrapInEval: !isProduction,
     minifyCSS: {
       enabled: true,
@@ -134,7 +135,9 @@ EmberApp.prototype.addonTreesFor = function(type) {
 EmberApp.prototype.populateLegacyFiles = function () {
   this.import('vendor/loader/loader.js');
 
-  this.import('vendor/jquery/dist/jquery.js');
+  if (this.options.includeJquery) {
+    this.import('vendor/jquery/dist/jquery.js');
+  }
 
   this.import({
     development: 'vendor/handlebars/handlebars.js',


### PR DESCRIPTION
You can remove jQuery form the vendor.js file by adding  `includeJquery: false` to your brocfile.js

We are loading our ember app into a page that has jquery already loaded in the page. We don't want to add it twice. 

``` js
var app = new EmberApp({
  name: require('./package.json').name,

  includeJquery: false,

  getEnvJSON: require('./config/environment')
});
```

Cheers for all the hard work.
