### PR TITLE
Pull `podModulePrefix` from config/environment.js.

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -7,6 +7,7 @@ Ember.MODEL_FACTORY_INJECTIONS = true;
 
 var App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
   Resolver: Resolver
 });
 

--- a/blueprints/app/files/tests/helpers/resolver.js
+++ b/blueprints/app/files/tests/helpers/resolver.js
@@ -4,7 +4,8 @@ import config from '../../config/environment';
 var resolver = Resolver.create();
 
 resolver.namespace = {
-  modulePrefix: config.modulePrefix
+  modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix
 };
 
 export default resolver;


### PR DESCRIPTION
This brings using a custom pod prefix inline with the normal `modulePrefix`.  If not defined (by default it isn't) then it will just fallback to `modulePrefix` (this done
[here](https://github.com/stefanpenner/ember-jj-abrams-resolver/blob/master/packages/ember-resolver/lib/core.js#L171)).

Related: #1994.
