### PR TITLE
Avoid issue where `ember init` stalls on fresh system

### DIFF
--- a/blueprints/app/files/.bowerrc
+++ b/blueprints/app/files/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "analytics": false
 }


### PR DESCRIPTION
There is an issue where (on a fresh system, which has never run bower before), the bower 'opt-in analytics prompt' will show for a sliver of time (since npm refreshes the cli output with a spinning pipe (`\ | / -`). This causes the initial `ember init` to stall indefinitely.

This patch opts out of analytics via .bowerrc, to circumvent the above issue.

More on bower analytics opt-in:
https://github.com/bower/bower/issues/1162
