### PR TITLE
Adds a new line after build error stack trace

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -53,7 +53,7 @@ module.exports = Task.extend({
           }
           ui.writeLine('File: ' + file);
         }
-        ui.write(err.stack);
+        ui.writeLine(err.stack);
 
         return 1;
       });


### PR DESCRIPTION
Just a minor prettify in build stack error trace

**Before:**

![stack-before-new-line-termination](https://cloud.githubusercontent.com/assets/2162441/3988220/df6da2c2-28ad-11e4-852a-72dec0476445.jpg)

**After:**

![stack-after-new-line-termination](https://cloud.githubusercontent.com/assets/2162441/3988226/e55a095a-28ad-11e4-8a91-a4324dfa3614.jpg)
