### PR TITLE
Allow array of paths to the preprocessCss phase

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -85,20 +85,7 @@ function EmberApp(options) {
     wrapInEval: !isProduction,
     storeConfigInMeta: true,
     autoRun: true,
-    outputPaths: {
-      app: {
-        css: '/assets/' + this.name + '.css',
-        js: '/assets/' + this.name + '.js'
-      },
-      vendor: {
-        css: '/assets/vendor.css',
-        js: '/assets/vendor.js'
-      },
-      testSupport: {
-        css: '/assets/test-support.css',
-        js: '/assets/test-support.js'
-      }
-    },
+    outputPaths: {},
     minifyCSS: {
       enabled: !!isProduction,
       options: { relativeTo: 'app/styles' }
@@ -114,6 +101,24 @@ function EmberApp(options) {
     trees: {},
     jshintrc: {},
     vendorFiles: {}
+  }, defaults);
+
+  // needs a deeper merge than is provided above
+  this.options.outputPaths = merge(this.options.outputPaths, {
+    app: {
+      css: {
+        'app': '/assets/' + this.name + '.css'
+      },
+      js: '/assets/' + this.name + '.js'
+    },
+    vendor: {
+      css: '/assets/vendor.css',
+      js: '/assets/vendor.js'
+    },
+    testSupport: {
+      css: '/assets/test-support.css',
+      js: '/assets/test-support.js'
+    }
   }, defaults);
 
   this.vendorFiles = omit(merge({
@@ -698,10 +703,9 @@ EmberApp.prototype.styles = function() {
     description: 'TreeMerger (stylesAndVendor)'
   });
 
-  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', {
-    registry: this.registry
-  });
-
+  var options = { outputPaths: this.options.outputPaths.app.css };
+  options.registry = this.registry;
+  var processedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
   var vendorStyles    = concatFiles(stylesAndVendor, {
     inputFiles: this.vendorStaticStyles.concat(['vendor/addons.css']),
     outputFile: this.options.outputPaths.vendor.css,
@@ -709,7 +713,7 @@ EmberApp.prototype.styles = function() {
   });
 
   if (this.options.minifyCSS.enabled === true) {
-    var options = this.options.minifyCSS.options || {};
+    options = this.options.minifyCSS.options || {};
     options.registry = this.registry;
     processedStyles = preprocessMinifyCss(processedStyles, options);
     vendorStyles    = preprocessMinifyCss(vendorStyles, options);

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -56,10 +56,15 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
       srcDir: inputPath,
 
       getDestinationPath: function(relativePath) {
-        if (relativePath === 'app.css' && options.registry.app.options) {
+        if (options.outputPaths) {
           // options.outputPaths is not present when compiling
           // an addon's styles
-          return options.registry.app.options.outputPaths.app.css;
+          var path = relativePath.replace(/\.css$/, '');
+
+          // is a rename rule present?
+          if (options.outputPaths[path]) {
+            return options.outputPaths[path];
+          }
         }
 
         return outputPath + '/' + relativePath;

--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -5,6 +5,7 @@ var Plugin       = require('./plugin');
 var requireLocal = require('../utilities/require-local');
 var merge        = require('lodash-node/modern/objects/merge');
 var SilentError  = require('../errors/silent');
+var mergeTrees   = require('broccoli-merge-trees');
 
 function StylePlugin () {
   this.type = 'css';
@@ -16,17 +17,23 @@ StylePlugin.prototype.constructor = StylePlugin;
 StylePlugin.prototype._superConstructor = Plugin;
 
 StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
-  var ext = this.getExt(inputPath, 'app');
+  options = merge({}, this.options, options);
+  var _this = this,
+      paths = options.outputPaths;
 
-  if (!ext) {
-    var attemptedExtensions = Array.isArray(this.ext) ? this.ext : [this.ext];
-    throw new SilentError('app/styles/app.[' + attemptedExtensions.join('/') + '] does not exist');
-  }
+  var trees = Object.keys(paths).map(function (file) {
+    var ext = _this.getExt(inputPath, file);
+    if (!ext) {
+      var attemptedExtensions = Array.isArray(_this.ext) ? _this.ext : [_this.ext];
+      throw new SilentError('app/styles/' + file + '.[' + attemptedExtensions.join('/') + '] does not exist');
+    }
+    var input = path.join(inputPath, file + '.' + ext);
+    var output = paths[file];
 
-  var input = path.join(inputPath, 'app.' + ext);
-  var output = this.options.app.options.outputPaths.app.css;
+    return requireLocal(_this.name).call(null, [tree], input, output, options);
+  });
 
-  return requireLocal(this.name).call(null, [tree], input, output, merge({}, this.options, options));
+  return mergeTrees(trees);
 };
 
 

--- a/tests/fixtures/brocfile-tests/custom-output-paths/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/custom-output-paths/Brocfile.js
@@ -5,7 +5,10 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 var app = new EmberApp({
   outputPaths: {
     app: {
-      css: '/css/app.css',
+      css: {
+        'app': '/css/app.css',
+        'theme': '/css/theme/a.css'
+      },
       js: '/js/app.js'
     },
     vendor: {

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/Brocfile.js
@@ -1,0 +1,10 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+var app = new EmberApp({
+  name: require('./package.json').name,
+  outputPaths: { app: { css: { 'main': '/assets/main.css', 'theme/a': '/assets/theme/a.css' } } }
+});
+
+module.exports = app.toTree();

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/app.scss
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/app.scss
@@ -1,0 +1,1 @@
+body { background: green; }

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/main.scss
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/main.scss
@@ -1,0 +1,1 @@
+body { background: black; }

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/theme/a.scss
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/app/styles/theme/a.scss
@@ -1,0 +1,1 @@
+.theme { color: red; }

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/broccoli-sass/index.js
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/broccoli-sass/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Writer = require('broccoli-writer');
+
+function copyPreserveSync (src, dest) {
+  var srcStats = fs.statSync(src);
+  if (srcStats.isFile()) {
+    var destDir = path.dirname(dest);
+    var dirs = [];
+    while (destDir && !fs.existsSync(destDir)) {
+      dirs.unshift(destDir);
+      destDir = path.dirname(destDir);
+    }
+    dirs.forEach(function (dir) {
+      fs.mkdirSync(dir);
+    });
+    var content = fs.readFileSync(src);
+    fs.writeFileSync(dest, content, { flag: 'wx' });
+    fs.utimesSync(dest, srcStats.atime, srcStats.mtime);
+  } else {
+    throw new Error('Unexpected file type for ' + src);
+  }
+}
+
+module.exports = SassCompiler;
+SassCompiler.prototype = Object.create(Writer.prototype);
+SassCompiler.prototype.constructor = SassCompiler;
+function SassCompiler (sourceTrees, inputFile, outputFile, options) {
+  if (!(this instanceof SassCompiler)) return new SassCompiler(sourceTrees, inputFile, outputFile, options);
+  if (!Array.isArray(sourceTrees)) throw new Error('Expected array for first argument - did you mean [tree] instead of tree?');
+  this.sourceTrees = sourceTrees;
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+}
+
+SassCompiler.prototype.write = function (readTree, destDir) {
+  var self = this;
+
+  return readTree(this.sourceTrees[0]).then(function (srcDir) {
+    copyPreserveSync(
+      path.join(srcDir, self.inputFile),
+      path.join(destDir, self.outputFile));
+  });
+};

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/broccoli-sass/package.json
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/broccoli-sass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broccoli-sass",
+  "private": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Allow a hash of files in `outputPaths.app.css` to be passed to the CSS preprocessor.

``` js
var app = new EmberApp({
    outputPaths: {
      app: {
        css: {
          'main': '/css/main.css',
          'theme/a': '/css/theme/a.css'
        }
      }
    }
  }
});
module.exports = app.toTree();

// app/styles/main.scss    -> dist/css/main.css
// app/styles/theme/a.scss -> dist/css/theme/a.css
```

_Ensures backwards compatibility_ so that when no paths are configured; `app/styles/app.scss` will still be written to `assets/<app name>.css`

Closes #1656.
