### PR TITLE
Add some documentation about the .ember-cli file.

### DIFF
--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -27,3 +27,14 @@ Additionally, Ember-CLI contains a number of environment-dependent helpers for a
 
 - [Env specific assets](#fingerprinting-and-cdn-urls)
 - [Env specific asset fingerprinting](#environment-specific-assets)
+ 
+It is now also possible to override command line options by creating a file in your app's root directory called `.ember-cli` and placing desired overrides in it.
+
+For example, a common desire is to [change the port](http://stackoverflow.com/questions/24003944/save-port-number-for-ember-cli-in-a-config-file) that ember-cli serves the app from. It's possible to pass the port number directly to ember server in the command line, e.g. `ember serve --port 8080`. If you wish to make this change a permanent conifguration change, make the `.ember-cli` file and add the options you wish to pass to the server in a hash.
+
+```json
+{
+  "port": 8080
+}
+```
+


### PR DESCRIPTION
It took a fair deal of googling to find out that this configuration file is now available. I think it would be very helpful to add mention of it and how to use it directly in the documentation.

I chose to place this information within this file because it's _sort of_ related to a developer's local environment and workflow... but feel it would be great for someone from the Ember-CLI core maintainers to vet both the phrasing and its location.

Thanks for the wonderful tool you've created!
