### PR TITLE
Removed use of `memoize` in EmberApp. Allows multiple EmberApps to be instantiated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Move history support into a separate internal addon. [#1552](https://github.com/stefanpenner/ember-cli/pull/1552)
 * [ENHANCEMENT] don't assume value of bowerrc.directory [#1553](https://github.com/stefanpenner/ember-cli/pull/1553)
 * [ENHANCEMENT] es6 namespaced addons [#1544](https://github.com/stefanpenner/ember-cli/pull/1544)
+* [ENHANCEMENT] Removed use of `memoize` from EmberApp. Allows multiple EmberApps to be instantiated [#1361](https://github.com/stefanpenner/ember-cli/issues/1361)
 
 ### 0.0.40
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -28,7 +28,6 @@ var upstreamMergeTrees  = require('broccoli-merge-trees');
 var unwatchedTree    = require('broccoli-unwatched-tree');
 var uglifyJavaScript = require('broccoli-uglify-js');
 
-var memoize       = require('lodash-node/modern/functions').memoize;
 var assign        = require('lodash-node/modern/objects/assign');
 var defaults      = require('lodash-node/modern/objects/defaults');
 var merge         = require('lodash-node/modern/objects/merge');
@@ -211,7 +210,7 @@ EmberApp.prototype.populateLegacyFiles = function () {
   }
 };
 
-EmberApp.prototype.index = memoize(function() {
+EmberApp.prototype.index = function() {
   var files = [
     'index.html'
   ];
@@ -223,9 +222,9 @@ EmberApp.prototype.index = memoize(function() {
   });
 
   return injectENVJson(this.options.getEnvJSON, this.env, index, files);
-});
+};
 
-EmberApp.prototype.testIndex = memoize(function() {
+EmberApp.prototype.testIndex = function() {
   var index = pickFiles(this.trees.tests, {
     srcDir: '/',
     files: ['index.html'],
@@ -235,7 +234,7 @@ EmberApp.prototype.testIndex = memoize(function() {
   return injectENVJson(this.options.getEnvJSON, this.env, index, [
     'tests/index.html'
   ]);
-});
+};
 
 EmberApp.prototype.publicFolder = function() {
   return 'public';
@@ -255,7 +254,7 @@ EmberApp.prototype._appWithoutStylesAndTemplates = function() {
   return this._appWithoutStylesAndTemplatesTree = this.removeStylesAndTemplates(this.trees.app);
 };
 
-EmberApp.prototype._processedAppTree = memoize(function() {
+EmberApp.prototype._processedAppTree = function() {
   var addonTrees = this.addonTreesFor('app');
   var mergedApp  = mergeTrees(addonTrees.concat(this._appWithoutStylesAndTemplates()), {
     overwrite: true,
@@ -268,7 +267,7 @@ EmberApp.prototype._processedAppTree = memoize(function() {
     srcDir: '/',
     destDir: this.name
   });
-});
+};
 
 EmberApp.prototype._processedTemplatesTree = function() {
   var addonTrees      = this.addonTreesFor('templates');
@@ -294,7 +293,7 @@ EmberApp.prototype._processedTemplatesTree = function() {
   });
 };
 
-EmberApp.prototype._processedTestsTree = memoize(function() {
+EmberApp.prototype._processedTestsTree = function() {
   var addonTrees  = this.addonTreesFor('test-support');
   var mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
     overwrite: true,
@@ -305,9 +304,13 @@ EmberApp.prototype._processedTestsTree = memoize(function() {
     srcDir: '/',
     destDir: this.name + '/tests'
   });
-});
+};
 
-EmberApp.prototype._processedVendorTree = memoize(function() {
+EmberApp.prototype._processedVendorTree = function() {
+  if(this._cachedVendorTree) {
+    return this._cachedVendorTree;
+  }
+
   var addonTrees   = mergeTrees(this.addonTreesFor('addon'));
   addonTrees = mergeTrees([
     concatFiles(addonTrees, { inputFiles: ['*.css'], outputFile: '/addons.css', allowNone: true }),
@@ -321,13 +324,14 @@ EmberApp.prototype._processedVendorTree = memoize(function() {
     description: 'TreeMerger (vendor)'
   });
 
-  return pickFiles(mergedVendor, {
+  this._cachedVendorTree = pickFiles(mergedVendor, {
     srcDir: '/',
     destDir: 'vendor/'
   });
-});
+  return this._cachedVendorTree;
+};
 
-EmberApp.prototype.appAndDependencies = memoize(function() {
+EmberApp.prototype.appAndDependencies = function() {
   var app       = this._processedAppTree();
   var templates = this._processedTemplatesTree();
 
@@ -388,9 +392,9 @@ EmberApp.prototype.appAndDependencies = memoize(function() {
     overwrite: true,
     description: 'TreeMerger (appAndDependencies)'
   });
-});
+};
 
-EmberApp.prototype.javascript = memoize(function() {
+EmberApp.prototype.javascript = function() {
   var applicationJs       = this.appAndDependencies();
   var legacyFilesToAppend = this.legacyFilesToAppend;
 
@@ -439,9 +443,9 @@ EmberApp.prototype.javascript = memoize(function() {
   } else {
     return vendorAndApp;
   }
-});
+};
 
-EmberApp.prototype.styles = memoize(function() {
+EmberApp.prototype.styles = function() {
   var addonTrees = this.addonTreesFor('styles');
   var vendor = this._processedVendorTree();
   var styles = pickFiles(this.trees.styles, {
@@ -478,9 +482,9 @@ EmberApp.prototype.styles = memoize(function() {
     ], {
       description: 'styles'
     });
-});
+};
 
-EmberApp.prototype.testFiles = memoize(function() {
+EmberApp.prototype.testFiles = function() {
   var vendor = this._processedVendorTree();
 
   var testJs = concatFiles(vendor, {
@@ -530,9 +534,9 @@ EmberApp.prototype.testFiles = memoize(function() {
       overwrite: true,
       description: 'TreeMerger (testFiles)'
     });
-});
+};
 
-EmberApp.prototype.otherAssets = memoize(function() {
+EmberApp.prototype.otherAssets = function() {
   var vendor = this._processedVendorTree();
   var otherAssetTrees = this.otherAssetPaths.map(function (path) {
     return pickFiles(vendor, {
@@ -544,7 +548,7 @@ EmberApp.prototype.otherAssets = memoize(function() {
   return mergeTrees(otherAssetTrees, {
     description: 'TreeMerger (otherAssetTrees)'
   });
-});
+};
 
 EmberApp.prototype.import = function(asset, options) {
   var assetPath;


### PR DESCRIPTION
See #1361 for details.

This feels a bit like a lazy commit. I really had no idea how to test a broccoli tree and it seems there isn't much of that yet. I thought about testing subsequent calls to `this._processedVendorTree` to compare objects ... but that's really testing a private API. 

I'd love to get some tests and I'm open to any suggestions.
