### PR TITLE
Force addon deps to be included before addon

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -108,11 +108,11 @@ Project.prototype.addIfAddon = function(addonPath) {
     addonPkg['ember-addon'] = addonPkg['ember-addon'] || {};
 
     if (keywords.indexOf('ember-addon') > -1) {
+      this.discoverAddons(addonPath, addonPkg);
       this.addonPackages[addonPkg.name] = {
         path: addonPath,
         pkg: addonPkg
       };
-      this.discoverAddons(addonPath, addonPkg);
     }
   }
 };


### PR DESCRIPTION
When building ignoredModules for addons any deps that an addon uses
won't have that namespace ignored unless that dep is processed prior to
the addon itself.
