### PR TITLE
Automatically ignore tarballs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp*
 _posts
 _site
 common-tmp
+*.tgz

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,6 @@ STEPS:
 * bump package.json version
 * `rm -rf node_modules`
 * npm cache clear
-* ensure we don't re-pack our an existing pack `rm -rf ember-cli-*.tgz`
 * `npm pack`
 * remove current installed version: `npm uninstall -g ember-cli`
 * install the new package (for testing) `npm install -g ./ember-cli-<version>.tgz`


### PR DESCRIPTION
I tested this locally, before the change running `npm pack && npm pack` resulted in a tarball of 41MiB, after the change the resulting tarball was on 21MiB.
