### PR TITLE
fix public folder deleted breaking build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [BUGFIX] eagerly requireing inquirer was cost ~100ms -> 150ms on boot [https://github.com/stefanpenner/ember-cli/commit/0ae78df5b4772b126facfed1d3203e9c695e80a1)
 * [BUGFIX] Fix issue with invalid warnings (regarding files in the root of `vendor/`) on Windows. [#1264](https://github.com/stefanpenner/ember-cli/issues/1264)
+* [BUGFIX] Fix issue with `ember build` failing if the public/ folder was deleted. [#1270](https://github.com/stefanpenner/ember-cli/issues/1270)
  
 ### 0.0.39
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -551,10 +551,14 @@ EmberApp.prototype.toArray = function() {
   var sourceTrees = [
     this.index(),
     this.javascript(),
-    this.publicFolder(),
     this.styles(),
     this.otherAssets()
   ];
+
+  var publicFolder = this.publicFolder();
+  if (fs.existsSync(publicFolder)) {
+    sourceTrees.push(publicFolder);
+  }
 
   if (this.tests) {
     sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles());


### PR DESCRIPTION
If the public folder is deleted, it breaks the build command.

Steps to reproduce in 0.0.39:

``` sh
ember new public-deleted
cd public-deleted
rm -r public
ember build
```

Should throw an error like:

```
version: 0.0.39
Build failed.
ENOENT, no such file or directory 'public/'
Error: ENOENT, no such file or directory 'public/'
  at Object.fs.readdirSync (fs.js:654:18)
  at walkSync (/Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/walk-sync/index.js:14:20)
  at /Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:26:26
  at tryCatch (/Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:163:16)
  at invokeCallback (/Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:172:17)
  at publish (/Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/-internal.js:150:13)
  at flush (/Users/jake/Work/ember-cli-cordova-auth/test-app/node_modules/ember-cli/node_modules/rsvp/dist/commonjs/rsvp/asap.js:51:9)
  at process._tickCallback (node.js:415:13)
```
