### PR TITLE
Allow testing of production assets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Allow `app.toTree` to accept an array of additional trees to merge in the final output. [#1214](https://github.com/stefanpenner/ember-cli/pull/1214)
 * [BUGFIX] Only run JSHint after preprocessing. [#1221](https://github.com/stefanpenner/ember-cli/pull/1221)
 * [ENHANCEMENT] Addons can add blueprints. [#1222](https://github.com/stefanpenner/ember-cli/pull/1222)
+* [ENHANCEMENT] Allow testing of production assets. [#1230](https://github.com/stefanpenner/ember-cli/pull/1230)
 
 ### 0.0.37
 

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,6 +26,6 @@
     "glob": "^3.2.9",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-ember-data": "0.1.0",
-    "broccoli-asset-rev": "0.0.10"
+    "broccoli-asset-rev": "0.0.11"
   }
 }

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -60,6 +60,10 @@ function EmberApp(options) {
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
 
+  if (process.env.EMBER_CLI_TEST_COMMAND) {
+    this.tests = true;
+  }
+
   this.options = merge(options, {
     es3Safe: true,
     wrapInEval: !isProduction,
@@ -286,7 +290,7 @@ EmberApp.prototype.javascript = memoize(function() {
   var applicationJs       = this.appAndDependencies();
   var legacyFilesToAppend = this.legacyFilesToAppend;
 
-  if (this.env !== 'production') {
+  if (this.tests) {
     this.import('vendor/ember-qunit/dist/named-amd/main.js', {
       exports: {
         'ember-qunit': [
@@ -402,6 +406,10 @@ EmberApp.prototype.testFiles = memoize(function() {
       srcDir: '/',
       destDir: '/'
     });
+
+  if (this.options.fingerprint && this.options.fingerprint.exclude) {
+    this.options.fingerprint.exclude.push('testem');
+  }
 
   var iconsPath = 'vendor/ember-qunit-notifications';
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -10,6 +10,7 @@ module.exports = Command.extend({
   description: 'Runs your apps test suite.',
 
   availableOptions: [
+    { name: 'environment', type: String, default: 'development' },
     { name: 'config-file', type: String,  default: './testem.json' },
     { name: 'server',      type: Boolean, default: false},
     { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.'},
@@ -18,6 +19,10 @@ module.exports = Command.extend({
   init: function() {
     this.assign    = require('lodash-node/modern/objects/assign');
     this.quickTemp = require('quick-temp');
+
+    if (!this.testing) {
+      process.env.EMBER_CLI_TEST_COMMAND = true;
+    }
   },
 
   tmp: function() {
@@ -38,7 +43,7 @@ module.exports = Command.extend({
     };
 
     if (commandOptions.server) {
-      options.builder = new Builder({outputPath: outputPath});
+      options.builder = new Builder(testOptions);
 
       var TestServerTask = this.tasks.TestServer;
       var testServer     = new TestServerTask(options);
@@ -54,7 +59,7 @@ module.exports = Command.extend({
       var build = new BuildTask(options);
 
       return build.run({
-          environment: 'development',
+          environment: commandOptions.environment,
           outputPath: outputPath
         })
         .then(function() {

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -11,6 +11,9 @@ var signalsTrapped = false;
 
 module.exports = Task.extend({
   setupBroccoliBuilder: function() {
+    this.environment = this.environment || 'development';
+    process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
+
     var broccoli = require('broccoli');
     this.tree    = broccoli.loadBrocfile();
     this.builder = new broccoli.Builder(this.tree);

--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -8,16 +8,16 @@ var Promise  = require('../ext/promise');
 
 module.exports = Task.extend({
   run: function(options) {
-    var env = options.environment || 'development';
-    process.env.EMBER_ENV = process.env.EMBER_ENV || env;
-
     this.ui.pleasantProgress.start(
       chalk.green('Building'), chalk.green('.')
     );
 
     return new Watcher({
       ui: this.ui,
-      builder: new Builder({outputPath: options.outputPath}),
+      builder: new Builder({
+        outputPath: options.outputPath,
+        environment: options.environment
+      }),
       analytics: this.analytics,
       options: options
     }).then(function() {

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -7,16 +7,14 @@ var Builder  = require('../models/builder');
 module.exports = Task.extend({
   // Options: String outputPath
   run: function(options) {
-    var env = options.environment || 'development';
-    process.env.EMBER_ENV = process.env.EMBER_ENV || env;
-
     var ui        = this.ui;
     var analytics = this.analytics;
 
     ui.pleasantProgress.start(chalk.green('Building'), chalk.green('.'));
 
     var builder = new Builder({
-      outputPath: options.outputPath
+      outputPath: options.outputPath,
+      environment: options.environment
     });
 
     return builder.build()

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -9,12 +9,10 @@ var Builder          = require('../models/builder');
 
 module.exports = Task.extend({
   run: function(options) {
-    var env = options.environment || 'development';
-
-    process.env.EMBER_ENV = process.env.EMBER_ENV || env;
     var builder = new Builder({
       outputPath: options.outputPath,
-      project: this.project
+      project: this.project,
+      environment: options.environment
     });
 
     var watcher = new Watcher({

--- a/lib/tasks/update.js
+++ b/lib/tasks/update.js
@@ -7,9 +7,6 @@ var fs       = require('fs');
 
 module.exports = Task.extend({
   run: function(options, updateInfo) {
-    var env = options.environment || 'development';
-    process.env.EMBER_ENV = process.env.EMBER_ENV || env;
-
     this.ui.write(chalk.yellow('\nA new version of ember-cli is available (' +
       updateInfo.newestVersion + ').\n'));
 

--- a/tests/fixtures/smoke-tests/passing-test/tests/unit/some-test.js
+++ b/tests/fixtures/smoke-tests/passing-test/tests/unit/some-test.js
@@ -1,0 +1,7 @@
+/*jshint strict:false */
+/* globals test, ok */
+
+test('passing test', function() {
+  ok(true, 'test should pass');
+});
+

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -21,7 +21,8 @@ describe('test command', function() {
     };
 
     options = commandOptions({
-      tasks: tasks
+      tasks: tasks,
+      testing: true
     });
 
     stub(tasks.Test.prototype,  'run', Promise.resolve());


### PR DESCRIPTION
- Allow `--environment` to be used in `ember test` command.
- Cleanup `EmberApp` so that it uses `this.tests` instead of checking for `production` environment.
- Use `process.env.EMBER_CLI_TEST_COMMAND` to signify the current build was triggered by `ember test` (as opposed to `ember build` or `ember server`).
- Consolidate `process.env.EMBER_ENV` checking to a single location.

This is pending https://github.com/rickharrison/broccoli-asset-rev/pull/9.

Closes #215.
