### PR TITLE
Exit properly from EADDRINUSE.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -59,7 +59,10 @@ CLI.prototype.logError = function(error) {
   if (error) {
     if (error instanceof Error) {
       this.ui.write(chalk.red(error.message));
-      this.ui.write(error.stack.toString().replace(/,/g, '\n'));
+
+      if (!error.suppressStacktrace) {
+        this.ui.write(error.stack.toString().replace(/,/g, '\n'));
+      }
     } else {
       this.ui.write(chalk.red(error));
     }

--- a/lib/errors/silent.js
+++ b/lib/errors/silent.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function SilentError(message) {
+  this.name     = 'SilentError';
+  this.message  = message;
+
+  this.suppressStacktrace = true;
+}
+SilentError.prototype = new Error();
+SilentError.prototype.constructor = SilentError;
+
+module.exports = SilentError;

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var Promise = require('../../ext/promise');
-var Task    = require('../../models/task');
+var Promise     = require('../../ext/promise');
+var Task        = require('../../models/task');
+var SilentError = require('../../errors/silent');
 
 // Middleware
 var serveFilesMiddleware = require('./middleware/serve-files');
@@ -82,7 +83,7 @@ module.exports = Task.extend({
         ui.write('Serving on http://' + options.host + ':' + options.port + '\n');
       })
       .catch(function() {
-        ui.write('Could not serve on http://' + options.host + ':' + options.port + '. It is either in use or you do not have permission.\n');
+        throw new SilentError('Could not serve on http://' + options.host + ':' + options.port + '. It is either in use or you do not have permission.\n');
       });
   }
 });

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var Promise = require('../../ext/promise');
-var chalk   = require('chalk');
-var Task    = require('../../models/task');
+var Promise     = require('../../ext/promise');
+var chalk       = require('chalk');
+var Task        = require('../../models/task');
+var SilentError = require('../../errors/silent');
 
 function createServer() {
   var instance;
@@ -46,7 +47,7 @@ module.exports = Task.extend({
 
   writeErrorBanner: function(print, port) {
     if (print) {
-      this.ui.write('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.\n');
+      throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.\n');
     }
   },
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -60,15 +60,20 @@ describe('express-server', function() {
     it('address in use', function(done) {
       var preexistingServer = net.createServer();
       preexistingServer.listen(1337);
+
       return subject.start({
-        host:  '0.0.0.0',
-        port: '1337'
-      }).then(function() {
-        var output = ui.output.trim().split('\n');
-        assert.deepEqual(output[0], 'Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
-        assert.deepEqual(output.length, 1, 'expected only one line of output');
-        preexistingServer.close(done);
-      });
+          host:  '0.0.0.0',
+          port: '1337'
+        })
+        .then(function() {
+          assert(false, 'should have rejected');
+        })
+        .catch(function(reason) {
+          assert.equal(reason, 'Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
+        })
+        .finally(function() {
+          preexistingServer.close(done);
+        });
     });
   });
 

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -40,13 +40,17 @@ describe('livereload-server', function() {
     it('informs of error during startup', function(done) {
       var preexistingServer = net.createServer();
       preexistingServer.listen(1337);
+
       return subject.start({
-        liveReloadPort: 1337,
-        liveReload: true
-      }).then(function() {
-        assert.equal(ui.output, 'Livereload failed on port 1337.  It is either in use or you do not have permission.\n');
-        preexistingServer.close(done);
-      });
+          liveReloadPort: 1337,
+          liveReload: true
+        })
+        .catch(function(reason) {
+          assert.equal(reason, 'Livereload failed on port 1337.  It is either in use or you do not have permission.\n');
+        })
+        .finally(function() {
+          preexistingServer.close(done);
+        });
     });
   });
 });


### PR DESCRIPTION
Closes #1314.

```
_____ember-cli-test master % ember server
version: 0.0.39-exit-properly-c791a21573

Livereload failed on port 35729.  It is either in use or you do not have permission.
```
