### PR TITLE
Don't add basic route to the router map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Make "ember version" show NPM and Node version (versions of all loaded modules with "--verbose" switch). [#1307](https://github.com/stefanpenner/ember-cli/pull/1307)
 * [BUGFIX] Duplicate-checking for generating routes now accounts for `"`-syntax. [#1371](https://github.com/stefanpenner/ember-cli/pull/1371)
 * [BREAKING BUGFIX] Standard variables passed in to Blueprints now handle slashes better. Breaking if you relied on the old behavior. [#1278](https://github.com/stefanpenner/ember-cli/pull/1278)
+* [BUGFIX] Generating a route named 'basic' no longer adds it to router.js. [#1390](https://github.com/stefanpenner/ember-cli/pull/1390)
 
 ### 0.0.39
 

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -28,6 +28,8 @@ function addRouteToRouter(name, options) {
     return;
   }
 
+  if (name === 'basic') { return; }
+
   switch (type) {
   case 'route':
     newContent = oldContent.replace(

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -258,6 +258,15 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('route basic isn\'t added to router', function() {
+    return generate(['route', 'basic']).then(function() {
+      assertFile('app/router.js', {
+        doesNotContain: "this.route('basic');"
+      });
+      assertFile('app/routes/basic.js');
+    });
+  });
+
   it('route bar does not create duplicates in router.js', function() {
     function checkRoute(testString) {
       var routerDefinition = (


### PR DESCRIPTION
The route name `basic` is reserved and will be used for all generated routes, and should never be used in the Router map. This makes sure it isn't added when running `ember generate route basic`.
