### PR TITLE
Bring back global app namespace assignment

### DIFF
--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -11,7 +11,7 @@ define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
 if (runningTests) {
   require('{{MODULE_PREFIX}}/tests/test-helper');
 } else {
-  require('{{MODULE_PREFIX}}/app')['default'].create({{APP_CONFIG}});
+  window.{{NAMESPACE}} = require('{{MODULE_PREFIX}}/app')['default'].create({{APP_CONFIG}});
 }
 
 /* jshint ignore:end */

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1,10 +1,11 @@
 /* global require, module, escape */
 'use strict';
 
-var fs    = require('fs');
-var p     = require('../preprocessors');
-var chalk = require('chalk');
-var EOL   = require('os').EOL;
+var fs          = require('fs');
+var p           = require('../preprocessors');
+var stringUtil  = require('../utilities/string');
+var chalk       = require('chalk');
+var EOL         = require('os').EOL;
 
 var Project      = require('../models/project');
 var cleanBaseURL = require('../utilities/clean-base-url');
@@ -252,6 +253,9 @@ EmberApp.prototype._configReplacePatterns = function() {
   }, {
     match: /\{\{MODULE_PREFIX\}\}/g,
     replacement: calculateModulePrefix
+  }, {
+    match: /\{\{NAMESPACE\}\}/g,
+    replacement: calculateNamespace
   }];
 };
 
@@ -810,4 +814,8 @@ function calculateAppConfig(config) {
 
 function calculateModulePrefix(config) {
   return config.modulePrefix;
+}
+
+function calculateNamespace(config) {
+  return stringUtil.classify(config.modulePrefix);
 }


### PR DESCRIPTION
References #2058 

This PR brings back the global `window.AppName` assignment to provide access to `__container__` and such
