### PR TITLE
[Bugfix] Ensure error on invalid component entityName

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -1,4 +1,20 @@
 var Blueprint = require('../../lib/models/blueprint');
 
 module.exports = Blueprint.extend({
+  normalizeEntityName: function(entityName) {
+    Blueprint.prototype.normalizeEntityName.apply(this, arguments);
+
+    if(! /\-/.test(entityName)) {
+      throw new Error('You specified "' + entityName + '", but in order to prevent ' +
+                      'clashes with current or future HTML element names you must have ' +
+                      'a hyphen.\n');
+    }
+
+    if(/\//.test(entityName)) {
+      throw new Error('You specified "' + entityName + '", but due to a bug in ' +
+                      'Handlebars (< 2.0) slashes within components/helpers are not ' +
+                      'allowed.\n');
+    }
+
+  }
 });

--- a/tests/unit/blueprints/component-test.js
+++ b/tests/unit/blueprints/component-test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var Blueprint = require('../../../lib/models/blueprint');
+var assert    = require('assert');
+
+describe('blueprint - component', function(){
+  describe('entityName', function(){
+    it('throws error when hyphen is not present', function(){
+      var blueprint = Blueprint.lookup('component');
+
+      assert.throws(function(){
+        var nonConformantComponentName = 'form';
+        blueprint.normalizeEntityName(nonConformantComponentName);
+      }, /must have a hyphen/);
+    });
+
+
+    it('keeps existing behavior by calling Blueprint.normalizeEntityName', function(){
+      var blueprint = Blueprint.lookup('component');
+
+      assert.throws(function(){
+        var nonConformantComponentName = 'x-form/';
+        blueprint.normalizeEntityName(nonConformantComponentName);
+      }, /trailing slash/);
+
+    });
+
+    it('throws error when slash is found within component', function(){
+      var blueprint = Blueprint.lookup('component');
+
+      assert.throws(function(){
+        var nonConformantComponentName = 'x-form/blah';
+        blueprint.normalizeEntityName(nonConformantComponentName);
+      }, /due to a bug in Handlebars \(< 2.0\) slashes within components\/helpers are not allowed/);
+
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1190

Also:
- preserves behavior of original Blueprint.entityName
- ensures that no slashes are present in the component entityName (due to Handlebars < 2.0 bug)
