### PR TITLE
Add `Registry.prototype.remove`.

### DIFF
--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -57,3 +57,28 @@ Registry.prototype.add = function(type, name, extension, options) {
 
   registered.push(plugin);
 };
+
+Registry.prototype.remove = function(type, name) {
+  var registered = this.registeredForType(type);
+  var registeredIndex, instantiatedPluginIndex;
+
+  // plugin is being added directly do not instantiate it
+  if (typeof name === 'object') {
+    instantiatedPluginIndex = this.instantiatedPlugins.indexOf(name);
+    registeredIndex = registered.indexOf(name);
+
+    if (instantiatedPluginIndex !== -1) {
+      this.instantiatedPlugins.splice(instantiatedPluginIndex, 1);
+    }
+  } else {
+    for (var i = 0, l = registered.length; i < l; i++) {
+      if (registered[i].name === name) {
+        registeredIndex = i;
+      }
+    }
+  }
+
+  if (registeredIndex !== -1) {
+    registered.splice(registeredIndex, 1);
+  }
+};

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -116,4 +116,28 @@ describe('Plugin Loader', function() {
       assert.equal(registry.registeredForType('foo'), fooArray);
     });
   });
+
+  it('allows removal of a specified plugin', function() {
+    registry.availablePlugins['broccoli-ruby-sass'] = 'latest';
+    registry.remove('css', 'broccoli-sass');
+
+    var plugins = registry.load('css');
+    assert.equal(plugins.length, 1);
+    assert.equal(plugins[0].name, 'broccoli-ruby-sass');
+  });
+
+  it('allows removal of plugin added as instantiated objects', function() {
+    var randomPlugin, plugins;
+
+    randomPlugin = {name: 'Awesome!'};
+    registry.add('foo', randomPlugin);
+
+    plugins = registry.load('foo');
+    assert.equal(plugins[0], randomPlugin); // precondition
+
+    registry.remove('foo', randomPlugin);
+
+    plugins = registry.load('foo');
+    assert.equal(plugins.length, 0);
+  });
 });


### PR DESCRIPTION
Makes it possible to remove a preregistered plugin.
