### PR TITLE
Throw an error if an Addon does not specify a name.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -11,6 +11,7 @@ var mergeTrees  = require('broccoli-merge-trees');
 var jshintTrees = require('broccoli-jshint');
 var concatFiles = require('broccoli-concat');
 var fileMover   = require('broccoli-file-mover');
+var SilentError = require('../errors/silent');
 
 var p                   = require('../preprocessors');
 var preprocessJs        = p.preprocessJs;
@@ -20,6 +21,10 @@ var preprocessTemplates = p.preprocessTemplates;
 function Addon(project) {
   this.project = project;
   this.registry = p.setupRegistry(this);
+
+  if (!this.name) {
+    throw new SilentError('An addon must define a `name` property.');
+  }
 }
 
 Addon.__proto__ = require('./core-object');

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -151,5 +151,14 @@ describe('models/addon.js', function() {
         });
       });
     });
+
+    it('must define a `name` property', function() {
+      var Foo = Addon.extend({ root: 'foo' });
+
+      assert.throws(function() {
+        new Foo(project);
+      },
+      /An addon must define a `name` property./ );
+    });
   });
 });


### PR DESCRIPTION
We use a generated name when an addon just uses the default implementation (meaning it doesn't need an index.js), but if you export an object that does not contain `name` you get very weird and bizarre errors (took me a bit to track it down).
