### PR TITLE
fix scrollspy by removing content min-height (closes #1462)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,4 @@
 (function() {
-  $('body').scrollspy({ target: '.sidebar' });
-
   FastClick.attach(document.body);
 
   (function() {
@@ -25,7 +23,6 @@
   var sheight = $('#showcase').css('height');
 
   $('#swap').height(sheight);
-  $('.guide-content').css('min-height',sheight);
 
   $('.sidebar').affix({
     offset: {


### PR DESCRIPTION
The other removal is basically a clean up, since the scroll spy is already handled in the html itself:
https://github.com/stefanpenner/ember-cli/blob/gh-pages/_layouts/default.html#L4
and
https://github.com/stefanpenner/ember-cli/blob/gh-pages/_layouts/post.html#L4
