### PR TITLE
Add support for templates in the app/ directory

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -128,7 +128,7 @@ function EmberApp(options) {
     templates: unwatchedTree('app/templates'),
 
     // do not watch vendor/ by default
-    vendor: unwatchedTree('vendor'),
+    vendor: unwatchedTree('vendor')
   }, defaults);
 
   this.importWhitelist     = {};
@@ -224,7 +224,9 @@ EmberApp.prototype._processedAppTree = memoize(function() {
   var mergedAppWithoutStylesAndTemplates = remove(mergedApp, {
     paths: ['styles', 'templates']
   });
-
+  mergedAppWithoutStylesAndTemplates = remove(mergedAppWithoutStylesAndTemplates, {
+    files: ['**/.hbs']
+  });
   return pickFiles(mergedAppWithoutStylesAndTemplates, {
     srcDir: '/',
     destDir: this.name
@@ -243,7 +245,13 @@ EmberApp.prototype._processedTemplatesTree = function() {
     destDir: this.name + '/templates'
   });
 
-  return preprocessTemplates(templates);
+  var pods = pickFiles(this._processedAppTree(), {
+    srcDir: '/',
+    files: ['**/*.hbs'],
+    destDir: '/'
+  });
+
+  return preprocessTemplates(mergeTrees([templates, pods]));
 };
 
 EmberApp.prototype._processedTestsTree = memoize(function() {


### PR DESCRIPTION
Fixes issue with #1238 where any templates in the app tree (eg. "pods") no longer work.
