### PR TITLE
Keep bower_components and vendor separate.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -134,7 +134,8 @@ function EmberApp(options) {
     templates: unwatchedTree('app/templates'),
 
     // do not watch vendor/ or bower's default directory by default
-    vendor: this.unwatchedVendorTrees(),
+    bower: unwatchedTree(this.bowerDirectory),
+    vendor: unwatchedTree('vendor'),
   }, defaults);
 
   this.options.jshintrc = merge(this.options.jshintrc, {
@@ -328,6 +329,19 @@ EmberApp.prototype._processedTestsTree = function() {
   });
 };
 
+EmberApp.prototype._processedBowerTree = function() {
+  if(this._cachedBowerTree) {
+    return this._cachedBowerTree;
+  }
+
+  this._cachedBowerTree = pickFiles(this.trees.bower, {
+    srcDir: '/',
+    destDir: this.bowerDirectory + '/'
+  });
+
+  return this._cachedBowerTree;
+};
+
 EmberApp.prototype._processedVendorTree = function() {
   if(this._cachedVendorTree) {
     return this._cachedVendorTree;
@@ -351,6 +365,19 @@ EmberApp.prototype._processedVendorTree = function() {
     destDir: 'vendor/'
   });
   return this._cachedVendorTree;
+};
+
+EmberApp.prototype._processedExternalTree = function() {
+  if (this._cachedExternalTree) {
+    return this._cachedExternalTree;
+  }
+
+  var vendor = this._processedVendorTree();
+  var bower = this._processedBowerTree();
+
+  return this._cachedExternalTree = mergeTrees([bower, vendor], {
+    description: 'TreeMerger (ExternalTree)'
+  });
 };
 
 EmberApp.prototype._configTree = function() {
@@ -383,12 +410,12 @@ EmberApp.prototype.appAndDependencies = function() {
     app = new ES3SafeFilter(app);
   }
 
-  var vendor          = this._processedVendorTree();
+  var external          = this._processedExternalTree();
   var preprocessedApp = preprocessJs(app, '/', this.name, {
     registry: this.registry
   });
 
-  var sourceTrees = [ vendor, preprocessedApp, templates, config ];
+  var sourceTrees = [ external, preprocessedApp, templates, config ];
 
   if (this.tests) {
     var tests  = this._processedTestsTree();
@@ -508,14 +535,14 @@ EmberApp.prototype.styles = function() {
 };
 
 EmberApp.prototype.testFiles = function() {
-  var vendor = this._processedVendorTree();
+  var external = this._processedExternalTree();
 
-  var testJs = concatFiles(vendor, {
+  var testJs = concatFiles(external, {
     inputFiles: this.legacyTestFilesToAppend,
     outputFile: '/assets/test-support.js'
   });
 
-  var testCss = concatFiles(vendor, {
+  var testCss = concatFiles(external, {
     inputFiles: this.vendorTestStaticStyles,
     outputFile: '/assets/test-support.css'
   });
@@ -533,9 +560,9 @@ EmberApp.prototype.testFiles = function() {
     this.options.fingerprint.exclude.push('testem');
   }
 
-  var testLoader = pickFiles(this.trees.vendor, {
+  var testLoader = pickFiles(external, {
     files: ['test-loader.js'],
-    srcDir: '/ember-cli-test-loader',
+    srcDir: '/' + this.bowerDirectory + '/ember-cli-test-loader',
     destDir: '/assets/'
   });
 
@@ -553,9 +580,9 @@ EmberApp.prototype.testFiles = function() {
 };
 
 EmberApp.prototype.otherAssets = function() {
-  var vendor = this._processedVendorTree();
+  var external = this._processedExternalTree();
   var otherAssetTrees = this.otherAssetPaths.map(function (path) {
-    return pickFiles(vendor, {
+    return pickFiles(external, {
       srcDir: path.src,
       files: [path.file],
       destDir: path.dest
@@ -609,7 +636,6 @@ EmberApp.prototype.import = function(asset, options) {
     this._importTrees.push(assetTree);
   }
 
-  assetPath = assetPath.replace(new RegExp('^'+this.bowerDirectory), 'vendor');
   directory = path.dirname(assetPath);
 
   if (isType(assetPath, 'js', {registry: this.registry})) {


### PR DESCRIPTION
This ensures that `import Baz from 'bower_components/foo-bar/baz';` works properly. Prior to this change you would have had to know and understand that we are internally merging `bower_components/` and `vendor/` together (and therefore you would need to use `import Baz from 'vendor/foo-bar/baz';`).

No fundamental functionality was lost, but it might be a breaking change for folks that were importing things that happened to be in `bower_components/`, but were using `vendor/` in the import.  I'll make sure to call it out as a breaking change in the changelog.

Addresses #1789, in that `app.import('bower_components/foo-bar/baz.js')` and `import Foo from 'bower_components/foo-bar/baz';` now show the proper directories in the errors that spit out.
