### PR TITLE
App blueprint: Npm dependencies in alphabetical order

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -18,14 +18,14 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli": "<%= emberCLIVersion %>",
-    "originate": "0.1.5",
-    "broccoli-ember-hbs-template-compiler": "^1.5.0",
-    "express": "^4.1.1",
     "body-parser": "^1.2.0",
-    "glob": "^3.2.9",
-    "ember-cli-ic-ajax": "0.1.1",
+    "broccoli-asset-rev": "0.0.11",
+    "broccoli-ember-hbs-template-compiler": "^1.5.0",
+    "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.0",
-    "broccoli-asset-rev": "0.0.11"
+    "ember-cli-ic-ajax": "0.1.1",
+    "express": "^4.1.1",
+    "glob": "^3.2.9",
+    "originate": "0.1.5"
   }
 }


### PR DESCRIPTION
Every `npm install some-package --save-dev` call orders the dependency list alphabetically. Thus, it makes sense to order the deps in the blueprint to ease ember cli app upgrades through `ember init`.
