### PR TITLE
Using Ember.$ instead of global jQuery

### DIFF
--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,8 +1,8 @@
 /* jshint ignore:start */
 
-define('{{MODULE_PREFIX}}/config/environment', [], function() {
+define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
   var metaName = '{{MODULE_PREFIX}}/config/environment';
-  var rawConfig = jQuery('meta[name="' + metaName + '"]').attr('content');
+  var rawConfig = Ember.$('meta[name="' + metaName + '"]').attr('content');
   var config = JSON.parse(unescape(rawConfig));
 
   return { 'default': config };


### PR DESCRIPTION
Mostly just an ember-idiomatic thing...and not really all that important...but this also allows someone to potentially use a different version of jQuery for Ember than what the global `jQuery` var is.
