### PR TITLE
Add test stub to adapter blueprint

### DIFF
--- a/blueprints/adapter/files/tests/unit/adapters/__name__-test.js
+++ b/blueprints/adapter/files/tests/unit/adapters/__name__-test.js
@@ -1,0 +1,12 @@
+import { test, moduleFor } from 'ember-qunit';
+
+moduleFor('adapter:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Adapter', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function() {
+  var adapter = this.subject();
+  ok(adapter);
+});

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -480,6 +480,12 @@ describe('Acceptance: ember generate', function() {
           "export default DS.RESTAdapter.extend({" + EOL + "});"
         ]
       });
+      assertFile('tests/unit/adapters/foo-test.js', {
+        contains: [
+          "import { test, moduleFor } from 'ember-qunit';",
+          "moduleFor('adapter:foo', 'FooAdapter'"
+        ]
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1702

I think these tests could be a bit more instructional though I’ll freely admit I’ve never had call to test an Ember Data adapter.
