### PR TITLE
Improve Overview

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -5,14 +5,9 @@ permalink: overview
 github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2014-04-05-overview.md"
 ---
 
-Ember CLI is an [Ember.js](http://emberjs.com) command line utility. It is based on
-the [Ember App Kit](https://github.com/stefanpenner/ember-app-kit) project that was
-intended to be an ideal project template (structure) for Ember.js projects. It has
-proved to be very useful. It allowed users to quickly iterate while building real
-ambitious applications.
+Ember CLI is an [Ember.js](http://emberjs.com) command line utility which provides a fast asset pipeline powered by [broccoli](https://github.com/joliss/broccoli) and strong conventional project structure. 
 
-The goal for Ember CLI is to eventually replace Ember App Kit with a faster [broccoli](https://github.com/joliss/broccoli)
-pipeline and strong conventions in place.
+Ember CLI was based on the [Ember App Kit Project](https://github.com/stefanpenner/ember-app-kit) which is now deprecated.
 
 ### Assets Compilation
 


### PR DESCRIPTION
= Ongoing PR = 

Ember CLI has replaced Ember App Kit, which is now officially deprecated. This could make people think the process is still going on. Does this sound reasonable? 

Intro is the best place to add more polish, so this still needs some more edits (language & grammar) right now.
