### PR TITLE
`locationType` hash or none during tests

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -210,7 +210,7 @@ EmberApp.prototype.index = memoize(function() {
     destDir: '/'
   });
 
-  return injectENVJson(this.options.getEnvJSON, this.env, index, files);
+  return this.injectENVJson(this.options.getEnvJSON, this.env, index, files);
 });
 
 EmberApp.prototype.testIndex = memoize(function() {
@@ -220,7 +220,7 @@ EmberApp.prototype.testIndex = memoize(function() {
     destDir: '/tests'
   });
 
-  return injectENVJson(this.options.getEnvJSON, this.env, index, [
+  return this.injectENVJson(this.options.getEnvJSON, this.env, index, [
     'tests/index.html'
   ]);
 });
@@ -593,7 +593,8 @@ EmberApp.prototype.toTree = function(additionalTrees) {
   return this.addonPostprocessTree('all', tree);
 };
 
-function injectENVJson(fn, env, tree, files) {
+EmberApp.prototype.injectENVJson = function(fn, env, tree, files) {
+  var app = this;
   // TODO: real templating
   var envJsonString = function(){
     return JSON.stringify(fn(env));
@@ -603,6 +604,11 @@ function injectENVJson(fn, env, tree, files) {
     var envJSON      = fn(env);
     var baseURL      = cleanBaseURL(envJSON.baseURL);
     var locationType = envJSON.locationType;
+
+
+    if (app.tests && baseURL) {
+      return '<base href="' + baseURL + '" />';
+    }
 
     if (locationType === 'hash' || locationType === 'none') {
       return '';
@@ -626,4 +632,4 @@ function injectENVJson(fn, env, tree, files) {
       replacement: baseTag
     }]
   });
-}
+};


### PR DESCRIPTION
When setting `locationType` to `none` or `hash` tests stops to work.
Specifically speaking the assets are not available. When trying to get any asset we receive:

```
Error: ENOENT, stat '/home/chrmod/Projects/test-project/tmp/class-tests_dist-Gw95HK2u.tmp/tests/assets/asset-name.css'
```

These seems to be correlated with missing BASE_TAG. 

This patch make sure that `test/index.html` will have a `<base href="/" />`. Will try to dig a little around, but currently that's the only way to have hash location in my app and working tests.
