### PR TITLE
Remove use of deprecated `view.state` property.

### DIFF
--- a/blueprints/component/files/tests/unit/components/__name__-test.js
+++ b/blueprints/component/files/tests/unit/components/__name__-test.js
@@ -10,9 +10,9 @@ test('it renders', function() {
 
   // creates the component instance
   var component = this.subject();
-  equal(component.state, 'preRender');
+  equal(component._state, 'preRender');
 
   // appends the component to the page
   this.append();
-  equal(component.state, 'inDOM');
+  equal(component._state, 'inDOM');
 });


### PR DESCRIPTION
Closes #1824.
