### PR TITLE
EmberAddon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@
 * [ENHANCEMENT] Display friendly error message when the server fails to start (e.g. address in use). [#1306](https://github.com/stefanpenner/ember-cli/pull/1306)
 * [BREAKING ENHANCEMENT] Rename test-vendor.{css,js} to test-support.{css,js} to better reflect its role. [#1320](https://github.com/stefanpenner/ember-cli/pull/1320)
 * [BUGFIX] Store version check information correctly, and only change the `lastVersionCheckAt` timestamp when the version is checked from npm. [#1323](https://github.com/stefanpenner/ember-cli/pull/1323)
-* [ENHANCEMENT] Ember apps can now be nested under any other directory as long as EmberApp is given the proper `root` path to run the app [#1338](https://github.com/stefanpenner/ember-cli/pull/1338)
 * [BUGFIX] Update `broccoli-es3-safe-recast` to fix bugs with incorrectly replaced segments. [#1340](https://github.com/stefanpenner/ember-cli/pull/1340)
 * [ENHANCEMENT] EmberApp can take jshintrc path options for app and test jshintrc files. [#1341](https://github.com/stefanpenner/ember-cli/pull/1341)
 * [ENHANCEMENT] Using broccoli-sass > 0.2.0 now allows you to use .sass files. [#1367](https://github.com/stefanpenner/ember-cli/pull/1367)
+* [ENHANCEMENT] EmberAddon constructor to build an EmberApp object with defaults for addon projects. [#1343](https://github.com/stefanpenner/ember-cli/pull/1343)
 
 ### 0.0.39
 

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -1,0 +1,30 @@
+/* global require, module */
+'use strict';
+
+var merge         = require('lodash-node/modern/objects/merge');
+var remove        = require('broccoli-file-remover');
+var defaults      = require('lodash-node/modern/objects/defaults');
+var EmberApp      = require('ember-cli/lib/broccoli/ember-app');
+var unwatchedTree = require('broccoli-unwatched-tree');
+ 
+module.exports = EmberAddon;
+
+function EmberAddon(options) {
+  options = options || {};
+
+  return new EmberApp(merge(options, {
+    name: 'dummy',
+    environment: './tests/dummy/config/environment',
+    trees: {
+      app: 'tests/dummy/app',
+      styles: 'tests/dummy/app/styles',
+      templates: 'tests/dummy/app/templates',
+      tests: remove('tests', {path: 'dummy'}),
+      vendor: unwatchedTree('vendor')
+    },
+    jshintrc: {
+      tests: './tests',
+      app: './tests/dummy'
+    },
+  }, defaults));
+}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -48,7 +48,7 @@ module.exports = EmberApp;
 function EmberApp(options) {
   options = options || {};
 
-  this.project = options.project || Project.closestSync(options.root || process.cwd());
+  this.project = options.project || Project.closestSync(process.cwd());
 
   this.env  = process.env.EMBER_ENV || 'development';
   this.name = options.name || this.project.name();
@@ -81,7 +81,7 @@ function EmberApp(options) {
     loader: 'vendor/loader/loader.js',
     trees: {},
     jshintrc: {},
-    getEnvJSON: this.project.require('./config/environment'),
+    getEnvJSON: this.project.require(options.environment || './config/environment'),
     vendorFiles: {}
   }, defaults);
 
@@ -135,15 +135,15 @@ function EmberApp(options) {
   }, defaults);
 
   this.options.trees = merge(this.options.trees, {
-    app:       this.project.pathTo('app'),
-    tests:     this.project.pathTo('tests'),
+    app:       'app',
+    tests:     'tests',
 
     // these are contained within app/ no need to watch again
-    styles:    unwatchedTree(this.project.pathTo('app/styles')),
-    templates: unwatchedTree(this.project.pathTo('app/templates')),
+    styles:    unwatchedTree('app/styles'),
+    templates: unwatchedTree('app/templates'),
 
     // do not watch vendor/ by default
-    vendor: unwatchedTree(this.project.pathTo('vendor')),
+    vendor: unwatchedTree('vendor'),
   }, defaults);
 
   this.options.jshintrc = merge(this.options.jshintrc, {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -24,10 +24,6 @@ Project.prototype.isEmberCLIProject = function() {
   return this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies;
 };
 
-Project.prototype.pathTo = function(file) {
-  return path.join(path.relative(process.cwd(), this.root), file);
-};
-
 Project.prototype.config = function(env) {
   if (fs.existsSync(path.join(this.root, 'config', 'environment.js'))) {
     return this.require('./config/environment')(env);

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -112,13 +112,4 @@ describe('models/project.js', function() {
       assert.equal(project.emberCLIVersion(), emberCLIVersion());
     });
   });
-
-  describe('pathTo', function() {
-    it('should return a relative path to the file', function() {
-      projectPath = 'test/dummy';
-
-      project = new Project(projectPath);
-      assert.equal(project.pathTo('app.js'), 'test/dummy/app.js');
-    });
-  });
 });


### PR DESCRIPTION
Will call the EmberApp constructor with defaults for addon projects. In
the addons Brocfile only the following is required:

``` js
var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
var addon = new EmberAddon();
module.exports = addon.toTree();
```
