### PR TITLE
Change bowerDirectory assignment order in case .bowerrc doesn't contain `directory`

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -61,11 +61,11 @@ function EmberApp(options) {
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
 
-  this.bowerDirectory = 'bower_components';
-
   if (fs.existsSync(path.join(this.project.root, '.bowerrc'))) {
     this.bowerDirectory = JSON.parse(fs.readFileSync(path.join(this.project.root, '.bowerrc'))).directory;
   }
+  
+  this.bowerDirectory = this.bowerDirectory || 'bower_components';
 
   if (process.env.EMBER_CLI_TEST_COMMAND) {
     this.tests = true;


### PR DESCRIPTION
This fixes the rare case that someone has a `.bowerrc` file but it doesn't actually have a `directory` prop defined. Before, the code would continue with `this.bowerDirectory === undefined`
