### PR TITLE
Add ability to output multiple styles files

### DIFF
--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -29,7 +29,8 @@ StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
       continue;
     }
 
-    var name = file.split('.')[0];
+    var ext = path.extname(file);
+    var name = path.basename(file, ext);
     var output = path.join(outputPath, name + '.css');
     trees.push(requireLocal(this.name).call(null, [tree], input, output, merge({}, this.options, options)));
   }


### PR DESCRIPTION
When using a different plugin, any stylesheet not starting with an underscore within the styles directory will be compiled and result in a separate output file.

This is a solution for the proposal #1656 
