### PR TITLE
Ensure imported assets are watched if they exist on disk.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -538,8 +538,6 @@ EmberApp.prototype.import = function(asset, options) {
     return;
   }
 
-  assetPath = assetPath.replace(new RegExp('^'+this.bowerDirectory), 'vendor');
-
   if (assetPath.split('/').length < 2) {
     console.log(chalk.red('Using `app.import` with a file in the root of `vendor/` causes a significant performance penalty. Please move `'+ assetPath + '` into a subdirectory.'));
   }
@@ -553,7 +551,7 @@ EmberApp.prototype.import = function(asset, options) {
   }
 
   var directory    = path.dirname(assetPath);
-  var subdirectory = directory.replace(/^vendor\//, '');
+  var subdirectory = directory.replace(new RegExp('^vendor/|' + this.bowerDirectory), '');
   var extension    = path.extname(assetPath);
   var basename     = path.basename(assetPath);
 
@@ -569,6 +567,9 @@ EmberApp.prototype.import = function(asset, options) {
 
     this._importTrees.push(assetTree);
   }
+
+  assetPath = assetPath.replace(new RegExp('^'+this.bowerDirectory), 'vendor');
+  directory = path.dirname(assetPath);
 
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if(options.type === 'vendor') {


### PR DESCRIPTION
Fixes #1772.

![reloads-properly](https://cloud.githubusercontent.com/assets/12637/4051987/0e71d990-2d67-11e4-9f49-fb319879292c.gif)
