### PR TITLE
Allow a --liveReloadScript flag to disable injection of livereload script

### DIFF
--- a/lib/tasks/server/middleware/live-reload/index.js
+++ b/lib/tasks/server/middleware/live-reload/index.js
@@ -9,7 +9,7 @@ LiveReloadAddon.prototype.serverMiddleware = function(options) {
   var app = options.app;
   options = options.options;
 
-  if (options.liveReload === true) {
+  if (options.liveReload === true && options.liveReloadScript !== false) {
     var livereloadMiddleware = require('connect-livereload');
     app.use(livereloadMiddleware({
       port: options.loveReloadPort


### PR DESCRIPTION
If you're using the browser plugin, you don't need the script injected. If you're using CSP with inline-scripts turned off, then not injecting this script can be quite helpful.

This is in reference to my comment on #365
