### PR TITLE
Allow addons to be vendored outside of node modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] EmberApp can take jshintrc path options for app and test jshintrc files. [#1341](https://github.com/stefanpenner/ember-cli/pull/1341)
 * [ENHANCEMENT] Using broccoli-sass > 0.2.0 now allows you to use .sass files. [#1367](https://github.com/stefanpenner/ember-cli/pull/1367)
 * [ENHANCEMENT] EmberAddon constructor to build an EmberApp object with defaults for addon projects. [#1343](https://github.com/stefanpenner/ember-cli/pull/1343)
+* [ENHANCEMENT] Allow addons to be vendored outside of node modules [#1370](https://github.com/stefanpenner/ember-cli/pull/1370)
 
 ### 0.0.39
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -60,21 +60,39 @@ Project.prototype.dependencies = function() {
 Project.prototype.availableAddons = function() {
   var addonPackages = {};
   Object.keys(this.dependencies()).forEach(function(name) {
-    if (name === 'ember-cli') { return false; }
-
-    var pkgPath = path.join(this.root, 'node_modules', name, 'package.json');
-
-    if(fs.existsSync(pkgPath)) {
-      var addonPkg = require(pkgPath);
-      var keywords = addonPkg.keywords || [];
-
-      addonPkg['ember-addon'] = addonPkg['ember-addon'] || {};
-
-      if (keywords.indexOf('ember-addon') > -1) {
-        addonPackages[addonPkg.name] = addonPkg;
-      }
+    if (name !== 'ember-cli') {
+      var addonPath = path.join('node_modules', name);
+      this.addIfAddon(addonPath, addonPackages);
     }
   }, this);
+
+  if (this.pkg['ember-addon'] && this.pkg['ember-addon'].paths) {
+    this.pkg['ember-addon'].paths.forEach(function(addonPath) {
+      this.addIfAddon(addonPath, addonPackages);
+    }, this);
+  }
+
+  return addonPackages;
+};
+
+Project.prototype.addIfAddon = function(addonPath, addonPackages) {
+  addonPath = path.join(this.root, addonPath);
+
+  var pkgPath = path.join(addonPath, 'package.json');
+
+  if(fs.existsSync(pkgPath)) {
+    var addonPkg = require(pkgPath);
+    var keywords = addonPkg.keywords || [];
+
+    addonPkg['ember-addon'] = addonPkg['ember-addon'] || {};
+
+    if (keywords.indexOf('ember-addon') > -1) {
+      addonPackages[addonPkg.name] = {
+        path: addonPath,
+        pkg: addonPkg
+      };
+    }
+  }
 
   return addonPackages;
 };
@@ -87,24 +105,23 @@ Project.prototype.initializeAddons = function() {
 
   for (var name in availableAddons) {
     addon            = availableAddons[name];
-    emberAddonConfig = addon['ember-addon'];
+    emberAddonConfig = addon.pkg['ember-addon'];
 
-    graph.addEdges(addon.name, addon, emberAddonConfig.before, emberAddonConfig.after);
+    graph.addEdges(name, addon, emberAddonConfig.before, emberAddonConfig.after);
   }
 
   this.addons = [];
   graph.topsort(function (vertex) {
-    var addonPkg  = vertex.value;
-    var addonPath = path.join(project.root, 'node_modules', addonPkg.name);
     var Addon;
+    var addon  = vertex.value;
 
-    if (addonPkg['ember-addon-main']) {
-      addonPath = path.join(addonPath, addonPkg['ember-addon-main']);
-    } else if (addonPkg['ember-addon'] && addonPkg['ember-addon'].main) {
-      addonPath = path.join(addonPath, addonPkg['ember-addon'].main);
+    if (addon.pkg['ember-addon-main']) {
+      addon.path = path.join(addon.path, addon.pkg['ember-addon-main']);
+    } else if (addon.pkg['ember-addon'] && addon.pkg['ember-addon'].main) {
+      addon.path = path.join(addon.path, addon.pkg['ember-addon'].main);
     }
 
-    Addon = require(addonPath);
+    Addon = require(addon.path);
 
     project.addons.push(new Addon(project));
   });

--- a/tests/fixtures/addon/simple/lib/ember-super-button/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var path = require('path');
+var fs   = require('fs');
+
+function EmberSuperButton(project) {
+  this.project = project;
+  this.name = 'Ember Super Button';
+}
+
+function unwatchedTree(dir){
+  return {read: function() { return dir; }};
+}
+
+EmberSuperButton.prototype.treeFor = function treeFor(name) {
+  var treePath = path.join(__dirname, name);
+
+  if (fs.existsSync(treePath)) {
+    return unwatchedTree(treePath);
+  }
+};
+
+EmberSuperButton.prototype.included = function included(app) {
+  this.app = app;
+};
+
+module.exports = EmberSuperButton;

--- a/tests/fixtures/addon/simple/lib/ember-super-button/package.json
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ember-super-button",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -4,6 +4,9 @@
   "dependencies": {
     "something-else": "latest"
   },
+  "ember-addon": {
+    "paths": ["./lib/ember-super-button"]
+  },
   "devDependencies": {
     "ember-cli": "latest",
     "ember-random-addon": "latest",

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -40,7 +40,7 @@ describe('models/project.js', function() {
     });
   });
 
-  describe('dependencies', function() {
+  describe('addons', function() {
     before(function() {
       projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');
       var packageContents = require(path.join(projectPath, 'package.json'));
@@ -62,7 +62,7 @@ describe('models/project.js', function() {
     });
 
     it('returns a listing of all ember-cli-addons', function() {
-      var expected = [ 'ember-random-addon', 'ember-non-root-addon' ];
+      var expected = [ 'ember-random-addon', 'ember-non-root-addon', 'ember-super-button' ];
 
       assert.deepEqual(Object.keys(project.availableAddons()), expected);
     });


### PR DESCRIPTION
In package.json you can add paths for additional addons

``` json
"ember-addon": {
  "paths": [
    "./lib/super-button"
  ]
}
```

The vendored library must conform to the addon spec, so it must have a
properly declared `package.json` file as well as its own loader.
