### PR TITLE
Modify service blueprint with more explicit initializer and injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [ENHANCEMENT] Remove chain from express server [#1474](https://github.com/stefanpenner/ember-cli/pull/1474)
 * [ENHANCEMENT] Remove Blueprint lookup failure stacktrace [#1476](https://github.com/stefanpenner/ember-cli/pull/1476)
 * [ENHANCEMENT] --verbose errors option to have SilentError output stacktrace [#1480](https://github.com/stefanpenner/ember-cli/pull/1480)
+* [BUGFIX] Modify service blueprint to create explicit injection [#1493](https://github.com/stefanpenner/ember-cli/pull/1493)
 
 ### 0.0.40
 

--- a/blueprints/service/files/app/initializers/__name__-service.js
+++ b/blueprints/service/files/app/initializers/__name__-service.js
@@ -1,0 +1,6 @@
+export default {
+  name: '<%= dasherizedModuleName %>-service',
+  initialize: function(container, app) {
+    app.inject('route', '<%= camelizedModuleName %>Service', 'service:<%= dasherizedModuleName %>');
+  }
+};

--- a/blueprints/service/files/app/initializers/__name__.js
+++ b/blueprints/service/files/app/initializers/__name__.js
@@ -1,6 +1,0 @@
-export default {
-  name: '<%= dasherizedModuleName %>',
-  initialize: function(container, app) {
-    app.inject('route', '<%= camelizedModuleName %>', 'service:<%= camelizedModuleName %>');
-  }
-};

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -593,11 +593,11 @@ describe('Acceptance: ember generate', function() {
           'export default Ember.Object.extend({\n});'
         ]
       });
-      assertFile('app/initializers/foo.js', {
+      assertFile('app/initializers/foo-service.js', {
         contains: "export default {\n" +
-                  "  name: 'foo',\n" +
+                  "  name: 'foo-service',\n" +
                   "  initialize: function(container, app) {\n" +
-                  "    app.inject('route', 'foo', 'service:foo');\n" +
+                  "    app.inject('route', 'fooService', 'service:foo');\n" +
                   "  }\n" +
                   "};"
       });
@@ -618,11 +618,11 @@ describe('Acceptance: ember generate', function() {
           'export default Ember.Object.extend({\n});'
         ]
       });
-      assertFile('app/initializers/foo/bar.js', {
+      assertFile('app/initializers/foo/bar-service.js', {
         contains: "export default {\n" +
-                  "  name: 'foo/bar',\n" +
+                  "  name: 'foo/bar-service',\n" +
                   "  initialize: function(container, app) {\n" +
-                  "    app.inject('route', 'fooBar', 'service:fooBar');\n" +
+                  "    app.inject('route', 'fooBarService', 'service:foo/bar');\n" +
                   "  }\n" +
                   "};"
       });


### PR DESCRIPTION
The injection will now be a property called `fooService` and the initializer will be named `foo-service`.

Addresses #1335

/fao @stefanpenner @kimroen
