### PR TITLE
Use resource-based stubs which are automatically namespaced

### DIFF
--- a/blueprints/api-stub/files/server/routes/__name__.js
+++ b/blueprints/api-stub/files/server/routes/__name__.js
@@ -1,5 +1,7 @@
 module.exports = function(app) {
-  app.get('<%= path %>', function(req, res) {
-    res.send('hello');
+  var <%= camelizedModuleName %>Router = express.Router();
+  <%= camelizedModuleName %>Router.get('/', function(req, res) {
+    res.send({<%= dasherizedModuleName %>:[]});
   });
+  app.use('/api<%= path %>', <%= camelizedModuleName %>Router);
 };

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -437,8 +437,8 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
-  it('api-stub foo/bar', function() {
-    return generate(['api-stub', '/foo/bar']).then(function() {
+  it('api-stub foo', function() {
+    return generate(['api-stub', 'foo']).then(function() {
       assertFile('server/index.js', {
         contains: "var bodyParser = require('body-parser');\n" +
                   "var globSync   = require('glob').sync;\n" +
@@ -453,11 +453,13 @@ describe('Acceptance: ember generate', function() {
                   "  routes.forEach(function(route) { route(app); });\n" +
                   "};"
       });
-      assertFile('server/routes/foo/bar.js', {
+      assertFile('server/routes/foo.js', {
         contains: "module.exports = function(app) {\n" +
-                  "  app.get('/foo/bar', function(req, res) {\n" +
-                  "    res.send('hello');\n" +
+                  "  var fooRouter = express.Router();\n" +
+                  "  fooRouter.get('/', function(req, res) {\n" +
+                  "    res.send({foo:[]});\n" +
                   "  });\n" +
+                  "  app.use('/api/foo', fooRouter);\n" +
                   "};"
       });
       assertFile('server/.jshintrc', {


### PR DESCRIPTION
Was working on the docs for the `ember generate api-stub` command and though it could be nice to actually do this resource-based instead of route-based. This is a first version but it sould basically make the code out-of-the box compatible with ember-data..

This means `ember generate api-stub posts` will generate `server/routes/posts.js` which contains:

``` javascript
module.exports = function(app) {
  var postsRouter = express.Router();
  postsRouter.get('/', function(req, res) {
    res.send({posts:[]});
  });
  app.use('/api/posts', postsRouter);
};
```

An alternative would be to use `ember generate api-stub --resource <resource_name>` to override the current behavior.
