### PR TITLE
Remove manual `env === 'production'` checks.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -89,11 +89,11 @@ function EmberApp(options) {
       }
     },
     minifyCSS: {
-      enabled: true,
+      enabled: !!isProduction,
       options: { relativeTo: 'app/styles' }
     },
     minifyJS: {
-      enabled: true,
+      enabled: !!isProduction,
       options: {
         mangle: true,
         compress: true
@@ -509,7 +509,7 @@ EmberApp.prototype.javascript = function() {
 
   var vendorAndApp = mergeTrees([vendor, es6]);
 
-  if (this.env === 'production' && this.options.minifyJS.enabled === true) {
+  if (this.options.minifyJS.enabled === true) {
     var options = this.options.minifyJS.options || {};
     return uglifyJavaScript(vendorAndApp, options);
   } else {
@@ -542,7 +542,7 @@ EmberApp.prototype.styles = function() {
     description: 'concatFiles - vendorStyles'
   });
 
-  if (this.env === 'production' && this.options.minifyCSS.enabled === true) {
+  if (this.options.minifyCSS.enabled === true) {
     var options = this.options.minifyCSS.options || {};
     options.registry = this.registry;
     processedStyles = preprocessMinifyCss(processedStyles, options);


### PR DESCRIPTION
We already have a `enabled` flag for each, why not use it?

Also, folks may need to minify other environemnts.

Closes #1444
