### PR TITLE
Add 'Hide content' button in QUnit toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Removed use of `memoize` from EmberApp. Allows multiple EmberApps to be instantiated [#1361](https://github.com/stefanpenner/ember-cli/issues/1361)
 * [ENHANCEMENT] Add `ember destroy` command [#1547](https://github.com/stefanpenner/ember-cli/pull/1547)
 * [BUGFIX] Ensure router.js is not modified when ember g route foo --dry-run [#1570](https://github.com/stefanpenner/ember-cli/pull/1570)
+* [ENHANCEMENT] Add possibility to hide #ember-testing-container while testing [#1579](https://github.com/stefanpenner/ember-cli/pull/1579)
 
 ### 0.0.40
 

--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -4,3 +4,10 @@ import { setResolver } from 'ember-qunit';
 setResolver(resolver);
 
 document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
+
+QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
+if (QUnit.urlParams.nocontainer) {
+  document.getElementById('ember-testing-container').style.visibility = 'hidden';
+} else {
+  document.getElementById('ember-testing-container').style.visibility = 'visible';
+}


### PR DESCRIPTION
Hi!
I have a 11-inch laptop and if i open chrome dev tools I don't can see part of results of tests.
It looks like this:

![screenshot](https://www.evernote.com/shard/s424/sh/695ac905-d54b-4975-8a58-9ad665bdfa1a/a26c38281025bfc1a903c0678144dee7/deep/0/--Apollo-Tests-and-test-helper.js---apollo.png)

It would be great able to toggle the visibility of the test container.
