### PR TITLE
Close #1567 Locating QUnit at /tests prevents creation of /tests route

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -17,7 +17,7 @@ HistorySupportAddon.prototype.serverMiddleware = function(config) {
     watcher.then(function(results) {
       var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
       var isAsset = fs.existsSync(path.join(results.directory, req.path));
-      var isForTests = /^\/tests/.test(req.path);
+      var isForTests = /^\/_tests/.test(req.path);
 
       if (req.method === 'GET' && hasHTMLHeader && !isAsset) {
         req.url = isForTests ? '/tests/index.html' : '/index.html';


### PR DESCRIPTION
- changed qunit access path from /tests to /_tests
- tests passing--this appears to be all that is necessary (though I may be wrong) and now works with a /tests route
