### PR TITLE
Default assets for unknown environment to production

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -502,7 +502,7 @@ EmberApp.prototype.import = function(asset, options) {
   var assetPath;
 
   if (typeof asset === 'object') {
-    assetPath = asset[this.env] || asset.development;
+    assetPath = asset[this.env] || asset.production;
   } else {
     assetPath = asset;
   }


### PR DESCRIPTION
Just wanted to open up a discussion about which version of assets is the default when the environment is unknown.

In my workflows, I want to have to code as close to what it will look like in production as early in the build chain as possible.  Ideally this would be as soon as the code has left my dev box.

Therefore it makes sense to me that if the environment config is an unknown one (ie, stage, pre-prod etc), we actually default to using the production assets.

So my questions are:
- **Was there an actual reason `development` was chose as the default?**
- **If so, what is the reasoning?**
- **If not, any reason not to change it to `production`?**

/cc @stefanpenner @xtian
