### PR TITLE
Add compileES6 method so addons can use broccoli-es6-concatenator

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -534,6 +534,10 @@ EmberApp.prototype.toTree = function(additionalTrees) {
   return this.addonPostprocessTree('all', tree);
 };
 
+EmberApp.prototype.compileES6 = function(inputTree, options) {
+  return compileES6(inputTree, options);
+};
+
 function injectENVJson(fn, env, tree, files) {
   // TODO: real templating
   var envJsonString = function(){


### PR DESCRIPTION
There is an issue with es6-module-transpiler that prevents the module being loaded more than once, and this prevents any ember-addons from using broccoli-es6-concatenator. See [this issue](https://github.com/joliss/broccoli-es6-concatenator/issues/20) for a summary of the issue. This PR provides a simple workaround that allows addons to use the instance of the module that's loaded by ember-cli.

I'm reluctant to submit this workaround, but AFAIK there's simply no other solution other than running another instance of broccoli, which is just horrible.
