### PR TITLE
Set absolute paths for assets in tests/index.html

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -9,9 +9,9 @@
 
     {{BASE_TAG}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/<%= name %>.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="/assets/vendor.css">
+    <link rel="stylesheet" href="/assets/<%= name %>.css">
+    <link rel="stylesheet" href="/assets/test-support.css">
     <style>
       #ember-testing-container {
         position: absolute;
@@ -37,13 +37,13 @@
       window.<%= namespace %>ENV = {{ENV}};
       window.EmberENV = window.<%= namespace %>ENV.EmberENV;
     </script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/<%= name %>.js"></script>
-    <script src="testem.js"></script>
+    <script src="/assets/test-support.js"></script>
+    <script src="/assets/vendor.js"></script>
+    <script src="/assets/<%= name %>.js"></script>
+    <script src="/testem.js"></script>
     <script>
       require('<%= modulePrefix %>/tests/test-helper');
     </script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/assets/test-loader.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Not sure if other people have encountered this, but I've confirmed it on 2 fresh `ember new` projects...Testem was looking for test assets relative to `/tests` when it should be looking at `/`. Changing to absolute paths in `tests/index.html` fixed this for me.
