### PR TITLE
Update CSP addon.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-content-security-policy": "0.1.2",
+    "ember-cli-content-security-policy": "0.1.3",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.1.0",


### PR DESCRIPTION
- Fix quoting issue with `self` and `none` default values (they must be quoted but they were not previously).
- Enable `unsafe-eval` when running in development environment. Required for use with `wrapInEval` (which defaults to "on" when running in development mode).
