### PR TITLE
Add `before` and `after` options to Blueprint#insertIntoFile

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -22,6 +22,7 @@ var writeFile   = Promise.denodeify(fs.outputFile);
 var removeFile  = Promise.denodeify(fs.remove);
 var SilentError = require('../errors/silent');
 var CoreObject  = require('core-object');
+var EOL         = require('os').EOL;
 
 module.exports = Blueprint;
 
@@ -756,7 +757,30 @@ Blueprint.prototype.taskFor = function(dasherizedName) {
   present in the current contents, the file will not be changed unless `force` option
   is passed.
 
-  This method currently, only inserts the new contents at the end of the file.
+  If `options.before` is specified, `contentsToInsert` will be inserted before
+  the first instance of that string.  If `options.after` is specified, the
+  contents will be inserted after the first instance of that string.
+  If the string specified by options.before or options.after is not in the file,
+  no change will be made.
+
+  If neither `options.before` nor `options.after` are present, `contentsToInsert`
+  will be inserted at the end of the file.
+
+  Example:
+  ```
+  // app/router.js
+  Router.map(function(){
+  });
+
+  insertIntoFile('app/router.js',
+                 '  this.route("admin");',
+                 {after:'Router.map(function() {'+EOL});
+
+  // new app/router.js
+  Router.map(function(){
+    this.route("admin");
+  });
+  ```
 
   @method insertIntoFile
   @param {String} pathRelativeToProjectRoot
@@ -777,11 +801,29 @@ Blueprint.prototype.insertIntoFile = function(pathRelativeToProjectRoot, content
   var options           = providedOptions || {};
   var alreadyPresent    = originalContents.indexOf(contentsToInsert) > -1;
   var insert            = !alreadyPresent;
+  var insertBehavior    = 'end';
+
+  if (options.before) { insertBehavior = 'before'; }
+  if (options.after)  { insertBehavior = 'after'; }
 
   if (options.force) { insert = true; }
 
   if (insert) {
-    contentsToWrite += contentsToInsert;
+    if (insertBehavior === 'end') {
+      contentsToWrite += contentsToInsert;
+    } else {
+      var contentMarker      = options[insertBehavior];
+      var contentMarkerIndex = contentsToWrite.indexOf(contentMarker);
+
+      if (contentMarkerIndex !== -1) {
+        var insertIndex = contentMarkerIndex;
+        if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
+
+        contentsToWrite = contentsToWrite.slice(0, insertIndex) +
+                          contentsToInsert + EOL +
+                          contentsToWrite.slice(insertIndex);
+      }
+    }
   }
 
   var returnValue = {

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -612,6 +612,126 @@ describe('Blueprint', function() {
           assert(result.inserted, 'inserted should indicate that the file was not modified');
         });
     });
+
+    it('will insert into the file after a specified string if options.after is specified', function(){
+      var toInsert = 'blahzorz blammo';
+      var line1 = 'line1 is here';
+      var line2 = 'line2 here';
+      var line3 = 'line3';
+      var originalContent = [line1, line2, line3].join(EOL);
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {after: line2 + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, [line1, line2, toInsert, line3].join(EOL),
+                       'inserted contents should be inserted after the `after` value');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(result.inserted, 'inserted should indicate that the file was modified');
+        });
+    });
+
+    it('will insert into the file after the first instance of options.after only', function(){
+      var toInsert = 'blahzorz blammo';
+      var line1 = 'line1 is here';
+      var line2 = 'line2 here';
+      var line3 = 'line3';
+      var originalContent = [line1, line2, line2, line3].join(EOL);
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {after: line2 + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, [line1, line2, toInsert, line2, line3].join(EOL),
+                       'inserted contents should be inserted after the `after` value');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(result.inserted, 'inserted should indicate that the file was modified');
+        });
+    });
+
+    it('will insert into the file before a specified string if options.before is specified', function(){
+      var toInsert = 'blahzorz blammo';
+      var line1 = 'line1 is here';
+      var line2 = 'line2 here';
+      var line3 = 'line3';
+      var originalContent = [line1, line2, line3].join(EOL);
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {before: line2 + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, [line1, toInsert, line2, line3].join(EOL),
+                       'inserted contents should be inserted before the `before` value');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(result.inserted, 'inserted should indicate that the file was modified');
+        });
+    });
+
+    it('will insert into the file before the first instance of options.before only', function(){
+      var toInsert = 'blahzorz blammo';
+      var line1 = 'line1 is here';
+      var line2 = 'line2 here';
+      var line3 = 'line3';
+      var originalContent = [line1, line2, line2, line3].join(EOL);
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {before: line2 + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, [line1, toInsert, line2, line2, line3].join(EOL),
+                       'inserted contents should be inserted after the `after` value');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(result.inserted, 'inserted should indicate that the file was modified');
+        });
+    });
+
+
+    it('it will make no change if options.after is not found in the original', function(){
+      var toInsert = 'blahzorz blammo';
+      var originalContent = 'the original content';
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {after: 'not found' + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, originalContent, 'original content is unchanged');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(!result.inserted, 'inserted should indicate that the file was not modified');
+        });
+    });
+
+    it('it will make no change if options.before is not found in the original', function(){
+      var toInsert = 'blahzorz blammo';
+      var originalContent = 'the original content';
+      var filePath = path.join(project.root, filename);
+
+      fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+      return blueprint.insertIntoFile(filename, toInsert, {before: 'not found' + EOL})
+        .then(function(result) {
+          var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
+
+          assert.equal(contents, originalContent, 'original content is unchanged');
+          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
+          assert(!result.inserted, 'inserted should indicate that the file was not modified');
+        });
+    });
+
   });
 
   describe('lookupBlueprint', function() {


### PR DESCRIPTION
Adds the ability to specify the string in a file to insert contents before or after, similar to the [same method in Thor](https://github.com/erikhuda/thor/blob/master/lib/thor/actions/inject_into_file.rb#L17).

 Example:

```
 // .jshintrc
 "predef": [
   "window",
   "document"
 ]

 insertIntoFile('.jshintrc', '  "newGlobal",', {after:'"predef": [\n'});

 // new .jshintrc
  "predef": [
    "newGlobal",
    "window",
    "document"
 ]
```
