### PR TITLE
closes #344 - ability to specify livereload port number

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -15,13 +15,14 @@ module.exports = Command.extend({
     { name: 'proxy',  type: String },
     { name: 'watcher',  type: String, default: 'events' },
     { name: 'live-reload',  type: Boolean, default: true },
+    { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)'},
     { name: 'environment', type: String, default: 'development' },
     { name: 'output-path', type: path, default: 'dist/' }
   ],
 
   run: function(commandOptions) {
     commandOptions = assign({}, commandOptions, {
-      liveReloadPort: commandOptions.port - 4200 + 35729,
+      liveReloadPort: commandOptions.liveReloadPort  || (commandOptions.port + 31529),
       baseURL: this.project.config('development').baseURL || '/'
     });
 

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -48,6 +48,19 @@ describe('server command', function() {
     assert.equal(ops.liveReloadPort, 35529,     'has correct liveReload port');
   });
 
+  it('has correct liveLoadPort', function() {
+    new ServeCommand(options).validateAndRun([
+      '--live-reload-port', '4001'
+    ]);
+
+    var serveRun = tasks.Serve.prototype.run;
+    var ops = serveRun.calledWith[0][0];
+
+    assert.equal(serveRun.called, 1, 'expected run to be called once');
+
+    assert.equal(ops.liveReloadPort, 4001,     'has correct liveReload port');
+  });
+  
   it('has correct proxy', function() {
     new ServeCommand(options).validateAndRun([
       '--proxy', 'http://localhost:3000/'


### PR DESCRIPTION
In some test environments (i.e. nitrous.io) you have limited control over which ports are open.  You need to override the location of the livereload port in these cases.

This change adds a new option  --live-reload-port nnnn  to the server command.  The default remains port + 31529.

Added appropriate unit test, and tested solution under fire on nitrous.io

As a follow up it would be good to add some documentation (i.e. type server --help)  to the ember cli web page 
