### PR TITLE
Make sure custom locationType doesn't break test env

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -27,7 +27,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
-    ENV.locationType = 'auto';
+    ENV.locationType = 'none';
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
Tests do not run if you set `locationType` to 'hash' by default, so this sets it to 'auto' explicitly for the test environment.
