### PR TITLE
Resource based stubs

### DIFF
--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -1,8 +1,36 @@
 module.exports = function(app) {
   var express = require('express');
   var <%= camelizedModuleName %>Router = express.Router();
+
   <%= camelizedModuleName %>Router.get('/', function(req, res) {
-    res.send({"<%= dasherizedModuleName %>":[]});
+    res.send({
+      "<%= dasherizedModuleName %>": []
+    });
   });
-  app.use('/api<%= path %>', <%= camelizedModuleName %>Router);
+
+  <%= camelizedModuleName %>Router.post('/', function(req, res) {
+    res.status(201).end();
+  });
+
+  <%= camelizedModuleName %>Router.get('/:id', function(req, res) {
+    res.send({
+      "<%= dasherizedModuleName %>": {
+        "id": req.params.id
+      }
+    });
+  });
+
+  <%= camelizedModuleName %>Router.put('/:id', function(req, res) {
+    res.send({
+      "<%= dasherizedModuleName %>": {
+        "id": req.params.id
+      }
+    });
+  });
+
+  <%= camelizedModuleName %>Router.delete('/:id', function(req, res) {
+    res.status(204).end();
+  });
+
+  app.use('/api/<%= decamelizedModuleName %>', <%= camelizedModuleName %>Router);
 };

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -693,6 +693,7 @@ Blueprint.prototype._locals = function(options) {
     dasherizedModuleName: stringUtils.dasherize(moduleName),
     classifiedModuleName: stringUtils.classify(sanitizedModuleName),
     camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
+    decamelizedModuleName: stringUtils.decamelize(sanitizedModuleName),
     fileMap: fileMap,
     targetFiles: options.targetFiles,
     rawArgs: options.rawArgs

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -870,9 +870,9 @@ describe('Acceptance: ember generate', function() {
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
@@ -885,9 +885,37 @@ describe('Acceptance: ember generate', function() {
         contains: "module.exports = function(app) {" + EOL +
                   "  var express = require('express');" + EOL +
                   "  var fooRouter = express.Router();" + EOL +
+                  EOL +
                   "  fooRouter.get('/', function(req, res) {" + EOL +
-                  "    res.send({\"foo\":[]});" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": []" + EOL +
+                  "    });" + EOL +
                   "  });" + EOL +
+                  EOL +
+                  "  fooRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.get('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.put('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.delete('/:id', function(req, res) {" + EOL +
+                  "    res.status(204).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use('/api/foo', fooRouter);" + EOL +
                   "};"
       });
@@ -910,9 +938,9 @@ describe('Acceptance: ember generate', function() {
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
@@ -925,9 +953,37 @@ describe('Acceptance: ember generate', function() {
         contains: "module.exports = function(app) {" + EOL +
                   "  var express = require('express');" + EOL +
                   "  var fooBarRouter = express.Router();" + EOL +
+                  EOL +
                   "  fooBarRouter.get('/', function(req, res) {" + EOL +
-                  "    res.send({\"foo-bar\":[]});" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": []" + EOL +
+                  "    });" + EOL +
                   "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.put('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.delete('/:id', function(req, res) {" + EOL +
+                  "    res.status(204).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                   "};"
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1143,9 +1143,9 @@ describe('Acceptance: ember generate pod', function() {
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
@@ -1158,9 +1158,37 @@ describe('Acceptance: ember generate pod', function() {
         contains: "module.exports = function(app) {" + EOL +
                   "  var express = require('express');" + EOL +
                   "  var fooRouter = express.Router();" + EOL +
+                  EOL +
                   "  fooRouter.get('/', function(req, res) {" + EOL +
-                  "    res.send({\"foo\":[]});" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": []" + EOL +
+                  "    });" + EOL +
                   "  });" + EOL +
+                  EOL +
+                  "  fooRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.get('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.put('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooRouter.delete('/:id', function(req, res) {" + EOL +
+                  "    res.status(204).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use('/api/foo', fooRouter);" + EOL +
                   "};"
       });
@@ -1183,9 +1211,9 @@ describe('Acceptance: ember generate pod', function() {
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  "" + EOL +
+                  EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
@@ -1198,9 +1226,37 @@ describe('Acceptance: ember generate pod', function() {
         contains: "module.exports = function(app) {" + EOL +
                   "  var express = require('express');" + EOL +
                   "  var fooBarRouter = express.Router();" + EOL +
+                  EOL +
                   "  fooBarRouter.get('/', function(req, res) {" + EOL +
-                  "    res.send({\"foo-bar\":[]});" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": []" + EOL +
+                  "    });" + EOL +
                   "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.put('/:id', function(req, res) {" + EOL +
+                  "    res.send({" + EOL +
+                  "      \"foo-bar\": {" + EOL +
+                  "        \"id\": req.params.id" + EOL +
+                  "      }" + EOL +
+                  "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "  fooBarRouter.delete('/:id', function(req, res) {" + EOL +
+                  "    res.status(204).end();" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                   "};"
       });


### PR DESCRIPTION
This is a follow up to #1248 (which I should've marked as WIP/proposal):
- The API-stub generator now works resource-based, so `ember generate api-stub someResource` will create `server/routes/some-resource.js` which has 5 express routes in it (get many, post, get single, put, delete). 
- Stubs routes are prefixed with `/api` by default
