### PR TITLE
Removed broccoli-sweetjs from registry since it doesn't work.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -15,7 +15,6 @@ module.exports.setupRegistry = function(app) {
   registry.add('minify-css', 'broccoli-csso', null);
 
   registry.add('js', 'broccoli-ember-script', 'em');
-  registry.add('js', 'broccoli-sweetjs', 'js');
 
   registry.add('template', 'broccoli-ember-hbs-template-compiler', ['hbs', 'handlebars']);
   registry.add('template', 'broccoli-emblem-compiler', ['embl', 'emblem']);


### PR DESCRIPTION
If you try and use it, you'll simply get `Unknown statement type: ImportDeclaration` because sweetjs doesn't know about ES6 modules yet.

/per @rwjblue 
