### PR TITLE
adding vagrant to help linux/mac test in windows

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+  end
+
+  config.vm.provision "shell", path: "install.ps1"
+end

--- a/dev/install.ps1
+++ b/dev/install.ps1
@@ -1,0 +1,17 @@
+Set-ExecutionPolicy RemoteSigned -Scope Process -Force
+iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+cinst nodejs.install
+$ENV:PATH += ";C:\Program Files\nodejs"
+npm install -g npm
+del "C:\Program Files\nodejs\npm*"
+rd "C:\Program Files\nodejs\node_modules" -recurse
+$ENV:PATH += ";C:\Users\vagrant\AppData\Roaming\npm"
+
+cinst git.install
+$ENV:PATH += ";C:\Program Files (x86)\Git\cmd"
+
+cd C:\Users\vagrant
+git clone https://github.com/stefanpenner/ember-cli.git
+cd ember-cli
+npm install

--- a/dev/instructions.txt
+++ b/dev/instructions.txt
@@ -1,0 +1,7 @@
+install virtualbox
+install vagrant
+run "vagrant up" in this directory
+wait for the command to finish
+open the command prompt in windows
+run "cd C:\Users\vagrant"
+run "npm test"


### PR DESCRIPTION
https://github.com/stefanpenner/ember-cli/issues/1558#issuecomment-51205776

I'm familiar with Vagrant so I made a script that will grab a Windows
box from vagrantcloud.com and set it up to `npm test`.

I could not test this with a Linux host because VMs inside VMs is tricky
business, but it should work.
