### PR TITLE
Fix NotFoundError's constructor property.

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -272,8 +272,8 @@ function NotFoundError(message) {
   this.stack = (new Error()).stack;
 }
 
-NotFoundError.constructor = NotFoundError;
 NotFoundError.prototype = Object.create(Error.prototype);
+NotFoundError.prototype.constructor = NotFoundError;
 
 Project.NotFoundError = NotFoundError;
 


### PR DESCRIPTION
The correct subclassing pattern is to set the prototype's `constructor` property after setting up the class's prototype. NotFoundError's constructor should remain `Function`, since it is an instance of `Function`.
