### PR TITLE
Prevent file deletions when the build output-path is a parent directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Upgrade `broccoli-ember-hbs-template-compiler` to `1.6.1`.
 * [ENHANCEMENT] Allow file patterns to be ignored by LiveReload [#1706](https://github.com/stefanpenner/ember-cli/pull/1706)
 * [BUGFIX] Switch to OS-friendly line endings [#1718](https://github.com/stefanpenner/ember-cli/pull/1718)
+* [BUGFIX] Prevent file deletions when the build `--output-path` is a parent directory [#1730](https://github.com/stefanpenner/ember-cli/pull/1730)
 
 ### 0.0.40
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -40,7 +40,8 @@ module.exports = Task.extend({
   },
 
   canDeleteOutputPath: function(outputPath) {
-    return outputPath !== Project.closestSync(process.cwd()).root && outputPath !== '/';
+    var projectRoot = Project.closestSync(process.cwd()).root;
+    return !projectRoot.contains(outputPath);
   },
 
   /**

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -67,6 +67,17 @@ describe('models/builder.js', function() {
           assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
+    
+    it('when outputPath is a parent directory ie., `--output-path=../../`', function() {
+      var outputPathArg = '--output-path=../../';
+      var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+      builder.outputPath = outputPath;
+
+      return builder.clearOutputPath()
+        .catch(function(error) {
+          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
+        });
+    });
   });
 
   describe('addons', function() {


### PR DESCRIPTION
Prevent self trolling when the build output path is a parent directory 

Fixes #1716 properly
