### PR TITLE
Bring back .bowerrc file.

### DIFF
--- a/blueprints/app/files/.bowerrc
+++ b/blueprints/app/files/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
This makes upgrades much easier, and prevents issues with bower searching an applications parent directories and finding an unrelated `.bowerrc` file that has a directory directive.
