### PR TITLE
Allow addon/ to contain any known JS filetypes.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -131,7 +131,8 @@ Addon.prototype.includedModules = function() {
 
   var moduleName = this.moduleName();
   var treePath   = path.join(this.root, this.treePaths['addon']).replace(/\\/g, '/');
-  this._includedModules = glob.sync(path.join(treePath, '**/*.js')).reduce(function(ignoredModules, filePath) {
+
+  this._includedModules = glob.sync(path.join(treePath, this._jsFileGlob())).reduce(function(ignoredModules, filePath) {
     ignoredModules[filePath.replace(treePath, moduleName).slice(0, -3)] = ['default'];
     return ignoredModules;
   }, {});
@@ -157,7 +158,7 @@ Addon.prototype.treeForAddon = function(tree) {
 
   if (addonTree) {
     jsTree = this.concatFiles(addonTree, {
-      inputFiles: ['*.js', '**/*.js'],
+      inputFiles: ['**/*.js'],
       outputFile: '/' + this.name + '.js',
       allowNone: true
     });
@@ -247,12 +248,19 @@ Addon.prototype.jshintAddonTree = function() {
   });
 };
 
+Addon.prototype._jsFileGlob = function() {
+  var extListing = this.registry.extensionsForType('js').join('|');
+
+  return '**/*.+(' + extListing + ')';
+};
+
 Addon.prototype.addonJsFiles = function(tree) {
   this._requireBuildPackages();
 
+
   var files = this.pickFiles(tree, {
     srcDir: '/',
-    files: ['**/*.js'],
+    files: [this._jsFileGlob()],
     destDir: this.name,
     allowEmpty: true
   });

--- a/lib/preprocessors/registry.js
+++ b/lib/preprocessors/registry.js
@@ -30,7 +30,7 @@ Registry.prototype.extensionsForType = function(type) {
 
   var extensions =  registered.reduce(function(memo, plugin) {
     return memo.concat(plugin.ext);
-  }, []);
+  }, [type]);
 
   return uniq(extensions);
 };

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -262,6 +262,10 @@ describe('models/addon.js', function() {
                 }
               }];
             },
+
+            extensionsForType: function() {
+              return ['js'];
+            }
           };
           addon.included(app);
           var tree = addon.treeFor('addon');

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -108,14 +108,14 @@ describe('Plugin Loader', function() {
 
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['scss', 'sass']);
+      assert.deepEqual(extensions, ['css', 'scss', 'sass']);
     });
 
     it('can handle mixed array and non-array extensions', function() {
       registry.add('css', 'broccoli-foo', 'foo');
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['scss', 'sass', 'foo']);
+      assert.deepEqual(extensions, ['css', 'scss', 'sass', 'foo']);
     });
   });
 


### PR DESCRIPTION
This allows usage of `*.coffee` (or any other `js` type preprocessor).

Fixes #2046.
