### PR TITLE
jshintrc: disable esnext Promise global

### DIFF
--- a/blueprints/app/files/.jshintrc
+++ b/blueprints/app/files/.jshintrc
@@ -2,6 +2,7 @@
   "predef": {
     "document": true,
     "window": true,
+    "-Promise": true,
     "<%= namespace %>ENV": true
   },
   "browser" : true,

--- a/blueprints/app/files/tests/.jshintrc
+++ b/blueprints/app/files/tests/.jshintrc
@@ -5,6 +5,7 @@
     "location",
     "setTimeout",
     "$",
+    "-Promise",
     "QUnit",
     "define",
     "console",


### PR DESCRIPTION
Prevents subtle trolls when RSVP Promise was intended but
(non-universally-implemented) global Promise was used instead due to
forgetting to import the Promise you wanted.
