### PR TITLE
ingore php file in the dist folder when it need to clean up

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -50,6 +50,9 @@ module.exports = Task.extend({
     var entries = fs.readdirSync(this.outputPath);
 
     for (var i = 0, l = entries.length; i < l; i++) {
+      if (entries[i].lastIndexOf('.php') === entries[i].length - 4) {
+        continue;
+      }
       promises.push(rimraf(path.join(this.outputPath, entries[i])));
     }
 


### PR DESCRIPTION
My project is use PHP as backend language.I need to put a api.php into dist folder.

However this pull request will empty all dist folder.

I fix this bug by ignore .php file in the folder. Is there a better way to do this?
#1122
