### PR TITLE
Make blueprintLookupPaths return empty array outside projects

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -170,10 +170,14 @@ Project.prototype.localBlueprintLookupPath = function() {
 };
 
 Project.prototype.blueprintLookupPaths = function() {
-  var lookupPaths = [this.localBlueprintLookupPath()];
-  var addonLookupPaths = this.addonBlueprintLookupPaths();
+  if (this.isEmberCLIProject()) {
+    var lookupPaths = [this.localBlueprintLookupPath()];
+    var addonLookupPaths = this.addonBlueprintLookupPaths();
 
-  return lookupPaths.concat(addonLookupPaths);
+    return lookupPaths.concat(addonLookupPaths);
+  } else {
+    return [];
+  }
 };
 
 Project.prototype.addonBlueprintLookupPaths = function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -149,6 +149,14 @@ describe('models/project.js', function() {
       assert.deepEqual(project.blueprintLookupPaths(), expected);
     });
 
+    it('returns an empty list of blueprint paths if outside a project', function() {
+      project.isEmberCLIProject = function() {
+        return false;
+      };
+
+      assert.deepEqual(project.blueprintLookupPaths(), []);
+    });
+
     it('returns an instance of an addon with an object export', function() {
       var addons = project.addons;
 


### PR DESCRIPTION
Fixes #1684
