### PR TITLE
[Bug] Proxy not bypassing /assets/* for test assets

### DIFF
--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -106,6 +106,9 @@ describe('express-server', function() {
       it('bypasses proxy for files that exist', function(done) {
         bypassTest(subject.app, '/test-file.txt', done);
       });
+      it('bypasses proxy for /assets/*', function (done) {
+        bypassTest(subject.app, '/assets/qunit.js', done);
+      });
       function apiTest(app, method, url, done) {
         var req = request(app);
         return req[method].call(req, url)


### PR DESCRIPTION
Using master, the proxy works well in all aspects _except_ that it does not bypass /assets/\* for assets used by qunit...

The following logs are from my rails server... 

```
Started GET "/assets/qunit.js" for 127.0.0.1 at 2014-07-12 03:51:24 -0700
ActionController::RoutingError (No route matches [GET] "/assets/qunit.js"):


Started GET "/assets/qunit.css" for 127.0.0.1 at 2014-07-12 03:51:24 -0700
ActionController::RoutingError (No route matches [GET] "/assets/qunit.css"):


Started GET "/assets/qunit-notifications.js" for 127.0.0.1 at 2014-07-12 03:51:24 -0700
ActionController::RoutingError (No route matches [GET] "/assets/qunit-notifications.js"):
```

I've wrote a failing test. It's likely worthless, but figured i'd get the party started.. 

I have no idea where to look to actually fix it, this is the first time I've dove into the source code... (that said, point me in the right direction and maybe I can help)

also, thanks for the hard work on this tool, it's amazing.... 
