### PR TITLE
Adds tests to ensure that all pre-1.0 package versions are locked

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,6 @@
     "mocha": "^1.18.0",
     "mocha-jshint": "0.0.7",
     "node-require-timings": "0.0.2",
-    "supertest": "^0.13.0"
+    "supertest": "0.13.0"
   }
 }

--- a/tests/unit/package/dependency-version-test.js
+++ b/tests/unit/package/dependency-version-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var assert = require('../../helpers/assert');
+var semver = require('semver');
+
+function assertVersionLock(deps) {
+  deps = deps || {};
+
+  Object.keys(deps).forEach(function(name) {
+    if (name !== 'ember-cli' && semver.gtr('1.0.0', deps[name])) {
+      // only valid if the version is fixed
+      assert(semver.valid(deps[name]), '"' + name + '" has a valid version');
+    }
+  });
+}
+
+describe('dependencies', function() {
+  var pkg;
+
+  describe('in package.json', function() {
+    before(function() {
+      pkg = require('../../../package.json');
+    });
+
+    it('are locked down for pre-1.0 versions', function() {
+      assertVersionLock(pkg.dependencies);
+      assertVersionLock(pkg.devDependencies);
+    });
+  });
+
+  describe('in blueprints/app/files/package.json', function() {
+    before(function() {
+      pkg = require('../../../blueprints/app/files/package.json');
+    });
+
+    it('are locked down for pre-1.0 versions', function() {
+      assertVersionLock(pkg.dependencies);
+      assertVersionLock(pkg.devDependencies);
+    });
+  });
+
+  describe('in blueprints/addon/files/package.json', function() {
+    before(function() {
+      pkg = require('../../../blueprints/addon/files/package.json');
+    });
+
+    it('are locked down for pre-1.0 versions', function() {
+      assertVersionLock(pkg.dependencies);
+      assertVersionLock(pkg.devDependencies);
+    });
+  });
+});


### PR DESCRIPTION
Let me know if the tests should be more thorough. I'm not checking for ranges, just for the use of `^` or `~`, but that seems to be how we specify all dependencies in ember-cli.
