### PR TITLE
LiveReload filter patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Fix tests/helpers/start-app.js location from addon generator [#1626](https://github.com/stefanpenner/ember-cli/pull/1626)
 * [BUGFIX] Allow addons to use history support middleware [#1632](https://github.com/stefanpenner/ember-cli/pull/1632)
 * [ENHANCEMENT] Upgrade `broccoli-ember-hbs-template-compiler` to `1.6.1`.
+* [ENHANCEMENT] Allow file patterns to be ignored by LiveReload [#1706](https://github.com/stefanpenner/ember-cli/pull/1706)
 
 ### 0.0.40
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -16,6 +16,7 @@ function Project(root, pkg) {
   this.root          = root;
   this.pkg           = pkg;
   this.addonPackages = {};
+  this.liveReloadFilterPatterns = [];
 }
 
 Project.prototype.name = function() {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -2,6 +2,7 @@
 
 var Promise     = require('../../ext/promise');
 var chalk       = require('chalk');
+var path        = require('path');
 var Task        = require('../../models/task');
 var SilentError = require('../../errors/silent');
 
@@ -51,17 +52,26 @@ module.exports = Task.extend({
     }
   },
 
-  didChange: function() {
-    this.liveReloadServer.changed({
-      body: {
-        files: ['LiveReload files']
-      }
-    });
+  didChange: function(results) {
+    var filePath = path.relative(this.project.root, results.filePath || '');
 
-    this.analytics.track({
-      name:    'broccoli watcher',
-      message: 'live-reload'
-    });
+    var canTrigger = this.project.liveReloadFilterPatterns.reduce(function(bool, pattern) {
+      bool = bool && !filePath.match(pattern);
+      return bool;
+    }, true);
+
+    if (canTrigger) {
+      this.liveReloadServer.changed({
+        body: {
+          files: ['LiveReload files']
+        }
+      });
+
+      this.analytics.track({
+        name:    'broccoli watcher',
+        message: 'live-reload'
+      });
+    }
   },
 
   didError: function(error) {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "broccoli-file-remover": "~0.2.2",
     "broccoli-jshint": "^0.5.1",
     "broccoli-merge-trees": "^0.1.3",
-    "broccoli-sane-watcher": "0.0.5",
+    "broccoli-sane-watcher": "0.0.6",
     "broccoli-static-compiler": "^0.1.4",
     "broccoli-string-replace": "^0.0.2",
     "broccoli-uglify-js": "^0.1.3",


### PR DESCRIPTION
Will allow a Project to add its own patterns for which the LiveReload
server can use to ignore certain file changes.

This PR is waiting on https://github.com/krisselden/broccoli-sane-watcher/pull/10
