### PR TITLE
Refactor Addon model.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -5,7 +5,7 @@ var path        = require('path');
 var deprecate   = require('../utilities/deprecate');
 var assign      = require('lodash-node/modern/objects/assign');
 var glob        = require('glob');
-var pickFiles   = require('broccoli-static-compiler');
+var pickFiles   = require('../broccoli/custom-static-compiler');
 var compileES6  = require('broccoli-es6-concatenator');
 var memoize     = require('lodash-node/modern/functions').memoize;
 var mergeTrees  = require('broccoli-merge-trees');
@@ -62,7 +62,7 @@ Addon.prototype.treeFor = function treeFor(name) {
   }
 
   if (process.env.EMBER_ADDON_ENV === 'development' && this.app.hinting && name === 'app') {
-    trees.push(this.jshinting());
+    trees.push(this.jshinting(tree));
   }
 
   return mergeTrees(trees);
@@ -73,36 +73,59 @@ Addon.prototype.included = function(app) {
 };
 
 Addon.prototype.includedModules = function() {
+  if (this._includedModules) {
+    return this._includedModules;
+  }
+
   var root       = this.root;
+  var treePath   = path.join(this.root, this.treePaths['addon']);
   var moduleName = this.moduleName();
-  return glob.sync(path.join(root, 'addon', '**/*.js')).reduce(function(ignoredModules, filePath) {
-    ignoredModules[filePath.replace(path.join(root, 'addon'), moduleName).slice(0, -3)] = ['default'];
+
+  this._includedModules = glob.sync(path.join(treePath, '**/*.js')).reduce(function(ignoredModules, filePath) {
+    ignoredModules[filePath.replace(treePath, moduleName).slice(0, -3)] = ['default'];
     return ignoredModules;
   }, {});
+
+  return this._includedModules;
 };
 
 Addon.prototype.treeForAddon = function(tree) {
-  var addonTree = this.compileAddon(tree);
-  var stylesTree = this.compileStyles(tree);
-  var templatesTree = this.compileTemplates(tree);
+  var trees = [], addonTree, stylesTree, templatesTree;
 
-  var jsTree = concatFiles(mergeTrees([addonTree, templatesTree]), {
+  addonTree = this.compileAddon(tree);
+  if (addonTree) { trees.push(addonTree); }
+
+  templatesTree = this.compileTemplates(tree);
+  if (templatesTree) { trees.push(templatesTree); }
+
+  var jsTree = concatFiles(mergeTrees(trees), {
     inputFiles: ['*.js', '**/*.js'],
     outputFile: '/' + this.name + '.js',
     allowNone: true
   });
 
-  return mergeTrees([jsTree, stylesTree]);
+  trees = [ jsTree ];
+
+  stylesTree = this.compileStyles(tree);
+  if (stylesTree) { trees.push(stylesTree); }
+
+  return mergeTrees(trees);
 };
 
 Addon.prototype.compileStyles = function(tree) {
+  if (!fs.existsSync(path.join(this.root, this.treePaths['addon'], 'styles'))) {
+    return;
+  }
+
   var styleFiles = pickFiles(tree, {
     srcDir: '/styles',
     destDir: '/'
   });
+
   var processedStyles = preprocessCss(styleFiles, '/', '/', {
     registry: this.registry
   });
+
   return fileMover(processedStyles, {
     srcFile: '/' + this.app.name + '.css',
     destFile: '/' + this.name + '.css'
@@ -128,13 +151,17 @@ Addon.prototype.compileTemplates = function(tree) {
 };
 
 Addon.prototype.compileAddon = function(tree) {
+  if (Object.keys(this.includedModules()).length === 0) {
+    return;
+  }
+
   var addonJs = this.addonJsFiles(tree);
 
   var es6Tree = compileES6(addonJs, {
     ignoredModules: Object.keys(this.app.importWhitelist),
     inputFiles: [this.name + '/**/*.js'],
     wrapInEval: this.app.options.wrapInEval,
-    outputFile: '/' + this.name + '.js',
+    outputFile: '/' + this.name + '.js'
   });
 
   this.app.importWhitelist = assign(this.app.importWhitelist, this.includedModules());
@@ -142,29 +169,37 @@ Addon.prototype.compileAddon = function(tree) {
   return es6Tree;
 };
 
-Addon.prototype.jshinting = function() {
-  var addonJs = this.addonJsFiles('addon');
+Addon.prototype.jshinting = function(tree) {
+  var addonJs = this.addonJsFiles(tree);
   var jshintedAddon = jshintTrees(addonJs, {
     jshintrcPath: this.app.options.jshintrc.app,
     description: 'JSHint - Addon'
   });
+
   return pickFiles(jshintedAddon, {
     srcDir: '/',
     destDir: this.name + '/tests/'
   });
 };
 
-Addon.prototype.addonJsFiles = memoize(function(tree) {
+Addon.prototype.addonJsFiles = function(tree) {
+  if (this._addonJsFiles) {
+    return this._addonJsFiles;
+  }
+
   var files = pickFiles(tree, {
     srcDir: '/',
     files: ['**/*.js'],
-    destDir: this.name
+    destDir: this.name,
+    allowEmpty: true
   });
 
-  return preprocessJs(files, '/', this.name, {
+  this._addonJsFiles = preprocessJs(files, '/', this.name, {
     registry: this.registry
   });
-});
+
+  return this._addonJsFiles;
+};
 
 Addon.prototype.moduleName = function() {
   return this.name.toLowerCase().replace(/\s/g, '-');


### PR DESCRIPTION
- Allow for addons that do not have any javascript files.
- Remove usage of `memoize` (this prevents usage of multiple instances).

/cc @bcardarella
