### PR TITLE
Allow calling this._super in subclasses of CoreObject.

### DIFF
--- a/lib/models/core-object.js
+++ b/lib/models/core-object.js
@@ -24,6 +24,7 @@ CoreObject.extend = function(options) {
   Class.prototype = Object.create(constructor.prototype);
   assign(Class.prototype, options);
   Class.prototype.constructor = Class;
+  Class.prototype._super = constructor.prototype;
 
   return Class;
 };

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -28,10 +28,16 @@ function buildAddon(addonName) {
     onOutput: function() {
       return; // no output for initial application build
     }
+  })
+  .catch(function(result) {
+    console.log(result.output.join('\n'));
+    console.log(result.errors.join('\n'));
+
+    throw result;
   });
 }
 
-describe('Acceptance: smoke-test', function() {
+describe('Acceptance: addon-smoke-test', function() {
   before(function() {
     this.timeout(360000);
 

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -18,6 +18,12 @@ function buildApp(appName) {
     onOutput: function() {
       return; // no output for initial application build
     }
+  })
+  .catch(function(result) {
+    console.log(result.output.join('\n'));
+    console.log(result.errors.join('\n'));
+
+    throw result;
   });
 }
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -20,6 +20,12 @@ function buildApp(appName) {
     onOutput: function() {
       return; // no output for initial application build
     }
+  })
+  .catch(function(result) {
+    console.log(result.output.join('\n'));
+    console.log(result.errors.join('\n'));
+
+    throw result;
   });
 }
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -30,6 +30,12 @@ function buildApp(appName) {
     onOutput: function() {
       return; // no output for initial application build
     }
+  })
+  .catch(function(result) {
+    console.log(result.output.join('\n'));
+    console.log(result.errors.join('\n'));
+
+    throw result;
   });
 }
 

--- a/tests/unit/models/core-object-test.js
+++ b/tests/unit/models/core-object-test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+var CoreObject = require('../../../lib/models/core-object');
+var assert  = require('assert');
+
+describe('models/core-object.js', function() {
+
+  it('can be extended with functions to add to the new class', function() {
+    var called = false;
+
+    var Klass = CoreObject.extend({
+      foo: function() {
+        called = true;
+      }
+    });
+
+    var instance = new Klass();
+    instance.foo();
+
+    assert(called);
+  });
+
+  it('can be provided a base object to `new`', function() {
+    var called = false;
+
+    var Klass = CoreObject.extend({
+      foo: function() {
+        called = 'klass.foo';
+      }
+    });
+
+    var instance = new Klass({
+      foo: function() {
+        called = 'instance.foo';
+      }
+    });
+    instance.foo();
+
+    assert.equal(called, 'instance.foo');
+  });
+
+
+  it('an extended class can be extended can be extended with functions to add to the new class', function() {
+    var fooCalled = false;
+    var barCalled = false;
+
+    var Klass1 = CoreObject.extend({
+      foo: function() {
+        fooCalled = true;
+      }
+    });
+
+    var Klass2 = Klass1.extend({
+      bar: function() {
+        barCalled = true;
+      }
+    });
+
+    var instance = new Klass2();
+    instance.foo();
+    assert(fooCalled);
+
+    instance.bar();
+    assert(barCalled);
+  });
+
+  describe('_super', function() {
+    it('an extended class can call methods on its parents constructor via _super.methodName', function() {
+      var fooCalled = false;
+      var barCalled = false;
+
+      var Klass1 = CoreObject.extend({
+        foo: function() {
+          fooCalled = true;
+        }
+      });
+
+      var Klass2 = Klass1.extend({
+        bar: function() {
+          barCalled = true;
+          this._super.foo();
+        }
+      });
+
+      var instance = new Klass2();
+
+      instance.bar();
+      assert(fooCalled, 'foo called');
+      assert(barCalled, 'bar called');
+    });
+
+    it('an extended class can call methods on its parent via _super.otherMethodName', function() {
+      var parentBarCalled = false;
+
+      var Klass1 = CoreObject.extend({
+        bar: function() {
+          parentBarCalled = true;
+        }
+      });
+
+      var Klass2 = Klass1.extend({
+        foo: function() {
+          this._super.bar();
+        }
+      });
+
+      var instance = new Klass2();
+
+      instance.foo();
+      assert(parentBarCalled, 'parent foo called');
+    });
+
+    it('all ancestors methods are available via _super.methodName', function() {
+      var fooCalled = false;
+      var barCalled = false;
+      var bazCalled = false;
+
+      var Klass1 = CoreObject.extend({
+        foo: function() {
+          fooCalled = true;
+        }
+      });
+
+      var Klass2 = Klass1.extend({
+        bar: function() {
+          barCalled = true;
+          this._super.foo();
+        }
+      });
+
+      var Klass3 = Klass2.extend({
+        baz: function() {
+          bazCalled = true;
+          this._super.foo();
+        }
+      });
+
+      var instance = new Klass3();
+
+      instance.baz();
+      assert(fooCalled, 'foo called');
+      assert(bazCalled, 'baz called');
+
+      fooCalled = false;
+      instance.bar();
+      assert(fooCalled, 'foo called');
+      assert(barCalled, 'bar called');
+    });
+  });
+});


### PR DESCRIPTION
- Add a few tests for `CoreObject`.
- Allow calling methods on your parent class via `this._super.someMethod()`.

Illustration:

``` javascript
var fooCalled, barCalled, instance;

var Klass1 = CoreObject.extend({
  foo: function() {
    fooCalled = true;
  }
});

var Klass2 = Klass1.extend({
  foo: function() {
    this._super.foo();
  },

  bar: function() {
    barCalled = true;
    this._super.foo();
  }
});

instance = new Klass2();
instance.bar();

assert(fooCalled, 'foo called');
assert(barCalled, 'bar called');

fooCalled = false;
instance.foo();

assert(fooCalled, 'foo called');
```
