### PR TITLE
Fixing bug with nesting multiple levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Upgrade `loader.js` to `1.0.1`. [#1543](https://github.com/stefanpenner/ember-cli/pull/1543)
 * [BUGFIX] Allow `public/` to contain files in the root of the project. [#1549](https://github.com/stefanpenner/ember-cli/pull/1549)
 * [ENHANCEMENT] Add `robots.txt` and `crossdomain.xml` files in the root of the project. [#1550](https://github.com/stefanpenner/ember-cli/pull/1550)
+* [BUGFIX] Generating mixins and utils with several levels of nesting no longer produces a failing test. [#1551](https://github.com/stefanpenner/ember-cli/pull/1551)
 
 ### 0.0.40
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -374,7 +374,7 @@ Blueprint.prototype._locals = function(options) {
   var packageName = options.project.name();
   var moduleName = options.entity && options.entity.name || packageName;
 
-  var sanitizedModuleName = moduleName.replace('/', '-');
+  var sanitizedModuleName = moduleName.replace(/\//g, '-');
 
   var standardLocals = {
     dasherizedPackageName: stringUtils.dasherize(packageName),

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -459,6 +459,16 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('mixin foo/bar/baz', function() {
+    return generate(['mixin', 'foo/bar/baz']).then(function() {
+      assertFile('tests/unit/mixins/foo/bar/baz-test.js', {
+        contains: [
+          "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
+        ]
+      });
+    });
+  });
+
   it('adapter foo', function() {
     return generate(['adapter', 'foo']).then(function() {
       assertFile('app/adapters/foo.js', {


### PR DESCRIPTION
Fixes an error made in a previous fix, which didn't account for multiple levels of nesting when sanitizing the module name for generators.

This was especially apparent in mixins (and utils), as those import the function for use in the associated test, so I added a test for that.

Somebody mentioned this in irc, but I can't remember who. Thanks to that person!
