### PR TITLE
EOL-ify all the things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [BUGFIX] Allow addons to use history support middleware [#1632](https://github.com/stefanpenner/ember-cli/pull/1632)
 * [ENHANCEMENT] Upgrade `broccoli-ember-hbs-template-compiler` to `1.6.1`.
 * [ENHANCEMENT] Allow file patterns to be ignored by LiveReload [#1706](https://github.com/stefanpenner/ember-cli/pull/1706)
+* [BUGFIX] Switch to OS-friendly line endings [#1718](https://github.com/stefanpenner/ember-cli/pull/1718)
 
 ### 0.0.40
 

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -1,19 +1,20 @@
 var Blueprint = require('../../lib/models/blueprint');
+var SilentError = require('../../lib/errors/silent');
 
 module.exports = Blueprint.extend({
   normalizeEntityName: function(entityName) {
     entityName = Blueprint.prototype.normalizeEntityName.apply(this, arguments);
 
     if(! /\-/.test(entityName)) {
-      throw new Error('You specified "' + entityName + '", but in order to prevent ' +
-                      'clashes with current or future HTML element names you must have ' +
-                      'a hyphen.\n');
+      throw new SilentError('You specified "' + entityName + '", but in order to prevent ' +
+                            'clashes with current or future HTML element names you must have ' +
+                            'a hyphen.');
     }
 
     if(/\//.test(entityName)) {
-      throw new Error('You specified "' + entityName + '", but due to a bug in ' +
-                      'Handlebars (< 2.0) slashes within components/helpers are not ' +
-                      'allowed.\n');
+      throw new SilentError('You specified "' + entityName + '", but due to a bug in ' +
+                            'Handlebars (< 2.0) slashes within components/helpers are not ' +
+                            'allowed.');
     }
 
     return entityName;

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -13,7 +13,7 @@ module.exports = Blueprint.extend({
     var type = options.type;
 
     if (options.type && !TYPE_MAP[options.type]) {
-      throw new SilentError('Unknown controller type "' + type + '". Should be "basic", "object", or "array".\n');
+      throw new SilentError('Unknown controller type "' + type + '". Should be "basic", "object", or "array".');
     }
   },
 
@@ -23,7 +23,7 @@ module.exports = Blueprint.extend({
     if (options.type) {
       baseClass = TYPE_MAP[options.type];
     } else {
-      this.ui.write(chalk.yellow('Warning: no controller type was specified, defaulting to basic.\n'));
+      this.ui.writeLine(chalk.yellow('Warning: no controller type was specified, defaulting to basic.'));
       baseClass = TYPE_MAP.basic;
     }
 

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,6 +1,7 @@
 var Blueprint   = require('../../lib/models/blueprint');
 var inflection  = require('inflection');
 var stringUtils = require('../../lib/utilities/string');
+var EOL         = require('os').EOL;
 
 module.exports = Blueprint.extend({
   locals: function(options) {
@@ -27,7 +28,7 @@ module.exports = Blueprint.extend({
       }
     }
 
-    attrs = attrs.join(',\n  ');
+    attrs = attrs.join(',' + EOL + '  ');
     needs = '  needs: [' + needs.join(', ') + ']';
 
     return {

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -3,13 +3,14 @@ var SilentError = require('../../lib/errors/silent');
 var fs          = require('fs-extra');
 var inflection  = require('inflection');
 var path        = require('path');
+var EOL         = require('os').EOL;
 
 module.exports = Blueprint.extend({
   beforeInstall: function(options) {
     var type = options.type;
 
     if (type && !/^(resource|route)$/.test(type)) {
-      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".\n');
+      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".');
     }
   },
 
@@ -28,7 +29,7 @@ module.exports = Blueprint.extend({
     var type = options.type;
 
     if (type && !/^(resource|route)$/.test(type)) {
-      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".\n');
+      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".');
     }
   },
 
@@ -97,7 +98,7 @@ function addRouteToRouter(name, options) {
   case 'route':
     newContent = oldContent.replace(
       /(map\(function\(\) {[\s\S]+)}\)/,
-      "$1  this.route('" + name + "');\n})"
+      "$1  this.route('" + name + "');" + EOL + "})"
     );
     break;
   case 'resource':
@@ -106,12 +107,12 @@ function addRouteToRouter(name, options) {
     if (plural === name) {
       newContent = oldContent.replace(
         /(map\(function\(\) {[\s\S]+)}\)/,
-        "$1  this.resource('" + name + "');\n})"
+        "$1  this.resource('" + name + "');" + EOL + "})"
       );
     } else {
       newContent = oldContent.replace(
         /(map\(function\(\) {[\s\S]+)}\)/,
-        "$1  this.resource('" + name + "', { path: '" + plural + "/:" + name + "_id' });\n})"
+        "$1  this.resource('" + name + "', { path: '" + plural + "/:" + name + "_id' });" + EOL + "})"
       );
     }
     break;

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -4,6 +4,7 @@
 var fs    = require('fs');
 var p     = require('../preprocessors');
 var chalk = require('chalk');
+var EOL   = require('os').EOL;
 
 var Project      = require('../models/project');
 var cleanBaseURL = require('../utilities/clean-base-url');
@@ -413,7 +414,7 @@ EmberApp.prototype.javascript = function() {
   var vendor = concatFiles(applicationJs, {
     inputFiles: legacyFilesToAppend.concat(['vendor/addons.js']),
     outputFile: '/assets/vendor.js',
-    separator: '\n;'
+    separator: EOL + ';'
   });
 
   var vendorAndApp = mergeTrees([vendor, es6]);

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -6,6 +6,7 @@ var Promise         = require('../ext/promise');
 var emberCLIVersion = require('../utilities/ember-cli-version');
 var UpdateChecker   = require('../models/update-checker');
 var getOptionArgs   = require('../utilities/get-option-args');
+var EOL             = require('os').EOL;
 
 function CLI(options) {
   this.ui   = options.ui;
@@ -16,7 +17,7 @@ function CLI(options) {
 module.exports = CLI;
 
 CLI.prototype.run = function(environment) {
-  this.ui.write('version: ' + emberCLIVersion() + '\n');
+  this.ui.writeLine('version: ' + emberCLIVersion());
 
   return Promise.hash(environment).then(function(environment) {
     var args = environment.cliArgs.slice();
@@ -64,13 +65,13 @@ CLI.prototype.logError = function(error) {
 
   if (error) {
     if (error instanceof Error) {
-      this.ui.write(chalk.red(error.message));
+      this.ui.writeLine(chalk.red(error.message));
 
       if (!error.suppressStacktrace) {
-        this.ui.write(error.stack.toString().replace(/,/g, '\n'));
+        this.ui.writeLine(error.stack.toString().replace(/,/g, EOL));
       }
     } else {
-      this.ui.write(chalk.red(error));
+      this.ui.writeLine(chalk.red(error));
     }
   }
 

--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -4,13 +4,13 @@ var Command = require('../models/command');
 
 var UnknownCommand = Command.extend({
   printBasicHelp: function() {
-    this.ui.write(chalk.red('No help entry for \'' + this.commandName + '\'\n'));
+    this.ui.writeLine(chalk.red('No help entry for \'' + this.commandName + '\''));
   },
 
   validateAndRun: function() {
-    this.ui.write('The specified command ' + chalk.green(this.commandName) +
-                  ' is invalid, for available options see ' +
-                  chalk.green('ember help') + '.\n');
+    this.ui.writeLine('The specified command ' + chalk.green(this.commandName) +
+                      ' is invalid, for available options see ' +
+                      chalk.green('ember help') + '.');
   }
 });
 
@@ -58,8 +58,8 @@ module.exports = function(commands, commandName, commandArgs, options) {
   }
 
   if (command && addonCommand) {
-    ui.write(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
-                        command.prototype.name + '". The core command will be used.\n'));
+    ui.writeLine(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
+                            command.prototype.name + '". The core command will be used.'));
     return command;
   }
 

--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -28,13 +28,13 @@ module.exports = Command.extend({
     if (!blueprintName) {
       return Promise.reject(new SilentError('The `ember destroy` command requires a ' +
                                             'blueprint name to be specified. ' +
-                                            'For more details, use `ember help`.\n'));
+                                            'For more details, use `ember help`.'));
     }
 
     if (!entityName) {
       return Promise.reject(new SilentError('The `ember destroy` command requires an ' +
                                             'entity name to be specified. ' +
-                                            'For more details, use `ember help`.\n'));
+                                            'For more details, use `ember help`.'));
     }
 
     var Task = this.tasks.DestroyFromBlueprint;
@@ -60,6 +60,7 @@ module.exports = Command.extend({
   printDetailedHelp: function() {
     var ui = this.ui;
 
-    ui.write('\n  Run `ember help generate` to view a list of available blueprints. \n');
+    ui.writeLine('');
+    ui.writeLine('  Run `ember help generate` to view a list of available blueprints.');
   }
 });

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -29,7 +29,7 @@ module.exports = Command.extend({
     if (!blueprintName) {
       return Promise.reject(new SilentError('The `ember generate` command requires a ' +
                                             'blueprint name to be specified. ' +
-                                            'For more details, use `ember help`.\n'));
+                                            'For more details, use `ember help`.'));
     }
 
     var Task = this.tasks.GenerateFromBlueprint;
@@ -56,14 +56,14 @@ module.exports = Command.extend({
   printDetailedHelp: function() {
     var ui = this.ui;
 
-    ui.write('\n  Available blueprints:\n');
+    ui.writeLine('  Available blueprints:');
 
     Blueprint.list({ paths: this.project.blueprintLookupPaths() })
       .forEach(function(collection) {
         if (collection.blueprints.length) {
-          ui.write('    ' + collection.source + ':\n');
+          ui.writeLine('    ' + collection.source + ':');
           collection.blueprints.forEach(function(blueprint) {
-            ui.write('      ' + chalk.yellow(blueprint) + '\n');
+            ui.writeLine('      ' + chalk.yellow(blueprint));
           });
         }
       });

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -15,14 +15,15 @@ module.exports = Command.extend({
   run: function(commandOptions, rawArgs) {
     if (rawArgs.length === 0) {
       // Display usage for all commands.
-      this.ui.write('Available commands in ember-cli:\n');
+      this.ui.writeLine('Available commands in ember-cli:');
 
       Object.keys(this.commands).forEach(this._printBasicHelpForCommand.bind(this));
 
       if(this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands){
           this.commands = commands;
-          this.ui.write('\nAvailable commands from ' + addonName + ':\n');
+          this.ui.writeLine('');
+          this.ui.writeLine('Available commands from ' + addonName + ':');
           Object.keys(this.commands).forEach(this._printBasicHelpForCommand.bind(this));
         }.bind(this));
       }
@@ -30,7 +31,8 @@ module.exports = Command.extend({
     } else {
       // If args were passed to the help command,
       // attempt to look up the command for each of them.
-      this.ui.write('Requested ember-cli commands:\n\n');
+      this.ui.writeLine('Requested ember-cli commands:');
+      this.ui.writeLine('');
 
       if(this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands){

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -66,7 +66,7 @@ module.exports = Command.extend({
     };
 
     if (!validProjectName(packageName)) {
-      return Promise.reject(new SilentError('We currently do not support a name of `' + packageName + '`.\n'));
+      return Promise.reject(new SilentError('We currently do not support a name of `' + packageName + '`.'));
     }
 
     return installBlueprint.run(blueprintOpts)

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -33,7 +33,7 @@ module.exports = Command.extend({
 
     if (!packageName) {
       message = chalk.yellow('The `ember ' + this.name + '` command requires a ' +
-                             'name to be specified. For more details, use `ember help`.\n');
+                             'name to be specified. For more details, use `ember help`.');
 
       return Promise.reject(new SilentError(message));
     }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -28,9 +28,9 @@ module.exports = Command.extend({
 
           return updateTask.run(commandOptions, updateInfo);
         } else {
-          this.ui.write(
+          this.ui.writeLine(
             chalk.green('✓ You have the latest version of ember-cli (' +
-              emberCLIVersion() + ').\n'));
+              emberCLIVersion() + ').'));
         }
       }.bind(this));
   }

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -25,6 +25,6 @@ module.exports = Command.extend({
     }
   },
   printVersion: function(module, version) {
-    this.ui.write(module + ': ' + version + '\n');
+    this.ui.writeLine(module + ': ' + version);
   }
 });

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -193,14 +193,14 @@ Blueprint.prototype.normalizeEntityName = function(entityName) {
   if (!entityName) {
     throw new SilentError('The `ember generate` command requires an ' +
                           'entity name to be specified. ' +
-                          'For more details, use `ember help`.\n');
+                          'For more details, use `ember help`.');
   }
 
   var trailingSlash = /(\/$|\\$)/;
   if(trailingSlash.test(entityName)) {
-    throw new Error('You specified "' + entityName + '", but you can\'t use a ' +
-                    'trailing slash as an entity name with generators. Please ' +
-                    're-run the command with "' + entityName.replace(trailingSlash, '') + '".\n');
+    throw new SilentError('You specified "' + entityName + '", but you can\'t use a ' +
+                          'trailing slash as an entity name with generators. Please ' +
+                          're-run the command with "' + entityName.replace(trailingSlash, '') + '".');
   }
 
   return entityName;
@@ -221,7 +221,7 @@ Blueprint.prototype.install = function(options) {
 
   var actions = {
     write: function(info) {
-      ui.write('  ' + chalk.green('create') + ' ' + info.displayPath + '\n');
+      ui.writeLine('  ' + chalk.green('create') + ' ' + info.displayPath);
       if (!dryRun) {
         return writeFile(info.outputPath, info.render());
       }
@@ -234,18 +234,18 @@ Blueprint.prototype.install = function(options) {
         label = 'identical';
       }
 
-      ui.write('  ' + chalk.yellow(label) + ' ' + info.displayPath + '\n');
+      ui.writeLine('  ' + chalk.yellow(label) + ' ' + info.displayPath);
     },
 
     overwrite: function(info) {
-      ui.write('  ' + chalk.yellow('overwrite') + ' ' + info.displayPath + '\n');
+      ui.writeLine('  ' + chalk.yellow('overwrite') + ' ' + info.displayPath);
       if (!dryRun) {
         return writeFile(info.outputPath, info.render());
       }
     },
 
     edit: function(info) {
-      ui.write('  ' + chalk.green('edited') + ' ' + info.displayPath + '\n');
+      ui.writeLine('  ' + chalk.green('edited') + ' ' + info.displayPath);
     }
   };
 
@@ -259,10 +259,10 @@ Blueprint.prototype.install = function(options) {
     }
   }
 
-  ui.write('installing\n');
+  ui.writeLine('installing');
 
   if (dryRun) {
-    ui.write(chalk.yellow('You specified the dry-run flag, so no changes will be written.\n'));
+    ui.writeLine(chalk.yellow('You specified the dry-run flag, so no changes will be written.'));
   }
 
   if(options.entity) {
@@ -291,7 +291,7 @@ Blueprint.prototype.uninstall = function(options) {
 
   var actions = {
     remove: function(info) {
-      ui.write('  ' + chalk.red('remove') + ' ' + info.displayPath + '\n');
+      ui.writeLine('  ' + chalk.red('remove') + ' ' + info.displayPath);
       if (!dryRun) {
         return removeFile(info.outputPath);
       }
@@ -308,10 +308,10 @@ Blueprint.prototype.uninstall = function(options) {
     }
   }
 
-  ui.write('uninstalling\n');
+  ui.writeLine('uninstalling');
 
   if (dryRun) {
-    ui.write(chalk.yellow('You specified the dry-run flag, so no files will be deleted.\n'));
+    ui.writeLine(chalk.yellow('You specified the dry-run flag, so no files will be deleted.'));
   }
 
   if(options.entity) {
@@ -515,7 +515,7 @@ Blueprint.prototype.addPackageToProject = function(packageName, version) {
   }
 
   if (ui) {
-    ui.write('  ' + chalk.green('install package') + ' ' + packageName + '\n');
+    ui.writeLine('  ' + chalk.green('install package') + ' ' + packageName);
   }
 
   return this._exec(command);

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -54,9 +54,9 @@ module.exports = Task.extend({
     if (!fs.existsSync(outputPath)) { return Promise.resolve();}
 
     if(!this.canDeleteOutputPath(outputPath)) {
-      return Promise.reject(new SilentError('Using a build destination path of `' + outputPath + '` is not supported. \n'));
+      return Promise.reject(new SilentError('Using a build destination path of `' + outputPath + '` is not supported.'));
     }
-    
+
     var promises = [];
     var entries = fs.readdirSync(outputPath);
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -7,6 +7,7 @@ var camelize      = require('../utilities/string').camelize;
 var getCallerFile = require('../utilities/get-caller-file');
 var Promise       = require('../ext/promise');
 var defaults      = require('lodash-node/modern/objects/defaults');
+var EOL           = require('os').EOL;
 
 var allowedWorkOptions = {
   insideProject: true,
@@ -85,8 +86,8 @@ Command.prototype.parseArgs = function(commandArgs) {
       if (option.default !== undefined) {
         commandOptions[option.key] = option.default;
       } else if (option.required) {
-        ui.write('The specified command ' + chalk.green(commandName) +
-                 ' requires the option ' + chalk.green(option.name) + '.\n');
+        ui.writeLine('The specified command ' + chalk.green(commandName) +
+                     ' requires the option ' + chalk.green(option.name) + '.');
         return false;
       }
 
@@ -104,16 +105,16 @@ Command.prototype.parseArgs = function(commandArgs) {
 
   if (this.works === 'insideProject') {
     if (!this.isWithinProject) {
-      this.ui.write('You have to be inside an ember-cli project in order to use ' +
-               'the ' + chalk.green(this.name) + ' command.\n');
+      this.ui.writeLine('You have to be inside an ember-cli project in order to use ' +
+                        'the ' + chalk.green(this.name) + ' command.');
       return null;
     }
   }
 
   if (this.works === 'outsideProject') {
     if (this.isWithinProject) {
-      this.ui.write('You cannot use the '+  chalk.green(this.name) +
-               ' command inside an ember-cli project.\n');
+      this.ui.writeLine('You cannot use the '+  chalk.green(this.name) +
+                        ' command inside an ember-cli project.');
       return null;
     }
   }
@@ -179,16 +180,16 @@ Command.prototype.printBasicHelp = function() {
     output += chalk.cyan(' <options...>');
   }
 
-  output += '\n';
+  output += EOL;
 
   // Description
   if (this.description) {
-    output += '  ' + this.description + '\n';
+    output += '  ' + this.description + EOL;
   }
 
   // aliases: a b c
   if (this.aliases.length) {
-    output += chalk.grey('  aliases: ' + this.aliases.filter(function(a) { return a; }).join(', ') + '\n');
+    output += chalk.grey('  aliases: ' + this.aliases.filter(function(a) { return a; }).join(', ') + EOL);
   }
 
   // --available-option (Required) (Default: value)
@@ -209,11 +210,11 @@ Command.prototype.printBasicHelp = function() {
         output += ' ' + option.description;
       }
 
-      output += '\n';
+      output += EOL;
     });
   }
 
-  this.ui.write(output);
+  this.ui.writeLine(output);
 };
 
 /*

--- a/lib/models/edit-file-diff.js
+++ b/lib/models/edit-file-diff.js
@@ -8,6 +8,7 @@ var childProcess = require('child_process');
 var jsdiff       = require('diff');
 var quickTemp    = require('quick-temp');
 var path         = require('path');
+var SilentError  = require('../errors/silent');
 
 function EditFileDiff(options) {
   this.info = options.info;
@@ -39,8 +40,8 @@ function applyPatch(resultHash) {
 
     if(!appliedDiff) {
       var message = 'Patch was not cleanly applied.';
-      this.info.ui.write(message + ' Please choose another action.\n');
-      throw new Error(message + '\n');
+      this.info.ui.writeLine(message + ' Please choose another action.');
+      throw new SilentError(message);
     }
 
     return writeFile(resultHash.outputPath, appliedDiff);

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -5,6 +5,7 @@ var Promise      = require('../ext/promise');
 var readFile     = Promise.denodeify(fs.readFile);
 var chalk        = require('chalk');
 var EditFileDiff = require('./edit-file-diff');
+var EOL          = require('os').EOL;
 
 function processTemplate(content, context) {
   return require('lodash-node/modern/utilities/template')(content)(context);
@@ -59,11 +60,11 @@ FileInfo.prototype.displayDiff = function() {
     var diff = jsdiff.createPatch(
       info.outputPath, result.output.toString(), result.input
     );
-    var lines = diff.split('\n');
+    var lines = diff.split(EOL);
 
     for (var i=0;i<lines.length;i++) {
       info.ui.write(
-        diffHighlight(lines[i]+'\n')
+        diffHighlight(lines[i]+EOL)
       );
     }
   });

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -23,9 +23,10 @@ UpdateChecker.prototype.checkForUpdates = function() {
   if (this.settings.checkForUpdates) {
     return this.doCheck().then(function(updateInfo) {
       if (updateInfo.updateNeeded) {
-        this.ui.write('\nA new version of ember-cli is available (' +
-                      updateInfo.newestVersion + '). To install it, type ' +
-                      chalk.green('ember update') + '.\n');
+        this.ui.writeLine('');
+        this.ui.writeLine('A new version of ember-cli is available (' +
+                          updateInfo.newestVersion + '). To install it, type ' +
+                          chalk.green('ember update') + '.');
       }
       return updateInfo;
     }.bind(this));
@@ -81,7 +82,7 @@ UpdateChecker.prototype.checkNPM = function() {
     // we only want to save the version information when we check NPM
     return this.saveVersionInformation(version);
   }.bind(this)).catch(function(error) {
-    this.ui.write('There was an error checking NPM for an update: ' + error + '\n');
+    this.ui.writeLine('There was an error checking NPM for an update: ' + error);
     throw error;
   }.bind(this));
 };

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -29,7 +29,8 @@ module.exports = Task.extend({
   didChange: function(results) {
     var totalTime = results.totalTime / 1e6;
 
-    this.ui.write(chalk.green('\nBuild successful - ' + Math.round(totalTime) + 'ms.\n'));
+    this.ui.writeLine('');
+    this.ui.writeLine(chalk.green('Build successful - ' + Math.round(totalTime) + 'ms.'));
 
     this.analytics.track({
       name:    'ember rebuild',

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -31,7 +31,7 @@ module.exports = Task.extend({
       })
       .finally(function() { ui.pleasantProgress.stop(); })
       .then(function() {
-        ui.write(chalk.green('Installed browser packages via Bower.\n'));
+        ui.writeLine(chalk.green('Installed browser packages via Bower.'));
       });
 
     function logBowerMessage(message) {
@@ -40,15 +40,15 @@ module.exports = Task.extend({
         //   conflict Unable to find suitable version for ember-data
         //     1) ember-data 1.0.0-beta.6
         //     2) ember-data ~1.0.0-beta.7
-        ui.write('  ' + chalk.red('conflict') + ' ' + message.message + '\n');
+        ui.writeLine('  ' + chalk.red('conflict') + ' ' + message.message);
         message.data.picks.forEach(function(pick, index) {
-          ui.write('    ' + chalk.green((index + 1) + ')') + ' ' +
-                   message.data.name + ' ' + pick.endpoint.target + '\n');
+          ui.writeLine('    ' + chalk.green((index + 1) + ')') + ' ' +
+                       message.data.name + ' ' + pick.endpoint.target);
         });
       } else if (message.level === 'info' && options.verbose) {
         // e.g.
         //   cached git://example.com/some-package.git#1.0.0
-        ui.write('  ' + chalk.green(message.id) + ' ' + message.message + '\n');
+        ui.writeLine('  ' + chalk.green(message.id) + ' ' + message.message);
       }
     }
   }

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -37,21 +37,21 @@ module.exports = Task.extend({
         ui.pleasantProgress.stop();
       })
       .then(function() {
-        ui.write(chalk.green('Built project successfully. Stored in "' +
-          options.outputPath + '".\n'));
+        ui.writeLine(chalk.green('Built project successfully. Stored in "' +
+          options.outputPath + '".'));
       })
       .catch(function(err) {
-        ui.write(chalk.red('Build failed.\n'));
+        ui.writeLine(chalk.red('Build failed.'));
 
         if (err.message) {
-          ui.write(err.message+'\n');
+          ui.writeLine(err.message);
         }
         if (err.file) {
           var file = err.file;
           if (err.line) {
             file += err.col ? ' ('+err.line+':'+err.col+')' : ' ('+err.line+')';
           }
-          ui.write('File: ' + file + '\n');
+          ui.writeLine('File: ' + file);
         }
         ui.write(err.stack);
 

--- a/lib/tasks/create-and-step-into-directory.js
+++ b/lib/tasks/create-and-step-into-directory.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   // Options: String directoryName, Boolean: dryRun
 
   warnDirectoryAlreadyExists: function warnDirectoryAlreadyExists(){
-    var message = 'Directory \'' + this.directoryName + '\' already exists.\n';
+    var message = 'Directory \'' + this.directoryName + '\' already exists.';
     return new SilentError(message);
   },
 

--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -34,7 +34,7 @@ module.exports = Task.extend({
           return exec('git commit -m "' + commitMessage + '"', {env: gitEnvironmentVariables});
         })
         .then(function(){
-          ui.write(chalk.green('Successfully initialized git.\n'));
+          ui.writeLine(chalk.green('Successfully initialized git.'));
         });
       }).catch(function(/*error*/){
         // if git is not found or an error was thrown during the `git`

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -47,7 +47,7 @@ module.exports = Task.extend({
   },
 
   announceCompletion: function() {
-    this.ui.write(chalk.green('Installed packages for tooling via npm.\n'));
+    this.ui.writeLine(chalk.green('Installed packages for tooling via npm.'));
   },
 
   finally: function() {

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -53,10 +53,10 @@ module.exports = Task.extend({
     this.setupHttpServer();
     return this.listen(options.port, options.host)
       .then(function() {
-        ui.write('Serving on http://' + options.host + ':' + options.port + '\n');
+        ui.writeLine('Serving on http://' + options.host + ':' + options.port);
       })
       .catch(function() {
-        throw new SilentError('Could not serve on http://' + options.host + ':' + options.port + '. It is either in use or you do not have permission.\n');
+        throw new SilentError('Could not serve on http://' + options.host + ':' + options.port + '. It is either in use or you do not have permission.');
       });
   }
 });

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -42,13 +42,13 @@ module.exports = Task.extend({
 
   writeBanner: function(print, port) {
     if (print) {
-      this.ui.write('Livereload server on port ' + port + '\n');
+      this.ui.writeLine('Livereload server on port ' + port);
     }
   },
 
   writeErrorBanner: function(print, port) {
     if (print) {
-      throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.\n');
+      throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.');
     }
   },
 
@@ -75,7 +75,8 @@ module.exports = Task.extend({
   },
 
   didError: function(error) {
-    this.ui.write(chalk.red(error.message) + '\n' + error.stack + '\n');
+    this.ui.writeLine(chalk.red(error.message));
+    this.ui.writeLine(error.stack);
 
     this.analytics.trackError({
       description: error.message + ' ' + error.stack,

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -14,7 +14,7 @@ ProxyServerAddon.prototype.serverMiddleware = function(options) {
     var proxy   = require('proxy-middleware');
     var morgan  = require('morgan');
 
-    options.ui.write('Proxying to ' + options.proxy + '\n');
+    options.ui.writeLine('Proxying to ' + options.proxy);
 
     app.use(morgan('dev'));
     app.use(proxy(urlOpts));

--- a/lib/tasks/update.js
+++ b/lib/tasks/update.js
@@ -20,8 +20,9 @@ module.exports = Task.extend({
 
     process.env.EMBER_ENV = process.env.EMBER_ENV || env;
 
-    this.ui.write(chalk.yellow('\nA new version of ember-cli is available (' +
-      updateInfo.newestVersion + ').\n'));
+    this.ui.writeLine('');
+    this.ui.writeLine(chalk.yellow('A new version of ember-cli is available (' +
+                                   updateInfo.newestVersion + ').'));
 
     var updatePrompt = {
       type: 'confirm',
@@ -52,9 +53,9 @@ module.exports = Task.extend({
     }.bind(this));
 
     var reportFailure = (function(reason) {
-      this.ui.write('There was an error – possibly a permissions issue. You ' +
-                    'may need to manually run ' +
-                    chalk.green('npm install -g ember-cli') + '.\n');
+      this.ui.writeLine('There was an error – possibly a permissions issue. You ' +
+                        'may need to manually run ' +
+                        chalk.green('npm install -g ember-cli') + '.');
       throw reason;
     }.bind(this));
 
@@ -69,7 +70,8 @@ module.exports = Task.extend({
 
       pkg.devDependencies['ember-cli'] = newestVersion;
       fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2));
-      this.ui.write(chalk.green('\n✓ ember-cli was successfully updated!\n'));
+      this.ui.writeLine('');
+      this.ui.writeLine(chalk.green('✓ ember-cli was successfully updated!'));
 
       return this.showEmberInitPrompt();
     }.bind(this));
@@ -85,8 +87,8 @@ module.exports = Task.extend({
   },
 
   showEmberInitPrompt: function() {
-    this.ui.write('To complete the update, you need to run ' +
-      chalk.green('ember init') + ' in your project directory.\n');
+    this.ui.writeLine('To complete the update, you need to run ' +
+                      chalk.green('ember init') + ' in your project directory.');
 
     var initPrompt = {
       type: 'confirm',

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -2,6 +2,7 @@
 
 var PleasantProgress = require('pleasant-progress');
 var Promise          = require('../ext/promise');
+var EOL              = require('os').EOL;
 
 // Note: You should use `ui.outputStream`, `ui.inputStream` and `ui.write()`
 //       instead of `process.stdout` and `console.log`.
@@ -31,6 +32,8 @@ function UI(options) { // options === { inputStream, outputStream }
 }
 
 UI.prototype.write = function(data) { this.outputStream.write(data); };
+
+UI.prototype.writeLine = function(data) { this.write(data + EOL); };
 
 UI.prototype.prompt = function(questions, callback) {
   // Pipe it to the output stream but don't forward end event

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -10,6 +10,7 @@ var assert     = require('assert');
 var walkSync   = require('walk-sync');
 var addonName  = 'some-cool-addon';
 var ncp        = Promise.denodeify(require('ncp'));
+var EOL        = require('os').EOL;
 
 var runCommand       = require('../helpers/run-command');
 
@@ -19,7 +20,7 @@ function assertTmpEmpty() {
       return !path.match(/output\//);
     });
 
-  assert(paths.length === 0, 'tmp/ should be empty after `ember` tasks. Contained: ' + paths.join('\n'));
+  assert(paths.length === 0, 'tmp/ should be empty after `ember` tasks. Contained: ' + paths.join(EOL));
 }
 
 function buildAddon(addonName) {

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -8,6 +8,7 @@ var rimraf     = Promise.denodeify(require('rimraf'));
 var fs         = require('fs');
 var ncp        = Promise.denodeify(require('ncp'));
 var assert     = require('assert');
+var EOL        = require('os').EOL;
 
 var runCommand       = require('../helpers/run-command');
 var copyFixtureFiles = require('../helpers/copy-fixture-files');
@@ -112,7 +113,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
       .then(function() {
         var subjectFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', 'file-to-import.txt'), { encoding: 'utf8' });
 
-        assert.equal(subjectFileContents, 'EXAMPLE TEXT FILE CONTENT\n');
+        assert.equal(subjectFileContents, 'EXAMPLE TEXT FILE CONTENT' + EOL);
       });
   });
 
@@ -153,7 +154,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
         fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
 
-        var horribleRoute = 'var blah = ""\nexport default Blah;';
+        var horribleRoute = 'var blah = ""' + EOL + 'export default Blah;';
         var horribleRoutePath = path.join('.', 'lib', 'ember-random-thing', 'app',
                                           'routes', 'horrible-route.js');
 

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -14,6 +14,7 @@ var rimraf     = require('rimraf');
 var root       = process.cwd();
 var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
+var EOL        = require('os').EOL;
 
 describe('Acceptance: ember destroy', function() {
   var tmpdir;
@@ -471,8 +472,8 @@ describe('Acceptance: ember destroy', function() {
       .then(function() {
         return outputFile(
           'blueprints/foo/files/app/foos/__name__.js',
-          "import Ember from 'ember';\n\n" +
-          'export default Ember.Object.extend({ foo: true });\n'
+          "import Ember from 'ember';" + EOL + EOL +
+          'export default Ember.Object.extend({ foo: true });' + EOL
         );
       })
       .then(function() {
@@ -496,8 +497,8 @@ describe('Acceptance: ember destroy', function() {
       .then(function() {
         return outputFile(
           'blueprints/controller/files/app/controllers/__name__.js',
-          "import Ember from 'ember';\n\n" +
-          "export default Ember.Controller.extend({ custom: true });\n"
+          "import Ember from 'ember';" + EOL + EOL +
+          "export default Ember.Controller.extend({ custom: true });" + EOL
         );
       })
       .then(function() {

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -13,6 +13,7 @@ var conf      = require('../helpers/conf');
 var minimatch = require('minimatch');
 var remove    = require('lodash-node/compat/arrays/remove');
 var any       = require('lodash-node/compat/collections/some');
+var EOL       = require('os').EOL;
 
 var defaultIgnoredFiles = Blueprint.ignoredFiles;
 
@@ -51,8 +52,8 @@ describe('Acceptance: ember init', function() {
 
     expected.sort();
 
-    assert.deepEqual(expected, actual, '\n expected: ' +  util.inspect(expected) +
-                     '\n but got: ' +  util.inspect(actual));
+    assert.deepEqual(expected, actual, EOL + ' expected: ' +  util.inspect(expected) +
+                     EOL + ' but got: ' +  util.inspect(actual));
   }
 
   function removeIgnored(array) {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -11,6 +11,7 @@ var tmp       = require('../helpers/tmp');
 var root      = process.cwd();
 var util      = require('util');
 var conf      = require('../helpers/conf');
+var EOL       = require('os').EOL;
 
 describe('Acceptance: ember new', function() {
   before(conf.setup);
@@ -42,8 +43,8 @@ describe('Acceptance: ember new', function() {
       expected.sort();
 
       assert.equal(folder, 'foo');
-      assert.deepEqual(expected, actual, '\n expected: ' +  util.inspect(expected) +
-                       '\n but got: ' +  util.inspect(actual));
+      assert.deepEqual(expected, actual, EOL + ' expected: ' +  util.inspect(expected) +
+                       EOL + ' but got: ' +  util.inspect(actual));
 
     };
   }

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -11,6 +11,7 @@ var assert   = require('assert');
 var walkSync = require('walk-sync');
 var appName  = 'some-cool-app';
 var ncp      = Promise.denodeify(require('ncp'));
+var EOL      = require('os').EOL;
 
 var runCommand       = require('../helpers/run-command');
 var copyFixtureFiles = require('../helpers/copy-fixture-files');
@@ -21,7 +22,7 @@ function assertTmpEmpty() {
       return !path.match(/output\//);
     });
 
-  assert(paths.length === 0, 'tmp/ should be empty after `ember` tasks. Contained: ' + paths.join('\n'));
+  assert(paths.length === 0, 'tmp/ should be empty after `ember` tasks. Contained: ' + paths.join(EOL));
 }
 
 function buildApp(appName) {
@@ -150,7 +151,7 @@ describe('Acceptance: smoke-test', function() {
           return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--environment=production')
               .then(function(result) {
                 var exitCode = result.code;
-                var output = result.output.join('\n');
+                var output = result.output.join(EOL);
 
                 assert.equal(exitCode, 0, 'exit code should be 0 for passing tests');
 
@@ -159,7 +160,7 @@ describe('Acceptance: smoke-test', function() {
                 assert(output.match(/pass\s+1/), '1 passing');
               })
               .catch(function(result) {
-                assert(false, 'failed `ember test --environment=production`.  The following output was received:\n' + result.output.join('\n'));
+                assert(false, 'failed `ember test --environment=production`.  The following output was received:' + EOL + result.output.join(EOL));
               });
         });
   });

--- a/tests/helpers/assert-file.js
+++ b/tests/helpers/assert-file.js
@@ -5,6 +5,7 @@ var contains = require('lodash-node/compat/collections/contains');
 var flatten  = require('lodash-node/compat/arrays/flatten');
 var fs       = require('fs-extra');
 var path     = require('path');
+var EOL      = require('os').EOL;
 
 /*
   Asserts that a given file exists.
@@ -56,10 +57,10 @@ module.exports = function assertFile(file, options) {
         pass = contains(actual, expected);
       }
 
-      assert(pass, '\n\nexpected ' + file + ':\n\n' +
+      assert(pass, EOL + EOL + 'expected ' + file + ':' + EOL + EOL +
                    actual +
-                   '\nto contain:\n\n' +
-                   expected + '\n');
+                   EOL + 'to contain:' + EOL + EOL +
+                   expected + EOL);
     });
   }
 
@@ -73,10 +74,10 @@ module.exports = function assertFile(file, options) {
         pass = !contains(actual, unexpected);
       }
 
-      assert(pass, '\n\nexpected ' + file + ':\n\n' +
-                   actual +
-                   '\nnot to contain:\n\n' +
-                   unexpected + '\n');
+      assert(pass, EOL + EOL + 'expected ' + file + ':' + EOL + EOL +
+                   actual + EOL +
+                   'not to contain:' + EOL + EOL +
+                   unexpected + EOL);
     });
   }
 };

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var EOL      = require('os').EOL;
 var assert   = require('../../helpers/assert');
 var stub     = require('../../helpers/stub').stub;
 var MockUI   = require('../../helpers/mock-ui');
@@ -79,7 +80,7 @@ describe('Unit: CLI', function() {
 
     return ember().then(function() {
       assert.equal(help.called, 1, 'expected help to be called once');
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
       assert.equal(output.length, 1, 'expected no extra output');
     });
@@ -92,7 +93,7 @@ describe('Unit: CLI', function() {
 
         return ember([command]).then(function() {
           assert.equal(help.called, 1, 'expected help to be called once');
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           assert.equal(output.length, 1, 'expected no extra output');
         });
@@ -104,7 +105,7 @@ describe('Unit: CLI', function() {
 
         return ember(['new', command]).then(function() {
           assert.equal(help.called, 1, 'expected help to be called once');
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           assert.equal(output.length, 1, 'expected no extra output');
 
@@ -119,7 +120,7 @@ describe('Unit: CLI', function() {
       var version = stubValidateAndRun('version');
 
       return ember([command]).then(function() {
-        var output = ui.output.trim().split('\n');
+        var output = ui.output.trim().split(EOL);
         assertVersion(output[0]);
         assert.equal(output.length, 1, 'expected no extra output');
         assert.equal(version.called, 1, 'expected version to be called once');
@@ -135,7 +136,7 @@ describe('Unit: CLI', function() {
         return ember([command]).then(function() {
           assert.equal(server.called, 1, 'expected the server command to be run');
 
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           assert.deepEqual(output.length, 1, 'expected no extra of output');
         });
@@ -281,7 +282,7 @@ describe('Unit: CLI', function() {
 
           assert.deepEqual(args, ['foo', 'bar', 'baz']);
 
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           assert.equal(output.length, 1, 'expected no extra of output');
         });
@@ -308,7 +309,7 @@ describe('Unit: CLI', function() {
           assert.equal(init.called, 1, 'expected the init command to be run');
           assert.deepEqual(args, ['my-blog'], 'expect first arg to be the app name');
 
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           assert.equal(output.length, 1, 'expected no extra of output');
         });
@@ -423,7 +424,7 @@ describe('Unit: CLI', function() {
       assert.equal(help.called, 0, 'expected the help command NOT to be run');
       assert.equal(serve.called, 1,  'expected the serve command to be run');
 
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
       assert.equal(output.length, 1, 'expected no extra output');
     });
@@ -442,7 +443,7 @@ describe('Unit: CLI', function() {
 
       assert.equal(serve.calledWith[0].length, 2, 'expect foo to receive a total of 4 args');
 
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
       assert.equal(output.length, 1, 'expected no extra output');
     });
@@ -452,7 +453,7 @@ describe('Unit: CLI', function() {
     var help = stubValidateAndRun('help');
 
     return ember(['unknownCommand']).then(function() {
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assert(/The specified command .*unknownCommand.* is invalid/.test(output[1]), 'expected an invalid command message');
       assert.equal(help.called, 0, 'expected the help command to be run');
     });

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -51,7 +51,7 @@ describe('generate command', function() {
         assert.equal(error.message,
             'The `ember destroy` command requires an ' +
             'entity name to be specified. ' +
-            'For more details, use `ember help`.\n');
+            'For more details, use `ember help`.');
       });
   });
 
@@ -64,7 +64,7 @@ describe('generate command', function() {
         assert.equal(error.message,
             'The `ember destroy` command requires a ' +
             'blueprint name to be specified. ' +
-            'For more details, use `ember help`.\n');
+            'For more details, use `ember help`.');
       });
   });
 });

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -51,7 +51,7 @@ describe('generate command', function() {
         assert.equal(error.message,
             'The `ember generate` command requires a ' +
             'blueprint name to be specified. ' +
-            'For more details, use `ember help`.\n');
+            'For more details, use `ember help`.');
       });
   });
 });

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -41,7 +41,7 @@ describe('init command', function() {
       assert.ok(false, 'should have rejected with an application name of test');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `test`.\n');
+      assert.equal(error.message, 'We currently do not support a name of `test`.');
     });
   });
 

--- a/tests/unit/commands/version-test.js
+++ b/tests/unit/commands/version-test.js
@@ -4,6 +4,7 @@ var assert         = require('../../helpers/assert');
 var commandOptions = require('../../factories/command-options');
 var VersionCommand = require('../../../lib/commands/version');
 var MockUI         = require('../../helpers/mock-ui');
+var EOL            = require('os').EOL;
 
 describe('version command', function() {
   var ui, command, options;
@@ -27,14 +28,14 @@ describe('version command', function() {
 
   it('reports node and npm versions', function() {
     command.validateAndRun();
-    var lines = ui.output.split('\n');
+    var lines = ui.output.split(EOL);
     assert(someLineStartsWith(lines, 'node:'), 'contains the version of node');
     assert(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
   });
 
   it('supports a --verbose flag', function() {
     command.validateAndRun(['--verbose']);
-    var lines = ui.output.split('\n');
+    var lines = ui.output.split(EOL);
     assert(someLineStartsWith(lines, 'node:'), 'contains the version of node');
     assert(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
     assert(someLineStartsWith(lines, 'v8:'), 'contains the version of v8');

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -8,6 +8,7 @@ var glob              = require('glob');
 var path              = require('path');
 var walkSync          = require('walk-sync');
 var rimraf            = require('rimraf');
+var EOL               = require('os').EOL;
 var root              = process.cwd();
 var tmp               = require('tmp-sync');
 var tmproot           = path.join(root, 'tmp');
@@ -159,7 +160,7 @@ describe('Blueprint', function() {
       return blueprint.install(options)
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
 
           assert.match(output.shift(), /^installing/);
           assert.match(output.shift(), /create.* .ember-cli/);
@@ -175,7 +176,7 @@ describe('Blueprint', function() {
     it('re-installing identical files', function() {
       return blueprint.install(options)
         .then(function() {
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           ui.output = '';
 
           assert.match(output.shift(), /^installing/);
@@ -189,7 +190,7 @@ describe('Blueprint', function() {
         })
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
 
           assert.match(output.shift(), /^installing/);
           assert.match(output.shift(), /identical.* \.ember-cli/);
@@ -205,7 +206,7 @@ describe('Blueprint', function() {
     it('re-installing conflicting files', function() {
       return blueprint.install(options)
         .then(function() {
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           ui.output = '';
 
           assert.match(output.shift(), /^installing/);
@@ -218,18 +219,18 @@ describe('Blueprint', function() {
           var blueprintNew = new Blueprint(basicNewBlueprint);
 
           setTimeout(function(){
-            ui.inputStream.write('n\n');
+            ui.inputStream.write('n' + EOL);
           }, 25);
 
           setTimeout(function(){
-            ui.inputStream.write('y\n');
+            ui.inputStream.write('y' + EOL);
           }, 50);
 
           return blueprintNew.install(options);
         })
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
-          var output = ui.output.trim().split('\n');
+          var output = ui.output.trim().split(EOL);
           assert.match(output.shift(), /^installing/);
           assert.match(output.shift(), /Overwrite.*foo.*\?/); // Prompt
           assert.match(output.shift(), /Overwrite.*foo.*No, skip/);
@@ -253,7 +254,7 @@ describe('Blueprint', function() {
       it('ignores files in ignoredUpdateFiles', function() {
         return blueprint.install(options)
           .then(function() {
-            var output = ui.output.trim().split('\n');
+            var output = ui.output.trim().split(EOL);
             ui.output = '';
 
             assert.match(output.shift(), /^installing/);
@@ -266,11 +267,11 @@ describe('Blueprint', function() {
             var blueprintNew = new Blueprint(basicNewBlueprint);
 
             setTimeout(function(){
-              ui.inputStream.write('n\n');
+              ui.inputStream.write('n' + EOL);
             }, 25);
 
             setTimeout(function(){
-              ui.inputStream.write('n\n');
+              ui.inputStream.write('n'+ EOL);
             }, 50);
 
             options.project.isEmberCLIProject = function() { return true; };
@@ -279,7 +280,7 @@ describe('Blueprint', function() {
           })
           .then(function() {
             var actualFiles = walkSync(tmpdir).sort();
-            var output = ui.output.trim().split('\n');
+            var output = ui.output.trim().split(EOL);
             assert.match(output.shift(), /^installing/);
             assert.match(output.shift(), /Overwrite.*test.*\?/); // Prompt
             assert.match(output.shift(), /Overwrite.*test.*No, skip/);

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -45,7 +45,7 @@ describe('models/builder.js', function() {
       trapSignals: function() { },
       cleanupOnExit: function() { }
     });
-    
+
     it('when outputPath is root directory ie., `--output-path=/`', function() {
       var outputPathArg = '--output-path=/';
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
@@ -53,10 +53,10 @@ describe('models/builder.js', function() {
 
       return builder.clearOutputPath()
         .catch(function(error) {
-          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported. \n');
+          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
-    
+
     it('when outputPath is project root ie., `--output-path=.`', function() {
       var outputPathArg = '--output-path=.';
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
@@ -64,7 +64,7 @@ describe('models/builder.js', function() {
 
       return builder.clearOutputPath()
         .catch(function(error) {
-          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported. \n');
+          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
   });

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -5,6 +5,7 @@ var MockUI    = require('../../helpers/mock-ui');
 var FileInfo  = require('../../../lib/models/file-info');
 var path      = require('path');
 var fs        = require('fs');
+var EOL       = require('os').EOL;
 var Promise   = require('../../../lib/ext/promise');
 var writeFile = Promise.denodeify(fs.writeFile);
 var rimraf     = require('rimraf');
@@ -69,10 +70,10 @@ describe('Unit - FileInfo', function(){
     validOptions.templateVariables.friend = 'Billy';
     var fileInfo = new FileInfo(validOptions);
 
-    return writeFile(testOutputPath, 'Something Old\n').then(function(){
+    return writeFile(testOutputPath, 'Something Old' + EOL).then(function(){
       return fileInfo.displayDiff();
     }).then(function(){
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assert.equal(output.shift(), 'Index: ' + testOutputPath);
       assert.match(output.shift(), /=+/);
       assert.match(output.shift(), /---/);
@@ -87,11 +88,11 @@ describe('Unit - FileInfo', function(){
     var fileInfo = new FileInfo(validOptions);
 
     setTimeout(function(){
-      ui.inputStream.write('Y\n');
+      ui.inputStream.write('Y' + EOL);
     }, 10);
 
     return fileInfo.confirmOverwrite().then(function(action){
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assert.match(output.shift(), /Overwrite.*\?/);
       assert.equal(action, 'overwrite');
     });
@@ -101,11 +102,11 @@ describe('Unit - FileInfo', function(){
     var fileInfo = new FileInfo(validOptions);
 
     setTimeout(function(){
-      ui.inputStream.write('n\n');
+      ui.inputStream.write('n' + EOL);
     }, 10);
 
     return fileInfo.confirmOverwrite().then(function(action){
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assert.match(output.shift(), /Overwrite.*\?/);
       assert.equal(action, 'skip');
     });
@@ -115,11 +116,11 @@ describe('Unit - FileInfo', function(){
     var fileInfo = new FileInfo(validOptions);
 
     setTimeout(function(){
-      ui.inputStream.write('d\n');
+      ui.inputStream.write('d' + EOL);
     }, 10);
 
     return fileInfo.confirmOverwrite().then(function(action){
-      var output = ui.output.trim().split('\n');
+      var output = ui.output.trim().split(EOL);
       assert.match(output.shift(), /Overwrite.*\?/);
       assert.equal(action, 'diff');
     });

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -6,6 +6,8 @@ var MockUI = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
 var MockWatcher  = require('../../helpers/mock-watcher');
 var Watcher = require('../../../lib/models/watcher');
+var EOL = require('os').EOL;
+var chalk = require('chalk');
 
 describe('Watcher', function() {
   var ui;
@@ -68,7 +70,7 @@ describe('Watcher', function() {
     });
 
     it('logs that the build was successful', function() {
-      assert.equal(ui.output, '\u001b[32m\nBuild successful - 12344ms.\n\u001b[39m');
+      assert.equal(ui.output, EOL + chalk.green('Build successful - 12344ms.') + EOL);
     });
   });
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -44,7 +44,7 @@ describe('express-server', function() {
         host:  '0.0.0.0',
         port: '1337'
       }).then(function() {
-        var output = ui.output.trim().split('\n');
+        var output = ui.output.trim().split(EOL);
         assert.deepEqual(output[1], 'Serving on http://0.0.0.0:1337');
         assert.deepEqual(output[0], 'Proxying to http://localhost:3001/');
         assert.deepEqual(output.length, 2, 'expected only two lines of output');
@@ -56,7 +56,7 @@ describe('express-server', function() {
         host:  '0.0.0.0',
         port: '1337'
       }).then(function() {
-        var output = ui.output.trim().split('\n');
+        var output = ui.output.trim().split(EOL);
         assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337');
         assert.deepEqual(output.length, 1, 'expected only one line of output');
       });

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -4,6 +4,7 @@ var assert           = require('../../../helpers/assert');
 var LiveReloadServer = require('../../../../lib/tasks/server/livereload-server');
 var MockUI           = require('../../../helpers/mock-ui');
 var net              = require('net');
+var EOL              = require('os').EOL;
 
 var MockWatcher  = require('../../../helpers/mock-watcher');
 describe('livereload-server', function() {
@@ -38,7 +39,7 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: true
       }).then(function() {
-        assert.equal(ui.output, 'Livereload server on port 1337\n');
+        assert.equal(ui.output, 'Livereload server on port 1337' + EOL);
       });
     });
 
@@ -51,7 +52,7 @@ describe('livereload-server', function() {
           liveReload: true
         })
         .catch(function(reason) {
-          assert.equal(reason, 'Livereload failed on port 1337.  It is either in use or you do not have permission.\n');
+          assert.equal(reason, 'Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
         })
         .finally(function() {
           preexistingServer.close(done);


### PR DESCRIPTION
- Adds `ui.writeLine`
- Removes `\n` from `ui.write...` calls and `SilentError` messages wherever possible
- Swaps `\n` for `EOL` everywhere else

There are probably mistakes, but wanted to get this out there just in case anyone else is working on it.
