### PR TITLE
Use the content security policy addon for new applications.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,6 +22,7 @@
     "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
+    "ember-cli-content-security-policy": "0.1.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.1.0",


### PR DESCRIPTION
Closes #1705.

Excerpts from the [repos README](https://github.com/rwjblue/ember-cli-content-security-policy/blob/master/README.md):

---

This addon adds the `Content-Security-Policy` header to response sent from the Ember CLI Express server.  Clearly, Ember CLI is not intended for production use, and neither is this addon. This is intended as a tool to ensure that CSP is kept in the forefront of your thoughts while developing an Ember application.
### Options

This addon is configured via your applications `config/environment.js` file. Two specific properties are used from your projects configuration:
- `contentSecurityPolicyHeader` -- The header to use for CSP (**default: `Content-Security-Policy`**)
- `contentSecurityPolicy` -- This is an object that is used to build the final header value. Each key/value in this object is converted into a key/value pair in the resulting header value.

The default `contentSecurityPolicy` value (if you do not override in your `config/environment.js`) is:

``` javascript
  contentSecurityPolicy: {
    'default-src': 'none',
    'script-src': 'self',
    'connect-src': 'self',
    'img-src': 'self',
    'style-src': 'self'
  }
```

Which is translated into:

```
default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';
```

Please note, that when running `ember serve` with live reload enabled, we also add the `liveReloadPort` to the `connect-src` whitelist.
