### PR TITLE
Allow EmberApp to optionally modify Project's root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Ember apps can now be nested under any other directory as long as EmberApp is given the proper `root` path to run the app [#1338](https://github.com/stefanpenner/ember-cli/pull/1338)
 * [BUGFIX] Update `broccoli-es3-safe-recast` to fix bugs with incorrectly replaced segments. [#1340](https://github.com/stefanpenner/ember-cli/pull/1340)
 * [ENHANCEMENT] EmberApp can take jshintrc path options for app and test jshintrc files. [#1341](https://github.com/stefanpenner/ember-cli/pull/1341)
+* [ENHANCEMENT] Allow EmberApp constructor to optionally override Project's root path [#1342](https://github.com/stefanpenner/ember-cli/pull/1342)
 
 ### 0.0.39
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -49,6 +49,7 @@ function EmberApp(options) {
   options = options || {};
 
   this.project = options.project || Project.closestSync(options.root || process.cwd());
+  this.project.root = options.root || this.project.root;
 
   this.env  = process.env.EMBER_ENV || 'development';
   this.name = options.name || this.project.name();

--- a/tests/fixtures/project/package.json
+++ b/tests/fixtures/project/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "test-project"
+}

--- a/tests/unit/broccoli/constructor-test.js
+++ b/tests/unit/broccoli/constructor-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var path     = require('path');
+var Project  = require('../../../lib/models/project');
+var EmberApp = require('../../../lib/broccoli/ember-app');
+var assert   = require('assert');
+
+describe('broccoli/ember-app', function() {
+  var project, projectPath;
+
+  describe('constructor', function() {
+    beforeEach(function() {
+      projectPath = path.resolve(__dirname, '../../fixtures/project');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+      project.require = function() {
+        return function() {};
+      };
+      project.initializeAddons = function() {
+        this.addons = [];
+      };
+    });
+
+    it('allows override', function() {
+      var emberApp = new EmberApp({
+        project: project,
+        root: '/Other'
+      });
+
+      assert.equal(emberApp.project.root, '/Other');
+    });
+  });
+});


### PR DESCRIPTION
This is necessary for addon projects that keep the package.json in its
root but the test/dummy app is nested elsewhere
