### PR TITLE
Fix incorrect npm loglevel with --verbose flag

### DIFF
--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -16,7 +16,7 @@ module.exports = Task.extend({
     this.ui.pleasantProgress.start(chalk.green('Installing packages for tooling via npm'), chalk.green('.'));
 
     var npmOptions = {
-      loglevel: options.verbose ? 'log' : 'error',
+      loglevel: options.verbose ? 'verbose' : 'error',
       logstream: this.ui.outputStream,
       color: 'always'
     };


### PR DESCRIPTION
I'm getting the following message: 

> npm WARN invalid config loglevel="log"

It seems npm has no level 'info' [1], there is a 'verbose' level though. Switching to 'verbose' should fix the error message.

[1] https://www.npmjs.org/doc/misc/npm-config.html
