### PR TITLE
The example code doesn't work -- config.ENV should just be ENV

### DIFF
--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -14,9 +14,9 @@ You can access these environment variables in your application code by importing
 For example:
 
 {% highlight javascript linenos %}
-import config from 'your-application-name/config/environment';
+import ENV from 'your-application-name/config/environment';
 
-if (config.ENV.environment === "development") {
+if (ENV.environment === "development") {
   // ...
 }
 {% endhighlight %}


### PR DESCRIPTION
When you import from 'your-app/config/environment' you get the ENV object back. . . not a "config" object, so you should just import it as ENV and use it directly.
