### PR TITLE
Do not require build related packages for every boot.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -6,11 +6,6 @@ var deprecate   = require('../utilities/deprecate');
 var assign      = require('lodash-node/modern/objects/assign');
 var glob        = require('glob');
 var pickFiles   = require('../broccoli/custom-static-compiler');
-var compileES6  = require('broccoli-es6-concatenator');
-var mergeTrees  = require('broccoli-merge-trees');
-var jshintTrees = require('broccoli-jshint');
-var concatFiles = require('broccoli-concat');
-var fileMover   = require('broccoli-file-mover');
 var SilentError = require('../errors/silent');
 
 var p                   = require('../preprocessors');
@@ -31,6 +26,14 @@ function Addon(project) {
 
 Addon.__proto__ = CoreObject;
 Addon.prototype.constructor = Addon;
+
+Addon.prototype._requireBuildPackages = function() {
+  this.compileES6  = this.compileES6 || require('broccoli-es6-concatenator');
+  this.mergeTrees  = this.mergeTrees || require('broccoli-merge-trees');
+  this.jshintTrees = this.jshintTrees|| require('broccoli-jshint');
+  this.concatFiles = this.concatFiles|| require('broccoli-concat');
+  this.fileMover   = this.fileMover  || require('broccoli-file-mover');
+};
 
 Addon.prototype._unwatchedTreeGenerator = function unwatchedTree(dir) {
   return {
@@ -66,6 +69,8 @@ Addon.prototype.treePaths = {
 };
 
 Addon.prototype.treeFor = function treeFor(name) {
+  this._requireBuildPackages();
+
   var tree;
   var trees = [];
 
@@ -77,7 +82,7 @@ Addon.prototype.treeFor = function treeFor(name) {
     trees.push(this.jshinting());
   }
 
-  return mergeTrees(trees);
+  return this.mergeTrees(trees);
 };
 
 Addon.prototype._treeFor = function _treeFor(name) {
@@ -116,20 +121,24 @@ Addon.prototype.includedModules = function() {
 };
 
 Addon.prototype.treeForAddon = function(tree) {
+  this._requireBuildPackages();
+
   var addonTree = this.compileAddon(tree);
   var stylesTree = this.compileStyles(this._treeFor('addon-styles'));
   var templatesTree = this.compileTemplates(this._treeFor('addon-templates'));
 
-  var jsTree = concatFiles(mergeTrees([addonTree, templatesTree].filter(Boolean)), {
+  var jsTree = this.concatFiles(this.mergeTrees([addonTree, templatesTree].filter(Boolean)), {
     inputFiles: ['*.js', '**/*.js'],
     outputFile: '/' + this.name + '.js',
     allowNone: true
   });
 
-  return mergeTrees([jsTree, stylesTree].filter(Boolean));
+  return this.mergeTrees([jsTree, stylesTree].filter(Boolean));
 };
 
 Addon.prototype.compileStyles = function(tree) {
+  this._requireBuildPackages();
+
   if (tree) {
     var styleFiles = pickFiles(tree, {
       srcDir: '/styles',
@@ -138,7 +147,7 @@ Addon.prototype.compileStyles = function(tree) {
     var processedStyles = preprocessCss(styleFiles, '/', '/', {
       registry: this.registry
     });
-    return fileMover(processedStyles, {
+    return this.fileMover(processedStyles, {
       srcFile: '/' + this.app.name + '.css',
       destFile: '/' + this.name + '.css'
     });
@@ -146,33 +155,37 @@ Addon.prototype.compileStyles = function(tree) {
 };
 
 Addon.prototype.compileTemplates = function(tree) {
+  this._requireBuildPackages();
+
   if (tree) {
-    var standardTemplates = pickFiles(tree, {
+    var standardTemplates = this.pickFiles(tree, {
       srcDir: '/',
       destDir: this.name + '/templates'
     });
 
-    var podTemplates = pickFiles(tree, {
+    var podTemplates = this.pickFiles(tree, {
       srcDir: '/',
       files: ['**/template.*'],
       destDir: this.name + '/',
       allowEmpty: true
     });
 
-    return preprocessTemplates(mergeTrees([standardTemplates, podTemplates]), {
+    return preprocessTemplates(this.mergeTrees([standardTemplates, podTemplates]), {
       registry: this.registry
     });
   }
 };
 
 Addon.prototype.compileAddon = function(tree) {
+  this._requireBuildPackages();
+
   if (Object.keys(this.includedModules()).length === 0) {
     return;
   }
 
   var addonJs = this.addonJsFiles(tree);
 
-  var es6Tree = compileES6(addonJs, {
+  var es6Tree = this.compileES6(addonJs, {
     ignoredModules: Object.keys(this.app.importWhitelist),
     inputFiles: [this.name + '/**/*.js'],
     wrapInEval: this.app.options.wrapInEval,
@@ -185,12 +198,14 @@ Addon.prototype.compileAddon = function(tree) {
 };
 
 Addon.prototype.jshinting = function() {
+  this._requireBuildPackages();
+
   var addonJs = this.addonJsFiles('addon');
-  var jshintedAddon = jshintTrees(addonJs, {
+  var jshintedAddon = this.jshintTrees(addonJs, {
     jshintrcPath: this.app.options.jshintrc.app,
     description: 'JSHint - Addon'
   });
-  return pickFiles(jshintedAddon, {
+  return this.pickFiles(jshintedAddon, {
     srcDir: '/',
     destDir: this.name + '/tests/'
   });


### PR DESCRIPTION
Requiring these at the top of the file means that for every start of the `ember` binary these packages are loaded up.
- Doing the requires lazily speeds things up.
- Requiring `broccoli-es6-concatenator` at boot makes `ember-cli` > 0.0.40 impossible to use for building Ember (or any tool that uses an alternate ES6 concatenator) due to a bug with `es6ify`.
