### PR TITLE
Make api-stubs available to tests

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -10,10 +10,13 @@ module.exports = Command.extend({
   description: 'Runs your apps test suite.',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'test' },
-    { name: 'config-file', type: String,  default: './testem.json' },
-    { name: 'server',      type: Boolean, default: false},
-    { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.'},
+    { name: 'environment',         type: String,  default: 'test' },
+    { name: 'config-file',         type: String,  default: './testem.json' },
+    { name: 'server',              type: Boolean, default: false },
+    { name: 'port',                type: Number,  default: 7357, description: 'The port to use when running with --server.' },
+    { name: 'express-server',      type: Boolean, default: true, description: 'Run the express server simultaneously.' },
+    { name: 'express-server-host', type: String,  default: '0.0.0.0' },
+    { name: 'express-server-port', type: Number,  default: 4201, description: 'The port to use when running with --express-server.' }
   ],
 
   init: function() {
@@ -39,7 +42,8 @@ module.exports = Command.extend({
 
     var options = {
       ui: this.ui,
-      analytics: this.analytics
+      analytics: this.analytics,
+      project: this.project
     };
 
     if (commandOptions.server) {

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -9,6 +9,7 @@ var Builder          = require('../models/builder');
 
 module.exports = Task.extend({
   run: function(options) {
+
     var builder = new Builder({
       outputPath: options.outputPath,
       project: this.project,

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -1,12 +1,16 @@
 'use strict';
 
-var Task    = require('../models/task');
-var Promise = require('../ext/promise');
+var ExpressServer    = require('./server/express-server');
+var Task             = require('../models/task');
+var Promise          = require('../ext/promise');
+var Watcher          = require('../models/watcher');
+var Builder          = require('../models/builder');
 
 module.exports = Task.extend({
   init: function() {
     this.testem = this.testem || new (require('testem'))();
   },
+
   invokeTestem: function (testemOptions) {
     return new Promise(function(resolve) {
       this.testem.startCI(testemOptions, resolve);
@@ -20,6 +24,51 @@ module.exports = Task.extend({
       cwd: options.outputPath
     };
 
-    return this.invokeTestem(testemOptions);
+    var expressServerOptions = {
+      host: options.expressServerHost,
+      port: options.expressServerPort,
+      liveReloadPort: options.expressServerPort - 4200 + 35729,
+      baseURL: this.project.config('test').baseURL || '/',
+      liveReload: true,
+      watcher: 'events'
+    };
+
+    var builder = new Builder({
+      outputPath: options.outputPath,
+      project: this.project,
+      environment: options.environment
+    });
+
+    var watcher = new Watcher({
+      ui: this.ui,
+      builder: builder,
+      analytics: this.analytics,
+      options: options
+    });
+
+    var expressServer = new ExpressServer({
+      ui: this.ui,
+      project: this.project,
+      watcher: watcher
+    });
+
+    var liveReloadServer = new LiveReloadServer({
+      ui: this.ui,
+      analytics: this.analytics,
+      watcher: watcher
+    });
+
+    if (options.expressServer) {
+      return Promise.all([
+          liveReloadServer.start(expressServerOptions),
+          expressServer.start(expressServerOptions)
+        ]).then(function() {
+          return new Promise(function() {
+            this.invokeTestem(testemOptions);
+          });
+        });
+    } else {
+      return this.invokeTestem(testemOptions);
+    }
   }
 });


### PR DESCRIPTION
_Do not merge._

Hopefully, this PR is enough to start a conversation.  The goal is to allow integration tests to make use of the awesome api-stubs.  In this PR, the express server is started before invoking Testem.  If it worked (which it doesn't, yet), it would allow tests to access api-stubs in /server/routes/—albeit on a different port than normal.

I think api-stubs should be readily available to tests, either:
- through some integration with the `test` command (preferred), or 
- by documentation instructing the user to fire up the express server in a separate process—some sort of helper command would probably be appropriate here for CI and general convenience
- something else?
