### PR TITLE
Provide useful error message when styles/app.[ext] is not found

### DIFF
--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -15,7 +15,14 @@ StylePlugin.prototype.constructor = StylePlugin;
 StylePlugin.prototype._superConstructor = Plugin;
 
 StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
-  var input = path.join(inputPath, 'app.' + this.getExt(inputPath, 'app'));
+  var ext = this.getExt(inputPath, 'app');
+
+  if (!ext) {
+    var attemptedExtensions = Array.isArray(this.ext) ? this.ext : [this.ext];
+    throw new Error('app/styles/app.[' + attemptedExtensions.join('/') + '] does not exist');
+  }
+
+  var input = path.join(inputPath, 'app.' + ext);
   var output = path.join(outputPath, this.applicationName + '.css');
 
   return requireLocal(this.name).call(null, [tree], input, output, merge({}, this.options, options));


### PR DESCRIPTION
To avoid future developer confusion as witnessed on issue #1641. This PR provides improved error messaging to assist developers in debugging their applications; it does not fix any actual bugs [since the problem is not really a bug].
