### PR TITLE
Add EditorConfig file to blueprints

### DIFF
--- a/blueprints/app/files/.editorconfig
+++ b/blueprints/app/files/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
As discussed in #1426, EditorConfig file is added to blueprints. I have set defaults for html, css, js and hbs files and they can be modified if needed. The default is 2 space indents for all of them. Please take a look.

cc @abuiles @treyhunner @ccoenen
