### PR TITLE
Allow vendor files to be easily configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BREAKING ENHANCEMENT] Split `app/templates` into its own tree to prevent preprocessing template files as if they were JavaScript. [#1238](https://github.com/stefanpenner/ember-cli/pull/1238)
 * [ENHANCEMENT] Print a warning when using `app.import` for assets in the root of `vendor/` (this is a significant performance penalty).
 * [ENHANCEMENT] Model generation no longer requires an attribute type. [#1252]
+* [ENHANCEMENT] Allow vendor files to be configurable. [#1187](https://github.com/stefanpenner/ember-cli/pull/1187)
 
 ### 0.0.37
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -81,7 +81,42 @@ function EmberApp(options) {
     },
     loader: 'vendor/loader/loader.js',
     trees: {},
-    getEnvJSON: this.project.require('./config/environment')
+    getEnvJSON: this.project.require('./config/environment'),
+    vendorFiles: {}
+  }, defaults);
+
+  this.vendorFiles = merge(options.vendorFiles, {
+    'loader.js': 'vendor/loader/loader.js',
+    'jquery.js': 'vendor/jquery/dist/jquery.js',
+    'handlebars.js': {
+      development: 'vendor/handlebars/handlebars.js',
+      production:  'vendor/handlebars/handlebars.runtime.js'
+    },
+    'ember.js': {
+      development: 'vendor/ember/ember.js',
+      production:  'vendor/ember/ember.prod.js'
+    },
+    'app-shims.js': [
+      'vendor/ember-cli-shims/app-shims.js', {
+        exports: {
+          ember: ['default']
+        }
+      }
+    ],
+    'ember-resolver.js': [
+      'vendor/ember-resolver/dist/modules/ember-resolver.js', {
+        exports: {
+          'ember/resolver': ['default']
+        }
+      }
+    ],
+    'ember-load-initializers.js': [
+      'vendor/ember-load-initializers/ember-load-initializers.js', {
+        exports: {
+          'ember/load-initializers': ['default']
+        }
+      }
+    ]
   }, defaults);
 
   this.options.trees = merge(this.options.trees, {
@@ -138,37 +173,15 @@ EmberApp.prototype.addonPostprocessTree = function(type, tree) {
 };
 
 EmberApp.prototype.populateLegacyFiles = function () {
-  this.import('vendor/loader/loader.js');
+  var name;
 
-  this.import('vendor/jquery/dist/jquery.js');
+  for (name in this.vendorFiles) {
+    var args = this.vendorFiles[name];
 
-  this.import({
-    development: 'vendor/handlebars/handlebars.js',
-    production:  'vendor/handlebars/handlebars.runtime.js'
-  });
+    if (args === null) { continue; }
 
-  this.import({
-    development: 'vendor/ember/ember.js',
-    production:  'vendor/ember/ember.prod.js'
-  });
-
-  this.import('vendor/ember-cli-shims/app-shims.js', {
-    exports: {
-      ember: ['default']
-    }
-  });
-
-  this.import('vendor/ember-resolver/dist/modules/ember-resolver.js', {
-    exports: {
-      'ember/resolver': ['default']
-    }
-  });
-
-  this.import('vendor/ember-load-initializers/ember-load-initializers.js', {
-    exports: {
-      'ember/load-initializers': ['default']
-    }
-  });
+    this.import.apply(this, [].concat(this.vendorFiles[name]));
+  }
 };
 
 EmberApp.prototype.index = memoize(function() {


### PR DESCRIPTION
This allows alternate paths to be specified, or completely removed.

For example to exclude jQuery from the generated `vendor.js` file:

``` javascript
var app = new EmberApp({
  vendorFiles: {
    'jquery.js': null
  }
});
```

This is a precursor to the new configuration syntax that will could something like `app.config('vendorFiles', 'ember.js', <options here>)`.

Closes #1182.

/cc @kiwiupover
