### PR TITLE
Hotfix table styles

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,5 +40,7 @@
   $('ul.nav a').click(function() {
     $('nav.navbar-collapse').height(1).removeClass('in');
   });
+  
+  $('.content-section table').addClass('table'); // TODO Remove this after tables are styled in CSS
 
 })();


### PR DESCRIPTION
After converting certain parts of "Getting Started", tables look
ugly on ember-cli.com, since Bootstrap leaves `table`s with no
`.table` class almost entirely unstyled.

This is considered as a hotfix, stuff like this should be styled
from CSS rather than adjusting the HTML structure from JS
