### PR TITLE
Ember apps can now be relative in any directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Display friendly error message when the server fails to start (e.g. address in use). [#1306](https://github.com/stefanpenner/ember-cli/pull/1306)
 * [BREAKING ENHANCEMENT] Rename test-vendor.{css,js} to test-support.{css,js} to better reflect its role. [#1320](https://github.com/stefanpenner/ember-cli/pull/1320)
 * [BUGFIX] Store version check information correctly, and only change the `lastVersionCheckAt` timestamp when the version is checked from npm. [#1323](https://github.com/stefanpenner/ember-cli/pull/1323)
+* [ENHANCEMENT] Ember apps can now be nested under any other directory as long as EmberApp is given the proper `root` path to run the app [#1338](https://github.com/stefanpenner/ember-cli/pull/1338)
 
 ### 0.0.39
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -48,7 +48,7 @@ module.exports = EmberApp;
 function EmberApp(options) {
   options = options || {};
 
-  this.project = options.project || Project.closestSync(process.cwd());
+  this.project = options.project || Project.closestSync(options.root || process.cwd());
 
   this.env  = process.env.EMBER_ENV || 'development';
   this.name = options.name || this.project.name();
@@ -134,15 +134,15 @@ function EmberApp(options) {
   }, defaults);
 
   this.options.trees = merge(this.options.trees, {
-    app:       'app',
-    tests:     'tests',
+    app:       this.project.pathTo('app'),
+    tests:     this.project.pathTo('tests'),
 
     // these are contained within app/ no need to watch again
-    styles:    unwatchedTree('app/styles'),
-    templates: unwatchedTree('app/templates'),
+    styles:    unwatchedTree(this.project.pathTo('app/styles')),
+    templates: unwatchedTree(this.project.pathTo('app/templates')),
 
     // do not watch vendor/ by default
-    vendor: unwatchedTree('vendor'),
+    vendor: unwatchedTree(this.project.pathTo('vendor')),
   }, defaults);
 
   this.importWhitelist         = {};
@@ -452,17 +452,15 @@ EmberApp.prototype.testFiles = memoize(function() {
     this.options.fingerprint.exclude.push('testem');
   }
 
-  var iconsPath = 'vendor/ember-qunit-notifications';
-
-  var iconsTree = pickFiles(iconsPath, {
+  var iconsTree = pickFiles(this.trees.vendor, {
     files: ['passed.png', 'failed.png'],
-    srcDir: '/',
+    srcDir: '/ember-qunit-notifications',
     destDir: '/assets/'
   });
 
-  var testLoader = pickFiles('vendor/ember-cli-test-loader', {
+  var testLoader = pickFiles(this.trees.vendor, {
     files: ['test-loader.js'],
-    srcDir: '/',
+    srcDir: '/ember-cli-test-loader',
     destDir: '/assets/'
   });
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -24,6 +24,10 @@ Project.prototype.isEmberCLIProject = function() {
   return this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies;
 };
 
+Project.prototype.pathTo = function(file) {
+  return path.join(path.relative(process.cwd(), this.root), file);
+};
+
 Project.prototype.config = function(env) {
   if (fs.existsSync(path.join(this.root, 'config', 'environment.js'))) {
     return this.require('./config/environment')(env);

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -112,4 +112,13 @@ describe('models/project.js', function() {
       assert.equal(project.emberCLIVersion(), emberCLIVersion());
     });
   });
+
+  describe('pathTo', function() {
+    it('should return a relative path to the file', function() {
+      projectPath = 'test/dummy';
+
+      project = new Project(projectPath);
+      assert.equal(project.pathTo('app.js'), 'test/dummy/app.js');
+    });
+  });
 });


### PR DESCRIPTION
In your Brocfile's EmberApp definition you would declare an alternate
root path:

``` js
var app = new EmberApp({
  root: path.join(process.cwd(), 'tests/dummy')
});
```
