### PR TITLE
Downgrade to loader.js v1.0.1.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember": "1.7.0",
     "ember-data": "1.0.0-beta.10",
     "ember-resolver": "~0.1.7",
-    "loader.js": "stefanpenner/loader.js#2.0.0",
+    "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",


### PR DESCRIPTION
We currently must use 1.0.1 of the loader, due to an inconsistency in ember-qunit's output.  The 1.x branch of loader.js specifically handles this issue, but that was removed for 2.0.0.

ember-qunit has the following modules (abbreviated):

``` javascript
define('ember-qunit', ['./isolated-container'], function() {});
define('ember-qunit/isolated-container', [], function() {});
```

Clearly `isolated-container` is not in the "same level" as the `ember-qunit` module.

---

The build system for ember-qunit is actively being rewritten and should resolve this problem.
