### PR TITLE
Reference usage of `ember-cli-coffeescript`.

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -83,11 +83,11 @@ npm install --save-dev broccoli-stylus-single
 ### CoffeeScript
 
 To enable [CoffeeScript](http://coffeescript.org/), you must
-first add [broccoli-coffee](https://github.com/joliss/broccoli-coffee) to your
+first add [ember-cli-coffeescript](https://github.com/kimroen/ember-cli-coffeescript) to your
 NPM modules:
 
 {% highlight bash %}
-npm install --save-dev broccoli-coffee
+npm install --save-dev ember-cli-coffeescript
 {% endhighlight %}
 
 The modified `package.json` should be checked into source control. CoffeeScript


### PR DESCRIPTION
https://github.com/kimroen/ember-cli-coffeescript can be used with 0.0.39 to provide both the preprocessor and coffeescript blueprints.
