### PR TITLE
pass the project into the postBuild add-on hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [BUGFIX] eagerly requireing inquirer was cost ~100ms -> 150ms on boot [https://github.com/stefanpenner/ember-cli/commit/0ae78df5b4772b126facfed1d3203e9c695e80a1)
 * [BUGFIX] Fix issue with invalid warnings (regarding files in the root of `vendor/`) on Windows. [#1264](https://github.com/stefanpenner/ember-cli/issues/1264)
+* [BREAKING ENHANCEMENT] Pass project into postBuild addon hook [#1272](https://github.com/stefanpenner/ember-cli/pull/1272)
  
 ### 0.0.39
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -76,12 +76,13 @@ module.exports = Task.extend({
   },
 
   addonsPostBuild: function(results){
-    var addonPromises = [];
+    var addonPromises = [],
+        builder = this;
 
     if(this.project && this.project.addons.length) {
       addonPromises = this.project.addons.map(function(addon){
         if(addon.postBuild) {
-          return addon.postBuild(results);
+          return addon.postBuild(builder.project, results);
         }
       }).filter(Boolean);
     }

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -41,7 +41,11 @@ describe('models/builder.js', function() {
         postBuild: function() { }
       };
       var postBuild = stub(addon, 'postBuild');
+      var project = {
+        addons: [addon]
+      };
       var results = 'build results';
+
       builder = new Builder({
         setupBroccoliBuilder: function() { },
         trapSignals:          function() { },
@@ -50,14 +54,13 @@ describe('models/builder.js', function() {
           build: function() { return Promise.resolve(results); }
         },
         processBuildResult: function(buildResults) { return Promise.resolve(buildResults); },
-        project: {
-          addons: [addon]
-        }
+        project: project
       });
 
       return builder.build().then(function() {
         assert.equal(postBuild.called, 1, 'expected postBuild to be called');
-        assert.equal(postBuild.calledWith[0][0], results, 'expected postBuild to be called with the results');
+        assert.deepEqual(postBuild.calledWith[0][0], project, 'expected postBuild to be called with the project');
+        assert.equal(postBuild.calledWith[0][1], results, 'expected postBuild to be called with the results');
       });
     });
   });


### PR DESCRIPTION
As I was working on my addon and implementing the postBuild hook I realized I had no way to get information about the project. Namely it's ENV config. This passes in the project so addon can read what it needs from it.

My use case is that I want my postBuild hook to be configured by the user to be on or off. With the ENV config I can do that.
