### PR TITLE
Allow addons to use history-support middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Addon blueprint [#1374](https://github.com/stefanpenner/ember-cli/pull/1374)
 * [BUGFIX] Fix addons with empty directories [#]()
 * [BUGFIX] Fix tests/helpers/start-app.js location from addon generator [#1626](https://github.com/stefanpenner/ember-cli/pull/1626)
+* [BUGFIX] Allow addons to use history support middleware [#1632](https://github.com/stefanpenner/ember-cli/pull/1632)
 
 ### 0.0.40
 

--- a/blueprints/addon/files/package.json
+++ b/blueprints/addon/files/package.json
@@ -18,6 +18,9 @@
   "keywords": [
     "ember-addon"
   ],
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
+  },
   "author": "",
   "license": "MIT",
   "devDependencies": {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -32,8 +32,13 @@ Project.prototype.isEmberCLIAddon = function() {
 
 
 Project.prototype.config = function(env) {
-  if (fs.existsSync(path.join(this.root, 'config', 'environment.js'))) {
-    return this.require('./config/environment')(env);
+  var configPath = 'config';
+
+  if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
+    configPath = this.pkg['ember-addon']['configPath'];
+  }
+  if (fs.existsSync(path.join(this.root, configPath, 'environment.js'))) {
+    return this.require('./' + path.join(configPath, 'environment'))(env);
   } else {
     return { };
   }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -12,7 +12,7 @@ var emberCLIVersion = require('../../../lib/utilities/ember-cli-version');
 describe('models/project.js', function() {
   var project, projectPath;
 
-  describe('Project.prototype.config', function() {
+  describe('Project.prototype.config default', function() {
     var called      = false;
     projectPath = process.cwd() + '/tmp/test-app';
 
@@ -36,6 +36,40 @@ describe('models/project.js', function() {
     });
 
     it('config() finds and requires config/environment', function() {
+      project.config('development');
+      assert.equal(called, true);
+    });
+  });
+
+  describe('Project.prototype.config custom config path from addon', function() {
+    var called      = false;
+    projectPath = process.cwd() + '/tmp/test-app';
+
+    before(function() {
+      tmp.setup(projectPath);
+
+      touch(projectPath + '/tests/dummy/config/environment.js', {
+        baseURL: '/foo/bar'
+      });
+
+      project = new Project(projectPath, { });
+      project.pkg = {
+        'ember-addon': {
+          'configPath': 'tests/dummy/config'
+        }
+      };
+      project.require = function() {
+        called = true;
+        return function() {};
+      };
+
+    });
+
+    after(function() {
+      tmp.teardown(projectPath);
+    });
+
+    it('config() finds and requires tests/dummy/config/environment', function() {
       project.config('development');
       assert.equal(called, true);
     });


### PR DESCRIPTION
The addon test dummmy app's environment file was not being found by
project.config(). This feels a little hackey but will allow the project
class for the addon to find the proper environment file to tell history
support what locationType is supported.
