### PR TITLE
[BUGFIX] error when trailing slash present in argument to generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] Ensure `ember generate` always operate in relation to project root. [#1165](https://github.com/stefanpenner/ember-cli/pull/1165)
 * [ENHANCEMENT] Upgrade `ember-cli-ember-data` to `0.1.0`.
 * [BUGFIX] Update `ember-cli-ic-ajax` to prevent warnings. [#1180](https://github.com/stefanpenner/ember-cli/pull/1180)
+* [BUGFIX] Throw error when trailing slash present in argument to `ember generate`. [#1184](https://github.com/stefanpenner/ember-cli/pull/1184)
 
 ### 0.0.37
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -183,6 +183,21 @@ Blueprint.prototype.srcPath = function(file) {
 };
 
 /*
+  Hook for normalizing entity name
+  @method normalizeEntityName
+  @param {String} entityName
+  @return {null}
+*/
+Blueprint.prototype.normalizeEntityName = function(entityName) {
+  var trailingSlash = /(\/$|\\$)/;
+  if(trailingSlash.test(entityName)) {
+    throw new Error('You specified "' + entityName + '", but you can\'t use a ' +
+                    'trailing slash as an entity name with generators. Please ' +
+                    're-run the command with "' + entityName.replace(trailingSlash, '') + '".\n');
+  }
+};
+
+/*
   @method install
   @param {Object} options
   @return {Promise}
@@ -236,6 +251,8 @@ Blueprint.prototype.install = function(options) {
   if (dryRun) {
     ui.write(chalk.yellow('You specified the dry-run flag, so no changes will be written.\n'));
   }
+
+  if(options.entity) { this.normalizeEntityName( options.entity.name); }
 
   return this.processFiles(intoDir, locals)
     .map(commit)

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -211,5 +211,31 @@ describe('Blueprint', function() {
           assert.deepEqual(actualFiles, basicBlueprintFiles);
         });
     });
+
+
+    it('throws error when there is a trailing forward slash in entityName', function(){
+      options.entity = { name: 'foo/' };
+      assert.throws(function(){
+        blueprint.install(options);
+      }, /You specified "foo\/", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
+
+      options.entity = { name: 'foo\\' };
+      assert.throws(function(){
+        blueprint.install(options);
+      }, /You specified "foo\\", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
+
+      options.entity = { name: 'foo' };
+      assert.doesNotThrow(function(){
+        blueprint.install(options);
+      });
+    });
+
+    it('calls normalizeEntityName hook during install', function(done){
+      blueprint.normalizeEntityName = function(){ done(); };
+      options.entity = { name: 'foo' };
+      blueprint.install(options);
+    });
+
   });
+
 });


### PR DESCRIPTION
This PR provides a hook inside the Blueprint install function that by default throws and error when there is a trailing slash in the argument to `ember generate`.  This can be overridden within each individual blueprint by overriding the normalizeEntityName function inside the constructor for that blueprint.

Let me know what you think.

resolves #1164
