### PR TITLE
Enable `ember init` inside an addon.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -15,7 +15,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false },
     { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: path, default: 'app' },
+    { name: 'blueprint', type: path },
     { name: 'skip-npm', type: Boolean, default: false },
     { name: 'skip-bower', type: Boolean, default: false }
   ],
@@ -23,6 +23,14 @@ module.exports = Command.extend({
   anonymousOptions: [
     '<app-name>'
   ],
+
+  _defaultBlueprint: function() {
+    if (this.project.isEmberCLIAddon()) {
+      return 'addon';
+    } else {
+      return 'app';
+    }
+  },
 
   run: function(commandOptions, rawArgs) {
     if (commandOptions.dryRun) {
@@ -52,7 +60,7 @@ module.exports = Command.extend({
     var packageName      = rawArgs[0] !== '.' && rawArgs[0] || project.name();
     var blueprintOpts    = {
       dryRun: commandOptions.dryRun,
-      blueprint: commandOptions.blueprint,
+      blueprint: commandOptions.blueprint || this._defaultBlueprint(),
       rawName: packageName
     };
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -26,6 +26,11 @@ Project.prototype.isEmberCLIProject = function() {
   return this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies;
 };
 
+Project.prototype.isEmberCLIAddon = function() {
+  return this.pkg.keywords && this.pkg.keywords.indexOf('ember-addon') > -1;
+};
+
+
 Project.prototype.config = function(env) {
   if (fs.existsSync(path.join(this.root, 'config', 'environment.js'))) {
     return this.require('./config/environment')(env);

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -151,4 +151,46 @@ describe('init command', function() {
         assert.equal(reason, 'Called run');
       });
   });
+
+  it('Uses the "app" blueprint by default', function() {
+    tasks.InstallBlueprint = Task.extend({
+      run: function(blueprintOpts) {
+        assert.equal(blueprintOpts.blueprint, 'app');
+        return Promise.reject('Called run');
+      }
+    });
+
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { name: 'some-random-name'}),
+      tasks: tasks
+    });
+
+    return command.validateAndRun(['provided-name'])
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+  });
+
+  it('Uses the "addon" blueprint for addons', function() {
+    tasks.InstallBlueprint = Task.extend({
+      run: function(blueprintOpts) {
+        assert.equal(blueprintOpts.blueprint, 'addon');
+        return Promise.reject('Called run');
+      }
+    });
+
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { keywords: [ 'ember-addon' ], name: 'some-random-name'}),
+      tasks: tasks
+    });
+
+    return command.validateAndRun(['provided-name'])
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+  });
 });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -135,4 +135,22 @@ describe('models/project.js', function() {
       assert.equal(project.emberCLIVersion(), emberCLIVersion());
     });
   });
+
+  describe('isEmberCLIAddon', function() {
+    it('should return true if `ember-addon` is included in keywords', function() {
+      project.pkg = {
+        keywords: [ 'ember-addon' ]
+      };
+
+      assert.equal(project.isEmberCLIAddon(), true);
+    });
+
+    it('should return false if `ember-addon` is not included in keywords', function() {
+      project.pkg = {
+        keywords: [ ]
+      };
+
+      assert.equal(project.isEmberCLIAddon(), false);
+    });
+  });
 });


### PR DESCRIPTION
- Add `Project.prototype.isEmberCLIAddon`.
- Use `addon` blueprint for projects with the `ember-addon` keyword.

Closes #1623.
