### PR TITLE
Remove extra nesting of `addon/styles` tree.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -169,13 +169,10 @@ Addon.prototype.compileStyles = function(tree) {
   this._requireBuildPackages();
 
   if (tree) {
-    var styleFiles = this.pickFiles(tree, {
-      srcDir: '/styles',
-      destDir: '/'
-    });
-    var processedStyles = preprocessCss(styleFiles, '/', '/', {
+    var processedStyles = preprocessCss(tree, '/', '/', {
       registry: this.registry
     });
+
     return this.fileMover(processedStyles, {
       srcFile: '/' + this.app.name + '.css',
       destFile: '/' + this.name + '.css'


### PR DESCRIPTION
The prior code was actually looking for `addon/styles/styles/` which was incorrect.

Closes #1962.

---

I am working up some more addon smoke tests so that these styles scenarios are directly under test, but IMHO this is a good fix for now.
