### PR TITLE
Update --dry-run, add --skip-npm and --skip-bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Update `ember-cli-ic-ajax` to prevent warnings. [#1180](https://github.com/stefanpenner/ember-cli/pull/1180)
 * [BUGFIX] Throw error when trailing slash present in argument to `ember generate`. [#1184](https://github.com/stefanpenner/ember-cli/pull/1184)
 * [ENHANCEMENT] Don't expect `Ember` or `Em` to be global in tests. `Ember` or `Em` needs to be imported. [#1201](https://github.com/stefanpenner/ember-cli/pull/1201)
+* [BUGFIX] Make behaviour of `--dry-run` more obvious & add `--skip-npm` and `--skip-bower`. [#1205](https://github.com/stefanpenner/ember-cli/pull/1205)
 
 ### 0.0.37
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -15,7 +15,9 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false },
     { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: path, default: 'app' }
+    { name: 'blueprint', type: path, default: 'app' },
+    { name: 'skip-npm', type: Boolean, default: false },
+    { name: 'skip-bower', type: Boolean, default: false }
   ],
 
   anonymousOptions: [
@@ -23,6 +25,11 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions, rawArgs) {
+    if (commandOptions.dryRun) {
+      commandOptions.skipNpm = true;
+      commandOptions.skipBower = true;
+    }
+
     var installBlueprint = new this.tasks.InstallBlueprint({
       ui: this.ui,
       analytics: this.analytics,
@@ -54,12 +61,12 @@ module.exports = Command.extend({
 
     return installBlueprint.run(blueprintOpts)
       .then(function() {
-        if (!commandOptions.dryRun) {
+        if (!commandOptions.skipNpm) {
           return npmInstall.run({ verbose: commandOptions.verbose });
         }
       })
       .then(function() {
-        if (!commandOptions.dryRun) {
+        if (!commandOptions.skipBower) {
           return bowerInstall.run({ verbose: commandOptions.verbose });
         }
       });

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -16,7 +16,9 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false },
     { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: path, default: 'app' }
+    { name: 'blueprint', type: path, default: 'app' },
+    { name: 'skip-npm', type: Boolean, default: false },
+    { name: 'skip-bower', type: Boolean, default: false }
   ],
 
   anonymousOptions: [

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -210,7 +210,9 @@ Blueprint.prototype.install = function(options) {
   var actions = {
     write: function(info) {
       ui.write('  ' + chalk.green('create') + ' ' + info.displayPath + '\n');
-      return writeFile(info.outputPath, info.render());
+      if (!dryRun) {
+        return writeFile(info.outputPath, info.render());
+      }
     },
 
     skip: function(info) {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -37,7 +37,7 @@ describe('Acceptance: ember generate', function() {
   });
 
   function initApp() {
-    return ember(['init', 'my-app', '--dry-run']);
+    return ember(['init', 'my-app', '--skip-npm', '--skip-bower']);
   }
 
   function generate(args) {

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -61,7 +61,8 @@ describe('Acceptance: ember init', function() {
   it('ember init', function() {
     return ember([
       'init',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower',
     ]).then(confirmBlueprinted);
   });
 
@@ -71,7 +72,8 @@ describe('Acceptance: ember init', function() {
 
     return ember([
       'init',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower'
     ]).then(confirmBlueprinted).then(function() {
       tmp.teardown('./tmp/foo');
     });
@@ -80,11 +82,13 @@ describe('Acceptance: ember init', function() {
   it('init an already init\'d folder', function() {
     return ember([
       'init',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower'
     ]).then(function() {
       return ember([
         'init',
-        '--dry-run'
+        '--skip-npm',
+        '--skip-bower'
       ]).then(confirmBlueprinted);
     });
   });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -54,7 +54,8 @@ describe('Acceptance: ember new', function() {
     return ember([
       'new',
       'foo',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower'
     ]).then(confirmBlueprinted);
   });
 
@@ -75,7 +76,8 @@ describe('Acceptance: ember new', function() {
     return ember([
       'new',
       'FooApp',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower'
     ]).then(function() {
       assert(!fs.existsSync('FooApp'));
 
@@ -88,12 +90,14 @@ describe('Acceptance: ember new', function() {
     return ember([
       'new',
       'foo',
-      '--dry-run'
+      '--skip-npm',
+      '--skip-bower'
     ]).then(function() {
       return ember([
         'new',
         'foo',
-        '--dry-run'
+        '--skip-npm',
+        '--skip-bower'
       ]).then(function() {
         assert(!fs.existsSync('foo'));
       });
@@ -109,7 +113,8 @@ describe('Acceptance: ember new', function() {
     return ember([
       'new',
       'foo',
-      '--dry-run',
+      '--skip-npm',
+      '--skip-bower',
       '--blueprint=my_blueprint'
     ]).then(confirmBlueprintedForDir('tmp/my_blueprint'));
   });


### PR DESCRIPTION
Previously --dry-run meant a couple different things.

In the `init` command it meant “don’t run npm install or bower install”.
In the `generate` command it meant “don’t overwrite any existing files”.

This patch changes the behaviour of the flag in both places.

--dry-run now only ever means “don’t write _any_ files”

Two new flags are introduced for `new` and `init`:

--skip-npm
--skip-bower

Their behaviour is hopefully self-explanatory.

Addresses #1199
