### PR TITLE
Remove `window.MyAppNameENV`.

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -14,8 +14,7 @@
   </head>
   <body>
     <script>
-      window.<%= namespace %>ENV = {{ENV}};
-      window.EmberENV = window.<%= namespace %>ENV.EmberENV;
+      window.EmberENV = {{EMBER_ENV}};
     </script>
     <script src="assets/vendor.js"></script>
     <script src="assets/<%= name %>.js"></script>

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -34,8 +34,7 @@
     <div id="qunit-fixture"></div>
 
     <script>
-      window.<%= namespace %>ENV = {{ENV}};
-      window.EmberENV = window.<%= namespace %>ENV.EmberENV;
+      window.EmberENV = {{EMBER_ENV}};
     </script>
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -229,8 +229,8 @@ EmberApp.prototype.index = function() {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: [ 'index.html' ],
     patterns: [{
-      match: /\{\{ENV\}\}/g,
-      replacement: calculateENV
+      match: /\{\{EMBER_ENV\}\}/g,
+      replacement: calculateEmberENV
     }, {
       match: /\{\{BASE_TAG\}\}/g,
       replacement: calculateBaseTag
@@ -250,8 +250,8 @@ EmberApp.prototype.testIndex = function() {
     files: [ 'tests/index.html' ],
     env: 'test',
     patterns: [{
-      match: /\{\{ENV\}\}/g,
-      replacement: calculateENV
+      match: /\{\{EMBER_ENV\}\}/g,
+      replacement: calculateEmberENV
     }, {
       match: /\{\{BASE_TAG\}\}/g,
       replacement: calculateBaseTag
@@ -714,6 +714,6 @@ function calculateBaseTag(config){
   }
 }
 
-function calculateENV(config) {
+function calculateEmberENV(config) {
   return JSON.stringify(config);
 }


### PR DESCRIPTION
Closes #1895.

I decided to not go with a deprecation for now. Having to manually update your app (and a `0.0.x` number) means it is likely OK to have a bit of upgrading to do.
