### PR TITLE
Don't error without vendor/

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -148,7 +148,7 @@ function EmberApp(options) {
     templates: unwatchedTree('app/templates'),
 
     // do not watch vendor/ or bower's default directory by default
-    vendor: mergeTrees([unwatchedTree('vendor'), unwatchedTree(this.bowerDirectory + '')]),
+    vendor: mergeTrees(this.unwatchedVendorTrees()),
   }, defaults);
 
   this.options.jshintrc = merge(this.options.jshintrc, {
@@ -169,6 +169,17 @@ function EmberApp(options) {
   this.populateLegacyFiles();
   this._notifyAddonIncluded();
 }
+
+EmberApp.prototype.unwatchedVendorTrees = function() {
+  var _this = this;
+  return ['vendor', this.bowerDirectory + ''].reduce(function(trees, treePath) {
+    if (fs.existsSync(path.join(_this.project.root, treePath))) {
+      trees.push(unwatchedTree(treePath));
+    }
+
+    return trees;
+  }, []);
+};
 
 EmberApp.prototype._notifyAddonIncluded = function() {
   this.project.initializeAddons();


### PR DESCRIPTION
Fixes #1560

During upgrade apps will fail if `vendor/` is not present. Seems silly to require an empty directory
