### PR TITLE
Fix lookupCommand with multiple addon commands

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -49,8 +49,9 @@ module.exports = function(commands, commandName, commandArgs, optionHash) {
   var addonCommand;
   // Attempt to find command within addons
   if (project && project.eachAddonCommand) {
-    project.eachAddonCommand(function(addonName, commands){
+    project.eachAddonCommand(function(addonName, commands) {
       addonCommand = findCommand(commands, commandName);
+      return !addonCommand;
     });
   }
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -10,6 +10,7 @@ var DAG     = require('../utilities/DAG');
 var Command = require('../models/command');
 var Addon   = require('../models/addon');
 var merge   = require('lodash-node/modern/objects/merge');
+var forOwn  = require('lodash-node/modern/objects/forOwn');
 
 var emberCLIVersion = require('../utilities/ember-cli-version');
 
@@ -202,13 +203,13 @@ Project.prototype.addonCommands = function() {
 };
 
 Project.prototype.eachAddonCommand = function(callback) {
-  if(this.initializeAddons && this.addonCommands) {
+  if (this.initializeAddons && this.addonCommands) {
     this.initializeAddons();
     var addonCommands = this.addonCommands();
 
-    Object.keys(addonCommands).forEach(function(addonName){
-      callback(addonName, addonCommands[addonName]);
-    }.bind(this));
+    forOwn(addonCommands, function(commands, addonName) {
+      return callback(addonName, commands);
+    });
   }
 };
 

--- a/tests/fixtures/addon/commands/other-addon-command.js
+++ b/tests/fixtures/addon/commands/other-addon-command.js
@@ -1,0 +1,15 @@
+function Addon() {
+  this.name = "Other Ember CLI Addon Command Test"
+  return this;
+}
+
+Addon.prototype.includedCommands = function() {
+  return {
+    'OtherAddonCommand': {
+      name: 'other-addon-command',
+      aliases: ['oac']
+    }
+  };
+}
+
+module.exports = Addon;

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -7,6 +7,7 @@ var Command       = require('../../../lib/models/command');
 var Project       = require('../../../lib/models/project');
 var MockUI        = require('../../helpers/mock-ui');
 var AddonCommand  = require('../../fixtures/addon/commands/addon-command');
+var OtherCommand  = require('../../fixtures/addon/commands/other-addon-command');
 
 var commands = {
   serve: Command.extend({
@@ -35,7 +36,7 @@ describe('cli/lookup-command.js', function() {
   var project = {
     isEmberCLIProject: function(){ return true; },
     initializeAddons: function() {
-      this.addons = [new AddonCommand()];
+      this.addons = [new AddonCommand(), new OtherCommand()];
     },
     addonCommands: Project.prototype.addonCommands,
     eachAddonCommand: Project.prototype.eachAddonCommand
@@ -77,6 +78,30 @@ describe('cli/lookup-command.js', function() {
     });
 
     expect(command.name).to.equal('addon-command');
+
+    Command = lookupCommand(commands, 'other-addon-command', [], {
+      project: project,
+      ui: ui
+    });
+
+    command = new Command({
+      ui: ui,
+      project: project
+    });
+
+    expect(command.name).to.equal('other-addon-command');
+
+    Command = lookupCommand(commands, 'oac', [], {
+      project: project,
+      ui: ui
+    });
+
+    command = new Command({
+      ui: ui,
+      project: project
+    });
+
+    expect(command.name).to.equal('other-addon-command');
   });
 
   it('lookupCommand() should write out a warning when overriding a core command', function() {


### PR DESCRIPTION
Previously `lookupCommand` iterated through every addon with commands,
reassigning `addonCommand` for each one. As a result, having multiple
addons with commands installed would clobber lookup of all but the last
addon’s commands.

Now it breaks out of the loop as soon as it finds a matching command.
