### PR TITLE
Prevent leaking environment information.

### DIFF
--- a/lib/broccoli/broccoli-config-loader.js
+++ b/lib/broccoli/broccoli-config-loader.js
@@ -33,7 +33,12 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
     fs.mkdirSync(outputDir);
   }
 
-  this.options.environments.forEach(function(env) {
+  var environments = [this.options.env];
+  if (this.options.tests) {
+    environments.push('test');
+  }
+
+  environments.forEach(function(env) {
     var config = configGenerator(env);
     var jsonString = JSON.stringify(config);
     var moduleString = 'export default ' + jsonString + ';';

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -202,21 +202,6 @@ EmberApp.prototype.addonPostprocessTree = function(type, tree) {
   return workingTree;
 };
 
-EmberApp.prototype.environments = function() {
-  var environments = {test: true, development: true, production: true};
-  var fileEnvironments;
-
-  for (var file in this.vendorFiles) {
-    if (typeof this.vendorFiles[file] === 'object') {
-      fileEnvironments = Object.keys(this.vendorFiles[file]);
-
-      environments = merge(environments, fileEnvironments);
-    }
-  }
-
-  return Object.keys(environments);
-};
-
 EmberApp.prototype.populateLegacyFiles = function () {
   var name;
   for (name in this.vendorFiles) {
@@ -377,7 +362,7 @@ EmberApp.prototype._configTree = function() {
 
   var configTree = configLoader(path.dirname(configPath), {
     env: this.env,
-    environments: this.environments(),
+    tests: this.tests,
     project: this.project
   });
 


### PR DESCRIPTION
Changes the implementation of #1820 to prevent leaking other environment information into the build output.  For example after #1820 the development, test, and production environment configurations were available in the build output (even for production builds).

Now we only export the current environment and test (if testing is enabled).

This addresses the security concerns in #1750.
