### PR TITLE
Better error messages

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -46,6 +46,8 @@ module.exports = Task.extend({
 
         if (err.message) {
           ui.writeLine(err.message);
+        } else {
+          ui.writeLine(err);
         }
         if (err.file) {
           var file = err.file;
@@ -54,7 +56,9 @@ module.exports = Task.extend({
           }
           ui.writeLine('File: ' + file);
         }
-        ui.writeLine(err.stack);
+        if (err.stack) {
+          ui.writeLine(err.stack);
+        }
 
         return 1;
       });

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -75,8 +75,14 @@ module.exports = Task.extend({
   },
 
   didError: function(error) {
-    this.ui.writeLine(chalk.red(error.message));
-    this.ui.writeLine(error.stack);
+    if (error.message) {
+      this.ui.writeLine(chalk.red(error.message));
+    } else {
+      this.ui.writeLine(chalk.red(error));
+    }
+    if (error.stack) {
+      this.ui.writeLine(error.stack);
+    }
 
     this.analytics.trackError({
       description: error.message + ' ' + error.stack,


### PR DESCRIPTION
It's possible to make broccoli / ember-cli fail with rejection values that aren't exceptions. A simple way to demonstrate this is to create a fresh ember-cli app and put a broken symlink in `public`. The resulting output looks like this:

```
$ ember build
version: 0.0.46
Build failed.
undefined
```

```
$ ember serve
version: 0.0.46
Livereload server on port 35729
Serving on http://0.0.0.0:4200
undefined
undefined
```

After this patch, you get the following instead:

```
$ ember build
version: 0.0.46-master-615fd3506d
Build failed.
Error: ENOENT, stat '/Users/edward/hacking/pristine-cli/tmp/tree_merger-tmp_dest_dir-7plRaOF5.tmp/badlink'
```

```
$ ember serve
version: 0.0.46-master-615fd3506d
Livereload server on port 35729
Serving on http://0.0.0.0:4200
Error: ENOENT, stat '/Users/edward/hacking/pristine-cli/tmp/tree_merger-tmp_dest_dir-zfvW7cri.tmp/badlink'
```

Which still isn't awesome, but at least gives you a useful clue about what's breaking your build.
