### PR TITLE
Update broccoli-caching-writer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bower": "^1.3.5",
     "bower-config": "0.5.2",
     "broccoli": "0.12.3",
-    "broccoli-caching-writer": "0.4.1",
+    "broccoli-caching-writer": "0.4.2",
     "broccoli-clean-css": "0.2.0",
     "broccoli-concat": "0.0.11",
     "broccoli-es3-safe-recast": "1.0.0",


### PR DESCRIPTION
There was a bug in the `canLink` test functionality in 0.4.0 and 0.4.1 that caused an uncaught exception to be thrown in environments that did not support linking (VMWare Fusion was the example provided).
