### PR TITLE
Ddded test section to environment.js blueprint

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -30,6 +30,10 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
+  if (environment === 'test') {
+
+  }
+
   if (environment === 'production') {
 
   }


### PR DESCRIPTION
see #1401 - actually meant to include it there, seems I forgot it. I think having this makes is clearer that there is a test env which should be set up in `config/environment.js` if necessary.
