### PR TITLE
Clear require cache for config reloads.

### DIFF
--- a/lib/broccoli/broccoli-config-loader.js
+++ b/lib/broccoli/broccoli-config-loader.js
@@ -22,9 +22,11 @@ ConfigLoader.prototype.targetExtension = 'js';
 ConfigLoader.prototype.processFile = function (srcDir, destDir, relativePath) {
   var outputPath = path.join(destDir, relativePath);
   var configPath = path.join(this.options.project.root, srcDir, relativePath);
-  var contents = fs.readFileSync(configPath, {encoding: 'utf8'});
-  var wrapperContents = '"use strict";\nvar module = { };\n' + contents + '; return module.exports(env);';
-  var configGenerator = new Function('env', wrapperContents);
+
+  // clear the previously cached version of this module
+  delete require.cache[configPath];
+
+  var configGenerator = require(configPath);
   var currentConfig = configGenerator(this.options.env);
 
   var moduleString = 'export default ' + JSON.stringify(currentConfig) + ';';


### PR DESCRIPTION
Wrapping in a `Function` worked for simple `config/environment.js` contents but breaks down in other scenarios that relied on the file being evaluated in "nodeland".  The prior implementation prevented custom `require`'s (to get the package name from the `package.json` for instance).

Now we just clear the `require` cache to allow re-requiring the file again.

Documentation of `require.cache`:

http://nodejs.org/api/globals.html#globals_require_cache
