### PR TITLE
[DOC] Using canary build instead of release

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -52,6 +52,21 @@ If you are using SublimeText 3 with `ember-cli`, by default it will try to index
 "folder_exclude_patterns": [".svn", ".git", ".hg", "CVS", "tmp/class-*", "tmp/es_*", "tmp/jshinter*", "tmp/replace_*", "tmp/static_compiler*", "tmp/template_compiler*", "tmp/tree_merger*", "tmp/coffee_script*", "tmp/concat-tmp*", "tmp/export_tree*", "tmp/sass_compiler*"]
 {% endhighlight %}
 
+### Using canary build instead of release
+
+In bower.json instead of a version number use:
+
+    "ember": "components/ember#canary",
+
+And, following `dependencies` add `resolutions`:
+
+    "resolutions": {
+      "ember": "canary"
+    }
+
+Wipe your vender directory clean then run `bower install`.
+
+
 ### Removing default ember-cli libraries
 
 * To use ember-cli without Ember Data


### PR DESCRIPTION
Adds instructions on editing bower.json to use ember canary build.

Based on https://github.com/rjackson/_____ember-cli-test/commit/e4a9413b0b6c6d87f325a58b6115326f852741cc
