### PR TITLE
Improve regex for finding existing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] EmberAddon constructor to build an EmberApp object with defaults for addon projects. [#1343](https://github.com/stefanpenner/ember-cli/pull/1343)
 * [ENHANCEMENT] Allow addons to be vendored outside of node modules [#1370](https://github.com/stefanpenner/ember-cli/pull/1370)
 * [ENHANCEMENT] Make "ember version" show NPM and Node version (versions of all loaded modules with "--verbose" switch). [#1307](https://github.com/stefanpenner/ember-cli/pull/1307)
+* [BUGFIX] Duplicate-checking for generating routes now accounts for `"`-syntax. [#1371](https://github.com/stefanpenner/ember-cli/pull/1371)
 
 ### 0.0.39
 

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -20,7 +20,7 @@ function addRouteToRouter(name, options) {
   var type       = options.type || 'route';
   var routerPath = path.join(process.cwd(), 'app', 'router.js');
   var oldContent = fs.readFileSync(routerPath, 'utf-8');
-  var existence  = new RegExp("(route|resource)\\(['\"]" + name + "'");
+  var existence  = new RegExp("(?:route|resource)\\s*\\(\\s*(['\"])" + name + "\\1");
   var newContent;
   var plural;
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -214,26 +214,39 @@ describe('Acceptance: ember generate', function() {
   });
 
   it('route bar does not create duplicates in router.js', function() {
-    var routerDefinition = (
-      "Router.map(function() {\n" +
-      "  this.resource('foo', function() {\n" +
-      "    this.route('bar');\n" +
-      "  });\n" +
-      "});\n"
-    );
-
-    return initApp()
-      .then(function() {
-        return outputFile('app/router.js', routerDefinition);
-      })
+    function checkRoute(testString) {
+      var routerDefinition = (
+        "Router.map(function() {\n" +
+        "  this.resource('foo', function() {\n" +
+        "    " + testString + "\n" +
+        "  });\n" +
+        "});\n"
+      );
+      return outputFile('app/router.js', routerDefinition)
       .then(function() {
         return ember(['generate', 'route', 'bar']);
       })
       .then(function() {
-        assertFile('app/router.js', {
+        return assertFile('app/router.js', {
           contains: routerDefinition
         });
       });
+    }
+
+
+    return initApp()
+    .then(function() {
+      return checkRoute("this.route('bar');");
+    })
+    .then(function() {
+      return checkRoute("this.route ('bar');");
+    })
+    .then(function() {
+      return checkRoute("this.route ( 'bar' );");
+    })
+    .then(function() {
+      return checkRoute('this.route("bar");');
+    });
   });
 
   it('template foo', function() {


### PR DESCRIPTION
Some improvements to the check for existing routes:
- More liberal with spaces around parenthesis
- `"` now works in addition to `'`. (This looks like it was an oversight)
- Don't capture the first group
