### PR TITLE
Indicate tests as a directory in package.json

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "directories": {
     "doc": "doc",
-    "test": "test"
+    "test": "tests"
   },
   "scripts": {
     "start": "ember server",


### PR DESCRIPTION
Ember-cli uses a tests directory, not test as indicated in the blueprint
- The blueprint for app/files/package.con indicated `test` not `tests`
