### PR TITLE
compiling jekyll (gh-pages) on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'kramdown'
+gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,3 +61,4 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   kramdown
+  yajl-ruby

--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ bundle install
 ```
 
 you can now view the result at http://localhost:4000/
+
+## Windows Users, read on
+
+On windows, yajl is a little bit uncooperative. You need to specify `--platform ruby` which is not possible via Gemfile. Run this:
+
+```sh
+gem uninstall yajl-ruby
+gem install yajl-ruby -v 1.1 --platform ruby
+```
+
+More information on [jekyll on windows](https://github.com/juthilo/run-jekyll-on-windows/)
+


### PR DESCRIPTION
Sadly, Jekyll is not very simple to set up on windows. I added a few pointers so other people will be able to modify the pages quicker.
