### PR TITLE
Pass options to app middleware as optional 2nd argument.

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -33,9 +33,9 @@ module.exports = Task.extend({
     }, this);
   },
 
-  processAppMiddlewares: function() {
+  processAppMiddlewares: function(options) {
     if (this.project.has('./server')) {
-      this.project.require('./server')(this.app);
+      this.project.require('./server')(this.app, options);
     }
   },
 
@@ -48,7 +48,7 @@ module.exports = Task.extend({
     options.ui          = this.ui;
 
     this.processAddonMiddlewares(options);
-    this.processAppMiddlewares();
+    this.processAppMiddlewares(options);
 
     this.setupHttpServer();
     return this.listen(options.port, options.host)

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -309,5 +309,24 @@ describe('express-server', function() {
         });
       });
     });
+
+    describe('app middleware', function() {
+      it('calls processAppMiddlewares upon start', function() {
+        var passedOptions;
+
+        subject.processAppMiddlewares = function(options) {
+          passedOptions = options;
+        };
+
+        var realOptions = {
+          host:  '0.0.0.0',
+          port: '1337'
+        };
+
+        return subject.start(realOptions).then(function() {
+          assert(passedOptions === realOptions);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This change adds a 2nd optional parameter that passes options to `server/index.js` when a custom server is present.

This allows the server to access the same properties like watcher that are exposed to addon middleware.
