### PR TITLE
Ensure non `/assets/` files can be served.

### DIFF
--- a/lib/tasks/server/middleware/serve-files/history-support.js
+++ b/lib/tasks/server/middleware/serve-files/history-support.js
@@ -3,17 +3,20 @@
 // Used in serve-files middleware
 
 var path = require('path');
+var fs   = require('fs');
 
-module.exports = function() {
+module.exports = function(watcher) {
   return function(req, res, next) {
-    var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
-    var isAsset = (req.path.indexOf('assets')>-1 && path.extname(req.path)!=='');
-    var isForTests = /^\/tests/.test(req.path);
+    watcher.then(function(results) {
+      var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
+      var isAsset = fs.existsSync(path.join(results.directory, req.path));
+      var isForTests = /^\/tests/.test(req.path);
 
-    if (req.method === 'GET' && hasHTMLHeader && !isAsset) {
-      req.url = isForTests ? '/tests/index.html' : '/index.html';
-    }
+      if (req.method === 'GET' && hasHTMLHeader && !isAsset) {
+        req.url = isForTests ? '/tests/index.html' : '/index.html';
+      }
 
-    next();
+      next();
+    });
   };
 };

--- a/lib/tasks/server/middleware/serve-files/serve-files.js
+++ b/lib/tasks/server/middleware/serve-files/serve-files.js
@@ -7,7 +7,7 @@ module.exports = function(options) {
   var chain              = options.chain || require('connect-chain');
   var broccoliMiddleware = options.middleware || require('broccoli/lib/middleware');
   var middleware = chain(
-    historySupportMiddlware(),
+    historySupportMiddlware(options.watcher),
     broccoliMiddleware(options.watcher)
   );
 

--- a/tests/fixtures/express-server/someurl-without-period
+++ b/tests/fixtures/express-server/someurl-without-period
@@ -1,0 +1,1 @@
+some other content

--- a/tests/fixtures/express-server/test-file.txt
+++ b/tests/fixtures/express-server/test-file.txt
@@ -1,0 +1,1 @@
+some contents


### PR DESCRIPTION
Previously, any files in `public/` (outside of `public/assets/`) would not be served up as it was assumed to match history API requests and redirect to `/index.html`.

This commit fixes that, by serving up any files that exist in the built output directory before falling back to checking for history API support (and subsequently proxying).

Closes #1404.

This is a prerequisite for #1542.
