### PR TITLE
Move /tests handler into its own middleware

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -114,6 +114,7 @@ Project.prototype.buildAddonPackages = function() {
 
   var internalMiddlewarePath = path.join(this.root, path.relative(this.root, path.join(__dirname, '../tasks/server/middleware')));
 
+  this.addIfAddon(path.join(internalMiddlewarePath, 'tests-server'));
   this.addIfAddon(path.join(internalMiddlewarePath, 'history-support'));
   this.addIfAddon(path.join(internalMiddlewarePath, 'serve-files'));
   this.addIfAddon(path.join(internalMiddlewarePath, 'proxy-server'));

--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -16,25 +16,20 @@ HistorySupportAddon.prototype.serverMiddleware = function(config) {
   var watcher = options.watcher;
 
   var baseURL = cleanBaseURL(options.baseURL);
-  var testsRegexp = new RegExp('^' + baseURL + 'tests');
   var baseURLRegexp = new RegExp('^' + baseURL);
   var locationType = this.project.config(options.environment).locationType;
 
   if (['auto', 'history'].indexOf(locationType) !== -1) {
     app.use(function(req, res, next) {
       watcher.then(function(results) {
+
         var acceptHeaders = req.headers.accept || [];
         var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
-        var hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
-        var assetPath = req.path.slice(baseURL.length);
-        var isAsset = fs.existsSync(path.join(results.directory, assetPath));
-        var isForTests = testsRegexp.test(req.path);
         var isForBaseURL = baseURLRegexp.test(req.path);
 
-        if (isForBaseURL && req.method === 'GET') {
-          if (isForTests && (hasHTMLHeader || hasWildcardHeader)) {
-            req.url = baseURL + 'tests/index.html';
-          } else if (!isAsset && hasHTMLHeader) {
+        if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
+          var assetPath = req.path.slice(baseURL.length);
+          if (!fs.existsSync(path.join(results.directory, assetPath))) {
             req.url = baseURL + 'index.html';
           }
         }

--- a/lib/tasks/server/middleware/serve-files/package.json
+++ b/lib/tasks/server/middleware/serve-files/package.json
@@ -2,5 +2,8 @@
   "name": "serve-files-middleware",
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "ember-addon": {
+    "before": "proxy-server-middleware"
+  }
 }

--- a/lib/tasks/server/middleware/tests-server/index.js
+++ b/lib/tasks/server/middleware/tests-server/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var cleanBaseURL = require('../../../../utilities/clean-base-url');
+
+function TestsServerAddon(project) {
+  this.project = project;
+  this.name = 'tests-server-middleware';
+}
+
+TestsServerAddon.prototype.serverMiddleware = function(config) {
+  var app = config.app;
+  var options = config.options;
+  var watcher = options.watcher;
+
+  var baseURL = cleanBaseURL(options.baseURL);
+  var testsRegexp = new RegExp('^' + baseURL + 'tests');
+  var baseURLRegexp = new RegExp('^' + baseURL);
+
+  app.use(function(req, res, next) {
+    watcher.then(function() {
+
+      var acceptHeaders = req.headers.accept || [];
+      var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
+      var hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
+
+      var isForTests = testsRegexp.test(req.path);
+
+      if (isForTests && (hasHTMLHeader || hasWildcardHeader) && req.method === 'GET') {
+        if (baseURLRegexp.test(req.path)) {
+          req.url = baseURL + 'tests/index.html';
+        } else {
+          req.url = '/tests/index.html';
+        }
+      }
+
+      next();
+    });
+  });
+};
+
+module.exports = TestsServerAddon;

--- a/lib/tasks/server/middleware/tests-server/package.json
+++ b/lib/tasks/server/middleware/tests-server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tests-server-middleware",
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "before": "history-support-middleware"
+  }
+}

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -105,7 +105,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon no-export', function() {
       before(function() {
-        addon = project.addons[6];
+        addon = project.addons[7];
       });
 
       it('sets it\'s project', function() {
@@ -204,7 +204,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon with-export', function() {
       before(function() {
-        addon = project.addons[5];
+        addon = project.addons[6];
       });
 
       it('sets it\'s project', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -155,6 +155,7 @@ describe('models/project.js', function() {
 
     it('returns a listing of all ember-cli-addons', function() {
       var expected = [
+        'tests-server-middleware',
         'history-support-middleware', 'serve-files-middleware',
         'proxy-server-middleware', 'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon', 'ember-generated-no-export-addon',
@@ -168,19 +169,19 @@ describe('models/project.js', function() {
     it('returns an instance of the addon', function() {
       var addons = project.addons;
 
-      assert.equal(addons[3].name, 'Ember Non Root Addon');
+      assert.equal(addons[4].name, 'Ember Non Root Addon');
     });
 
     it('addons get passed the project instance', function() {
       var addons = project.addons;
 
-      assert.equal(addons[0].project, project);
+      assert.equal(addons[1].project, project);
     });
 
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       var addons = project.addons;
 
-      assert.equal(addons[4].name, 'Ember Random Addon');
+      assert.equal(addons[5].name, 'Ember Random Addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -215,15 +216,15 @@ describe('models/project.js', function() {
     it('returns an instance of an addon with an object export', function() {
       var addons = project.addons;
 
-      assert.ok(addons[5] instanceof Addon);
-      assert.equal(addons[5].name, 'Ember CLI Generated with export');
+      assert.ok(addons[6] instanceof Addon);
+      assert.equal(addons[6].name, 'Ember CLI Generated with export');
     });
 
     it('returns an instance of a generated addon with no export', function() {
       var addons = project.addons;
 
-      assert.ok(addons[6] instanceof Addon);
-      assert.equal(addons[6].name, '(generated ember-generated-no-export-addon addon)');
+      assert.ok(addons[7] instanceof Addon);
+      assert.equal(addons[7].name, '(generated ember-generated-no-export-addon addon)');
     });
   });
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -218,7 +218,29 @@ describe('express-server', function() {
           });
       });
 
-      it('serves index.html for mime of */* when file not found with auto/history location', function(done) {
+      it('GET /tests serves tests/index.html for mime of */* (hash location)', function(done) {
+        project._config = {
+          baseURL: '/',
+          locationType: 'hash'
+        };
+
+        return startServer()
+          .then(function() {
+            request(subject.app)
+              .get('/tests')
+              .set('accept', '*/*')
+              .expect(200)
+              .expect('Content-Type', /html/)
+              .end(function(err) {
+                if (err) {
+                  return done(err);
+                }
+                done();
+              });
+          });
+      });
+
+      it('GET /tests serves tests/index.html for mime of */* (auto location)', function(done) {
         return startServer()
           .then(function() {
             request(subject.app)


### PR DESCRIPTION
The /tests behavior was coupled to the auto and location behavior, despite the fact that all location types will need to map `/tests` to the `tests/index.html` file.

I've moved tests into its own middleware which also clarifies what the behavior for `/tests` is. This refactor corrects a bug where hash location servers would redirect to `/tests/`.
