### PR TITLE
Add `Blueprint.prototype.addBowerPackageToProject`.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -524,6 +524,50 @@ Blueprint.prototype.addPackageToProject = function(packageName, version) {
 };
 
 /*
+  Used to add a package to the projects `bower.json`.
+
+  Generally, this would be done from the `afterInstall` hook, to
+  ensure that a package that is required by a given blueprint is
+  available.
+
+  @method addBowerPackageToProject
+  @param {String} packageName
+  @param {String} target
+  @return {Promise}
+*/
+Blueprint.prototype.addBowerPackageToProject = function(packageName, target) {
+  var task = this.taskFor('bower-install');
+  var packageNameAndVersion = packageName;
+
+  if (target) {
+    packageNameAndVersion += '#' + target;
+  }
+
+  return task.run({
+    verbose: true,
+    packages: [packageNameAndVersion]
+  });
+};
+
+/*
+  Used to retrieve a task with the given name. Passes the new task
+  the standard information available (like `ui`, `analytics`, `project`, etc).
+
+  @method taskFor
+  @param dasherizedName
+  @public
+*/
+Blueprint.prototype.taskFor = function(dasherizedName) {
+  var Task = require('../tasks/' + dasherizedName);
+
+  return new Task({
+    ui: this.ui,
+    project: this.project,
+    analytics: this.analytics
+  });
+};
+
+/*
   @private
   @method _exec
   @param {String} command

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -16,6 +16,7 @@ module.exports = Task.extend({
     var bower       = this.bower;
     var bowerConfig = this.bowerConfig;
     var ui          = this.ui;
+    var packages    = options.packages || [];
 
     ui.pleasantProgress.start(chalk.green('Installing browser packages via Bower'), chalk.green('.'));
 
@@ -23,7 +24,7 @@ module.exports = Task.extend({
     config.interactive = true;
 
     return new Promise(function(resolve, reject) {
-        bower.commands.install([], { save: true }, config) // Packages, options, config
+        bower.commands.install(packages, { save: true }, config) // Packages, options, config
           .on('log', logBowerMessage)
           .on('prompt', ui.prompt.bind(ui))
           .on('error', reject)


### PR DESCRIPTION
This will allow addons that need bower packages, to avoid vendoring the files or requiring `bower` as a dependency.
