### PR TITLE
Add Blueprint.prototype.lookupBlueprint.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -1,12 +1,11 @@
 var fs         = require('fs');
 var path       = require('path');
 var walkSync   = require('walk-sync');
-var Blueprint  = require('../../lib/models/blueprint');
 var stringUtil = require('../../lib/utilities/string');
 var assign     = require('lodash-node/modern/objects/assign');
 var uniq       = require('lodash-node/underscore/arrays/uniq');
 
-module.exports = Blueprint.extend({
+module.exports = {
   description: 'The default blueprint for ember-cli addons.',
 
   afterInstall: function(options) {
@@ -53,14 +52,14 @@ module.exports = Blueprint.extend({
   files: function() {
     if (this._files) { return this._files; }
 
-    var appFiles   = Blueprint.lookup('app').files();
+    var appFiles   = this.lookupBlueprint('app').files();
     var addonFiles = walkSync(path.join(this.path, 'files'));
 
     return this._files = uniq(appFiles.concat(addonFiles));
   },
 
   mapFile: function(file, locals) {
-    var result = Blueprint.prototype.mapFile.call(this, file, locals);
+    var result = this._super.mapFile.call(this, file, locals);
     return this.fileMapper(result);
   },
 
@@ -89,8 +88,8 @@ module.exports = Blueprint.extend({
     if (fs.existsSync(filePath)) {
       return filePath;
     } else {
-      var appBlueprint = Blueprint.lookup('app');
+      var appBlueprint = this.lookupBlueprint('app');
       return path.resolve(appBlueprint.path, 'files', file);
     }
   }
-});
+};

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -649,6 +649,21 @@ Blueprint.prototype._exec = function(command) {
 };
 
 /*
+  Used to retrieve a blueprint with the given name.
+
+  @method lookupBlueprint
+  @param dasherizedName
+  @public
+*/
+Blueprint.prototype.lookupBlueprint = function(dasherizedName) {
+  var projectPaths = this.project ? this.project.blueprintLookupPaths() : [];
+
+  return Blueprint.lookup(dasherizedName, {
+    paths: projectPaths
+  });
+};
+
+/*
   @static
   @method lookup
   @namespace Blueprint

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -579,4 +579,44 @@ describe('Blueprint', function() {
         });
     });
   });
+
+  describe('lookupBlueprint', function() {
+    var blueprint;
+    var ui;
+    var tmpdir;
+    var project;
+    var filename;
+
+    beforeEach(function() {
+      tmpdir    = tmp.in(tmproot);
+      blueprint = new Blueprint(basicBlueprint);
+      ui        = new MockUI();
+      project   = new MockProject();
+
+      // normally provided by `install`, but mocked here for testing
+      project.root = tmpdir;
+      blueprint.project = project;
+      project.blueprintLookupPaths = function() {
+        return [fixtureBlueprints];
+      };
+
+      filename = 'foo-bar-baz.txt';
+    });
+
+    afterEach(function() {
+      rimraf.sync(tmproot);
+    });
+
+    it('can lookup other Blueprints from the project blueprintLookupPaths', function() {
+      var result = blueprint.lookupBlueprint('basic_2');
+
+      assert.equal(result.description, 'Another basic blueprint');
+    });
+
+    it('can find internal blueprints', function() {
+      var result = blueprint.lookupBlueprint('controller');
+
+      assert.equal(result.description, 'Generates a controller of the given type.');
+    });
+  });
 });


### PR DESCRIPTION
Allows custom blueprints to inherit the `files` from another blueprint without requiring `ember-cli` itself.
