### PR TITLE
Add blueprint descriptions to ember help generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [BUGFIX] Fixed an issue where project.config() could be called with undefined environment when starting express server. [#1959](https://github.com/stefanpenner/ember-cli/pull/1959)
 * [ENHANCEMENT] Update `broccoli-asset-rev`to `0.1.1`
+* [ENHANCEMENT] Improve blueprint self-documentation. [#1279](https://github.com/stefanpenner/ember-cli/pull/1279)
 
 ### 0.0.44
 

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates an acceptance test for a feature.'
+};

--- a/blueprints/adapter-test/index.js
+++ b/blueprints/adapter-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates an ember-data adapter unit test'
+};

--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -1,9 +1,14 @@
 var fs         = require('fs');
 var path       = require('path');
 var stringUtil = require('../../lib/utilities/string');
-var Blueprint  = require('../../lib/models/blueprint');
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates an ember-data adapter.',
+
+  availableOptions: [
+    { name: 'base-class', type: String, default: 'application' }
+  ],
+
   locals: function(options) {
     var baseClass       = 'DS.RESTAdapter';
     var importStatement = 'import DS from \'ember-data\';';
@@ -27,4 +32,4 @@ module.exports = Blueprint.extend({
       baseClass: baseClass
     };
   }
-});
+};

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -7,6 +7,8 @@ var assign     = require('lodash-node/modern/objects/assign');
 var uniq       = require('lodash-node/underscore/arrays/uniq');
 
 module.exports = Blueprint.extend({
+  description: 'The default blueprint for ember-cli addons.',
+
   afterInstall: function(options) {
     if (options.dryRun) { return; }
 
@@ -47,6 +49,7 @@ module.exports = Blueprint.extend({
       emberCLIVersion: require('../../package').version
     }
   },
+
   files: function() {
     if (this._files) { return this._files; }
 
@@ -80,6 +83,7 @@ module.exports = Blueprint.extend({
 
     return path;
   },
+
   srcPath: function(file) {
     var filePath = path.resolve(this.path, 'files', file);
     if (fs.existsSync(filePath)) {

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -1,7 +1,8 @@
-var Blueprint  = require('../../lib/models/blueprint');
 var stringUtil = require('../../lib/utilities/string');
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'The default blueprint for ember-cli projects.',
+
   locals: function(options) {
     var entity    = options.entity;
     var rawName   = entity.name;
@@ -15,4 +16,4 @@ module.exports = Blueprint.extend({
       emberCLIVersion: require('../../package').version
     }
   }
-});
+};

--- a/blueprints/blueprint/index.js
+++ b/blueprints/blueprint/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a blueprint and defintion.'
+};

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a component unit test.'
+};

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -1,7 +1,9 @@
 var Blueprint = require('../../lib/models/blueprint');
 var SilentError = require('../../lib/errors/silent');
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a component. Name must contain a hyphen.',
+
   normalizeEntityName: function(entityName) {
     entityName = Blueprint.prototype.normalizeEntityName.apply(this, arguments);
 
@@ -19,4 +21,4 @@ module.exports = Blueprint.extend({
 
     return entityName;
   }
-});
+};

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a controller unit test.'
+};

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -1,4 +1,3 @@
-var Blueprint   = require('../../lib/models/blueprint');
 var SilentError = require('../../lib/errors/silent');
 var chalk       = require('chalk');
 
@@ -8,7 +7,13 @@ var TYPE_MAP = {
   basic: 'Controller'
 };
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a controller of the given type.',
+
+  availableOptions: [
+    { name: 'type', values: ['basic', 'object', 'array'], default: 'basic' }
+  ],
+
   beforeInstall: function(options) {
     var type = options.type;
 
@@ -31,4 +36,4 @@ module.exports = Blueprint.extend({
       baseClass: baseClass
     };
   }
-});
+};

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a helper unit test.'
+};

--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a helper function.'
+};

