### PR TITLE
Add import statements to examples

### DIFF
--- a/_posts/2013-04-12-ember-data.md
+++ b/_posts/2013-04-12-ember-data.md
@@ -26,6 +26,8 @@ For example, we can create a todo model like so:
 
 {% highlight javascript linenos %}
 // models/todo.js
+import DS from "ember-data";
+
 export default DS.Model.extend({
   title: DS.attr('string'),
   isCompleted: DS.attr('boolean'),
@@ -33,6 +35,8 @@ export default DS.Model.extend({
 });
 
 // models/quick-note.js
+import DS from "ember-data";
+
 export default DS.Model.extend({
   name: DS.attr('string'),
   todo: DS.belongsTo('todo')
@@ -52,6 +56,8 @@ Adapters can be placed at `/app/adapters/type.js`:
 
 {% highlight javascript linenos %}
 // adapters/post.js
+import DS from "ember-data";
+
 export default DS.RESTAdapter.extend({});
 {% endhighlight %}
 
@@ -59,6 +65,8 @@ And its serializer can be placed in `/app/serializers/type.js`:
 
 {% highlight javascript linenos %}
 // serializers/post.js
+import DS from "ember-data";
+
 export default DS.RESTSerializer.extend({});
 {% endhighlight %}
 

--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -15,6 +15,9 @@ Ember Data and Handlebars. In this section we review some of these naming conven
 
 {% highlight javascript linenos %}
 // app/adapters/application.js
+import Ember from "ember";
+import DS from "ember-data";
+
 export default DS.RESTAdapter.extend({});
 {% endhighlight %}
 
@@ -29,6 +32,8 @@ export default Ember.TextField.extend({});
 
 {% highlight javascript linenos %}
 // app/controllers/stop-watch.js
+import Ember from "ember";
+
 export default Ember.ObjectController.extend({});
 {% endhighlight %}
 
@@ -39,6 +44,8 @@ like such: `app/controllers/posts/index.js`.
 
 {% highlight javascript linenos %}
 // app/helpers/format-time.js
+import Ember from "ember";
+
 export default Ember.Handlebars.makeBoundHelper(function(){});
 {% endhighlight %}
 
@@ -60,6 +67,8 @@ Note: `initializers` are loaded automatically.
 
 {% highlight javascript linenos %}
 // app/mixins/evented.js
+import Ember from "ember";
+
 export default Ember.Mixin.create({});
 {% endhighlight %}
 
@@ -67,6 +76,9 @@ export default Ember.Mixin.create({});
 
 {% highlight javascript linenos %}
 // app/models/observation.js
+import Ember from "ember";
+import DS from "ember-data";
+
 export default DS.Model.extend({});
 {% endhighlight %}
 
@@ -83,6 +95,9 @@ Nested routes as such: `app/routes/timer/index.js` or `app/routes/timer/record.j
 
 {% highlight javascript linenos %}
 // app/serializers/observation.js
+import Ember from "ember";
+import DS from "ember-data";
+
 export default DS.RESTSerializer.extend({});
 {% endhighlight %}
 
@@ -90,6 +105,9 @@ export default DS.RESTSerializer.extend({});
 
 {% highlight javascript linenos %}
 // app/transforms/time.js
+import Ember from "ember";
+import DS from "ember-data";
+
 export default DS.Transform.extend({});
 {% endhighlight %}
 
@@ -146,6 +164,7 @@ yourself. But there a couple of things you should know.
 
 {% highlight javascript linenos %}
 // models/user.js
+import Ember from "ember";
 export default Ember.Model.extend();
 {% endhighlight %}
 
@@ -155,6 +174,7 @@ You may want to name your files according to their function, this is easily acco
 
 {% highlight javascript %}
 // models/user-model.js
+import Ember from "ember";
 export default Ember.Model.extend();
 {% endhighlight %}
 
@@ -164,6 +184,7 @@ If you prefer to nest your files to better manage your application, you can easi
 
 {% highlight javascript linenos %}
 // controllers/posts/new.js results in a controller named "controllers.posts/new"
+import Ember from "ember";
 export default Ember.Controller.extend();
 {% endhighlight %}
 
@@ -172,6 +193,7 @@ them back to dots. Simply create an alias like this:
 
 {% highlight javascript linenos %}
 // controllers/posts.js
+import Ember from "ember";
 export default Ember.Controller.extend({
   needs: ['posts/details'],
   postsDetails: Ember.computed.alias('controllers.posts/details')
@@ -191,6 +213,7 @@ export default Ember.Controller.extend({
 Let's say we were using Ember out of the box with the following view:
 
 {% highlight javascript %}
+import Ember from "ember";
 App.UserView = Ember.View.extend({});
 {% endhighlight %}
 

--- a/_posts/2014-04-02-using-modules.md
+++ b/_posts/2014-04-02-using-modules.md
@@ -21,6 +21,8 @@ namespace.
 For example, this route definition in `app/routes/index.js`:
 
 {% highlight javascript linenos %}
+// import Ember from "ember";
+
 var IndexRoute = Ember.Route.extend({
   model: function() {
     return ['red', 'yellow', 'blue'];
@@ -37,6 +39,8 @@ exports.
 You can also export directly, i.e., without having to declare a variable:
 
 {% highlight javascript linenos %}
+import Ember from "ember";
+
 export default Ember.Route.extend({
   model: function() {
     return ['red', 'yellow', 'blue'];
@@ -153,6 +157,8 @@ Ember automatically loads files under `app/helpers` if they contain a dash:
 
 {% highlight javascript linenos %}
 // app/helpers/upper-case.js
+import Ember from "ember";
+
 export default Ember.Handlebars.makeBoundHelper(function(value, options) {
   return value.toUpperCase();
 });
@@ -176,7 +182,9 @@ export default function(value, options) {
 In `app.js`:
 
 {% highlight javascript linenos %}
+import Ember from "ember";
 import exampleHelper from './helpers/example';
+
 Ember.Handlebars.registerBoundHelper('example', exampleHelper);
 {% endhighlight %}
 
@@ -200,13 +208,14 @@ instead of:
 
 {% highlight javascript linenos %}
 // app/views/my-text-field.js
+import Ember from "ember";
 export default Ember.TextField.extend(
   // some custom behaviour
 });
 
 // app/helpers/my-text-field.js... the below does not work!!!
 import MyTextField from 'my-app/helpers/my-text-field';
-
+import Ember from "ember";
 Ember.Handlebars.helper('my-text-field', MyTextField);
 {% endhighlight %}
 
@@ -214,6 +223,7 @@ Do this:
 
 {% highlight javascript linenos %}
 // Given... app/components/my-text-field.js
+import Ember from "ember";
 export default Ember.TextField.extend({
   // some custom behaviour...
 });


### PR DESCRIPTION
While there is already a note about having to import `DS` and `Ember` in the docs, examples speak louder than notes so I propose we add these import statements to all examples.
