### PR TITLE
Bump CSP addon version.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-content-security-policy": "0.1.0",
+    "ember-cli-content-security-policy": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.1.0",


### PR DESCRIPTION
Version 0.1.1 now also sets `X-*` headers to support FireFox < 23 and IE10 & IE11.
