### PR TITLE
Add a default .ember-cli file and document disableAnalytics.

### DIFF
--- a/blueprints/app/files/.ember-cli
+++ b/blueprints/app/files/.ember-cli
@@ -1,0 +1,9 @@
+{
+  /**
+    Ember CLI sends analytics information by default. The data is completely
+    anonymous, but there are times when you might want to disable this behavior.
+
+    Setting `disableAnalytics` to true will prevent any data from being sent.
+  */
+  "disableAnalytics": false
+}


### PR DESCRIPTION
Add default `.ember-cli` file with a section describing `disableAnalytics` option.
