### PR TITLE
adds screencast URL for integration tests

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -36,7 +36,7 @@ pass any option to `Testem` using a configuration file.
 
 **We plan to make your test runner pluggable, so you can use your favorite runner.**
 
-#### Using ember-qunit for integration tests
+#### Using ember-qunit for integration tests ( [screencast](http://youtu.be/2O24ltr0pPU?list=PLxP_o-ABjKLFuDpuJ2Tw_3__OzxE7kFnh) )
 
 All Ember Apps come with built-in [ember test helpers](http://emberjs.com/guides/testing/test-helpers/),
 which are useful for writing integration tests.


### PR DESCRIPTION
It adds a URL to Robin Ward's (@Evil Trout) screen cast showing example on getting started with Integration tests using ember-cli. 

I think adding video URL's at proper places in the documentation is a good idea. Watching videos helps me grasp things faster compare to reading documentation. It also allows new developers to know the people in the community who does public speaking on this topic so they can follow them & keep up to the speed. 