--- a/blueprints/http-mock/index.js
+++ b/blueprints/http-mock/index.js
@@ -1,6 +1,12 @@
-var Blueprint = require('../../lib/models/blueprint');
+var EOL = require('os').EOL;
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a mock api endpoint in /api prefix.',
+
+  anonymousOptions: [
+    'endpoint-path'
+  ],
+
   locals: function(options) {
     return {
       path: '/' + options.entity.name.replace(/^\//, '')
@@ -9,4 +15,4 @@ module.exports = Blueprint.extend({
   afterInstall: function() {
     return this.addPackageToProject('connect-restreamer', '^1.0.0');
   }
-});
+};

--- a/blueprints/http-proxy/index.js
+++ b/blueprints/http-proxy/index.js
@@ -1,7 +1,13 @@
-var Blueprint = require('../../lib/models/blueprint');
 var Promise   = require('../../lib/ext/promise');
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a relative proxy to another server.',
+
+  anonymousOptions: [
+    'local-path',
+    'remote-url'
+  ],
+
   locals: function(options) {
     var proxyUrl = options.args[2];
     return {
@@ -16,4 +22,4 @@ module.exports = Blueprint.extend({
       this.addPackageToProject('connect-restreamer', '^1.0.0')
     ]);
   }
-});
+};

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates an initialiser unit test.'
+};

--- a/blueprints/initializer/index.js
+++ b/blueprints/initializer/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates an initializer.'
+};

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a mixin unit test.'
+};

--- a/blueprints/mixin/index.js
+++ b/blueprints/mixin/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a mixin.'
+};

--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a model unit test.'
+};

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,9 +1,15 @@
-var Blueprint   = require('../../lib/models/blueprint');
 var inflection  = require('inflection');
 var stringUtils = require('../../lib/utilities/string');
 var EOL         = require('os').EOL;
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates an ember-data model.',
+
+  anonymousOptions: [
+    'name',
+    'attr:type'
+  ],
+
   locals: function(options) {
     var attrs = [];
     var needs = [];
@@ -36,7 +42,7 @@ module.exports = Blueprint.extend({
       needs: needs
     };
   }
-});
+};
 
 function dsAttr(name, type) {
   switch (type) {

--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -3,7 +3,9 @@ var Promise    = require('../../lib/ext/promise');
 var merge      = require('lodash-node/compat/objects/merge');
 var inflection = require('inflection');
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a model and route.',
+
   install: function(options) {
     return this._process('install', options);
   },
@@ -49,6 +51,7 @@ module.exports = Blueprint.extend({
         name: inflection.singularize(options.entity.name)
       }
     });
+
     var routeOptions = merge({}, options, { type: 'resource' });
 
     return Promise.all([
@@ -56,4 +59,4 @@ module.exports = Blueprint.extend({
       this._processBlueprint(type, 'route', routeOptions)
     ]);
   }
-});
+};

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a route unit test.'
+};

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -1,11 +1,16 @@
-var Blueprint   = require('../../lib/models/blueprint');
 var SilentError = require('../../lib/errors/silent');
 var fs          = require('fs-extra');
 var inflection  = require('inflection');
 var path        = require('path');
 var EOL         = require('os').EOL;
 
-module.exports = Blueprint.extend({
+module.exports = {
+  description: 'Generates a route and registers it with the router.',
+
+  availableOptions: [
+    { name: 'type', values: ['route', 'resource'], default: 'route' }
+  ],
+
   beforeInstall: function(options) {
     var type = options.type;
 
@@ -49,7 +54,7 @@ module.exports = Blueprint.extend({
       });
     }
   }
-});
+};
 
 function removeRouteFromRouter(name, options) {
   var type       = options.type || 'route';

--- a/blueprints/serializer-test/index.js
+++ b/blueprints/serializer-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a serializer unit test.'
+};

--- a/blueprints/serializer/index.js
+++ b/blueprints/serializer/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates an ember-data serializer.'
+};

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a route unit test.'
+};

--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a service and initializer for injections.'
+};

--- a/blueprints/template/index.js
+++ b/blueprints/template/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a template.'
+};

--- a/blueprints/transform-test/index.js
+++ b/blueprints/transform-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a transform unit test.'
+};

--- a/blueprints/transform/index.js
+++ b/blueprints/transform/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates an ember-data value transform.'
+};

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a util unit test.'
+};

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a simple utility module/function.'
+};

--- a/blueprints/view-test/index.js
+++ b/blueprints/view-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a view unit test.'
+};

