### PR TITLE
Limit concurrent number of copy operations.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -76,7 +76,8 @@ module.exports = Task.extend({
     return ncp(inputPath, this.outputPath, {
       dereference: true,
       clobber: true,
-      stopOnErr: true
+      stopOnErr: true,
+      limit: 2
     });
   },
 


### PR DESCRIPTION
If the output directory contains more than 16 files (for example if you have merged in some fonts/themes/etc) you would get EMFILE errors due to the copy operation.  This limits the concurrency when copying to 2.
