### PR TITLE
Fix model-test blueprint.

### DIFF
--- a/blueprints/model-test/files/tests/unit/models/__name__-test.js
+++ b/blueprints/model-test/files/tests/unit/models/__name__-test.js
@@ -11,5 +11,5 @@ moduleForModel('<%= dasherizedModuleName %>', '<%= classifiedModuleName %>', {
 test('it exists', function() {
   var model = this.subject();
   // var store = this.store();
-  ok(model);
+  ok(!!model);
 });


### PR DESCRIPTION
Passing a model (anything with a `toJSON` actually) into a test assertion causes infinite loop with Testem.

Steps:
- Do an assert in your test like ok(store.find('person', 1), "record
  exists")
- QUnit stores the assertion in a test object.
- The test finishes so the record is destroyed automatically.
- QUnit notifies listeners the test is over.
- Testem listens for test end notification and attempts to ensure that
  there are no cycles in it by calling `JSON.parse(JSON.stringify(testObject))`.
- Calls `toJSON()` recursively, including any destroyed object that was
  used in an assertion.

Watch as tests hang when running ember test but work fine everywhere else.

Thanks to @tomdale for identifying  and tracking the above steps down.

Closes: #1970.
