### PR TITLE
test-running mini-howto added front and center

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -5,6 +5,18 @@ permalink: testing
 github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-11-testing.md"
 ---
 
+### Running existing tests
+
+Running your Tests is as easy as one of these two commands:
+
+{% highlight bash %}
+ember test            # will run your test-suite in your current shell once
+ember test --server   # will run your tests on every file-change
+{% endhighlight %}
+
+
+Alternatively you can run the tests in your regular browser using the QUnit interface. Run `ember server` and navigate to `http://localhost:4200/tests`. In this case, the tests will run in your default environment, usually 'development'.
+
 ### Writing a Test
 
 * ember-testing
@@ -21,12 +33,6 @@ If you are using Pods to organize your application, be sure to add your `podModu
 
 If you have manually set the locationType in your environment.js to `hash` or `none` you need to update your `tests/index.html` to have absolute paths (`/assets/vendor.css` and `/testem.js` vs the default relative paths).
 
-To run the tests in your browser using the QUnit interface, run `ember server`
-and navigate to `http://localhost:4200/tests`. Note that just like your app, your
-tests will auto rebuild when `ember server` is running.
-
-By default, your integration tests will run on [PhantomJS](http://phantomjs.org/).  You can install via [npm](https://www.npmjs.org/):
-
 {% highlight bash %}
 npm install -g phantomjs
 {% endhighlight %}
@@ -35,6 +41,8 @@ npm install -g phantomjs
 
 `ember test` will run your tests with `Testem` on CI mode. You can
 pass any option to `Testem` using a configuration file.
+
+By default, your integration tests will run on [PhantomJS](http://phantomjs.org/).  You can install via [npm](https://www.npmjs.org/):
 
 **We plan to make your test runner pluggable, so you can use your favorite runner.**
 


### PR DESCRIPTION
Belongs to #1810. the `ember test` and `ember test --server` commands are not one of the first things to come across. I also moved more detailed explanations around a little bit (the part on phantomjs, for example)
