### PR TITLE
Update docs regarding app.import()

### DIFF
--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -161,14 +161,23 @@ The vendor trees that are provided upon instantiation are available to your dyna
 
 ##### Using app.import()
 
-All other assets like images or fonts can also be added via `import()`. They
+All other assets like images or fonts can also be added via `import()`. By default, they
 will be copied to `dist/` as they are.
 
 {% highlight javascript linenos %}
 app.import('vendor/font-awesome/fonts/fontawesome-webfont.ttf');
 {% endhighlight %}
 
-This example would create the font file in `dist/font-awesome/fonts/font-awesome-webfonts.ttf`.
+This example would create the font file in `dist/font-awesome/fonts/fontawesome-webfont.ttf`.
+
+You can also optionally tell `import()` to place the file at a different path.
+The following example will copy the file to `dist/assets/fontawesome-webfont.ttf`.
+
+{% highlight javascript linenos %}
+app.import('vendor/font-awesome/fonts/fontawesome-webfont.ttf', {
+  destDir: 'assets'
+});
+{% endhighlight %}
 
 ##### Using broccoli-static-compiler
 


### PR DESCRIPTION
Documented the use of `destDir` with `app.import()` from #1293.
