### PR TITLE
Fix Travis failures.

### DIFF
--- a/blueprints/addon/files/package.json
+++ b/blueprints/addon/files/package.json
@@ -30,6 +30,7 @@
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.0",
     "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-qunit": "0.0.4",
     "express": "^4.1.1",
     "glob": "^3.2.9"
   }

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember": "1.6.1",
     "ember-resolver": "~0.1.7",
     "loader": "stefanpenner/loader.js#1.0.1",
-    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.2",
+    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rjackson/ember-cli-test-loader#0.0.2",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -24,7 +24,7 @@
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.0",
     "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-qunit": "0.0.3",
+    "ember-cli-qunit": "0.0.4",
     "express": "^4.1.1",
     "glob": "^3.2.9"
   }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -103,7 +103,7 @@ describe('models/project.js', function() {
         'live-reload-middleware', 'history-support-middleware', 'serve-files-middleware',
         'proxy-server-middleware', 'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon', 'ember-generated-no-export-addon',
-        'ember-super-button', 'ember-yagni', 'ember-ng'
+        'ember-yagni', 'ember-ng', 'ember-super-button'
       ];
 
       project.buildAddonPackages();


### PR DESCRIPTION
- Bump ember-cli-qunit version.
- Reorder addon listing.
- Add `ember-cli-qunit` to `addon` blueprint's `package.json`.
- Bump `ember-cli-shims` version to avoid bower warning.

Closes #1646.
