### PR TITLE
Abstract Addon logic for tree generation.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -32,12 +32,27 @@ function Addon(project) {
 Addon.__proto__ = CoreObject;
 Addon.prototype.constructor = Addon;
 
-function unwatchedTree(dir) {
+Addon.prototype._unwatchedTreeGenerator = function unwatchedTree(dir) {
   return {
     read:    function() { return dir; },
     cleanup: function() { }
   };
-}
+};
+
+Addon.prototype.isDevelopingAddon = function() {
+  return process.env.EMBER_ADDON_ENV === 'development';
+};
+
+Addon.prototype.treeGenerator = function(dir) {
+  var tree;
+  if (this.isDevelopingAddon()) {
+    tree = dir;
+  } else {
+    tree = this._unwatchedTreeGenerator(dir);
+  }
+
+  return tree;
+};
 
 Addon.prototype.treePaths = {
   app:               'app',
@@ -58,7 +73,7 @@ Addon.prototype.treeFor = function treeFor(name) {
     trees.push(tree);
   }
 
-  if (process.env.EMBER_ADDON_ENV === 'development' && this.app.hinting && name === 'app') {
+  if (this.isDevelopingAddon() && this.app.hinting && name === 'app') {
     trees.push(this.jshinting());
   }
 
@@ -70,11 +85,7 @@ Addon.prototype._treeFor = function _treeFor(name) {
   var tree;
 
   if (fs.existsSync(treePath)) {
-    if (process.env.EMBER_ADDON_ENV === 'development') {
-      tree = treePath;
-    } else {
-      tree = unwatchedTree(treePath);
-    }
+    tree = this.treeGenerator(treePath);
 
     if (name === 'addon') {
       tree = this.treeForAddon(tree);

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -160,5 +160,53 @@ describe('models/addon.js', function() {
       },
       /An addon must define a `name` property./ );
     });
+
+    describe('isDevelopingAddon', function() {
+      var originalEnvValue;
+
+      beforeEach(function() {
+        originalEnvValue = process.env.EMBER_ADDON_ENV;
+      });
+
+      afterEach(function() {
+        process.env.EMBER_ADDON_ENV = originalEnvValue;
+      });
+
+      it('returns true when `EMBER_ADDON_ENV` is set to development', function() {
+        process.env.EMBER_ADDON_ENV = 'development';
+
+        assert(addon.isDevelopingAddon());
+      });
+
+      it('returns false when `EMBER_ADDON_ENV` is not set', function() {
+        delete process.env.EMBER_ADDON_ENV;
+
+        assert(!addon.isDevelopingAddon());
+      });
+
+      it('returns false when `EMBER_ADDON_ENV` is something other than `development`', function() {
+        process.env.EMBER_ADDON_ENV = 'production';
+
+        assert(!addon.isDevelopingAddon());
+      });
+    });
+
+    describe('treeGenerator', function() {
+      it('watch tree when developing the addon itself', function() {
+        addon.isDevelopingAddon = function() { return true; };
+
+        var tree = addon.treeGenerator('foo/bar');
+
+        assert.equal(tree, 'foo/bar');
+      });
+
+      it('uses unwatchedTree when not developing the addon itself', function() {
+        addon.isDevelopingAddon = function() { return false; };
+
+        var tree = addon.treeGenerator('foo/bar');
+
+        assert.equal(tree.read(), 'foo/bar');
+      });
+    });
   });
 });


### PR DESCRIPTION
- Expose `Addon.prototype.isDevelopingAddon` function.
- Expose `Addon.prototype.treeGenerator` function, that automatically handles the returning an `unwatchedTree` vs the bare directory (therefore causing it to be watched).
