### PR TITLE
cleanup http-proxy blueprint

### DIFF
--- a/blueprints/http-mock/files/server/index.js
+++ b/blueprints/http-mock/files/server/index.js
@@ -1,29 +1,20 @@
-// To use it create some files under `routes/`
-// e.g. `server/routes/ember-hamsters.js`
-//
-// module.exports = function(app) {
-//   app.get('/ember-hamsters', function(req, res) {
-//     res.send('hello');
-//   });
-// };
-
-var bodyParser = require('body-parser');
-var globSync   = require('glob').sync;
-var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
-var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
-
 module.exports = function(app) {
+  var globSync   = require('glob').sync;
+  var bodyParser = require('body-parser');
+  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
+  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
+
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({
     extended: true
   }));
 
-  mocks.forEach(function(route) { route(app)});
+  mocks.forEach(function(route) { route(app); });
 
   // proxy expects a stream, but express will have turned
   // the request stream into an object because bodyParser
   // has run. We have to convert it back to stream:
   // https://github.com/nodejitsu/node-http-proxy/issues/180
   app.use(require('connect-restreamer')());
-  proxies.forEach(function(route) { route(app)});
+  proxies.forEach(function(route) { route(app); });
 };

--- a/blueprints/http-proxy/files/server/index.js
+++ b/blueprints/http-proxy/files/server/index.js
@@ -7,23 +7,23 @@
 //   });
 // };
 
-var bodyParser = require('body-parser');
-var globSync   = require('glob').sync;
-var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
-var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
-
 module.exports = function(app) {
+  var bodyParser = require('body-parser');
+  var globSync   = require('glob').sync;
+  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
+  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
+
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({
     extended: true
   }));
 
-  mocks.forEach(function(route) { route(app)});
+  mocks.forEach(function(route) { route(app); });
 
   // proxy expects a stream, but express will have turned
   // the request stream into an object because bodyParser
   // has run. We have to convert it back to stream:
   // https://github.com/nodejitsu/node-http-proxy/issues/180
   app.use(require('connect-restreamer')());
-  proxies.forEach(function(route) { route(app)});
+  proxies.forEach(function(route) { route(app); });
 };

