### PR TITLE
Normalize entity name before getting locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ember-cli Changelog
 
+* [BUGFIX] Call `normalizeEntityName` hook before `locals` hook [#1717](https://github.com/stefanpenner/ember-cli/pull/1717)
 * [ENHANCEMENT] replace multiple instances of __name__ in blueprints.
 * [ENHANCEMENT] adds http-proxy for explicit, multi proxy use[#1474](https://github.com/stefanpenner/ember-cli/pull/1530)
 * [BREAKING ENHANCEMENT] renames apiStub to http-mock to match other http-related generators [#1474] (https://github.com/stefanpenner/ember-cli/pull/1530)

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -215,7 +215,6 @@ Blueprint.prototype.install = function(options) {
   var ui       = this.ui = options.ui;
   var intoDir  = options.target;
   var dryRun   = options.dryRun;
-  var locals   = this._locals(options);
   this.project = options.project;
   this.testing = options.testing;
 
@@ -268,6 +267,8 @@ Blueprint.prototype.install = function(options) {
   if(options.entity) {
     options.entity.name = this.normalizeEntityName(options.entity.name);
   }
+
+  var locals = this._locals(options);
 
   return Promise.resolve()
     .then(this.beforeInstall.bind(this, options))

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -335,6 +335,16 @@ describe('Blueprint', function() {
             assert.deepEqual(actualFiles, basicBlueprintFiles);
           });
     });
+
+    it('calls normalizeEntityName before locals hook is called', function(done) {
+      blueprint.normalizeEntityName = function(){ return 'foo'; };
+      blueprint.locals = function(options) {
+        assert.equal(options.entity.name, 'foo');
+        done();
+      };
+      options.entity = { name: 'bar' };
+      blueprint.install(options);
+    });
   });
 
   describe('addPackageToProject', function() {


### PR DESCRIPTION
Fixes #1713 for blueprints `http-proxy`, `http-mock`, `app` and `addon`.

The generators were trying to access and modify `options.entity.name` in the `locals` hook, which was called before `normalizeEntityName`, causing them to err out.

```
$ ember g addon
version: 0.0.40-master-84e031b5c0
Cannot call method 'replace' of undefined
```

Is the test I added sufficient?
