### PR TITLE
Quote module name in object literal

### DIFF
--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -2,7 +2,7 @@ module.exports = function(app) {
   var express = require('express');
   var <%= camelizedModuleName %>Router = express.Router();
   <%= camelizedModuleName %>Router.get('/', function(req, res) {
-    res.send({<%= dasherizedModuleName %>:[]});
+    res.send({"<%= dasherizedModuleName %>":[]});
   });
   app.use('/api<%= path %>', <%= camelizedModuleName %>Router);
 };


### PR DESCRIPTION
Module names passed to the http-mock generator are dasherized and
used as a property in an object literal. Therefore, they need to be
quoted in case they contain a dash, which is not otherwise a valid
identifier
