### PR TITLE
Introducing `config` hook for addons

### DIFF
--- a/lib/broccoli/broccoli-config-loader.js
+++ b/lib/broccoli/broccoli-config-loader.js
@@ -2,6 +2,7 @@
 
 var fs     = require('fs');
 var path   = require('path');
+var merge = require('lodash-node/modern/objects/merge');
 var Writer = require('broccoli-caching-writer');
 
 function ConfigLoader (inputTree, options) {
@@ -15,6 +16,13 @@ function ConfigLoader (inputTree, options) {
 
 ConfigLoader.prototype = Object.create(Writer.prototype);
 ConfigLoader.prototype.constructor = ConfigLoader;
+
+ConfigLoader.prototype.getAddonsConfig = function(env, appConfig) {
+  var addons = this.options.project.addons;
+  return addons.reduce(function(config, addon) {
+    return  addon.config ? merge(config, addon.config(env, config)) : config;
+  }, appConfig);
+};
 
 ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   var self = this;
@@ -39,7 +47,9 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   }
 
   environments.forEach(function(env) {
-    var config = configGenerator(env);
+    var appConfig = configGenerator(env);
+    var addonsConfig = this.getAddonsConfig(env, appConfig);
+    var config = merge(appConfig, addonsConfig);
     var jsonString = JSON.stringify(config);
     var moduleString = 'export default ' + jsonString + ';';
     var outputPath = path.join(outputDir, env);
@@ -51,7 +61,7 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
     if (self.options.env === env) {
       fs.writeFileSync(defaultPath, moduleString, { encoding: 'utf8' });
     }
-  });
+  }, this);
 };
 
 module.exports = ConfigLoader;

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -172,11 +172,16 @@ EmberApp.prototype.unwatchedVendorTrees = function() {
 
 EmberApp.prototype._notifyAddonIncluded = function() {
   this.initializeAddons();
+  this.configureAddons();
   this.project.addons.forEach(function(addon) {
     if (addon.included) {
       addon.included(this);
     }
   }, this);
+};
+
+EmberApp.prototype.configureAddons = function() {
+  // do something that will make addon `config` hook to fire
 };
 
 EmberApp.prototype.initializeAddons = function() {
@@ -391,7 +396,6 @@ EmberApp.prototype._configTree = function() {
   }
 
   var configPath = this.options.environment || 'config/environment.js';
-
   var configTree = configLoader(path.dirname(configPath), {
     env: this.env,
     tests: this.tests,


### PR DESCRIPTION
Implements: #1907

A new `config` hook is available for addons. It can be used to alternate application configuration (example: toggling FEATURE flags for Ember) or to read the current config and change addon behaviour (example: importing dependencies conditionally).

Interface:

```
// environment - 'development', 'test', 'production'
// currentConfig - hash with config for given environment
config: function(environment, currentConfig) {}
```
