### PR TITLE
Allow multiple pre-processors per type.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -35,20 +35,24 @@ module.exports.isType = function(file, type, options) {
 };
 
 module.exports.preprocessMinifyCss = function(tree, options) {
-  var plugin = options.registry.load('minify-css');
+  var plugins = options.registry.load('minify-css');
 
-  if (!plugin) {
+  if (plugins.length === 0) {
     var compiler = require('broccoli-clean-css');
     return compiler(tree, options);
+  } else if (plugins.length > 1) {
+    throw new Error('You cannot use more than one minify-css plugin at once.');
   }
+
+  var plugin = plugins[0];
 
   return requireLocal(plugin.name).call(null, tree, options);
 };
 
 module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
-  var plugin = options.registry.load('css');
+  var plugins = options.registry.load('css');
 
-  if (!plugin) {
+  if (plugins.length === 0) {
     var compiler = require('broccoli-static-compiler');
     var fileMover = require('broccoli-file-mover');
 
@@ -70,25 +74,36 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
     });
   }
 
-  return plugin.toTree.apply(plugin, arguments);
+  return processPlugins(plugins, arguments[0], arguments);
 };
 
 module.exports.preprocessTemplates = function(/* tree */) {
   var options = arguments[arguments.length - 1];
-  var plugin = options.registry.load('template');
+  var plugins = options.registry.load('template');
 
-  if (!plugin) {
+  if (plugins.length === 0) {
     throw new Error('Missing template processor');
   }
 
-  return plugin.toTree.apply(plugin, arguments);
+  return processPlugins(plugins, arguments[0], arguments);
 };
 
 module.exports.preprocessJs = function(/* tree, inputPath, outputPath, options */) {
   var options = arguments[arguments.length - 1];
-  var plugin = options.registry.load('js');
+  var plugins = options.registry.load('js');
+  var tree    = arguments[0];
 
-  if (!plugin) { return arguments[0]; }
+  if (plugins.length === 0) { return tree; }
 
-  return plugin.toTree.apply(plugin, arguments);
+  return processPlugins(plugins, tree, arguments);
 };
+
+function processPlugins(plugins, startingTree, args) {
+  var tree = startingTree;
+
+  plugins.forEach(function(plugin) {
+    tree = plugin.toTree.apply(plugin, args);
+  });
+
+  return tree;
+}

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -19,13 +19,13 @@ function Registry(plugins, app) {
 module.exports = Registry;
 
 Registry.prototype.load = function(type) {
-  return this.registry[type].reduce(function(actual, plugin) {
+  var plugins = this.registry[type].map(function(plugin) {
     if(this.availablePlugins.hasOwnProperty(plugin.name)) {
       return plugin;
-    } else {
-      return actual;
     }
-  }.bind(this), null);
+  }.bind(this));
+
+  return plugins.filter(Boolean);
 };
 
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -145,11 +145,11 @@ describe('models/addon.js', function() {
           addon.registry = {
             app: addon,
             load: function() {
-              return {
+              return [{
                 toTree: function(tree) {
                   return tree;
                 }
-              };
+              }];
             },
           };
           addon.included(app);

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -25,54 +25,64 @@ describe('Plugin Loader', function() {
     registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
   });
 
-  it('returns first plugin when only one', function() {
-    var plugin = registry.load('css');
-    assert.equal(plugin.name, 'broccoli-sass');
+  it('returns array of one plugin when only one', function() {
+    var plugins = registry.load('css');
+
+    assert.equal(plugins.length, 1);
+    assert.equal(plugins[0].name, 'broccoli-sass');
   });
 
-  it('returns the correct plugin when there are more than one', function() {
-    registry.availablePlugins = { 'broccoli-ruby-sass': 'latest' };
-    var plugin = registry.load('css');
-    assert.equal(plugin.name, 'broccoli-ruby-sass');
+  it('returns the correct list of plugins when there are more than one', function() {
+    registry.availablePlugins['broccoli-ruby-sass'] = 'latest';
+    var plugins = registry.load('css');
+
+    assert.equal(plugins.length, 2);
+    assert.equal(plugins[0].name, 'broccoli-sass');
+    assert.equal(plugins[1].name, 'broccoli-ruby-sass');
   });
 
   it('returns plugin of the correct type', function() {
     registry.add('js', 'broccoli-coffee');
-    var plugin = registry.load('js');
-    assert.equal(plugin.name, 'broccoli-coffee');
+    var plugins = registry.load('js');
+
+    assert.equal(plugins.length, 1);
+    assert.equal(plugins[0].name, 'broccoli-coffee');
   });
 
   it('returns plugin that was in dependencies', function() {
     registry.add('template', 'broccoli-emblem');
-    var plugin = registry.load('template');
-    assert.equal(plugin.name, 'broccoli-emblem');
+    var plugins = registry.load('template');
+    assert.equal(plugins[0].name, 'broccoli-emblem');
   });
 
   it('returns null when no plugin available for type', function() {
     registry.add('blah', 'not-available');
-    var plugin = registry.load('blah');
-    assert.notOk(plugin, 'loaded a plugin that wasn\'t in dependencies');
+    var plugins = registry.load('blah');
+    assert.equal(plugins.length, 0);
   });
 
   it('returns the configured extension for the plugin', function() {
     registry.add('css', 'broccoli-less-single', 'less');
     registry.availablePlugins = { 'broccoli-less-single': 'latest' };
-    var plugin = registry.load('css');
-    assert.equal(plugin.ext, 'less');
+    var plugins = registry.load('css');
+
+    assert.equal(plugins[0].ext, 'less');
   });
 
   it('can specify fallback extensions', function() {
     registry.availablePlugins = { 'broccoli-ruby-sass': 'latest' };
-    var plugin = registry.load('css');
+    var plugins = registry.load('css');
+    var plugin  = plugins[0];
+
     assert.equal(plugin.ext[0], 'scss');
     assert.equal(plugin.ext[1], 'sass');
   });
 
   it('provides the application name to each plugin', function() {
     registry.add('js', 'broccoli-coffee');
-    var plugin = registry.load('js');
+    var plugins = registry.load('js');
 
-    assert.equal(plugin.applicationName, 'some-application-name');
+    assert.equal(plugins[0].applicationName, 'some-application-name');
   });
 
   it('adds a plugin directly if it is provided', function() {


### PR DESCRIPTION
- `Registry.prototype.load` always returns an array of plugins available.
- The preprocess helper functions chain each plugins output tree into the next ones input.
