### PR TITLE
Correct npm dependency order

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,8 +23,8 @@
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.0",
-    "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.0.5",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
Fixed order since npm sorts dependencies alphabetically after `npm install`.
