### PR TITLE
pass project to livereload-server

### DIFF
--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -31,6 +31,7 @@ module.exports = Task.extend({
     var liveReloadServer = new LiveReloadServer({
       ui: this.ui,
       analytics: this.analytics,
+      project: this.project,
       watcher: watcher
     });
 


### PR DESCRIPTION
Fixes an issue with aeb015594632fa4d5b1af1247ea59f8a01d903e3

https://github.com/stefanpenner/ember-cli/blob/aeb015594632fa4d5b1af1247ea59f8a01d903e3/lib/tasks/server/livereload-server.js#L56-L58

`project` was not passed to the `livereload-server`-task, causing the `ember serve` task to hang.
