### PR TITLE
Allow addons to include themselves in dummy tests

### DIFF
--- a/blueprints/addon/files/package.json
+++ b/blueprints/addon/files/package.json
@@ -18,6 +18,11 @@
   "keywords": [
     "ember-addon"
   ],
+  "ember-addon": {
+    "paths": [
+      "."
+    ]
+  }
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Forgot this, will allow the dummy app in the test suite to include this as its own addon
