### PR TITLE
Move testing dependencies to "devDependencies"

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -7,8 +7,10 @@
     "ember-resolver": "~0.1.7",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
+    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2"
+  },
+  "devDependencies": {
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"


### PR DESCRIPTION
This pull request puts testing-related Bower dependencies under `devDependencies`.

These dependencies can be omitted when installing by running `bower install --production`. A deployment script (the Heroku buildpack, for example) could use this flag to avoid downloading these dependencies when they're not necessary. `bower install` without the production flag will install both `dependencies` and `devDependencies`, so everything will continue to work the same during the initial project setup.
