### PR TITLE
Blueprint: replace multiple occurences of __name__ with module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [ENHANCEMENT] replace multiple instances of __name__ in blueprints.
 * [ENHANCEMENT] adds http-proxy for explicit, multi proxy use[#1474](https://github.com/stefanpenner/ember-cli/pull/1530)
 * [BREAKING ENHANCEMENT] renames apiStub to http-mock to match other http-related generators [#1474] (https://github.com/stefanpenner/ember-cli/pull/1530)
 * [ENHANCEMENT] Log proxy server traffic when using `ember serve --proxy` [#1583](https://github.com/stefanpenner/ember-cli/pull/1583)

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -466,7 +466,7 @@ Blueprint.prototype.processFilesForUninstall = function(intoDir, templateVariabl
 */
 Blueprint.prototype.mapFile = function(file, locals) {
   file = Blueprint.renamedFiles[file] || file;
-  return file.replace('__name__', locals.dasherizedModuleName);
+  return file.replace(/__name__/g, locals.dasherizedModuleName);
 };
 
 /*

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -39,6 +39,18 @@ describe('Blueprint', function() {
     Blueprint.ignoredFiles = defaultIgnoredFiles;
   });
 
+  describe('.mapFile', function() {
+    it('replaces all occurences of __name__ with module name',function(){
+      var path = Blueprint.prototype.mapFile('__name__/__name__-controller.js',{dasherizedModuleName: 'my-blueprint'});
+      assert.equal(path,'my-blueprint/my-blueprint-controller.js');
+
+      path = Blueprint.prototype.mapFile('__name__/controller.js',{dasherizedModuleName: 'my-blueprint'});
+      assert.equal(path,'my-blueprint/controller.js');
+
+      path = Blueprint.prototype.mapFile('__name__/__name__.js',{dasherizedModuleName: 'my-blueprint'});
+      assert.equal(path,'my-blueprint/my-blueprint.js');
+    });
+  });
   describe('.lookup', function() {
     it('uses an explicit path if one is given', function() {
       var expectedClass = require(basicBlueprint);


### PR DESCRIPTION
When using a folder structure like below, only the first occurence of `__name__` would be replaced by the module name. By using `String.replace(/__name__/g)`, all occurences are replaced, allowing for a more scalable blueprint structure. 

```
files
|__app
   |__pods
      |____name__
        |____name__-controller.js
```
