### PR TITLE
FIX: Require express when generating an API stub

### DIFF
--- a/blueprints/api-stub/files/server/routes/__name__.js
+++ b/blueprints/api-stub/files/server/routes/__name__.js
@@ -1,3 +1,5 @@
+var express = require('express');
+
 module.exports = function(app) {
   var <%= camelizedModuleName %>Router = express.Router();
   <%= camelizedModuleName %>Router.get('/', function(req, res) {


### PR DESCRIPTION
When using the API stub generator, the generated file has a reference to the express library, yet it is not required. This results in an error:

`express is not definedReferenceError: express is not defined`.
