### PR TITLE
Prevent deletion of files when invalid output-path is provided

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var fs         = require('fs');
-var path       = require('path');
-var Promise    = require('../ext/promise');
-var rimraf     = Promise.denodeify(require('rimraf'));
-var ncp        = Promise.denodeify(require('ncp'));
-var Task       = require('./task');
+var fs          = require('fs');
+var path        = require('path');
+var Promise     = require('../ext/promise');
+var rimraf      = Promise.denodeify(require('rimraf'));
+var ncp         = Promise.denodeify(require('ncp'));
+var Task        = require('./task');
+var Project     = require('../models/project');
+var SilentError = require('../errors/silent');
 
 var signalsTrapped = false;
 
@@ -37,6 +39,10 @@ module.exports = Task.extend({
     this.trapSignals();
   },
 
+  canDeleteOutputPath: function(outputPath) {
+    return outputPath !== Project.closestSync(process.cwd()).root && outputPath !== '/';
+  },
+
   /**
     This is used to ensure that the output path is emptied, but not deleted
     itself. If we simply used `rimraf(this.outputPath)`, any symlinks would
@@ -44,13 +50,18 @@ module.exports = Task.extend({
     and calls `rimraf` on each (this preserving any symlinks).
   */
   clearOutputPath: function() {
-    if (!fs.existsSync(this.outputPath)) { return Promise.resolve();}
+    var outputPath = this.outputPath;
+    if (!fs.existsSync(outputPath)) { return Promise.resolve();}
 
+    if(!this.canDeleteOutputPath(outputPath)) {
+      return Promise.reject(new SilentError('Using a build destination path of `' + outputPath + '` is not supported. \n'));
+    }
+    
     var promises = [];
-    var entries = fs.readdirSync(this.outputPath);
+    var entries = fs.readdirSync(outputPath);
 
     for (var i = 0, l = entries.length; i < l; i++) {
-      promises.push(rimraf(path.join(this.outputPath, entries[i])));
+      promises.push(rimraf(path.join(outputPath, entries[i])));
     }
 
     return Promise.all(promises);


### PR DESCRIPTION
Being a newbie in the node-land, i tried to provide an misspelled environment variable as output-path to the build command as `ember build --output-path=$SOME_MISSPELLED_PATH` . But this deleted my entire app files. 

On further digging, the project root is assigned as output path if the empty o/p paths are provided ([from here](https://github.com/npm/nopt/blob/4296f7aba7847c198fea2da594f9e1bec02817ec/lib/nopt.js#L136)). And the builder tries to empty the entries in the outputPath [here](https://github.com/stefanpenner/ember-cli/blob/master/lib/models/builder.js#L46-L57) before bundling up again unfortunately costing me to lose my entire app files
