### PR TITLE
Fix #1919

### DIFF
--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -24,7 +24,7 @@ StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
   }
 
   var input = path.join(inputPath, 'app.' + ext);
-  var output = this.app.options.outputPaths.app.css;
+  var output = this.options.app.options.outputPaths.app.css;
 
   return requireLocal(this.name).call(null, [tree], input, output, merge({}, this.options, options));
 };


### PR DESCRIPTION
Fix Cannot read property 'options' of undefined when installed `broccoli-sass` v0.2.2
I don't know the intention of this line so I cannot create a test for it.
