### PR TITLE
Addon configuration.

### DIFF
--- a/lib/broccoli/broccoli-config-loader.js
+++ b/lib/broccoli/broccoli-config-loader.js
@@ -2,7 +2,6 @@
 
 var fs     = require('fs');
 var path   = require('path');
-var merge = require('lodash-node/modern/objects/merge');
 var Writer = require('broccoli-caching-writer');
 
 function ConfigLoader (inputTree, options) {
@@ -17,20 +16,17 @@ function ConfigLoader (inputTree, options) {
 ConfigLoader.prototype = Object.create(Writer.prototype);
 ConfigLoader.prototype.constructor = ConfigLoader;
 
-ConfigLoader.prototype.getAddonsConfig = function(env, appConfig) {
-  var addons = this.options.project.addons;
-  return addons.reduce(function(config, addon) {
-    return  addon.config ? merge(config, addon.config(env, config)) : config;
-  }, appConfig);
+ConfigLoader.prototype.clearConfigGeneratorCache = function() {
+  var configPath = this.options.project.configPath();
+
+  // clear the previously cached version of this module
+  delete require.cache[configPath];
 };
 
 ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   var self = this;
-  var configPath = path.join(this.options.project.root, srcDir, 'environment.js');
 
-  // clear the previously cached version of this module
-  delete require.cache[configPath];
-  var configGenerator = require(configPath);
+  this.clearConfigGeneratorCache();
 
   var outputDir = path.join(destDir, 'environments');
   fs.mkdirSync(outputDir);
@@ -47,9 +43,7 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   }
 
   environments.forEach(function(env) {
-    var appConfig = configGenerator(env);
-    var addonsConfig = this.getAddonsConfig(env, appConfig);
-    var config = merge(appConfig, addonsConfig);
+    var config = self.options.project.config(env);
     var jsonString = JSON.stringify(config);
     var moduleString = 'export default ' + jsonString + ';';
     var outputPath = path.join(outputDir, env);

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -175,16 +175,11 @@ function EmberApp(options) {
 
 EmberApp.prototype._notifyAddonIncluded = function() {
   this.initializeAddons();
-  this.configureAddons();
   this.project.addons.forEach(function(addon) {
     if (addon.included) {
       addon.included(this);
     }
   }, this);
-};
-
-EmberApp.prototype.configureAddons = function() {
-  // do something that will make addon `config` hook to fire
 };
 
 EmberApp.prototype.initializeAddons = function() {
@@ -424,7 +419,8 @@ EmberApp.prototype._configTree = function() {
   var configTree = configLoader(path.dirname(configPath), {
     env: this.env,
     tests: this.tests,
-    project: this.project
+    project: this.project,
+    configPath: configPath
   });
 
   this._cachedConfigTree = pickFiles(configTree, {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -9,6 +9,7 @@ var assign  = require('lodash-node/modern/objects/assign');
 var DAG     = require('../utilities/DAG');
 var Command = require('../models/command');
 var Addon   = require('../models/addon');
+var merge   = require('lodash-node/modern/objects/merge');
 
 var emberCLIVersion = require('../utilities/ember-cli-version');
 
@@ -48,17 +49,39 @@ Project.prototype.isEmberCLIAddon = function() {
   return this.pkg.keywords && this.pkg.keywords.indexOf('ember-addon') > -1;
 };
 
-Project.prototype.config = function(env) {
+Project.prototype.configPath = function() {
   var configPath = 'config';
 
   if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
     configPath = this.pkg['ember-addon']['configPath'];
   }
-  if (fs.existsSync(path.join(this.root, configPath, 'environment.js'))) {
-    return this.require('./' + path.join(configPath, 'environment'))(env);
+
+  return path.join(configPath, 'environment');
+};
+
+Project.prototype.config = function(env) {
+  var configPath = this.configPath();
+
+  if (fs.existsSync(path.join(this.root, configPath + '.js'))) {
+    var appConfig = this.require('./' + configPath)(env);
+    var addonsConfig = this.getAddonsConfig(env, appConfig);
+
+    return merge(addonsConfig, appConfig);
   } else {
-    return { };
+    return this.getAddonsConfig(env, {});
   }
+};
+
+Project.prototype.getAddonsConfig = function(env, appConfig) {
+  this.initializeAddons();
+
+  return this.addons.reduce(function(config, addon) {
+    if (addon.config) {
+      merge(config, addon.config(env, config));
+    }
+
+    return config;
+  }, appConfig);
 };
 
 Project.prototype.has = function(file) {
@@ -134,6 +157,10 @@ Project.prototype.addIfAddon = function(addonPath) {
 };
 
 Project.prototype.initializeAddons = function() {
+  if (this._addonsInitialized) {
+    return;
+  }
+
   var project         = this;
   var graph           = new DAG();
   var addon, emberAddonConfig;
@@ -154,6 +181,8 @@ Project.prototype.initializeAddons = function() {
 
     project.addons.push(new AddonConstructor(project));
   });
+
+  this._addonsInitialized = true;
 };
 
 Project.prototype.addonCommands = function() {

--- a/tests/unit/broccoli/config-loader-test.js
+++ b/tests/unit/broccoli/config-loader-test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var fs           = require('fs');
+var path         = require('path');
+var ConfigLoader = require('../../../lib/broccoli/broccoli-config-loader');
+var assert       = require('assert');
+var root         = process.cwd();
+var tmp          = require('tmp-sync');
+var tmproot      = path.join(root, 'tmp');
+var rimraf       = require('rimraf');
+
+describe('broccoli/broccoli-config-loader', function() {
+  var configLoader, tmpDestDir, tmpSrcDir,  project, options;
+
+  beforeEach(function() {
+    tmpDestDir   = tmp.in(tmproot);
+    tmpSrcDir    = tmp.in(tmproot);
+
+    project = {
+      root: tmpSrcDir,
+      addons: [],
+      configPath: function() {
+        return 'config/environment';
+      },
+
+      config: function(env) {
+        return {
+          env: env,
+          foo: 'bar',
+          baz: 'qux'
+        };
+      }
+    };
+
+    options = {
+      env: 'development',
+      tests: true,
+      project: project
+    };
+
+    configLoader = new ConfigLoader('.', options);
+  });
+
+  afterEach(function() {
+    rimraf.sync(tmpDestDir);
+  });
+
+  describe('updateCache', function() {
+    it('writes the current environments file', function() {
+      configLoader.updateCache(tmpSrcDir, tmpDestDir);
+
+      assert(fs.existsSync(path.join(tmpDestDir, 'environment.js')));
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.js')));
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
+
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'test.js')));
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
+    });
+
+    it('does not generate test environment files if testing is disabled', function() {
+      options.tests = false;
+      configLoader.updateCache(tmpSrcDir, tmpDestDir);
+
+      assert(fs.existsSync(path.join(tmpDestDir, 'environment.js')));
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.js')));
+      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
+
+      assert(!fs.existsSync(path.join(tmpDestDir, 'environments', 'test.js')));
+      assert(!fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
+    });
+  });
+});


### PR DESCRIPTION
- Replaces #1914.
- Adds basic unit tests for `updateCache` method.
- Add `Project.prototype.configPath`.
- Add `Project.prototype.getAddonConfig`.
- Update `Project.prototype.config` to merge addon config with application config.
  - Ensure that app config ALWAYS wins.
  - If no app config exists, return addon config result.
