### PR TITLE
Allow more time for directory cleanup in acceptance tests.

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -45,6 +45,8 @@ describe('Acceptance: smoke-test', function() {
   });
 
   after(function() {
+    this.timeout(10000);
+
     tmp.teardown('./common-tmp');
     conf.restore();
   });
@@ -69,6 +71,8 @@ describe('Acceptance: smoke-test', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     assertTmpEmpty();
     tmp.teardown('./tmp');
   });

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -60,6 +60,8 @@ describe('Acceptance: blueprint smoke tests', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     tmp.teardown('./tmp');
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -37,12 +37,15 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   after(function() {
+    this.timeout(10000);
+
     tmp.teardown('./common-tmp');
     conf.restore();
   });
 
   beforeEach(function() {
     this.timeout(10000);
+
     tmp.setup('./tmp');
     return ncp('./common-tmp/' + appName, './tmp/' + appName, {
       clobber: true,
@@ -61,6 +64,8 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     tmp.teardown('./tmp');
   });
 

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -35,6 +35,8 @@ describe('Acceptance: ember destroy', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     process.chdir(root);
     rimraf.sync(tmproot);
   });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -33,6 +33,8 @@ describe('Acceptance: ember generate', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     process.chdir(root);
     rimraf.sync(tmproot);
   });

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -18,6 +18,8 @@ describe('Acceptance: ember help', function() {
   });
 
   afterEach(function(done) {
+    this.timeout(10000);
+
     process.chdir(root);
     rimraf(tmproot, done);
   });

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -32,6 +32,8 @@ describe('Acceptance: ember init', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     tmp.teardown('./tmp');
   });
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -23,6 +23,8 @@ describe('Acceptance: ember new', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     tmp.teardown('./tmp');
   });
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -47,12 +47,15 @@ describe('Acceptance: smoke-test', function() {
   });
 
   after(function() {
+    this.timeout(10000);
+
     tmp.teardown('./common-tmp');
     conf.restore();
   });
 
   beforeEach(function() {
     this.timeout(10000);
+
     tmp.setup('./tmp');
     return ncp('./common-tmp/' + appName, './tmp/' + appName, {
       clobber: true,
@@ -71,6 +74,8 @@ describe('Acceptance: smoke-test', function() {
   });
 
   afterEach(function() {
+    this.timeout(10000);
+
     assertTmpEmpty();
     tmp.teardown('./tmp');
   });


### PR DESCRIPTION
I/O is slow on Travis, and this is the single largest cause of failing
Travis runs.
