### PR TITLE
Add some paths Sublime Text should ignore

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -49,7 +49,7 @@ If you are using SublimeText 3 with `ember-cli`, by default it will try to index
 // folder_exclude_patterns and file_exclude_patterns control which files
 // are listed in folders on the side bar. These can also be set on a per-
 // project basis.
-"folder_exclude_patterns": [".svn", ".git", ".hg", "CVS", "tmp/class-*", "tmp/es_*", "tmp/jshinter*", "tmp/replace_*", "tmp/static_compiler*", "tmp/template_compiler*", "tmp/tree_merger*", "tmp/coffee_script*", "tmp/concat-tmp*", "tmp/export_tree*", "tmp/sass_compiler*", "tmp/caching*", "tmp/custom*", "tmp/remover*", "tmp/simple_replace*",]
+"folder_exclude_patterns": [".svn", ".git", ".hg", "CVS", "tmp/*"]
 {% endhighlight %}
 
 ### Using canary build instead of release


### PR DESCRIPTION
I suggest that because of some internal changes ember-cli generates files with other names. These were not included in the common issue with Sublime Text that causes a cpu usage of about 90%.
