### PR TITLE
<base> tag does not need closing slash in HTML5 as it is a void element.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -678,7 +678,7 @@ function injectENVJson(fn, env, tree, files) {
     }
 
     if (baseURL) {
-      return '<base href="' + baseURL + '" />';
+      return '<base href="' + baseURL + '">';
     } else {
       return '';
     }


### PR DESCRIPTION
`<base />` Is perfectly valid in every browser so this is really just removing it cause it's frivolous. Pretty dumb of me to care...but for whatever reason I do.

References:
http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag
http://www.w3.org/html/wg/drafts/html/master/single-page.html#void-elements
