### PR TITLE
[windows] - always split diff using unix line endings

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -60,7 +60,7 @@ FileInfo.prototype.displayDiff = function() {
     var diff = jsdiff.createPatch(
       info.outputPath, result.output.toString(), result.input
     );
-    var lines = diff.split(EOL);
+    var lines = diff.split('\n');
 
     for (var i=0;i<lines.length;i++) {
       info.ui.write(


### PR DESCRIPTION
jsdiff always uses unix line endings `\n` which causes tests to fail on
windows because we are trying to split the result based on enviornment EOL
