### PR TITLE
Move config into meta.

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{BASE_TAG}}
+    {{CONFIG_META}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= name %>.css">

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import Router from '../../router';
-import config from '../../config/environments/test';
+import config from '../../config/environment';
 
 export default function startApp(attrs) {
   var App;

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{BASE_TAG}}
+    {{CONFIG_META}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= name %>.css">

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,5 +1,13 @@
 /* jshint ignore:start */
 
+define('{{MODULE_PREFIX}}/config/environment', [], function() {
+  var metaName = '{{MODULE_PREFIX}}/config/environment';
+  var rawConfig = jQuery('meta[name="' + metaName + '"]').attr('content');
+  var config = JSON.parse(unescape(rawConfig));
+
+  return { 'default': config };
+});
+
 if (runningTests) {
   require('{{MODULE_PREFIX}}/tests/test-helper');
 } else {

--- a/lib/broccoli/broccoli-config-loader.js
+++ b/lib/broccoli/broccoli-config-loader.js
@@ -32,12 +32,6 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   var outputDir = path.join(destDir, 'environments');
   fs.mkdirSync(outputDir);
 
-  var defaultPath = path.join(destDir, 'environment.js');
-
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir);
-  }
-
   var environments = [this.options.env];
   if (this.options.tests) {
     environments.push('test');
@@ -46,16 +40,9 @@ ConfigLoader.prototype.updateCache = function(srcDir, destDir) {
   environments.forEach(function(env) {
     var config = self.options.project.config(env);
     var jsonString = JSON.stringify(config);
-    var moduleString = 'export default ' + jsonString + ';';
     var outputPath = path.join(outputDir, env);
 
-
-    fs.writeFileSync(outputPath + '.js',   moduleString, { encoding: 'utf8' });
     fs.writeFileSync(outputPath + '.json', jsonString,   { encoding: 'utf8' });
-
-    if (self.options.env === env) {
-      fs.writeFileSync(defaultPath, moduleString, { encoding: 'utf8' });
-    }
   }, this);
 };
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* global require, module, escape */
 'use strict';
 
 var fs    = require('fs');
@@ -235,17 +235,27 @@ EmberApp.prototype.index = function() {
   return configReplace(index, this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: [ 'index.html' ],
-    patterns: [{
-      match: /\{\{EMBER_ENV\}\}/g,
-      replacement: calculateEmberENV
-    }, {
-      match: /\{\{BASE_TAG\}\}/g,
-      replacement: calculateBaseTag
-    }, {
-      match: /\{\{APP_CONFIG\}\}/g,
-      replacement: calculateAppConfig
-    }]
+    patterns: this._configReplacePatterns()
   });
+};
+
+EmberApp.prototype._configReplacePatterns = function() {
+  return [{
+    match: /\{\{EMBER_ENV\}\}/g,
+    replacement: calculateEmberENV
+  }, {
+    match: /\{\{BASE_TAG\}\}/g,
+    replacement: calculateBaseTag
+  }, {
+    match: /\{\{APP_CONFIG\}\}/g,
+    replacement: calculateAppConfig
+  }, {
+    match: /\{\{CONFIG_META\}\}/g,
+    replacement: calculateConfigMeta
+  }, {
+    match: /\{\{MODULE_PREFIX\}\}/g,
+    replacement: calculateModulePrefix
+  }];
 };
 
 EmberApp.prototype.testIndex = function() {
@@ -259,13 +269,7 @@ EmberApp.prototype.testIndex = function() {
     configPath: path.join(this.name, 'config', 'environments', 'test.json'),
     files: [ 'tests/index.html' ],
     env: 'test',
-    patterns: [{
-      match: /\{\{EMBER_ENV\}\}/g,
-      replacement: calculateEmberENV
-    }, {
-      match: /\{\{BASE_TAG\}\}/g,
-      replacement: calculateBaseTag
-    }]
+    patterns: this._configReplacePatterns()
   });
 };
 
