### PR TITLE
Update broccoli-sass to support sass files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Ember apps can now be nested under any other directory as long as EmberApp is given the proper `root` path to run the app [#1338](https://github.com/stefanpenner/ember-cli/pull/1338)
 * [BUGFIX] Update `broccoli-es3-safe-recast` to fix bugs with incorrectly replaced segments. [#1340](https://github.com/stefanpenner/ember-cli/pull/1340)
 * [ENHANCEMENT] EmberApp can take jshintrc path options for app and test jshintrc files. [#1341](https://github.com/stefanpenner/ember-cli/pull/1341)
+* [ENHANCEMENT] Using broccoli-sass > 0.2.0 now allows you to use .sass files. [#1367](https://github.com/stefanpenner/ember-cli/pull/1367)
 
 ### 0.0.39
 

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -9,7 +9,7 @@ var registry;
 module.exports.setupRegistry = function(app) {
   registry = new Registry(app.project.dependencies(), app);
 
-  registry.add('css', 'broccoli-sass', 'scss');
+  registry.add('css', 'broccoli-sass', ['scss', 'sass']);
   registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
   registry.add('css', 'broccoli-less-single', 'less');
   registry.add('css', 'broccoli-stylus-single', 'styl');

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -21,7 +21,7 @@ describe('Plugin Loader', function() {
 
     app = { name: 'some-application-name' };
     registry = new PluginRegistry(assign(pkg.devDependencies, pkg.dependencies), app);
-    registry.add('css', 'broccoli-sass', 'scss');
+    registry.add('css', 'broccoli-sass', ['scss', 'sass']);
     registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
   });
 
@@ -55,8 +55,10 @@ describe('Plugin Loader', function() {
   });
 
   it('returns the configured extension for the plugin', function() {
+    registry.add('css', 'broccoli-less-single', 'less');
+    registry.availablePlugins = { 'broccoli-less-single': 'latest' };
     var plugin = registry.load('css');
-    assert.equal(plugin.ext, 'scss');
+    assert.equal(plugin.ext, 'less');
   });
 
   it('can specify fallback extensions', function() {


### PR DESCRIPTION
With broccoli-sass 0.2.1 it now supports `.sass` files. This
PR adds support for that.

refs #1366
