### PR TITLE
Only start livereload server when enabled.

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -17,12 +17,18 @@ function createServer() {
 }
 
 module.exports = Task.extend({
-  init: function() {
-    this.liveReloadServer = createServer();
+  liveReloadServer: function() {
+    if (this._liveReloadServer) {
+      return this._liveReloadServer;
+    }
+
+    this._liveReloadServer = createServer();
+    return this._liveReloadServer;
   },
 
+
   listen: function(port) {
-    var server = this.liveReloadServer;
+    var server = this.liveReloadServer();
     return new Promise(function(resolve, reject) {
       server.error = reject;
       server.listen(port, resolve);
@@ -30,26 +36,26 @@ module.exports = Task.extend({
   },
 
   start: function(options) {
+    if (options.liveReload !== true) {
+      return Promise.resolve('Livereload server manually disabled.');
+    }
+
     // Reload on file changes
     this.watcher.on('change', this.didChange.bind(this));
     this.watcher.on('error',  this.didError.bind(this));
 
     // Start LiveReload server
     return this.listen(options.liveReloadPort)
-      .then(this.writeBanner.bind(this, options.liveReload, options.liveReloadPort))
-      .catch(this.writeErrorBanner.bind(this, options.liveReload, options.liveReloadPort));
+      .then(this.writeBanner.bind(this, options.liveReloadPort))
+      .catch(this.writeErrorBanner.bind(this, options.liveReloadPort));
   },
 
-  writeBanner: function(print, port) {
-    if (print) {
-      this.ui.writeLine('Livereload server on port ' + port);
-    }
+  writeBanner: function(port) {
+    this.ui.writeLine('Livereload server on port ' + port);
   },
 
-  writeErrorBanner: function(print, port) {
-    if (print) {
-      throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.');
-    }
+  writeErrorBanner: function(port) {
+    throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.');
   },
 
   didChange: function(results) {
@@ -61,7 +67,7 @@ module.exports = Task.extend({
     }, true);
 
     if (canTrigger) {
-      this.liveReloadServer.changed({
+      this.liveReloadServer().changed({
         body: {
           files: ['LiveReload files']
         }

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -30,11 +30,23 @@ describe('livereload-server', function() {
 
   afterEach(function() {
     try {
-      subject.liveReloadServer.close();
+      if (subject._liveReloadServer) {
+        subject._liveReloadServer.close();
+      }
     } catch (err) { }
   });
 
-  describe('output', function() {
+  describe('start', function() {
+    it('does not start the server if `liveReload` option is not true', function() {
+      return subject.start({
+        liveReloadPort: 1337,
+        liveReload: false
+      }).then(function(output) {
+        assert.equal(output, 'Livereload server manually disabled.');
+        assert(!subject._liveReloadServer);
+      });
+    });
+
     it('correctly indicates which port livereload is present on', function() {
       return subject.start({
         liveReloadPort: 1337,
@@ -62,6 +74,7 @@ describe('livereload-server', function() {
   });
 
   describe('filter pattern', function() {
+    var liveReloadServer;
     var changedCount;
     var oldChanged;
     var stubbedChanged = function() {
@@ -75,9 +88,10 @@ describe('livereload-server', function() {
     };
 
     beforeEach(function() {
+      liveReloadServer = subject.liveReloadServer();
       changedCount = 0;
-      oldChanged = subject.liveReloadServer.changed;
-      subject.liveReloadServer.changed = stubbedChanged;
+      oldChanged = liveReloadServer.changed;
+      liveReloadServer.changed = stubbedChanged;
 
       trackCount = 0;
       oldTrack = subject.analytics.track;
@@ -85,7 +99,7 @@ describe('livereload-server', function() {
     });
 
     afterEach(function() {
-      subject.liveReloadServer.changed = oldChanged;
+      liveReloadServer.changed = oldChanged;
       subject.analytics.track = oldTrack;
       subject.project.liveReloadFilterPatterns = [];
     });


### PR DESCRIPTION
Change internals to create the server instance lazily.

Fixes #2069.
