### PR TITLE
Add Blueprint.prototype.insertIntoFile.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -575,6 +575,60 @@ Blueprint.prototype.taskFor = function(dasherizedName) {
 };
 
 /*
+
+  Inserts the given content into a file. If the `contentsToInsert` string is already
+  present in the current contents, the file will not be changed unless `force` option
+  is passed.
+
+  This method currently, only inserts the new contents at the end of the file.
+
+  @method insertIntoFile
+  @param {String} pathRelativeToProjectRoot
+  @param {String} contentsToInsert
+  @param {Object} options
+  @return {Promise}
+*/
+Blueprint.prototype.insertIntoFile = function(pathRelativeToProjectRoot, contentsToInsert, providedOptions) {
+  var fullPath          = path.join(this.project.root, pathRelativeToProjectRoot);
+  var originalContents  = '';
+
+  if (fs.existsSync(fullPath)) {
+    originalContents = fs.readFileSync(fullPath, { encoding: 'utf8' });
+  }
+
+  var contentsToWrite   = originalContents;
+
+  var options           = providedOptions || {};
+  var alreadyPresent    = originalContents.indexOf(contentsToInsert) > -1;
+  var insert            = !alreadyPresent;
+
+  if (options.force) { insert = true; }
+
+  if (insert) {
+    contentsToWrite += contentsToInsert;
+  }
+
+  var returnValue = {
+    path: fullPath,
+    originalContents: originalContents,
+    contents: contentsToWrite,
+    inserted: false
+  };
+
+  if (contentsToWrite !== originalContents) {
+    returnValue.inserted = true;
+
+    return writeFile(fullPath, contentsToWrite)
+      .then(function() {
+        return returnValue;
+      });
+  } else {
+    return Promise.resolve(returnValue);
+  }
+};
+
+
+/*
   @private
   @method _exec
   @param {String} command


### PR DESCRIPTION
- Inserts the provided content into a file (always at the end right now).
- Only inserts once unless `force` option is truthy.

Inspired by `Thor#insert_into_file`.

Future additons will include more options:
- `before` - Insert before given string/regex.
- `after` - Insert after a given string/regex.
