### PR TITLE
Allow Blueprint to determine if entity name is required.

### DIFF
--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -24,19 +24,10 @@ module.exports = Command.extend({
   run: function(commandOptions, rawArgs) {
     var ui            = this.ui;
     var blueprintName = rawArgs[0];
-    var entityName    = rawArgs[1];
 
     if (!blueprintName) {
       ui.write(chalk.yellow('The `ember generate` command requires a ' +
                             'blueprint name to be specified. ' +
-                            'For more details, use `ember help`.\n'));
-
-      return Promise.reject();
-    }
-
-    if (!entityName) {
-      ui.write(chalk.yellow('The `ember generate` command requires an ' +
-                            'entity name to be specified. ' +
                             'For more details, use `ember help`.\n'));
 
       return Promise.reject();

--- a/lib/errors/silent.js
+++ b/lib/errors/silent.js
@@ -12,7 +12,7 @@ function SilentError(message) {
   }
 }
 
-SilentError.prototype = new Error();
+SilentError.prototype = Error.prototype;
 SilentError.prototype.constructor = SilentError;
 
 module.exports = SilentError;

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -190,6 +190,12 @@ Blueprint.prototype.srcPath = function(file) {
   @return {null}
 */
 Blueprint.prototype.normalizeEntityName = function(entityName) {
+  if (!entityName) {
+    throw new SilentError('The `ember generate` command requires an ' +
+                          'entity name to be specified. ' +
+                          'For more details, use `ember help`.\n');
+  }
+
   var trailingSlash = /(\/$|\\$)/;
   if(trailingSlash.test(entityName)) {
     throw new Error('You specified "' + entityName + '", but you can\'t use a ' +

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -41,19 +41,6 @@ describe('generate command', function() {
       });
   });
 
-  it('complains if no entity name is given', function() {
-    return command.validateAndRun(['controller'])
-      .then(function() {
-        assert.ok(false, 'should not have called run');
-      })
-      .catch(function() {
-        assert.equal(command.ui.output, chalk.yellow(
-            'The `ember generate` command requires an ' +
-            'entity name to be specified. ' +
-            'For more details, use `ember help`.\n'));
-      });
-  });
-
   it('complains if no blueprint name is given', function() {
     return command.validateAndRun([])
       .then(function() {

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -11,6 +11,7 @@ var rimraf            = require('rimraf');
 var root              = process.cwd();
 var tmp               = require('tmp-sync');
 var tmproot           = path.join(root, 'tmp');
+var SilentError       = require('../../../lib/errors/silent');
 
 var defaultBlueprints = path.resolve(__dirname, '..', '..', '..', 'blueprints');
 var fixtureBlueprints = path.resolve(__dirname, '..', '..', 'fixtures', 'blueprints');
@@ -296,6 +297,14 @@ describe('Blueprint', function() {
         blueprint.install(options);
       });
     });
+
+    it('throws error when an entityName is not provided', function(){
+      options.entity = { };
+      assert.throws(function(){
+        blueprint.install(options);
+      }, SilentError, /'The `ember generate` command requires an entity name to be specified./);
+    });
+
 
     it('calls normalizeEntityName hook during install', function(done){
       blueprint.normalizeEntityName = function(){ done(); };


### PR DESCRIPTION
Prior to this change an entity name was always required (which makes sense for all of our bundled blueprints). In some cases you just want to run a generator that does not need a name (for example you are just initializing some required files for an addon).

This change still requires an entity name by default, but allows the blueprint to override the `normalizeEntityName` and prevent the error.
