### PR TITLE
Adds a util function

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -1,30 +1,11 @@
 #!/usr/bin/env node
+
 'use strict';
 
-// Provide a title to the process in `ps`
-process.title = 'ember';
+var instantiate = require('../lib/utilities/instantiate');
 
-var resolve = require('resolve');
-
-resolve('ember-cli', {
-  basedir: process.cwd()
-}, function(error, projectLocalCli) {
-  var cli;
-  if (error) {
-    // If there is an error, resolve could not find the ember-cli
-    // library from a package.json. Instead, include it from a relative
-    // path to this script file (which is likely a globally installed
-    // npm package). Most common cause for hitting this is `ember new`
-    cli = require('../lib/cli');
-  } else {
-    // No error implies a projectLocalCli, which will load whatever
-    // version of ember-cli you have installed in a local package.json
-    cli = require(projectLocalCli);
-  }
-
-  cli({
-    cliArgs: process.argv.slice(2),
-    inputStream: process.stdin,
-    outputStream: process.stdout
-  }).then(process.exit);
+instantiate('ember', process.cwd(), {
+  cliArgs:      process.argv.slice(2),
+  inputStream:  process.stdin,
+  outputStream: process.stdout
 });

--- a/lib/utilities/instantiate.js
+++ b/lib/utilities/instantiate.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var resolve = require('resolve');
+
+function instantiate(name, path, options) {
+  // Provide a title to the process in `ps`
+  process.title = name;
+
+  resolve(name, {
+    basedir: path
+  }, function(error, projectLocalCli) {
+    var cli;
+    if (error) {
+      // If there is an error, resolve could not find the ember-cli
+      // library from a package.json. Instead, include it from a relative
+      // path to this script file (which is likely a globally installed
+      // npm package). Most common cause for hitting this is `ember new`
+      cli = require('../cli');
+    } else {
+      // No error implies a projectLocalCli, which will load whatever
+      // version of ember-cli you have installed in a local package.json
+      cli = require(projectLocalCli);
+    }
+
+    cli(options).then(process.exit);
+  });
+}
+
+module.exports = instantiate;


### PR DESCRIPTION
Hides the internals of how we boot up `ember-cli`.
Makes it easy to swap for another loader.
