### PR TITLE
Use the passed app tree for styles and tests

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -145,10 +145,10 @@ function EmberApp(options) {
 
     // these are contained within app/ no need to watch again
     styles: unwatchedTree(
-      (this.options.trees ? (this.options.trees.app ? this.options.trees.app : 'app') : 'app') + '/styles'
+      (this.options.trees.app ? this.options.trees.app : 'app') + '/styles'
     ),
     templates: unwatchedTree(
-      (this.options.trees ? (this.options.trees.app ? this.options.trees.app : 'app') : 'app') + '/templates'
+      (this.options.trees.app ? this.options.trees.app : 'app') + '/templates'
     ),
 
     // do not watch vendor/ or bower's default directory by default


### PR DESCRIPTION
If your application lives somewhere other than 'app' this blows up.  Probably more things that need to be fixed like this, if you're going to run multiple app builds.  This the first thing I ran into.
