### PR TITLE
Remove extra slash from assetPath.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -576,7 +576,7 @@ EmberApp.prototype.import = function(asset, options) {
     return;
   }
 
-  assetPath = assetPath.replace(new RegExp('^'+this.bowerDirectory), 'vendor/');
+  assetPath = assetPath.replace(new RegExp('^'+this.bowerDirectory), 'vendor');
 
   if (assetPath.split('/').length < 2) {
     console.log(chalk.red('Using `app.import` with a file in the root of `vendor/` causes a significant performance penalty. Please move `'+ assetPath + '` into a subdirectory.'));


### PR DESCRIPTION
`this.bowerDirectory` does not contain a trailing slash so we should
not add one back.
