### PR TITLE
Remove usage of rewire.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 // Main entry point
-var UI            = require('../ui');
 var Project       = require('../models/project');
 var requireAsHash = require('../utilities/require-as-hash');
 var Command       = require('../models/command');
@@ -9,7 +8,6 @@ var commands      = requireAsHash('../commands/*.js', Command);
 var Task          = require('../models/task');
 var tasks         = requireAsHash('../tasks/*.js', Task);
 var CLI           = require('./cli');
-var Leek          = require('leek');
 var Yam           = require('yam');
 var packageConfig = require('../../package.json');
 
@@ -21,6 +19,9 @@ var trackingCode  = packageConfig.trackingCode;
 module.exports = cli;
 
 function cli(options) {
+  var UI = options.UI || require('../ui');
+  var Leek = options.Leek || require('leek');
+
   var ui = new UI({
     inputStream:  options.inputStream,
     outputStream: options.outputStream

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "mocha": "^1.18.0",
     "mocha-jshint": "0.0.7",
     "node-require-timings": "^0.0.2",
-    "rewire": "^2.0.0",
     "supertest": "^0.13.0",
     "tmp-sync": "^1.0.1"
   }

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -1,25 +1,10 @@
 'use strict';
 
-var rewire   = require('rewire');
-var Cli      = rewire('../../lib/cli');
+var MockUI   = require('./mock-ui');
+var MockLeek = require('./mock-leek');
+var Cli      = require('../../lib/cli');
+
 var baseArgs = ['node', 'path/to/cli'];
-
-Cli.__set__('Leek', function() {
-  return {
-      track:      function() {},
-      trackEvent: function() {},
-      trackError: function() {}
-    };
-});
-
-Cli.__set__('UI', function() {
-  this.outputStream = [];
-  this.inputStream  = [];
-
-  this.write = function(data) {
-    this.outputStream.push(data);
-  };
-});
 
 module.exports = function ember(args) {
   var argv, cli;
@@ -34,6 +19,8 @@ module.exports = function ember(args) {
     inputStream:  [],
     outputStream: [],
     cliArgs:      args,
+    Leek: MockLeek,
+    UI: MockUI,
     testing: true
   });
 

--- a/tests/helpers/mock-leek.js
+++ b/tests/helpers/mock-leek.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function MockLeek() {}
+
+MockLeek.prototype.track = function() {};
+MockLeek.prototype.trackEvent = function() {};
+MockLeek.prototype.trackError = function() {};
+
+module.exports = MockLeek;
+

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -3,8 +3,7 @@
 var expect  = require('chai').expect;
 var MockUI  = require('../../helpers/mock-ui');
 var MockAnalytics  = require('../../helpers/mock-analytics');
-var rewire  = require('rewire');
-var Command = rewire('../../../lib/models/command');
+var Command = require('../../../lib/models/command');
 var Project       = require('../../../lib/models/project');
 var AddonCommand  = require('../../fixtures/addon/commands/addon-command');
 
@@ -30,7 +29,7 @@ describe('help command', function() {
     })
   };
 
-  var HelpCommand = rewire('../../../lib/commands/help');
+  var HelpCommand = require('../../../lib/commands/help');
 
   beforeEach(function() {
     ui = new MockUI();

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -4,8 +4,6 @@ var path          = require('path');
 var assert        = require('../../helpers/assert');
 var MockUI        = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
-var rewire        = require('rewire');
-var stubPath      = require('../../helpers/stub').stubPath;
 var Promise       = require('../../../lib/ext/promise');
 var Project       = require('../../../lib/models/project');
 var Task          = require('../../../lib/models/task');
@@ -27,8 +25,7 @@ describe('init command', function() {
     };
 
     project = new Project(process.cwd(), { name: 'some-random-name'});
-    InitCommand = rewire('../../../lib/commands/init');
-    InitCommand.__set__('path', stubPath('test'));
+    InitCommand = require('../../../lib/commands/init');
   });
 
   it('doesn\'t allow to create an application named `test`', function() {

--- a/tests/unit/tasks/update-test.js
+++ b/tests/unit/tasks/update-test.js
@@ -4,9 +4,8 @@ var fs         = require('fs');
 var path       = require('path');
 var assert     = require('../../helpers/assert');
 var MockUI     = require('../../helpers/mock-ui');
-var rewire     = require('rewire');
 var Promise    = require('../../../lib/ext/promise');
-var UpdateTask = rewire('../../../lib/tasks/update');
+var UpdateTask = require('../../../lib/tasks/update');
 
 describe('update task', function() {
   var updateTask;


### PR DESCRIPTION
Rewire is neat, but mucks around with node internals to change the way require works.  I'd rather avoid it if possible (and most of our usage was just left-over).
