### PR TITLE
Addons can pull in test trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX] Modify service blueprint to create explicit injection [#1493](https://github.com/stefanpenner/ember-cli/pull/1493)
 * [ENHANCEMENT] Generating a helper now also generates a test [#1503](https://github.com/stefanpenner/ember-cli/pull/1503)
 * [BUGFIX] Do not run JSHint against trees returned from an addon.
+* [BREAKING ENHANCEMENT] Addons can pull in test assets into test tree [#1453](https://github.com/stefanpenner/ember-cli/pull/1453)
 
 ### 0.0.40
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -287,7 +287,13 @@ EmberApp.prototype._processedTemplatesTree = function() {
 };
 
 EmberApp.prototype._processedTestsTree = memoize(function() {
-  return pickFiles(this.trees.tests, {
+  var addonTrees  = this.addonTreesFor('test-support');
+  var mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
+    overwrite: true,
+    description: 'TreeMerger (tests)'
+  });
+
+  return pickFiles(mergedTests, {
     srcDir: '/',
     destDir: this.name + '/tests'
   });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -20,10 +20,11 @@ function unwatchedTree(dir) {
 }
 
 Addon.prototype.treePaths = {
-  app:       'app',
-  styles:    'app/styles',
-  templates: 'app/templates',
-  vendor:    'vendor'
+  app:            'app',
+  styles:         'app/styles',
+  templates:      'app/templates',
+  vendor:         'vendor',
+  'test-support': 'test-support'
 };
 
 Addon.prototype.treeFor = function treeFor(name) {


### PR DESCRIPTION
The use case for this is with `ember-cli-proxy-fixtures`. I need to add additional QUnit functionality to the test suite to serve up proxy fixtures. Anything in `test-support/` will get pulled into the test free