--- a/blueprints/http-proxy/files/server/proxies/__name__.js
+++ b/blueprints/http-proxy/files/server/proxies/__name__.js
@@ -1,17 +1,14 @@
-var Proxy = require('http-proxy');
-
-// For options, see:
-// https://github.com/nodejitsu/node-http-proxy
-var proxy = Proxy.createProxyServer({});
-
 var proxyPath = '/<%=camelizedModuleName %>';
 
 module.exports = function(app) {
+  // For options, see:
+  // https://github.com/nodejitsu/node-http-proxy
+  var proxy = require('http-proxy').createProxyServer({});
+  var path = require('path');
 
   app.use(proxyPath, function(req, res, next){
     // include root path in proxied request
     req.url = path.join(proxyPath, req.url);
     proxy.web(req, res, { target: '<%=proxyUrl %>' });
-  })
-
+  });
 };

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -810,25 +810,25 @@ describe('Acceptance: ember generate', function() {
   it('http-mock foo', function() {
     return generate(['http-mock', 'foo']).then(function() {
       assertFile('server/index.js', {
-        contains: "var bodyParser = require('body-parser');" + EOL +
-                  "var globSync   = require('glob').sync;" + EOL +
-                  "var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "" + EOL +
-                  "module.exports = function(app) {" + EOL +
+        contains:"module.exports = function(app) {" + EOL +
+                 "  var globSync   = require('glob').sync;" + EOL +
+                 "  var bodyParser = require('body-parser');" + EOL +
+                 "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+                 "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+                 EOL +
                   "  app.use(bodyParser.json());" + EOL +
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
                   "" + EOL +
-                  "  mocks.forEach(function(route) { route(app)});" + EOL +
+                  "  mocks.forEach(function(route) { route(app); });" + EOL +
                   "" + EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
                   "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
                   "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app)});" + EOL +
+                  "  proxies.forEach(function(route) { route(app); });" + EOL +
                   "};"
       });
       assertFile('server/mocks/foo.js', {
@@ -850,25 +850,25 @@ describe('Acceptance: ember generate', function() {
   it('http-mock foo-bar', function() {
     return generate(['http-mock', 'foo-bar']).then(function() {
       assertFile('server/index.js', {
-        contains: "var bodyParser = require('body-parser');" + EOL +
-                  "var globSync   = require('glob').sync;" + EOL +
-                  "var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "" + EOL +
-                  "module.exports = function(app) {" + EOL +
+        contains: "module.exports = function(app) {" + EOL +
+                  "  var globSync   = require('glob').sync;" + EOL +
+                  "  var bodyParser = require('body-parser');" + EOL +
+                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+                  EOL +
                   "  app.use(bodyParser.json());" + EOL +
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
                   "" + EOL +
-                  "  mocks.forEach(function(route) { route(app)});" + EOL +
+                  "  mocks.forEach(function(route) { route(app); });" + EOL +
                   "" + EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
                   "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
                   "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app)});" + EOL +
+                  "  proxies.forEach(function(route) { route(app); });" + EOL +
                   "};"
       });
       assertFile('server/mocks/foo-bar.js', {
@@ -890,44 +890,41 @@ describe('Acceptance: ember generate', function() {
   it('http-proxy foo', function() {
     return generate(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
       assertFile('server/index.js', {
-        contains: "var bodyParser = require('body-parser');" + EOL +
-                  "var globSync   = require('glob').sync;" + EOL +
-                  "var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+        contains: "module.exports = function(app) {" + EOL +
+                  "  var bodyParser = require('body-parser');" + EOL +
+                  "  var globSync   = require('glob').sync;" + EOL +
+                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
+                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
                   EOL +
-                  "module.exports = function(app) {" + EOL +
                   "  app.use(bodyParser.json());" + EOL +
                   "  app.use(bodyParser.urlencoded({" + EOL +
                   "    extended: true" + EOL +
                   "  }));" + EOL +
                   EOL +
-                  "  mocks.forEach(function(route) { route(app)});" + EOL +
+                  "  mocks.forEach(function(route) { route(app); });" + EOL +
                   EOL +
                   "  // proxy expects a stream, but express will have turned" + EOL +
                   "  // the request stream into an object because bodyParser" + EOL +
                   "  // has run. We have to convert it back to stream:" + EOL +
                   "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
                   "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app)});" + EOL +
+                  "  proxies.forEach(function(route) { route(app); });" + EOL +
                   "};"
       });
       assertFile('server/proxies/foo.js', {
-        contains: "var Proxy = require('http-proxy');" + EOL +
-                  EOL +
-                  "// For options, see:" + EOL +
-                  "// https://github.com/nodejitsu/node-http-proxy" + EOL +
-                  "var proxy = Proxy.createProxyServer({});" + EOL +
-                  EOL +
-                  "var proxyPath = '/foo';" + EOL +
+        contains: "var proxyPath = '/foo';" + EOL +
                   EOL +
                   "module.exports = function(app) {" + EOL +
+                  "  // For options, see:" + EOL +
+                  "  // https://github.com/nodejitsu/node-http-proxy" + EOL +
+                  "  var proxy = require('http-proxy').createProxyServer({});" + EOL +
+                  "  var path = require('path');" + EOL +
                   EOL +
                   "  app.use(proxyPath, function(req, res, next){" + EOL +
                   "    // include root path in proxied request" + EOL +
                   "    req.url = path.join(proxyPath, req.url);" + EOL +
                   "    proxy.web(req, res, { target: 'http://localhost:5000' });" + EOL +
-                  "  })" + EOL +
-                  EOL +
+                  "  });" + EOL +
                   "};"
       });
       assertFile('server/.jshintrc', {


### PR DESCRIPTION
- Proxy makes jshint unhappy “redefines global”
- add missing semi-colon
- require it on-demand, as to not negatively impact cli boot
