### PR TITLE
Allow Blueprints to add packages to projects package.json.

### DIFF
--- a/blueprints/http-proxy/index.js
+++ b/blueprints/http-proxy/index.js
@@ -1,4 +1,5 @@
 var Blueprint = require('../../lib/models/blueprint');
+var Promise   = require('../../lib/ext/promise');
 
 module.exports = Blueprint.extend({
   locals: function(options) {
@@ -7,5 +8,12 @@ module.exports = Blueprint.extend({
       path: '/' + options.entity.name.replace(/^\//, ''),
       proxyUrl: proxyUrl
     };
+  },
+
+  afterInstall: function() {
+    return Promise.all([
+      this.addPackageToProject('http-proxy', '^1.1.6'),
+      this.addPackageToProject('connect-restreamer', '^1.0.0')
+    ]);
   }
 });

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -38,7 +38,8 @@ CLI.prototype.run = function(environment) {
       commands:  environment.commands,
       tasks:     environment.tasks,
       project:   environment.project,
-      settings:  environment.settings
+      settings:  environment.settings,
+      testing:   this.testing
     });
 
     var update;

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -46,7 +46,8 @@ module.exports = Command.extend({
     var task = new Task({
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
+      project: this.project,
+      testing: this.testing
     });
 
     var taskArgs = {

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -211,6 +211,7 @@ Blueprint.prototype.install = function(options) {
   var dryRun   = options.dryRun;
   var locals   = this._locals(options);
   this.project = options.project;
+  this.testing = options.testing;
 
   var actions = {
     write: function(info) {
@@ -485,6 +486,49 @@ Blueprint.prototype._locals = function(options) {
   var customLocals = this.locals(options);
 
   return merge({}, standardLocals, customLocals);
+};
+
+/*
+  Used to add a package to the projects `package.json`.
+
+  Generally, this would be done from the `afterInstall` hook, to
+  ensure that a package that is required by a given blueprint is
+  available.
+
+  @method addPackageToProject
+  @param {String} packageName
+  @param {String} version
+  @return {Promise}
+*/
+Blueprint.prototype.addPackageToProject = function(packageName, version) {
+  var command = 'npm install --save-dev ' + packageName;
+  var ui      = this.ui;
+
+  if (version) {
+    command += '@' + version;
+  }
+
+  if (ui) {
+    ui.write('  ' + chalk.green('install package') + ' ' + packageName + '\n');
+  }
+
+  return this._exec(command);
+};
+
+/*
+  @private
+  @method _exec
+  @param {String} command
+  @return {Promise}
+*/
+Blueprint.prototype._exec = function(command) {
+  var exec = Promise.denodeify(require('child_process').exec);
+
+  if (this.testing) {
+    return Promise.resolve();
+  } else {
+    return exec(command);
+  }
 };
 
 /*

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -23,7 +23,8 @@ module.exports = Task.extend({
       entity: entity,
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
+      project: this.project,
+      testing: this.testing
     };
 
     installOptions = merge(installOptions, options || {});

--- a/package.json
+++ b/package.json
@@ -134,9 +134,7 @@
     "tiny-lr": "0.0.9",
     "tmp-sync": "^1.0.1",
     "walk-sync": "^0.1.2",
-    "yam": "0.0.12",
-    "http-proxy": "^1.1.6",
-    "connect-restreamer": "^1.0.0"
+    "yam": "0.0.12"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -1,0 +1,80 @@
+'use strict';
+
+var tmp        = require('../helpers/tmp');
+var conf       = require('../helpers/conf');
+var Promise    = require('../../lib/ext/promise');
+var path       = require('path');
+var rimraf     = Promise.denodeify(require('rimraf'));
+var fs         = require('fs');
+var ncp        = Promise.denodeify(require('ncp'));
+var assert     = require('assert');
+
+var runCommand       = require('../helpers/run-command');
+
+var appName  = 'some-cool-app';
+
+function buildApp(appName) {
+  return runCommand(path.join('..', 'bin', 'ember'), 'new', appName, {
+    onOutput: function() {
+      return; // no output for initial application build
+    }
+  });
+}
+
+describe.only('Acceptance: blueprint smoke tests', function() {
+  before(function() {
+    this.timeout(360000);
+
+    tmp.setup('./common-tmp');
+    process.chdir('./common-tmp');
+
+    conf.setup();
+    return buildApp(appName)
+      .then(function() {
+        return rimraf(path.join(appName, 'node_modules', 'ember-cli'));
+      });
+  });
+
+  after(function() {
+    tmp.teardown('./common-tmp');
+    conf.restore();
+  });
+
+  beforeEach(function() {
+    this.timeout(10000);
+    tmp.setup('./tmp');
+    return ncp('./common-tmp/' + appName, './tmp/' + appName, {
+      clobber: true,
+      stopOnErr: true
+    })
+    .then(function() {
+      process.chdir('./tmp');
+
+      var appsECLIPath = path.join(appName, 'node_modules', 'ember-cli');
+      var pwd = process.cwd();
+
+      fs.symlinkSync(path.join(pwd, '..'), appsECLIPath);
+
+      process.chdir(appName);
+    });
+  });
+
+  afterEach(function() {
+    tmp.teardown('./tmp');
+  });
+
+  it('generating an http-proxy installs packages to package.json', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'http-proxy', 'api', 'http://localhost/api')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = require(packageJsonPath);
+
+        assert(packageJson.devDependencies['http-proxy']);
+        assert(packageJson.devDependencies['connect-restreamer']);
+      });
+  });
+});

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -316,4 +316,57 @@ describe('Blueprint', function() {
     });
   });
 
+  describe('addPackageToProject', function() {
+    var blueprint;
+    var ui;
+    var tmpdir;
+
+    beforeEach(function() {
+      tmpdir    = tmp.in(tmproot);
+      blueprint = new Blueprint(basicBlueprint);
+      ui        = new MockUI();
+    });
+
+    afterEach(function() {
+      rimraf.sync(tmproot);
+    });
+
+    it('calls _exec with the proper command when no version is supplied', function() {
+      blueprint._exec = function(command) {
+        assert.equal(command, 'npm install --save-dev foo-bar');
+      };
+
+      blueprint.addPackageToProject('foo-bar');
+    });
+
+    it('calls _exec with the proper command when a version is supplied', function() {
+      blueprint._exec = function(command) {
+        assert.equal(command, 'npm install --save-dev foo-bar@^123.1.12');
+      };
+
+      blueprint.addPackageToProject('foo-bar', '^123.1.12');
+    });
+
+    it('writes information to the ui log', function() {
+      blueprint._exec = function() { };
+      blueprint.ui = ui;
+
+      blueprint.addPackageToProject('foo-bar', '^123.1.12');
+
+      var output = ui.output.trim();
+
+      assert.match(output, /install package.*foo-bar/);
+    });
+
+    it('does not error if ui is not present', function() {
+      blueprint._exec = function() { };
+      delete blueprint.ui;
+
+      blueprint.addPackageToProject('foo-bar', '^123.1.12');
+
+      var output = ui.output.trim();
+
+      assert(!output.match(/install package.*foo-bar/));
+    });
+  });
 });


### PR DESCRIPTION
- Add `Blueprint.prototype.addPackageToProject`.
- Add slow smoke test to confirm `ember g http-proxy` adds packages.
- Removes unneeded packages from ember-cli's package.json.
