### PR TITLE
Add description to addon command.

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -5,6 +5,7 @@ var path       = require('path');
 
 module.exports = NewCommand.extend({
   name: 'addon',
+  description: 'Generates a new folder structure for building an addon, complete with test harness.',
 
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false },


### PR DESCRIPTION
Without this, it inherits the description from `ember new`.

Closes #2194.
