### PR TITLE
Provide Ember CLI version to Project model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [BUGFIX] Only run JSHint after preprocessing. [#1221](https://github.com/stefanpenner/ember-cli/pull/1221)
 * [ENHANCEMENT] Addons can add blueprints. [#1222](https://github.com/stefanpenner/ember-cli/pull/1222)
 * [ENHANCEMENT] Allow testing of production assets. [#1230](https://github.com/stefanpenner/ember-cli/pull/1230)
+* [ENHANCEMENT] Provide Ember CLI version to Project model. [#1239](https://github.com/stefanpenner/ember-cli/pull/1239)
 
 ### 0.0.37
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -9,6 +9,8 @@ var assign  = require('lodash-node/modern/objects/assign');
 var DAG     = require('../utilities/DAG');
 var Command = require('../models/command');
 
+var emberCLIVersion = require('../utilities/ember-cli-version');
+
 function Project(root, pkg) {
   this.root = root;
   this.pkg  = pkg;
@@ -47,6 +49,8 @@ Project.prototype.require = function(file) {
     return require(path.join(this.root, 'node_modules', file));
   }
 };
+
+Project.prototype.emberCLIVersion = emberCLIVersion;
 
 Project.prototype.dependencies = function() {
   this.pkg = this.pkg || {};

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -6,6 +6,8 @@ var tmp     = require('../../helpers/tmp');
 var touch   = require('../../helpers/file-utils').touch;
 var assert  = require('assert');
 
+var emberCLIVersion = require('../../../lib/utilities/ember-cli-version');
+
 describe('models/project.js', function() {
   var project, projectPath;
 
@@ -102,6 +104,12 @@ describe('models/project.js', function() {
       ];
 
       assert.deepEqual(project.blueprintLookupPaths(), expected);
+    });
+  });
+
+  describe('emberCLIVersion', function() {
+    it('should return the same value as the utlity function', function() {
+      assert.equal(project.emberCLIVersion(), emberCLIVersion());
     });
   });
 });


### PR DESCRIPTION
This will allow addons to do different things based on various Ember CLI versions so that things like https://github.com/stefanpenner/ember-cli/pull/1238 can be handled gracefully.
