### PR TITLE
Coffee script support is provided by `ember-cli-coffeescript` addon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] eagerly requireing inquirer was cost ~100ms -> 150ms on boot [https://github.com/stefanpenner/ember-cli/commit/0ae78df5b4772b126facfed1d3203e9c695e80a1)
 * [BUGFIX] Fix issue with invalid warnings (regarding files in the root of `vendor/`) on Windows. [#1264](https://github.com/stefanpenner/ember-cli/issues/1264)
 * [BUGFIX] Fix issue with `ember build` failing if the public/ folder was deleted. [#1270](https://github.com/stefanpenner/ember-cli/issues/1270)
+* [BREAKING ENHANCEMENT] CoffeeScript support is now brought in by `ember-cli-coffeescript`. To use CoffeeScript with future versions run `npm install --save-dev ember-cli-coffeescript` (and `broccoli-coffee` is no longer needed as a direct dependency). [#1289](https://github.com/stefanpenner/ember-cli/pull/1289)
  
 ### 0.0.39
 

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -16,7 +16,6 @@ module.exports.setupRegistry = function(app) {
 
   registry.add('minify-css', 'broccoli-csso', null);
 
-  registry.add('js', 'broccoli-coffee', 'coffee');
   registry.add('js', 'broccoli-ember-script', 'em');
   registry.add('js', 'broccoli-sweetjs', 'js');
 

--- a/lib/preprocessors/javascript-plugin.js
+++ b/lib/preprocessors/javascript-plugin.js
@@ -13,7 +13,7 @@ JavascriptPlugin.prototype.constructor = JavascriptPlugin;
 JavascriptPlugin.prototype._superConstructor = Plugin;
 
 JavascriptPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
-  if (this.name.indexOf('coffee') !== -1 || this.name.indexOf('ember-script') !== -1) {
+  if (this.name.indexOf('ember-script') !== -1) {
     options = options || {};
     options.bare = true;
     options.srcDir = inputPath;


### PR DESCRIPTION
This addon provides both blueprints and preprocessor support via a single `npm
install --save-dev ember-cli-coffeescript` command.

https://github.com/kimroen/ember-cli-coffeescript

Thanks to @kimroen for the awesome addon!