--- a/blueprints/view/index.js
+++ b/blueprints/view/index.js
@@ -1,4 +1,3 @@
-var Blueprint = require('../../lib/models/blueprint');
-
-module.exports = Blueprint.extend({
-});
+module.exports = {
+  description: 'Generates a view subclass.'
+};

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -1,10 +1,12 @@
 'use strict';
 
 var chalk     = require('chalk');
+var reject    = require('lodash-node/modern/collections/reject');
 var Command   = require('../models/command');
 var Promise   = require('../ext/promise');
 var Blueprint = require('../models/blueprint');
 var merge     = require('lodash-node/modern/objects/merge');
+var EOL       = require('os').EOL;
 
 var SilentError = require('../errors/silent');
 
@@ -53,19 +55,88 @@ module.exports = Command.extend({
     return task.run(taskOptions);
   },
 
-  printDetailedHelp: function() {
-    var ui = this.ui;
+  printDetailedHelp: function(options) {
+    this.printAllBlueprints(options);
+  },
 
-    ui.writeLine('  Available blueprints:');
+  printAllBlueprints: function(options) {
+    var lookupPaths   = this.project.blueprintLookupPaths();
+    var blueprintList = Blueprint.list({ paths: lookupPaths });
 
-    Blueprint.list({ paths: this.project.blueprintLookupPaths() })
-      .forEach(function(collection) {
-        if (collection.blueprints.length) {
-          ui.writeLine('    ' + collection.source + ':');
-          collection.blueprints.forEach(function(blueprint) {
-            ui.writeLine('      ' + chalk.yellow(blueprint));
-          });
-        }
+    this.ui.writeLine('');
+    this.ui.writeLine('  Available blueprints:');
+
+    blueprintList.forEach(function(collection) {
+      this.printPackageBlueprints(collection, options);
+    }, this);
+  },
+
+  printPackageBlueprints: function(collection, options) {
+    var verbose    = options.verbose;
+    var blueprints = collection.blueprints;
+
+    if (!verbose) {
+      blueprints = reject(blueprints, 'overridden');
+    }
+
+    if (blueprints.length === 0) {
+      return;
+    }
+
+    this.ui.writeLine('    ' + collection.source + ':');
+
+    blueprints.forEach(function(blueprint) {
+      this.printBlueprintInfo(blueprint);
+    }, this);
+  },
+
+  printBlueprintInfo: function(blueprint) {
+    var options;
+    var output = '      ';
+
+    if (blueprint.overridden) {
+      output += chalk.grey('(overridden) ');
+      output += chalk.grey(blueprint.name);
+    } else {
+      output += blueprint.name;
+
+      blueprint.anonymousOptions.forEach(function(opt) {
+        output += ' ' + chalk.yellow('<' + opt + '>');
       });
+
+      options = blueprint.availableOptions || [];
+
+      if (options.length > 0) {
+        output += ' ' + chalk.cyan('<options...>');
+      }
+
+      if (blueprint.description) {
+        output += EOL + '        ' + chalk.grey(blueprint.description);
+      }
+
+      if (options.length > 0) {
+        options.forEach(function(opt) {
+          output += EOL + '        ' + chalk.cyan('--' + opt.name);
+
+          if (opt.values) {
+            output += chalk.cyan('=' + opt.values.join('|'));
+          }
+
+          if (opt.default !== undefined) {
+            output += chalk.cyan(' (Default: ' + opt.default + ')');
+          }
+
+          if (opt.required) {
+            output += chalk.cyan(' (Required)');
+          }
+
+          if (opt.description) {
+            output += ' ' + opt.description;
+          }
+        });
+      }
+    }
+
+    this.ui.writeLine(output);
   }
 });

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -10,21 +10,31 @@ module.exports = Command.extend({
   works: 'everywhere',
   description: 'Outputs the usage instructions for all commands or the provided command',
   aliases: [undefined, 'h', 'help', '-h', '--help'],
-  anonymousOptions: ['<command-name (Default: all)>'],
+
+  availableOptions: [
+    { name: 'verbose', type: Boolean, default: false }
+  ],
+
+  anonymousOptions: [
+    '<command-name (Default: all)>'
+  ],
 
   run: function(commandOptions, rawArgs) {
     if (rawArgs.length === 0) {
       // Display usage for all commands.
       this.ui.writeLine('Available commands in ember-cli:');
 
-      Object.keys(this.commands).forEach(this._printBasicHelpForCommand.bind(this));
+      Object.keys(this.commands).forEach(function(commandName) {
+        this._printBasicHelpForCommand(commandName, commandOptions);
+      }.bind(this));
 
-      if(this.project.eachAddonCommand) {
+      if (this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands){
           this.commands = commands;
-          this.ui.writeLine('');
-          this.ui.writeLine('Available commands from ' + addonName + ':');
-          Object.keys(this.commands).forEach(this._printBasicHelpForCommand.bind(this));
+          this.ui.writeLine('\nAvailable commands from ' + addonName + ':');
+          Object.keys(this.commands).forEach(function(commandName) {
+            this._printBasicHelpForCommand(commandName, commandOptions);
+          }.bind(this));
         }.bind(this));
       }
 
@@ -34,7 +44,7 @@ module.exports = Command.extend({
       this.ui.writeLine('Requested ember-cli commands:');
       this.ui.writeLine('');
 
-      if(this.project.eachAddonCommand) {
+      if (this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands){
           assign(this.commands, commands);
         }.bind(this));
@@ -42,25 +52,27 @@ module.exports = Command.extend({
 
       // Iterate through each arg beyond the initial 'help' command,
       // and try to display usage instructions.
-      rawArgs.forEach(this._printDetailedHelpForCommand.bind(this));
+      rawArgs.forEach(function(commandName) {
+        this._printDetailedHelpForCommand(commandName, commandOptions);
+      }.bind(this));
     }
   },
 
-  _printBasicHelpForCommand: function(commandName) {
-    this._printHelpForCommand(commandName, false);
+  _printBasicHelpForCommand: function(commandName, options) {
+    this._printHelpForCommand(commandName, false, options);
   },
 
-  _printDetailedHelpForCommand: function(commandName) {
-    this._printHelpForCommand(commandName, true);
+  _printDetailedHelpForCommand: function(commandName, options) {
+    this._printHelpForCommand(commandName, true, options);
   },
 
-  _printHelpForCommand: function(commandName, detailed) {
+  _printHelpForCommand: function(commandName, detailed, options) {
     var command = this._lookupCommand(commandName);
 
-    command.printBasicHelp();
+    command.printBasicHelp(options);
 
     if (detailed) {
-      command.printDetailedHelp();
+      command.printDetailedHelp(options);
     }
   },
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -3,6 +3,7 @@ var FileInfo    = require('./file-info');
 var Promise     = require('../ext/promise');
 var any         = require('lodash-node/compat/collections/some');
 var chalk       = require('chalk');
+var contains    = require('lodash-node/compat/collections/contains');
 var fs          = require('fs-extra');
 var glob        = require('glob');
 var merge       = require('lodash-node/compat/objects/merge');
@@ -164,6 +165,9 @@ function Blueprint(blueprintPath) {
 
 Blueprint.__proto__ = CoreObject;
 Blueprint.prototype.constructor = Blueprint;
+
+Blueprint.prototype.availableOptions = [];
+Blueprint.prototype.anonymousOptions = ['name'];
 
 /*
   @method files
@@ -661,37 +665,46 @@ Blueprint.lookup = function(name, options) {
 
   var lookupPath;
   var blueprintPath;
-  var constructorPath;
-  var blueprintModule;
-  var Constructor;
 
   for (var i = 0; lookupPath = lookupPaths[i]; i++) {
     blueprintPath = path.resolve(lookupPath, name);
 
-    if (!fs.existsSync(blueprintPath)) {
-      continue;
+    if (fs.existsSync(blueprintPath)) {
+      return Blueprint.load(blueprintPath);
     }
-
-    constructorPath = path.resolve(blueprintPath, 'index.js');
-
-    if (fs.existsSync(constructorPath)) {
-      blueprintModule = require(constructorPath);
-
-      if (typeof blueprintModule === 'function') {
-        Constructor = blueprintModule;
-      } else {
-        Constructor = Blueprint.extend(blueprintModule);
-      }
-    } else {
-      Constructor = Blueprint;
-    }
-
-    return new Constructor(blueprintPath);
   }
 
   if (!options.ignoreMissing) {
     throw new SilentError('Unknown blueprint: ' + name);
   }
+};
+
+/*
+  Loads a blueprint from given path.
+  @static
+  @method load
+  @namespace Blueprint
+  @param {String} path
+  @return {Blueprint} blueprint instance
+*/
+Blueprint.load = function(blueprintPath) {
+  var constructorPath = path.resolve(blueprintPath, 'index.js');
+  var blueprintModule;
+  var Constructor;
+
+  if (fs.existsSync(constructorPath)) {
+    blueprintModule = require(constructorPath);
+
+    if (typeof blueprintModule === 'function') {
+      Constructor = blueprintModule;
+    } else {
+      Constructor = Blueprint.extend(blueprintModule);
+    }
+  } else {
+    Constructor = Blueprint;
+  }
+
+  return new Constructor(blueprintPath);
 };
 
 /*
@@ -706,13 +719,28 @@ Blueprint.list = function(options) {
   options = options || {};
 
   var lookupPaths = generateLookupPaths(options.paths);
+  var seen = [];
 
   return lookupPaths.map(function(lookupPath) {
-    var source = path.basename(path.join(lookupPath, '..'));
-
     var blueprints = glob.sync(path.join(lookupPath, '*'));
-    blueprints = blueprints.map(function(blueprint) {
-      return path.basename(blueprint);
+    var packagePath = path.join(lookupPath, '../package.json');
+    var source;
+
+    if (fs.existsSync(packagePath)) {
+      source = require(packagePath).name;
+    } else {
+      source = path.basename(path.join(lookupPath, '..'));
+    }
+
+    blueprints = blueprints.map(function(blueprintPath) {
+      var blueprint   = Blueprint.load(blueprintPath);
+      var name        = blueprint.name;
+
+      blueprint.overridden = contains(seen, name);
+
+      seen.push(name);
+
+      return blueprint;
     });
 
     return {

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -18,42 +18,46 @@ describe('Acceptance: ember help', function() {
   });
 
   afterEach(function(done) {
-    this.timeout(10000);
-
     process.chdir(root);
     rimraf(tmproot, done);
   });
 
-  it('generate', function() {
+  it('generate lists blueprints', function() {
+    this.timeout(10000);
     var output = '';
 
-    return runCommand(ember, 'help', 'generate', {
-      onOutput: function(string) {
-        output += string;
-      }
-    }).then(function() {
-      assert.include(output, 'ember-cli commands:');
-      assert.include(output, '  app');
-      assert.include(output, '  adapter');
-      assert.include(output, '  http-mock');
-      assert.include(output, '  http-proxy');
-      assert.include(output, '  app');
-      assert.include(output, '  blueprint');
-      assert.include(output, '  component');
-      assert.include(output, '  controller');
-      assert.include(output, '  helper');
-      assert.include(output, '  initializer');
-      assert.include(output, '  acceptance-test');
-      assert.include(output, '  mixin');
-      assert.include(output, '  model');
-      assert.include(output, '  resource');
-      assert.include(output, '  route');
-      assert.include(output, '  serializer');
-      assert.include(output, '  service');
-      assert.include(output, '  template');
-      assert.include(output, '  transform');
-      assert.include(output, '  util');
-      assert.include(output, '  view');
-    });
+    return runCommand(ember, 'init', 'my-app', '--skip-npm', '--skip-bower', { verbose: false })
+      .then(function() {
+        return runCommand(ember, 'generate', 'blueprint', 'component', { verbose: false });
+      })
+      .then(function() {
+        return runCommand(ember, 'help', 'generate', '--verbose', {
+          onOutput: function(string) {
+            output += string;
+          }
+        });
+      })
+      .then(function() {
+        assert.include(output, 'my-app:');
+        assert.include(output, '  component');
+        assert.include(output, 'ember-cli:');
+        assert.include(output, '  acceptance-test');
+        assert.include(output, '  adapter');
+        assert.include(output, '  app');
+        assert.include(output, '  blueprint');
+        assert.include(output, '  (overridden) component');
+        assert.include(output, '  controller');
+        assert.include(output, '  helper');
+        assert.include(output, '  http-mock');
+        assert.include(output, '  http-proxy');
+        assert.include(output, '  initializer');
+        assert.include(output, '  mixin');
+        assert.include(output, '  resource');
+        assert.include(output, '  route');
+        assert.include(output, '  service');
+        assert.include(output, '  template');
+        assert.include(output, '  util');
+        assert.include(output, '  view');
+      });
   });
 });

--- a/tests/fixtures/blueprints/basic/index.js
+++ b/tests/fixtures/blueprints/basic/index.js
@@ -1,4 +1,5 @@
 var Blueprint = require('../../../../lib/models/blueprint');
 
 module.exports = Blueprint.extend({
+  description: 'A basic blueprint'
 });

--- a/tests/fixtures/blueprints/basic_2/index.js
+++ b/tests/fixtures/blueprints/basic_2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Another basic blueprint'
+};

--- a/tests/fixtures/blueprints/exporting-object/index.js
+++ b/tests/fixtures/blueprints/exporting-object/index.js
@@ -1,3 +1,4 @@
 module.exports = {
+  description: 'A blueprint that exports an object',
   woot: 'someValueHere'
 };

--- a/tests/fixtures/blueprints/with-templating/index.js
+++ b/tests/fixtures/blueprints/with-templating/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'A blueprint with templating'
+};

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -60,7 +60,8 @@ describe('help command', function() {
       ui: ui,
       analytics: analytics,
       commands: commands,
-      project: { isEmberCLIProject: function(){ return true; }}
+      project: { isEmberCLIProject: function(){ return true; }},
+      settings: {}
     }).validateAndRun(['test-command-2']);
 
     expect(ui.output).to.include('test-command-2');

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -6,7 +6,6 @@ var Task              = require('../../../lib/models/task');
 var MockProject       = require('../../helpers/mock-project');
 var MockUI            = require('../../helpers/mock-ui');
 var assert            = require('assert');
-var glob              = require('glob');
 var path              = require('path');
 var walkSync          = require('walk-sync');
 var rimraf            = require('rimraf');
@@ -77,7 +76,7 @@ describe('Blueprint', function() {
 
     it('finds blueprints in the ember-cli package', function() {
       var expectedPath = path.resolve(defaultBlueprints, 'app');
-      var expectedClass = require('../../../blueprints/app');
+      var expectedClass = Blueprint;
 
       var blueprint = Blueprint.lookup('app');
 
@@ -112,22 +111,30 @@ describe('Blueprint', function() {
 
   describe('.list', function() {
     it('returns a list of blueprints grouped by lookup path', function() {
-      var expectedDefaults = glob.sync(path.join(defaultBlueprints, '*'));
-      expectedDefaults = expectedDefaults.map(function(blueprint) {
-        return path.basename(blueprint);
-      });
-      var expectedFixtures = glob.sync(path.join(fixtureBlueprints, '*'));
-      expectedFixtures = expectedFixtures.map(function(blueprint) {
-        return path.basename(blueprint);
-      });
-
-      assert.deepEqual(Blueprint.list({ paths: [fixtureBlueprints] }), [{
+      var list = Blueprint.list({ paths: [fixtureBlueprints] });
+      var actual = list[0];
+      var expected = {
         source: 'fixtures',
-        blueprints: expectedFixtures
-      }, {
-        source: 'ember-cli',
-        blueprints: expectedDefaults
-      }]);
+        blueprints: [{
+          name: 'basic',
+          description: 'A basic blueprint',
+          overridden: false
+        }, {
+          name: 'basic_2',
+          description: 'Another basic blueprint',
+          overridden: false
+        }, {
+          name: 'exporting-object',
+          description: 'A blueprint that exports an object',
+          overridden: false
+        }, {
+          name: 'with-templating',
+          description: 'A blueprint with templating',
+          overridden: false
+        }]
+      };
+
+      assert.deepEqual(actual[0], expected[0]);
     });
   });
 


### PR DESCRIPTION
Also display `(overridden)` next to overridden blueprints.

Addresses #1237
Addresses #1274

![ember-cli](https://cloud.githubusercontent.com/assets/34030/4287644/ba22f786-3da4-11e4-89c4-0fe9ee0269c8.png)

**TODO:**
- [x] Add support for `--verbose` flag to show overridden blueprints (default: false)
- [x] Add descriptions to existing blueprints
- [x] Discuss `availableOptions` with regard to blueprints
