### PR TITLE
Failed build returns 0 exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [BUGFIX] Failed build should return non-zero exit code. [#1169](https://github.com/stefanpenner/ember-cli/pull/1169)
 * [BUGFIX] Ensure `ember generate` always operate in relation to project root. [#1165](https://github.com/stefanpenner/ember-cli/pull/1165)
 * [ENHANCEMENT] Upgrade `ember-cli-ember-data` to `0.1.0`.
 * [BUGFIX] Update `ember-cli-ic-ajax` to prevent warnings. [#1180](https://github.com/stefanpenner/ember-cli/pull/1180)

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -56,6 +56,8 @@ module.exports = Task.extend({
           ui.write('File: ' + file + '\n');
         }
         ui.write(err.stack);
+
+        return 1;
       });
   }
 });

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -150,6 +150,38 @@ describe('Acceptance: smoke-test', function() {
       });
   });
 
+  it('ember build exits with non-zero code when build fails', function () {
+    console.log('    running the slow build tests');
+    this.timeout(360000);
+
+    var appJsPath   = path.join('.', 'app', 'app.js');
+    var ouputContainsBuildFailed = false;
+
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build')
+      .then(function (result) {
+        assert(result.code === 0, 'expected exit code to be zero, but got ' + result.code);
+
+        // add something broken to the project to make build fail
+        fs.appendFileSync(appJsPath, '{(syntaxError>$@}{');
+
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
+          onOutput: function(string) {
+            // discard output as there will be a lot of errors and a long stacktrace
+            // just mark that the output contains expected text
+            if (!ouputContainsBuildFailed && string.match(/Build failed/)) {
+              ouputContainsBuildFailed = true;
+            }
+          }
+        });
+
+      }).then(function () {
+        assert(false, 'should have rejected with a failing build');
+      }).catch(function (result) {
+        assert(ouputContainsBuildFailed, 'command output must contain "Build failed" text');
+        assert(result.code !== 0, 'expected exit code to be non-zero, but got ' + result.code);
+      });
+  });
+
   it('ember new foo, build --watch development, and verify rebuilt after change', function() {
     console.log('    running the slow build --watch tests');
     this.timeout(360000);


### PR DESCRIPTION
When `ember build` fails a non-zero error code should be returned. This is similar to #1150 

Steps to reproduce

``` bash
ember init
# builds project and outputs OK
ember build && echo "OK"
# remove some dependency to break the build
rm -rf vendor/jquery
ember build && echo "OK"
```

Output:

``` bash
version: 0.0.36
Build failed.
Path or pattern "vendor/jquery/dist/jquery.js" did not match any files
Error: Path or pattern "vendor/jquery/dist/jquery.js" did not match any files
    at Object.multiGlob (./node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-kitchen-sink-helpers/index.js:216:13)
    at ./node_modules/ember-cli/node_modules/broccoli-concat/index.js:41:30
    at tryCatch (./node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:163:16)
    at invokeCallback (./node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:172:17)
    at publish (./node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:150:13)
    at flush (./node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/asap.js:51:9)
    at process._tickCallback (node.js:419:13)OK
```
