### PR TITLE
[windows] split output on unix line endings for blueprint tests

### DIFF
--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -247,7 +247,9 @@ describe('Blueprint', function() {
         })
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
-          var output = ui.output.trim().split(EOL);
+          // Prompts contain \n EOL
+          // Split output on \n since it will have the same affect as spliting on OS specific EOL
+          var output = ui.output.trim().split('\n');
           assert.match(output.shift(), /^installing/);
           assert.match(output.shift(), /Overwrite.*foo.*\?/); // Prompt
           assert.match(output.shift(), /Overwrite.*foo.*No, skip/);
@@ -297,7 +299,9 @@ describe('Blueprint', function() {
           })
           .then(function() {
             var actualFiles = walkSync(tmpdir).sort();
-            var output = ui.output.trim().split(EOL);
+            // Prompts contain \n EOL
+            // Split output on \n since it will have the same affect as spliting on OS specific EOL
+            var output = ui.output.trim().split('\n');
             assert.match(output.shift(), /^installing/);
             assert.match(output.shift(), /Overwrite.*test.*\?/); // Prompt
             assert.match(output.shift(), /Overwrite.*test.*No, skip/);


### PR DESCRIPTION
Looks like inquirer which is used by ui for creating prompts uses unix
line endings instead of enviornment specific. This causes the tests that
split the output to run assertions to fail.

Switched those specific tests to split on unix line endings as that split
the lines at the same place anyway and none of the regex are specific
enough to care about the extra `\r`
