### PR TITLE
Generating a helper also generates a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] Remove Blueprint lookup failure stacktrace [#1476](https://github.com/stefanpenner/ember-cli/pull/1476)
 * [ENHANCEMENT] --verbose errors option to have SilentError output stacktrace [#1480](https://github.com/stefanpenner/ember-cli/pull/1480)
 * [BUGFIX] Modify service blueprint to create explicit injection [#1493](https://github.com/stefanpenner/ember-cli/pull/1493)
+* [ENHANCEMENT] Generating a helper now also generates a test [#1503](https://github.com/stefanpenner/ember-cli/pull/1503)
 
 ### 0.0.40
 

--- a/blueprints/helper/files/app/helpers/__name__.js
+++ b/blueprints/helper/files/app/helpers/__name__.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Handlebars.makeBoundHelper(function(value) {
+function <%= camelizedModuleName %>(value) {
   return value;
-});
+}
+
+export { <%= camelizedModuleName %> };
+
+export default Ember.Handlebars.makeBoundHelper(<%= camelizedModuleName %>);

--- a/blueprints/helper/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper/files/tests/unit/helpers/__name__-test.js
@@ -1,0 +1,9 @@
+import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers/<%= dasherizedModuleName %>';
+
+module('<%= classifiedModuleName %>Helper');
+
+// Replace this with your real tests.
+test('it works', function() {
+  var result = <%= camelizedModuleName %>(42);
+  ok(result);
+});

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -128,9 +128,14 @@ describe('Acceptance: ember generate', function() {
     return generate(['helper', 'foo-bar']).then(function() {
       assertFile('app/helpers/foo-bar.js', {
         contains: "import Ember from 'ember';\n\n" +
-                  "export default Ember.Handlebars.makeBoundHelper(function(value) {\n" +
+                  "function fooBar(value) {\n" +
                   "  return value;\n" +
-                  "});"
+                  "}\n\n" +
+                  "export { fooBar };\n\n" +
+                  "export default Ember.Handlebars.makeBoundHelper(fooBar);"
+      });
+      assertFile('tests/unit/helpers/foo-bar-test.js', {
+        contains: "import { fooBar } from 'my-app/helpers/foo-bar';"
       });
     });
   });
@@ -139,9 +144,14 @@ describe('Acceptance: ember generate', function() {
     return generate(['helper', 'foo/bar-baz']).then(function() {
       assertFile('app/helpers/foo/bar-baz.js', {
         contains: "import Ember from 'ember';\n\n" +
-                  "export default Ember.Handlebars.makeBoundHelper(function(value) {\n" +
+                  "function fooBarBaz(value) {\n" +
                   "  return value;\n" +
-                  "});"
+                  "}\n\n" +
+                  "export { fooBarBaz };\n\n" +
+                  "export default Ember.Handlebars.makeBoundHelper(fooBarBaz);"
+      });
+      assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
+        contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
       });
     });
   });


### PR DESCRIPTION
This will generate a test in addition to the helper when you run `ember generate helper my-helper`.

The helper itself was also restructured a bit to accommodate for this, as per a suggestion by @rwjblue (thanks!).
