### PR TITLE
Remove broccoli-sweetjs from registry.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -26,6 +26,8 @@ module.exports.isType = function(file, type, options) {
   var plugins   = options.registry.registry[type] || [];
   var extension = path.extname(file).replace('.', '');
 
+  if (extension === type) { return true; }
+
   for (var i = 0; i < plugins.length; i++) {
     if (extension === plugins[i].ext) {
       return true;

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -25,7 +25,7 @@ function Registry(plugins, app) {
 module.exports = Registry;
 
 Registry.prototype.load = function(type) {
-  var plugins = this.registry[type].map(function(plugin) {
+  var plugins = this.registeredForType(type).map(function(plugin) {
     if(this.instantiatedPlugins.indexOf(plugin) > -1 || this.availablePlugins.hasOwnProperty(plugin.name)) {
       return plugin;
     }


### PR DESCRIPTION
Real work by @jayphelps:

> If you try and use it, you'll simply get Unknown statement type: ImportDeclaration because sweetjs doesn't know about ES6 modules yet.

Closes #1973
Closes #2013
