### PR TITLE
Moved modulePrefix to config/environment.js

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -1,14 +1,15 @@
 import Ember from 'ember';
 import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
+import config from './config/environment';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 var App = Ember.Application.extend({
-  modulePrefix: '<%= modulePrefix %>', // TODO: loaded via config
+  modulePrefix: config.modulePrefix,
   Resolver: Resolver
 });
 
-loadInitializers(App, '<%= modulePrefix %>');
+loadInitializers(App, config.modulePrefix);
 
 export default App;

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -2,6 +2,7 @@
 
 module.exports = function(environment) {
   var ENV = {
+    modulePrefix: '<%= modulePrefix %>',
     environment: environment,
     baseURL: '/',
     locationType: 'auto',

--- a/blueprints/app/files/tests/helpers/resolver.js
+++ b/blueprints/app/files/tests/helpers/resolver.js
@@ -1,9 +1,10 @@
 import Resolver from 'ember/resolver';
+import config from '../../config/environment';
 
 var resolver = Resolver.create();
 
 resolver.namespace = {
-  modulePrefix: '<%= modulePrefix %>'
+  modulePrefix: config.modulePrefix
 };
 
 export default resolver;

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import Application from '<%= modulePrefix %>/app';
-import Router from '<%= modulePrefix %>/router';
-import config from '<%= modulePrefix %>/config/environment';
+import Application from '../../app';
+import Router from '../../router';
+import config from '../../config/environment';
 
 export default function startApp(attrs) {
   var App;


### PR DESCRIPTION
This is what I'm doing in my apps...but I have a `modulePrefix` that differs from the project name so maybe this isn't what you all intended by the "TODO: loaded via config"
