### PR TITLE
Generate pod components within components subdirectory.

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -7,9 +7,15 @@ module.exports = {
 
   fileMapTokens: function() {
     return {
+      __path__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, 'components', options.dasherizedModuleName);
+        }
+        return 'components';
+      },
       __templatepath__: function(options) {
         if (options.pod) {
-          return path.join(options.podPath, options.dasherizedModuleName);
+          return path.join(options.podPath, 'components', options.dasherizedModuleName);
         }
         return 'templates/components';
       },

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -110,8 +110,8 @@ describe('Acceptance: ember destroy pod', function() {
   it('component x-foo --pod', function() {
     var commandArgs = ['component', 'x-foo', '--pod'];
     var files       = [
-      'app/pods/x-foo/component.js',
-      'app/pods/x-foo/template.hbs',
+      'app/pods/components/x-foo/component.js',
+      'app/pods/components/x-foo/template.hbs',
       'tests/unit/components/x-foo-test.js'
     ];
 

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -195,13 +195,13 @@ describe('Acceptance: ember generate pod', function() {
 
   it('component x-foo --pod', function() {
     return generate(['component', 'x-foo', '--pod']).then(function() {
-      assertFile('app/x-foo/component.js', {
+      assertFile('app/components/x-foo/component.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Component.extend({" + EOL + "});"
         ]
       });
-      assertFile('app/x-foo/template.hbs', {
+      assertFile('app/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
       assertFile('tests/unit/components/x-foo-test.js', {
@@ -218,13 +218,13 @@ describe('Acceptance: ember generate pod', function() {
 
   it('component x-foo --pod podModulePrefix', function() {
     return generateWithPrefix(['component', 'x-foo', '--pod']).then(function() {
-      assertFile('app/pods/x-foo/component.js', {
+      assertFile('app/pods/components/x-foo/component.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Component.extend({" + EOL + "});"
         ]
       });
-      assertFile('app/pods/x-foo/template.hbs', {
+      assertFile('app/pods/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
       assertFile('tests/unit/components/x-foo-test.js', {


### PR DESCRIPTION
This PR makes `ember g component x-foo --pod` generate within components sub directory, resulting in 

```
app/pods/components/x-foo/component.js
app/pods/components/x-foo/template.hbs
```

made possible with [ember-resolver/pull/61](https://github.com/stefanpenner/ember-resolver/pull/61)

Feel free to close this if `app/pods/x-foo/component.js` is the preferred default.
