### PR TITLE
Always use forward slash for vendor warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ember-cli Changelog
 
 * [BUGFIX] eagerly requireing inquirer was cost ~100ms -> 150ms on boot [https://github.com/stefanpenner/ember-cli/commit/0ae78df5b4772b126facfed1d3203e9c695e80a1)
+* [BUGFIX] Fix issue with invalid warnings (regarding files in the root of `vendor/`) on Windows. [#1264](https://github.com/stefanpenner/ember-cli/issues/1264)
  
 ### 0.0.39
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -494,7 +494,7 @@ EmberApp.prototype.import = function(asset, options) {
     return;
   }
 
-  if (assetPath.split(path.sep).length < 2) {
+  if (assetPath.split('/').length < 2) {
     console.log(chalk.red('Using `app.import` with a file in the root of `vendor/` causes a significant performance penalty. Please move `'+ assetPath + '` into a subdirectory.'));
   }
 


### PR DESCRIPTION
Fixes #1261.
