### PR TITLE
[win] delay process.exit when running on windows

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -57,6 +57,18 @@ CLI.prototype.run = function(environment) {
 
     return Promise.resolve(update).then(function() {
       return command.validateAndRun(commandArgs);
+    }).then(function(exitCode) {
+      // TODO: fix this
+      // Possibly this issue: https://github.com/joyent/node/issues/8329
+      // Wait to resolve promise when running on windows.
+      // This ensures that stdout is flushed so acceptance tests get full output
+      return new Promise(function(resolve) {
+        if (process.platform === 'win32') {
+          setTimeout(resolve, 250, exitCode);
+        } else {
+          resolve(exitCode);
+        }
+      });
     });
 
   }.bind(this)).catch(this.logError.bind(this));


### PR DESCRIPTION
This is super hacky but it might be worth including so we can focus on the other tests, and then circle back.
