### PR TITLE
add RSVP to bundledDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "readline2",
     "resolve",
     "rimraf",
+    "rsvp",
     "semver",
     "through",
     "tiny-lr",


### PR DESCRIPTION
after this mornings incident i realized RSVP was not being bundled. Although it was good to catch the bug early, we should likely keep our dependencies bundled and locked down to ensure stability + faster npm downloads
