### PR TITLE
use new external tree in styles instead of vendor

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -497,13 +497,13 @@ EmberApp.prototype.javascript = function() {
 
 EmberApp.prototype.styles = function() {
   var addonTrees = this.addonTreesFor('styles');
-  var vendor = this._processedVendorTree();
+  var external = this._processedExternalTree();
   var styles = pickFiles(this.trees.styles, {
     srcDir: '/',
     destDir: '/app/styles'
   });
 
-  var trees = [vendor].concat(addonTrees);
+  var trees = [external].concat(addonTrees);
   trees.push(styles);
 
   var stylesAndVendor = mergeTrees(trees, {


### PR DESCRIPTION
fixes imported bower css assets not being included
