### PR TITLE
remove .gitkeep from init updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [BUGFIX] Throw error when trailing slash present in argument to `ember generate`. [#1184](https://github.com/stefanpenner/ember-cli/pull/1184)
 * [ENHANCEMENT] Don't expect `Ember` or `Em` to be global in tests. `Ember` or `Em` needs to be imported. [#1201](https://github.com/stefanpenner/ember-cli/pull/1201)
 * [BUGFIX] Make behaviour of `--dry-run` more obvious & add `--skip-npm` and `--skip-bower`. [#1205](https://github.com/stefanpenner/ember-cli/pull/1205)
+* [ENHANCEMENT] Remove .gitkeep files from `ember init` inside an existing project [#1209](https://github.com/stefanpenner/ember-cli/pull/1209)
 
 ### 0.0.37
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -202,10 +202,11 @@ Blueprint.prototype.normalizeEntityName = function(entityName) {
   @return {Promise}
 */
 Blueprint.prototype.install = function(options) {
-  var ui      = this.ui = options.ui;
-  var intoDir = options.target;
-  var dryRun  = options.dryRun;
-  var locals  = this._locals(options);
+  var ui       = this.ui = options.ui;
+  var intoDir  = options.target;
+  var dryRun   = options.dryRun;
+  var locals   = this._locals(options);
+  this.project = options.project;
 
   var actions = {
     write: function(info) {
@@ -295,18 +296,31 @@ Blueprint.prototype.buildFileInfo = function(destPath, templateVariables, file) 
 };
 
 /*
+  @method isUpdate
+  @return {Boolean}
+*/
+Blueprint.prototype.isUpdate = function() {
+  if (this.project && this.project.isEmberCLIProject) {
+    return this.project.isEmberCLIProject();
+  }
+};
+
+/*
   @method processFiles
   @param {String} intoDir
   @param {Object} templateVariables
 */
 Blueprint.prototype.processFiles = function(intoDir, templateVariables) {
-
   function destPath(file) {
     return path.join(intoDir, file);
   }
 
   var fileInfos = this.files().
     map(this.buildFileInfo.bind(this, destPath, templateVariables));
+
+  if (this.isUpdate()) {
+    Blueprint.ignoredFiles = Blueprint.ignoredFiles.concat(Blueprint.ignoredUpdateFiles);
+  }
 
   function isValidFile(fileInfo) {
     if (isIgnored(fileInfo)) {
@@ -443,6 +457,14 @@ Blueprint.renamedFiles = {
 */
 Blueprint.ignoredFiles = [
   '.DS_Store'
+];
+
+/*
+  @static
+  @property ignoredUpdateFiles
+*/
+Blueprint.ignoredUpdateFiles = [
+  '.gitkeep'
 ];
 
 /*

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -434,7 +434,6 @@ describe('Acceptance: ember generate', function() {
                   "module.exports = Blueprint.extend({\n" +
                   "});"
       });
-      assertFile('blueprints/foo/files/.gitkeep');
     });
   });
 

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -14,6 +14,8 @@ var minimatch = require('minimatch');
 var remove    = require('lodash-node/compat/arrays/remove');
 var any       = require('lodash-node/compat/collections/some');
 
+var defaultIgnoredFiles = Blueprint.ignoredFiles;
+
 describe('Acceptance: ember init', function() {
   before(function() {
     conf.setup();
@@ -26,6 +28,7 @@ describe('Acceptance: ember init', function() {
   beforeEach(function() {
     tmp.setup('./tmp');
     process.chdir('./tmp');
+    Blueprint.ignoredFiles = defaultIgnoredFiles;
   });
 
   afterEach(function() {

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -17,6 +17,8 @@ var fixtureBlueprints = path.resolve(__dirname, '..', '..', 'fixtures', 'bluepri
 var basicBlueprint    = path.join(fixtureBlueprints, 'basic');
 var basicNewBlueprint = path.join(fixtureBlueprints, 'basic_2');
 
+var defaultIgnoredFiles = Blueprint.ignoredFiles;
+
 var basicBlueprintFiles = [
   '.ember-cli',
   '.gitignore',
@@ -32,6 +34,9 @@ assert.match = function(actual, matcher) {
 };
 
 describe('Blueprint', function() {
+  beforeEach(function() {
+    Blueprint.ignoredFiles = defaultIgnoredFiles;
+  });
 
   describe('.lookup', function() {
     it('uses an explicit path if one is given', function() {
@@ -218,6 +223,53 @@ describe('Blueprint', function() {
         });
     });
 
+    describe('called on an existing project', function() {
+      beforeEach(function() {
+        Blueprint.ignoredUpdateFiles.push('foo.txt');
+      });
+
+      it('ignores files in ignoredUpdateFiles', function() {
+        return blueprint.install(options)
+          .then(function() {
+            var output = ui.output.trim().split('\n');
+            ui.output = '';
+
+            assert.match(output.shift(), /^installing/);
+            assert.match(output.shift(), /create.* \.ember-cli/);
+            assert.match(output.shift(), /create.* \.gitignore/);
+            assert.match(output.shift(), /create.* foo.txt/);
+            assert.match(output.shift(), /create.* test.txt/);
+            assert.equal(output.length, 0);
+
+            var blueprintNew = new Blueprint(basicNewBlueprint);
+
+            setTimeout(function(){
+              ui.inputStream.write('n\n');
+            }, 25);
+
+            setTimeout(function(){
+              ui.inputStream.write('n\n');
+            }, 50);
+
+            options.project.isEmberCLIProject = function() { return true; };
+
+            return blueprintNew.install(options);
+          })
+          .then(function() {
+            var actualFiles = walkSync(tmpdir).sort();
+            var output = ui.output.trim().split('\n');
+            assert.match(output.shift(), /^installing/);
+            assert.match(output.shift(), /Overwrite.*test.*\?/); // Prompt
+            assert.match(output.shift(), /Overwrite.*test.*No, skip/);
+            assert.match(output.shift(), /identical.* \.ember-cli/);
+            assert.match(output.shift(), /identical.* \.gitignore/);
+            assert.match(output.shift(), /skip.* test.txt/);
+            assert.equal(output.length, 0);
+
+            assert.deepEqual(actualFiles, basicBlueprintFiles);
+          });
+      });
+    });
 
     it('throws error when there is a trailing forward slash in entityName', function(){
       options.entity = { name: 'foo/' };


### PR DESCRIPTION
refs https://github.com/stefanpenner/ember-cli/issues/1208

Provide a property on Blueprint of what files to ignore when updating a current CLI project. This could possibly be extended to let the user define what they want to skip in a config
