### PR TITLE
Bump ember-cli-inject-live-reload version.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,7 +23,7 @@
     "broccoli-ember-hbs-template-compiler": "^1.5.0",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.0",
-    "ember-cli-inject-live-reload": "^1.0.1",
+    "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-qunit": "0.0.4",
     "express": "^4.1.1",


### PR DESCRIPTION
- Removes stray debugger.
- Fixes typo in port number.
