### PR TITLE
Add addon.postBuild hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BUGFIX] Make behaviour of `--dry-run` more obvious & add `--skip-npm` and `--skip-bower`. [#1205](https://github.com/stefanpenner/ember-cli/pull/1205)
 * [ENHANCEMENT] Remove .gitkeep files from `ember init` inside an existing project [#1209](https://github.com/stefanpenner/ember-cli/pull/1209)
 * [ENHANCEMENT] Addons can add commands to the local `ember` command. [#1196](https://github.com/stefanpenner/ember-cli/pull/1196)
+* [ENHANCEMENT] Addons can implement a postBuild hook. [#1215](https://github.com/stefanpenner/ember-cli/pull/1215)
 
 ### 0.0.37
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -72,9 +72,26 @@ module.exports = Task.extend({
       });
   },
 
+  addonsPostBuild: function(results){
+    var addonPromises = [];
+
+    if(this.project && this.project.addons.length) {
+      addonPromises = this.project.addons.map(function(addon){
+        if(addon.postBuild) {
+          return addon.postBuild(results);
+        }
+      }).filter(Boolean);
+    }
+
+    return Promise.all(addonPromises).then(function() {
+      return results;
+    });
+  },
+
   build: function() {
     return this.builder.build.apply(this.builder, arguments)
-      .then(this.processBuildResult.bind(this));
+      .then(this.processBuildResult.bind(this))
+      .then(this.addonsPostBuild.bind(this));
   },
 
   onExit: function() {

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -13,7 +13,8 @@ module.exports = Task.extend({
 
     process.env.EMBER_ENV = process.env.EMBER_ENV || env;
     var builder = new Builder({
-      outputPath: options.outputPath
+      outputPath: options.outputPath,
+      project: this.project
     });
 
     var watcher = new Watcher({

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -4,6 +4,8 @@ var fs      = require('fs-extra');
 var Builder = require('../../../lib/models/builder');
 var touch   = require('../../helpers/file-utils').touch;
 var assert  = require('assert');
+var Promise = require('../../../lib/ext/promise');
+var stub    = require('../../helpers/stub').stub;
 
 describe('models/builder.js', function() {
   var builder, outputPath;
@@ -30,5 +32,33 @@ describe('models/builder.js', function() {
         assert(!fs.existsSync(firstFile));
         assert(!fs.existsSync(secondFile));
       });
+  });
+
+  describe('addons', function() {
+    it('allows addons to add promises postbuild', function() {
+      var addon = {
+        name: 'TestAddon',
+        postBuild: function() { }
+      };
+      var postBuild = stub(addon, 'postBuild');
+      var results = 'build results';
+      builder = new Builder({
+        setupBroccoliBuilder: function() { },
+        trapSignals:          function() { },
+        cleanupOnExit:        function() { },
+        builder: {
+          build: function() { return Promise.resolve(results); }
+        },
+        processBuildResult: function(buildResults) { return Promise.resolve(buildResults); },
+        project: {
+          addons: [addon]
+        }
+      });
+
+      return builder.build().then(function() {
+        assert.equal(postBuild.called, 1, 'expected postBuild to be called');
+        assert.equal(postBuild.calledWith[0][0], results, 'expected postBuild to be called with the results');
+      });
+    });
   });
 });


### PR DESCRIPTION
implement a postBuild hook in the builder addons can use to run arbitrarary code after each build

This allows an added to hook into the build/rebuild process and return a promise that will be passed the results from the processBuildResult method.

My use case for this is that after every rebuild, I need to run `cordova build ios` on the command line but it does not affect the output of the js/css files so it needs to be after everything is done
