### PR TITLE
Allow addons to inject middleware into testem

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -22,11 +22,24 @@ module.exports = Task.extend({
     }.bind(this));
   },
 
+  addonMiddlewares: function() {
+    this.project.initializeAddons();
+
+    return this.project.addons.reduce(function(addons, addon) {
+      if (addon.testemMiddleware) {
+        addons.push(addon.testemMiddleware.bind(addon));
+      }
+
+      return addons;
+    }, []);
+  },
+
   run: function(options) {
     var testemOptions = {
       file: options.configFile,
       port: options.port,
-      cwd: options.outputPath
+      cwd: options.outputPath,
+      middleware: this.addonMiddlewares()
     };
 
     return this.invokeTestem(testemOptions);

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "semver": "^3.0.1",
     "symlink-or-copy": "^1.0.0",
     "temp": "0.8.1",
-    "testem": "0.6.19",
+    "testem": "0.6.22",
     "through": "^2.3.4",
     "tiny-lr": "0.1.4",
     "walk-sync": "0.1.3",

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var assert   = require('../../helpers/assert');
-var TestTask = require('../../../lib/tasks/test');
+var assert      = require('../../helpers/assert');
+var TestTask    = require('../../../lib/tasks/test');
+var MockProject = require('../../helpers/mock-project');
 
 describe('test', function() {
   var subject;
 
   it('transforms the options and invokes testem properly', function() {
     subject = new TestTask({
+      project: new MockProject(),
       invokeTestem: function(options) {
         assert.equal(options.file, 'blahzorz.conf');
         assert.equal(options.port, 123324);


### PR DESCRIPTION
This PR depends upon https://github.com/airportyh/testem/pull/410 being
accepted before it should be pulled in

Primarily the use case is with any addon that injects a middleware into
the ember server's, this will allow addon authors to also expose that
middleware through `ember test` if/when noted PR above is accepted by
@airportyh
