### PR TITLE
Do not share `treePaths` or `treeForMethods` on the prototype.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -19,6 +19,28 @@ function Addon(project) {
   this.registry = p.setupRegistry(this);
   this._didRequiredBuildPackages = false;
 
+  this.treePaths = {
+    app:               'app',
+    styles:            'app/styles',
+    templates:         'app/templates',
+    addon:             'addon',
+    'addon-styles':    'addon/styles',
+    'addon-templates': 'addon/templates',
+    vendor:            'vendor',
+    'test-support':    'test-support',
+    public:            'public'
+  };
+
+  this.treeForMethods = {
+    app:               'treeForApp',
+    styles:            'treeForStyles',
+    templates:         'treeForTemplates',
+    addon:             'treeForAddon',
+    vendor:            'treeForVendor',
+    'test-support':    'treeForTestSupport',
+    public:            'treeForPublic'
+  };
+
   if (!this.name) {
     throw new SilentError('An addon must define a `name` property.');
   }
@@ -62,28 +84,6 @@ Addon.prototype.treeGenerator = function(dir) {
   }
 
   return tree;
-};
-
-Addon.prototype.treePaths = {
-  app:               'app',
-  styles:            'app/styles',
-  templates:         'app/templates',
-  addon:             'addon',
-  'addon-styles':    'addon/styles',
-  'addon-templates': 'addon/templates',
-  vendor:            'vendor',
-  'test-support':    'test-support',
-  public:            'public'
-};
-
-Addon.prototype.treeForMethods = {
-  app:               'treeForApp',
-  styles:            'treeForStyles',
-  templates:         'treeForTemplates',
-  addon:             'treeForAddon',
-  vendor:            'treeForVendor',
-  'test-support':    'treeForTestSupport',
-  public:            'treeForPublic'
 };
 
 Addon.prototype.treeFor = function treeFor(name) {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -17,6 +17,52 @@ var fixturePath = path.resolve(__dirname, '../../fixtures/addon');
 describe('models/addon.js', function() {
   var addon, project, projectPath;
 
+  describe('treePaths and treeForMethods', function() {
+    var FirstAddon, SecondAddon;
+
+    beforeEach(function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+
+      FirstAddon = Addon.extend({
+        name: 'first',
+
+        init: function() {
+          this.treePaths.vendor = 'blazorz';
+          this.treeForMethods.public = 'huzzah!';
+        }
+      });
+
+      SecondAddon = Addon.extend({
+        name: 'first',
+
+        init: function() {
+          this.treePaths.vendor = 'blammo';
+          this.treeForMethods.public = 'boooo';
+        }
+      });
+
+    });
+
+    it('modifying a treePath does not affect other addons', function() {
+      var first = new FirstAddon(project);
+      var second = new SecondAddon(project);
+
+      assert.equal(first.treePaths.vendor, 'blazorz');
+      assert.equal(second.treePaths.vendor, 'blammo');
+    });
+
+    it('modifying a treeForMethod does not affect other addons', function() {
+      var first = new FirstAddon(project);
+      var second = new SecondAddon(project);
+
+      assert.equal(first.treeForMethods.public, 'huzzah!');
+      assert.equal(second.treeForMethods.public, 'boooo');
+    });
+  });
+
   describe('resolvePath', function() {
     before(function() {
       addon = {


### PR DESCRIPTION
When shared on the prototype, any addon that modifies these paths will change the `treePaths.vendor` location for ALL OTHER addons.
