### PR TITLE
fool-proofing the generated README.md

### DIFF
--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -2,24 +2,50 @@
 
 This README outlines the details of collaborating on this Ember application.
 
+A short introduction of this app could easily go here.
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](http://git-scm.com/)
+* [Node.js](http://nodejs.org/) (with NPM) and [Bower](http://bower.io/)
+
 ## Installation
 
-* `git clone` this repository
+* `git clone <repository-url>` this repository
+* change into the new directory
 * `npm install`
 * `bower install`
 
-## Running
+## Running / Development
 
 * `ember server`
 * Visit your app at http://localhost:4200.
 
-## Running Tests
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
 
 * `ember test`
 * `ember test --server`
 
-## Building
+### Building
 
-* `ember build`
+* `ember build` (development)
+* `ember build --environment production` (production)
 
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+### Deploying
+
+Specify what it takes to deploy your app.
+
+## Further Reading / Useful Links
+
+* ember: http://emberjs.com/
+* ember-cli: http://www.ember-cli.com/
+* Development Browser Extensions
+  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+


### PR DESCRIPTION
This is more or less what we now use as a readme-starting-point. I thought I'd share it with you.

We also usually have more prerequisites up there (usually ruby + bundler). Other than that, i merely used more levels of headlines and added a section for deployment. The intention is to enable any developer to clone, use, test and deploy the resulting codebase.
