### PR TITLE
Specified name for Leek

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -32,6 +32,7 @@ function cli(options) {
   var leek = new Leek({
     trackingCode: trackingCode,
     globalName:   name,
+    name:         name,
     version:      version,
     silent:       config.get('disableAnalytics')
   });


### PR DESCRIPTION
After cloning the latest ember-cli I get the following error:

``` js
ember-cli/node_modules/leek/lib/leek.js:21
    throw new Error('You need to specify the name.');
          ^
Error: You need to specify the name.
    at new Leek (ember-cli/node_modules/leek/lib/leek.js:21:11)
    at cli (ember-cli/lib/cli/index.js:32:14)
    at ember-cli/bin/ember:25:3
    at ember-cli/node_modules/resolve/lib/async.js:48:21
    at ember-cli/node_modules/resolve/lib/async.js:127:35
    at ember-cli/node_modules/resolve/lib/async.js:99:39
    at ember-cli/node_modules/resolve/lib/async.js:65:30
    at ember-cli/node_modules/resolve/lib/async.js:23:18
    at Object.oncomplete (fs.js:107:15)
```

Adding a name property fixes it.
