### PR TITLE
fix ember init command in empty directory

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -217,6 +217,10 @@ NULL_PROJECT.isEmberCLIProject = function() {
   return false;
 };
 
+NULL_PROJECT.isEmberCLIAddon = function() {
+  return false;
+};
+
 NULL_PROJECT.name = function() {
   return path.basename(process.cwd());
 };


### PR DESCRIPTION
Fixes #1759

As mentioned in the issue:

There is a test for `ember init` in an empty directory, but it is being contaminated by ember-cli itself. The temp directory created by the test is a descendant of the ember-cli directory, so when `Project.closest` is called it walks through the temp directory's ancestors until it finds `package.json` in the ember-cli root. Consequently `NULL_PROJECT` is not used by the test.
