### PR TITLE
Ensure that JSHint is done after preprocessors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Addons can add post-processing steps to the `Brocfile.js` process. [#1214](https://github.com/stefanpenner/ember-cli/pull/1214)
 * [ENHANCEMENT] `broccoli-asset-rev` has been moved to an addon using the standard addon post-processing hooks. [#1214](https://github.com/stefanpenner/ember-cli/pull/1214)
 * [ENHANCEMENT] Allow `app.toTree` to accept an array of additional trees to merge in the final output. [#1214](https://github.com/stefanpenner/ember-cli/pull/1214)
+* [BUGFIX] Only run JSHint after preprocessing. [#1221](https://github.com/stefanpenner/ember-cli/pull/1221)
 
 ### 0.0.37
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -18,7 +18,6 @@ var preprocessMinifyCss = p.preprocessMinifyCss;
 
 var replace     = require('broccoli-replace');
 var compileES6  = require('broccoli-es6-concatenator');
-//var validateES6 = require('broccoli-es6-import-validate');
 var pickFiles   = require('broccoli-static-compiler');
 var jshintTrees = require('broccoli-jshint');
 var concatFiles = require('broccoli-concat');
@@ -234,8 +233,9 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
   var vendor = this._processedVendorTree();
 
   var appAndTemplates = preprocessTemplates(app);
+  var preprocessedApp = preprocessJs(appAndTemplates, '/', this.name);
 
-  var sourceTrees = [ vendor ];
+  var sourceTrees = [ vendor, preprocessedApp ];
 
   if (this.tests) {
     var tests  = this._processedTestsTree();
@@ -244,7 +244,7 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
     sourceTrees.push(preprocessedTests);
 
     if (this.hinting) {
-      var jshintedApp = jshintTrees(app, {
+      var jshintedApp = jshintTrees(preprocessedApp, {
         jshintrcPath: this.project.root,
         description: 'JSHint - App'
       });
@@ -266,17 +266,6 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
       sourceTrees.push(jshintedApp);
       sourceTrees.push(jshintedTests);
     }
-  }
-
-  // js hint should be applied before preprocessing, validateES6 after
-  var preprocessedApp = preprocessJs(appAndTemplates, '/', this.name);
-  sourceTrees.unshift(preprocessedApp);
-
-  if (this.hinting) {
-    //var applicationJs = validateES6(preprocessedApp, {
-    //  whitelist: this.importWhitelist
-    //});
-    sourceTrees.push(preprocessedApp);
   }
 
   var emberCLITree = pickFiles(unwatchedTree(__dirname), {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "broccoli-concat",
     "broccoli-es3-safe-recast",
     "broccoli-es6-concatenator",
-    "broccoli-es6-import-validate",
     "broccoli-file-mover",
     "broccoli-jshint",
     "broccoli-merge-trees",


### PR DESCRIPTION
JSHint currently does not work for JS that needs to be preprocessed. Specifically, this affects CoffeeScript users and folks that use custom sweet-js macros.

Also, removed left over commented out references to validateES6.
