### PR TITLE
Ensure that things loaded by server/index.js override addons.

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -43,11 +43,12 @@ module.exports = Task.extend({
     var ui             = this.ui;
     this.app = require('express')();
 
+    options.project     = this.project;
     options.watcher     = this.watcher;
     options.ui          = this.ui;
 
-    this.processAddonMiddlewares(options);
     this.processAppMiddlewares(options);
+    this.processAddonMiddlewares(options);
 
     this.setupHttpServer();
     return this.listen(options.port, options.host)


### PR DESCRIPTION
Express will always process the first matching middleware.

A couple examples where this is bad:
- If a proxy was setup, it is always hit before any http-mocks you have setup (since it is itself an addon).
- If you want to serve static content (or another express middleware) from `server/index.js` you could never handle requests with an accept header including HTML. If you did, it would have hit the history state addon and just served up `app/index.html`.

In general, it is our policy that the application will always "trump" addon code.

Closes #1997.
