### PR TITLE
Pluralize generated api-stub routes

### DIFF
--- a/blueprints/api-stub/index.js
+++ b/blueprints/api-stub/index.js
@@ -1,9 +1,10 @@
 var Blueprint = require('../../lib/models/blueprint');
+var inflection = require('inflection');
 
 module.exports = Blueprint.extend({
   locals: function(options) {
     return {
-      path: '/' + options.entity.name.replace(/^\//, '')
+      path: '/' + inflection.pluralize(options.entity.name.replace(/^\//, ''))
     };
   }
 });


### PR DESCRIPTION
This commit makes the api-stub generated server routes have
the same path as Ember model generated routes. For example,

```
`ember g api-stub person`
```

... will generate a stubbed route at /api/people. This
behaviour is matched on the Ember side, with this

```
`ember g resource person`
```

... generating the path /people/:person_id for the
Ember route.
