### PR TITLE
Ensure all addon hooks are executed in addon test harness.

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -31,9 +31,3 @@ function EmberAddon(options) {
 EmberAddon.prototype = Object.create(EmberApp.prototype);
 EmberAddon.prototype.constructor = EmberAddon;
 EmberAddon.prototype.appConstructor = EmberApp.prototype.constructor;
-EmberAddon.prototype.oldInitializeAddons = EmberApp.prototype.initializeAddons;
-
-EmberAddon.prototype.initializeAddons = function() {
-  this.project.addIfAddon(this.project.root);
-  this.oldInitializeAddons();
-};

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -122,6 +122,10 @@ Project.prototype.buildAddonPackages = function() {
   this.addIfAddon(path.join(internalMiddlewarePath, 'serve-files'));
   this.addIfAddon(path.join(internalMiddlewarePath, 'proxy-server'));
 
+  if (this.isEmberCLIAddon()) {
+    this.addIfAddon(this.root);
+  }
+
   this.discoverAddons(this.root, this.pkg);
 };
 

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -40,5 +40,8 @@ MockProject.prototype.addIfAddon = Project.prototype.addIfAddon;
 MockProject.prototype.dependencies = function() {
   return [];
 };
+MockProject.prototype.isEmberCLIAddon = function() {
+  return false;
+};
 
 module.exports = MockProject;

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -32,7 +32,7 @@ describe('models/project.js', function() {
         });
     });
 
-    after(function() {
+    afterEach(function() {
       return tmp.teardown(projectPath);
     });
 
@@ -137,7 +137,7 @@ describe('models/project.js', function() {
   });
 
   describe('addons', function() {
-    before(function() {
+    beforeEach(function() {
       projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');
       var packageContents = require(path.join(projectPath, 'package.json'));
 
@@ -232,6 +232,22 @@ describe('models/project.js', function() {
       assert.ok(addons[7] instanceof Addon);
       assert.equal(addons[7].name, '(generated ember-generated-no-export-addon addon)');
     });
+
+    it('adds the project itself if it is an addon', function() {
+      var added = false;
+      project.addonPackages = {};
+      project.isEmberCLIAddon = function() { return true; };
+
+      project.addIfAddon = function(path) {
+        if (path === project.root) {
+          added = true;
+        }
+      };
+
+      project.buildAddonPackages();
+
+      assert.ok(added);
+    });
   });
 
   describe('emberCLIVersion', function() {
@@ -241,6 +257,13 @@ describe('models/project.js', function() {
   });
 
   describe('isEmberCLIAddon', function() {
+    beforeEach(function() {
+      projectPath = process.cwd() + '/tmp/test-app';
+
+      project = new Project(projectPath, {});
+      project.initializeAddons();
+    });
+
     it('should return true if `ember-addon` is included in keywords', function() {
       project.pkg = {
         keywords: [ 'ember-addon' ]


### PR DESCRIPTION
Previously, when using the `tests/dummy/` app in an addon project, the only hooks that were called were build related (because we only added the addon project to the `addons` list in the `Brocfile.js`).

Now, we always add the addon project. This allows testing commands, blueprints, middleware hooks, etc.

Closes #2188.