@@ -444,16 +448,7 @@ EmberApp.prototype._processedEmberCLITree = function() {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: files,
 
-    patterns: [{
-      match: /\{\{EMBER_ENV\}\}/g,
-      replacement: calculateEmberENV
-    }, {
-      match: /\{\{APP_CONFIG\}\}/g,
-      replacement: calculateAppConfig
-    }, {
-      match: /\{\{MODULE_PREFIX\}\}/g,
-      replacement: calculateModulePrefix
-    }]
+    patterns: this._configReplacePatterns()
   });
 
   return this._cachedEmberCLITree = pickFiles(emberCLITree, {
@@ -527,6 +522,11 @@ EmberApp.prototype.javascript = function() {
   var applicationJs       = this.appAndDependencies();
   var legacyFilesToAppend = this.legacyFilesToAppend;
   var appOutputPath       = this.options.outputPaths.app.js;
+
+  var modulePrefix = this.project.config(this.env).modulePrefix;
+  this.importWhitelist[modulePrefix + '/config/environment'] = [
+    'default'
+  ];
 
   var es6 = compileES6(applicationJs, {
     loaderFile: 'vendor/ember-cli/loader.js',
@@ -792,4 +792,9 @@ function calculateAppConfig(config) {
 
 function calculateModulePrefix(config) {
   return config.modulePrefix;
+}
+
+function calculateConfigMeta(config) {
+  return '<meta name="' + config.modulePrefix + '/config/environment" ' +
+         '      content="' + escape(JSON.stringify(config)) + '">';
 }

--- a/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
@@ -1,5 +1,6 @@
 module.exports = function() {
   return  {
+    modulePrefix: 'some-cool-app',
     EmberENV: {
       asdflkmawejf: ';jlnu3yr23'
     }

--- a/tests/unit/broccoli/config-loader-test.js
+++ b/tests/unit/broccoli/config-loader-test.js
@@ -55,14 +55,14 @@ describe('broccoli/broccoli-config-loader', function() {
   describe('clearConfigGeneratorCache', function() {
     it('resets the cache', function() {
       configLoader.updateCache(tmpSrcDir, tmpDestDir);
-      var originalConfig = fs.readFileSync(path.join(tmpDestDir, 'environment.js'), { encoding: 'utf8' });
+      var originalConfig = fs.readFileSync(path.join(tmpDestDir, 'environments', 'development.json'), { encoding: 'utf8' });
 
       config.foo = 'blammo';
       writeConfig(config);
       configLoader.clearConfigGeneratorCache();
 
       configLoader.updateCache(tmpSrcDir, tmpDestDir2);
-      var updatedConfig = fs.readFileSync(path.join(tmpDestDir2, 'environment.js'), { encoding: 'utf8' });
+      var updatedConfig = fs.readFileSync(path.join(tmpDestDir2, 'environments', 'development.json'), { encoding: 'utf8' });
 
       assert.notEqual(originalConfig, updatedConfig);
       assert(updatedConfig.match(/blammo/));
@@ -73,11 +73,7 @@ describe('broccoli/broccoli-config-loader', function() {
     it('writes the current environments file', function() {
       configLoader.updateCache(tmpSrcDir, tmpDestDir);
 
-      assert(fs.existsSync(path.join(tmpDestDir, 'environment.js')));
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.js')));
       assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
-
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'test.js')));
       assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
     });
 
@@ -85,11 +81,7 @@ describe('broccoli/broccoli-config-loader', function() {
       options.tests = false;
       configLoader.updateCache(tmpSrcDir, tmpDestDir);
 
-      assert(fs.existsSync(path.join(tmpDestDir, 'environment.js')));
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.js')));
       assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
-
-      assert(!fs.existsSync(path.join(tmpDestDir, 'environments', 'test.js')));
       assert(!fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
     });
   });


### PR DESCRIPTION
- Adds `{{CONFIG_META}}` to the `app/index.html` and `tests/index.html`.
- Adds module at `<my-app-name>/config/environment` that simply reads the current meta value.
- Removes `<my-app-name>/config/environments/*` from module system output.
- Makes build output the same regardless of environment config.
- Makes injection of custom config information as simple as adding/modifying/customizing the meta contents.

Closes #2059.
