### PR TITLE
Update app blueprint's package.json/bower.sjon to depend on ember-data directly

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,6 +4,7 @@
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
     "ember": "1.7.0",
+    "ember-data": "1.0.0-beta.10",
     "ember-resolver": "~0.1.7",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-ember-data": "0.1.1",
+    "ember-data": "1.0.0-beta.10",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.1.0",


### PR DESCRIPTION
Once ~~https://github.com/emberjs/data/pull/2238 is merged and~~ a release is published in npm we can swap out `ember-cli-ember-data`.

~~I'm not sure if we want to depend directly on an exact beta version, i.e. `1.0.0-beta.9` and keep updating it or if we should just use `1.0.0` so it'll auto install the latest beta?~~
