### PR TITLE
Updates broccoli-asset-rev to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### master
 
+* [ENHANCEMENT] Update `broccoli-asset-rev`to `0.1.1`
+
 ### 0.0.44
 
 #### Applications

--- a/blueprints/addon/files/package.json
+++ b/blueprints/addon/files/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.0.17",
+    "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.1",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.0.17",
+    "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-ember-data": "0.1.1",

--- a/tests/fixtures/dummy-project-outdated/package.json
+++ b/tests/fixtures/dummy-project-outdated/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.0.17",
+    "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.5.0",
     "ember-cli": "0.0.1",
     "ember-cli-ember-data": "0.1.1",


### PR DESCRIPTION
broccoli-asset-rev was updated to avoid deprecation warnings. It is currently configured to have a `main` entry in the `package.json` for standard broccoli usage. It also has an index.js in the root of the module to function as the ember addon. Please let me know if it is configured incorrectly or could be better. Thanks!
