### PR TITLE
Do not use non-standard `String#contains` which may not be available.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -41,7 +41,7 @@ module.exports = Task.extend({
   },
 
   canDeleteOutputPath: function(outputPath) {
-    return !this.project.root.contains(outputPath);
+    return this.project.root.indexOf(outputPath) === -1;
   },
 
   /**


### PR DESCRIPTION
In the tests the traceur runtime (included with es6-module-transpiler < v0.4.x) polyfills `String#contains`. When not including anything polyfilling this it will not be available.

This is the error I get:

```
$ ember build --watch
version: 0.0.44
Building...
undefined is not a function
TypeError: undefined is not a function
    at Class.module.exports.Task.extend.canDeleteOutputPath (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/lib/models/builder.js:44:31)
    at Class.module.exports.Task.extend.clearOutputPath (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/lib/models/builder.js:57:14)
    at Class.module.exports.Task.extend.processBuildResult (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/lib/models/builder.js:86:17)
    at $$$internal$$tryCatch (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:470:16)
    at $$$internal$$invokeCallback (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:482:17)
    at $$$internal$$publish (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:453:11)
    at $$rsvp$asap$$flush (/Users/donovan/Development/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1531:9)
    at process._tickCallback (node.js:343:11)
```

With this `Brocfile.js`:

``` js
var esnext = require('broccoli-esnext');
var compileModules = require('broccoli-es6-module-transpiler');

var src = 'src';
var es5src = esnext(src);
var cjssrc = compileModules(es5src, {
  formatter: 'commonjs'
});

module.exports = cjssrc;
```
