### PR TITLE
Enable easier customization of production environments.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -55,12 +55,14 @@ function EmberApp(options) {
     this.project.configPath = function() { return options.configPath; };
   }
 
-  this.env  = process.env.EMBER_ENV || 'development';
+  this.env  = process.env.EMBER_ENV || options.environment || 'development';
   this.name = options.name || this.project.name();
 
   this.registry = options.registry || p.setupRegistry(this);
 
-  var isProduction = this.env === 'production';
+  this.productionEnvironments = options.productionEnvironments || ['production'];
+
+  var isProduction = this.productionEnvironments.indexOf(this.env) > -1;
 
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
@@ -109,17 +111,19 @@ function EmberApp(options) {
     vendorFiles: {}
   }, defaults);
 
+  var emberPath = this.bowerDirectory + '/ember/ember.js';
+  var handlebarsPath = this.bowerDirectory + '/handlebars/handlebars.js';
+
+  if (isProduction) {
+    emberPath = this.bowerDirectory + '/ember/ember.prod.js'
+    handlebarsPath = this.bowerDirectory + '/handlebars/handlebars.runtime.js'
+  }
+
   this.vendorFiles = merge(options.vendorFiles, {
     'loader.js': this.options.loader,
     'jquery.js': this.bowerDirectory + '/jquery/dist/jquery.js',
-    'handlebars.js': {
-      development: this.bowerDirectory + '/handlebars/handlebars.js',
-      production:  this.bowerDirectory + '/handlebars/handlebars.runtime.js'
-    },
-    'ember.js': {
-      development: this.bowerDirectory + '/ember/ember.js',
-      production:  this.bowerDirectory + '/ember/ember.prod.js'
-    },
+    'handlebars.js': handlebarsPath,
+    'ember.js': emberPath,
     'app-shims.js': [
       this.bowerDirectory + '/ember-cli-shims/app-shims.js', {
         exports: {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -36,6 +36,46 @@ describe('broccoli/ember-app', function() {
 
       assert.equal(project.configPath(), 'custom config path');
     });
+
+    it('should enable tests and hinting in development', function() {
+      var emberApp = new EmberApp({
+        project: project
+      });
+
+      assert.equal(emberApp.tests, true);
+      assert.equal(emberApp.hinting, true);
+    });
+
+    it('should not enable tests and hinting in production', function() {
+      var emberApp = new EmberApp({
+        project: project,
+        environment: 'production'
+      });
+
+      assert.equal(emberApp.tests, false);
+      assert.equal(emberApp.hinting, false);
+    });
+
+    it('uses custom productionEnvironments to determine tests or hinting enabled', function() {
+      var emberApp = new EmberApp({
+        project: project,
+        environment: 'asdflkj',
+        productionEnvironments: ['asdflkj']
+      });
+
+      assert.equal(emberApp.tests, false);
+      assert.equal(emberApp.hinting, false);
+    });
+
+    it('users productionEnvironments to determine to use production builds', function() {
+      var emberApp = new EmberApp({
+        project: project,
+        environment: 'asdflkj',
+        productionEnvironments: ['asdflkj']
+      });
+
+      assert(emberApp.legacyFilesToAppend.indexOf('bower_components/ember/ember.prod.js'))
+    });
   });
 
   describe('contentFor', function() {


### PR DESCRIPTION
The following is all that is needed to enable building `staging` as another `production` type environment:

``` javascript
var app = new EmberApp({
  productionEnvironments: [ 'production', 'staging' ]
});
```
