### PR TITLE
Use configstore for storing versionCheck information, and only store the timestamp when the version is checked from npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Update default Ember version to 1.6.0.
 * [ENHANCEMENT] Display friendly error message when the server fails to start (e.g. address in use). [#1306](https://github.com/stefanpenner/ember-cli/pull/1306)
 * [BREAKING ENHANCEMENT] Rename test-vendor.{css,js} to test-support.{css,js} to better reflect its role. [#1320](https://github.com/stefanpenner/ember-cli/pull/1320)
+* [BUGFIX] Store version check information correctly, and only change the `lastVersionCheckAt` timestamp when the version is checked from npm. [#1323](https://github.com/stefanpenner/ember-cli/pull/1323)
 
 ### 0.0.39
 

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -4,6 +4,7 @@ var Promise         = require('../ext/promise');
 var emberCLIVersion = require('../utilities/ember-cli-version');
 var chalk           = require('chalk');
 var semver          = require('semver');
+var Configstore     = require('configstore');
 
 module.exports = UpdateChecker;
 
@@ -11,18 +12,14 @@ function UpdateChecker(ui, settings, localVersion) {
   this.ui = ui;
   this.settings = settings;
   this.localVersion = localVersion || emberCLIVersion();
+  this.versionConfig = null;
 }
 
 /**
 * Checks local config or npm for most recent version of ember-cli
-* @param {UI} ui
-* @param {Object} environment
 */
-
 UpdateChecker.prototype.checkForUpdates = function() {
   // if 'checkForUpdates' is true, check for an updated ember-cli version
-  // if environment.settings is undefined, that means there
-  // is no .ember-cli file, so check by default
   if (this.settings.checkForUpdates) {
     return this.doCheck().then(function(updateInfo) {
       if (updateInfo.updateNeeded) {
@@ -40,23 +37,33 @@ UpdateChecker.prototype.checkForUpdates = function() {
 };
 
 UpdateChecker.prototype.doCheck = function() {
-  var settings = this.settings;
-  var lastVersionCheckedAt = settings.lastVersionCheckedAt;
-
+  this.versionConfig = this.versionConfig || new Configstore('ember-cli-version');
+  var lastVersionCheckAt = this.versionConfig.get('lastVersionCheckAt');
   var now = new Date().getTime();
-  var version = null;
 
   return new Promise(function(resolve, reject) {
     // if the last check was less than a day ago, don't remotely check version
-    if (lastVersionCheckedAt && lastVersionCheckedAt > (now - 86400000)) {
-      version = settings.newestVersion;
-      resolve(version);
+    if (lastVersionCheckAt && lastVersionCheckAt > (now - 86400000)) {
+      resolve(this.versionConfig.get('newestVersion'));
     }
 
-    // make an http call to npm to get the latest version
-    var http = require('http');
-    var concat = require('concat-stream');
+    reject();
+  }.bind(this)).catch(function() {
+    return this.checkNPM();
+  }.bind(this)).then(function(version) {
+    return {
+      updateNeeded: version && semver.lt(this.localVersion, version),
+      newestVersion: version
+    };
+  }.bind(this));
+};
 
+UpdateChecker.prototype.checkNPM = function() {
+  // make an http call to npm to get the latest version
+  var http = require('http');
+  var concat = require('concat-stream');
+
+  return new Promise(function(resolve, reject) {
     http.get('http://registry.npmjs.org/ember-cli/latest', function(res) {
       res.setEncoding('utf8');
 
@@ -71,30 +78,19 @@ UpdateChecker.prototype.doCheck = function() {
       res.on('error', reject);
     });
   }).then(function(version) {
-    // save version so we don't have to check again for another day
-    saveVersionInformation(version);
-
-    return {
-      updateNeeded: version && semver.lt(this.localVersion, version),
-      newestVersion: version
-    };
-  }.bind(this))
-  .catch(function(error) {
+    // we only want to save the version information when we check NPM
+    return this.saveVersionInformation(version);
+  }.bind(this)).catch(function(error) {
     this.ui.write('There was an error checking NPM for an update: ' + error + '\n');
     throw error;
   }.bind(this));
 };
 
-/**
-* Saves updated version information to .ember-cli file
-* @param {String} version
-*/
-function saveVersionInformation(version) {
-  var Yam    = require('yam');
-  var config = new Yam('ember-cli');
-  var now    = new Date().getTime();
+UpdateChecker.prototype.saveVersionInformation = function(version) {
+  var versionConfig = this.versionConfig;
+  var now = new Date().getTime();
 
-  config.set('newestVersion', version);
-  config.set('lastVersionCheckedAt', now);
-  config.flush();
-}
+  // save version so we don't have to check again for another day
+  versionConfig.set('newestVersion', version);
+  versionConfig.set('lastVersionCheckAt', now);
+};

--- a/tests/unit/commands/update-test.js
+++ b/tests/unit/commands/update-test.js
@@ -6,6 +6,7 @@ var MockAnalytics = require('../../helpers/mock-analytics');
 var Task          = require('../../../lib/models/task');
 var UpdateCommand = require('../../../lib/commands/update');
 var UpdateChecker = require('../../../lib/models/update-checker');
+var Promise       = require('../../../lib/ext/promise');
 
 describe('update command', function() {
   var ui;
@@ -38,6 +39,10 @@ describe('update command', function() {
       checkForUpdates: true
     }, '100.0.0');
 
+    updateChecker.checkNPM = function() {
+      return Promise.resolve('0.0.1');
+    };
+
     return new UpdateCommand({
       ui: ui,
       analytics: analytics,
@@ -54,6 +59,10 @@ describe('update command', function() {
     var updateChecker = new UpdateChecker(ui, {
       checkForUpdates: true
     }, '0.0.1');
+
+    updateChecker.checkNPM = function() {
+      return Promise.resolve('100.0.0');
+    };
 
     return new UpdateCommand({
       ui: ui,

--- a/tests/unit/models/update-checker-test.js
+++ b/tests/unit/models/update-checker-test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var assert        = require('../../helpers/assert');
+var MockUI        = require('../../helpers/mock-ui');
+var UpdateChecker = require('../../../lib/models/update-checker');
+var Promise       = require('../../../lib/ext/promise');
+
+describe('Update Checker', function() {
+  var ui;
+  var versionConfig;
+
+  beforeEach(function() {
+    ui = new MockUI();
+    versionConfig = {
+      store: {},
+      get: function(key) {
+        return this.store[key];
+      },
+      set: function(key, val) {
+        this.store[key] = val;
+      }
+    };
+  });
+
+  it('returns { updatedNeeded: false } if no update is needed', function() {
+    var updateChecker = new UpdateChecker(ui, {
+      checkForUpdates: true
+    }, '0.0.5');
+
+    // overwrite doCheck so it ignores any existing configstore
+    updateChecker.doCheck = (function() {
+        var doCheck = updateChecker.doCheck;
+
+        return function() {
+          updateChecker.versionConfig = versionConfig;
+          return doCheck.apply(this);
+        };
+      }());
+
+    updateChecker.checkNPM = function() {
+      return Promise.resolve('0.0.1');
+    };
+
+    return updateChecker.checkForUpdates().then(function(updateInfo) {
+      assert.isFalse(updateInfo.updateNeeded, 'updateNeeded should be false');
+    });
+  });
+
+  it('says \'A new version of ember-cli is available\' if an update is needed', function() {
+    var updateChecker = new UpdateChecker(ui, {
+      checkForUpdates: true
+    }, '0.0.1');
+
+    // overwrite doCheck so it ignores any existing configstore
+    updateChecker.doCheck = (function() {
+        var doCheck = updateChecker.doCheck;
+
+        return function() {
+          updateChecker.versionConfig = versionConfig;
+          return doCheck.apply(this, arguments);
+        };
+      }());
+
+    updateChecker.checkNPM = function() {
+      return Promise.resolve('1000.0.0');
+    };
+
+    return updateChecker.checkForUpdates().then(function() {
+      assert.include(ui.output, 'A new version of ember-cli is available');
+    });
+  });
+
+  it('should not check if last check was less than a day ago', function() {
+    var updateChecker = new UpdateChecker(ui, {
+      checkForUpdates: true
+    }, '0.0.1');
+
+    var now = new Date().getTime();
+    var npmCalled = false;
+
+    updateChecker.doCheck = (function() {
+        var doCheck = updateChecker.doCheck;
+
+        return function() {
+          updateChecker.versionConfig = versionConfig;
+          versionConfig.set('lastVersionCheckAt', now - 86400);
+          return doCheck.apply(this);
+        };
+      }());
+
+    updateChecker.checkNPM = function() {
+      npmCalled = true;
+    };
+
+    return updateChecker.checkForUpdates().then(function() {
+      assert.isFalse(npmCalled, 'NPM should not be called if the last check was less than a day ago');
+    });
+  });
+
+  it('should save version information in configstore if checking with npm', function() {
+    var updateChecker = new UpdateChecker(ui, {
+      checkForUpdates: true
+    }, '0.0.1');
+
+    updateChecker.versionConfig = versionConfig;
+    updateChecker.saveVersionInformation('1000.0.0');
+
+    var now = new Date().getTime();
+
+    assert.equal(updateChecker.versionConfig.store.newestVersion, '1000.0.0', 'should store newest version in configstore');
+    assert.closeTo(updateChecker.versionConfig.store.lastVersionCheckAt, now, 100, 'should store lastVersionCheckAt in configstore');
+  });
+
+});


### PR DESCRIPTION
Per #1223, using configstore instead of yam for storing `lastVersionCheck` and `newestVersion` for the UpdateChecker.
