### PR TITLE
Fix the /tests URL in IE8

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -23,14 +23,20 @@ HistorySupportAddon.prototype.serverMiddleware = function(config) {
   if (['auto', 'history'].indexOf(locationType) !== -1) {
     app.use(function(req, res, next) {
       watcher.then(function(results) {
-        var hasHTMLHeader = (req.headers.accept || []).indexOf('text/html') === 0;
+        var acceptHeaders = req.headers.accept || [];
+        var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
+        var hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
         var assetPath = req.path.slice(baseURL.length);
         var isAsset = fs.existsSync(path.join(results.directory, assetPath));
         var isForTests = testsRegexp.test(req.path);
         var isForBaseURL = baseURLRegexp.test(req.path);
 
-        if (req.method === 'GET' && hasHTMLHeader && isForBaseURL && !isAsset) {
-          req.url = isForTests ? baseURL + 'tests/index.html' : baseURL + 'index.html';
+        if (isForBaseURL && req.method === 'GET') {
+          if (isForTests && (hasHTMLHeader || hasWildcardHeader)) {
+            req.url = baseURL + 'tests/index.html';
+          } else if (!isAsset && hasHTMLHeader) {
+            req.url = baseURL + 'index.html';
+          }
         }
 
         next();

--- a/tests/fixtures/express-server/tests/index.html
+++ b/tests/fixtures/express-server/tests/index.html
@@ -1,0 +1,1 @@
+This here be test html

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -184,6 +184,23 @@ describe('express-server', function() {
           });
       });
 
+      it('serves index.html for mime of */* when file not found with auto/history location', function(done) {
+        return startServer()
+          .then(function() {
+            request(subject.app)
+              .get('/tests')
+              .set('accept', '*/*')
+              .expect(200)
+              .expect('Content-Type', /html/)
+              .end(function(err) {
+                if (err) {
+                  return done(err);
+                }
+                done();
+              });
+          });
+      });
+
       it('serves index.html when file not found (with baseURL) with auto/history location', function(done) {
         return startServer('/foo')
           .then(function() {


### PR DESCRIPTION
IE8 does not sent a text/html header, so tests don't load unless we allow _/_ requests to fetch the test file.

This is, unfortunately, complicated by a strange proxy requirement that `*/*` requests be passed through to the proxy as if they were JSON. That limits this fix to being pretty narrow, and I believe the wildcard route catcher will not work correctly in IE8.

I understand that history isn't supported in IE8 anyway, but still having the request treated like other browsers are treated seems more ideal.
