### PR TITLE
ember init <path/to/file> or <glob> should apply init to those files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * [BUGFIX] Fix automatic generated model belongs-to and has-many relations to resolve test lookup. [#2351][https://github.com/stefanpenner/ember-cli/pull/2351]
 
+#### Applications
+* [BREAKING ENHANCEMENT] Replace `ember init appName` with `ember init --name=appName` to allow globbing support for `ember init` command. [#2197](https://github.com/stefanpenner/ember-cli/pull/2197)
+
 ### 0.1.2
 
 #### Applications

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -18,11 +18,12 @@ module.exports = Command.extend({
     { name: 'verbose', type: Boolean, default: false },
     { name: 'blueprint', type: path },
     { name: 'skip-npm', type: Boolean, default: false },
-    { name: 'skip-bower', type: Boolean, default: false }
+    { name: 'skip-bower', type: Boolean, default: false },
+    { name: 'name', type: String, default: '' }
   ],
 
   anonymousOptions: [
-    '<app-name>'
+    '<glob-pattern>'
   ],
 
   _defaultBlueprint: function() {
@@ -58,11 +59,13 @@ module.exports = Command.extend({
     });
 
     var project          = this.project;
-    var packageName      = rawArgs[0] !== '.' && rawArgs[0] || project.name();
+    var packageName      = commandOptions.name !== '.' && commandOptions.name || project.name();
     var blueprintOpts    = {
       dryRun: commandOptions.dryRun,
       blueprint: commandOptions.blueprint || this._defaultBlueprint(),
-      rawName: packageName
+      rawName: packageName,
+      targetFiles: rawArgs || '',
+      rawArgs: rawArgs.toString()
     };
 
     if (!validProjectName(packageName)) {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -30,6 +30,8 @@ module.exports = Command.extend({
     var packageName = rawArgs[0],
         message;
 
+    commandOptions.name = rawArgs.shift();
+
     if (!packageName) {
       message = chalk.yellow('The `ember ' + this.name + '` command requires a ' +
                              'name to be specified. For more details, use `ember help`.');

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -15,6 +15,7 @@ var sequence    = require('../utilities/sequence');
 var stat        = Promise.denodeify(fs.stat);
 var stringUtils = require('../utilities/string');
 var uniq        = require('lodash-node/compat/arrays/uniq');
+var intersect   = require('lodash-node/compat/arrays/intersection');
 var values      = require('lodash-node/compat/objects/values');
 var walkSync    = require('walk-sync');
 var zipObject   = require('lodash-node/compat/arrays/zipObject');
@@ -263,7 +264,11 @@ Blueprint.prototype.availableOptions = [];
 Blueprint.prototype.anonymousOptions = ['name'];
 
 /*
+  Used to retrieve files for blueprint. The `file` param is an
+  optional string that is turned into a glob.
+
   @method files
+  @param {String} file
   @return {Array} Contents of the blueprint's files directory
 */
 Blueprint.prototype.files = function() {
@@ -571,8 +576,16 @@ Blueprint.prototype.processFiles = function(intoDir, templateVariables) {
     return path.join(intoDir, file);
   }
 
-  var fileInfos = this.files().
-    map(this.buildFileInfo.bind(this, destPath, templateVariables));
+  // if we've defined targetFiles, get file info on ones that match
+  var files = templateVariables.targetFiles && templateVariables.targetFiles.length > 0 &&
+    intersect(this.files(),templateVariables.targetFiles) || this.files();
+
+  var fileInfos = files.map(this.buildFileInfo.bind(this, destPath, templateVariables));
+
+  if (fileInfos.filter(isFilePath).length < 1) {
+    this.ui.writeLine(chalk.yellow('The globPattern \"' + templateVariables.rawArgs +
+      '\" did not match any files, so no file updates will be made.'));
+  }
 
   if (this.isUpdate()) {
     Blueprint.ignoredFiles = Blueprint.ignoredFiles.concat(Blueprint.ignoredUpdateFiles);
@@ -584,6 +597,10 @@ Blueprint.prototype.processFiles = function(intoDir, templateVariables) {
     } else {
       return isFile(fileInfo);
     }
+  }
+
+  function isFilePath(fileInfo) {
+    return fileInfo.outputPath.indexOf('.') > -1;
   }
 
   return Promise.filter(fileInfos, isValidFile).
@@ -676,7 +693,9 @@ Blueprint.prototype._locals = function(options) {
     dasherizedModuleName: stringUtils.dasherize(moduleName),
     classifiedModuleName: stringUtils.classify(sanitizedModuleName),
     camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
-    fileMap: fileMap
+    fileMap: fileMap,
+    targetFiles: options.targetFiles,
+    rawArgs: options.rawArgs
   };
 
   return merge({}, standardLocals, customLocals);

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -132,7 +132,7 @@ FileInfo.prototype.confirmOverwriteTask = function() {
   return function() {
     return new Promise(function(resolve, reject){
       function doConfirm(){
-        info.confirmOverwrite(info.outputPath).then(function(action){
+        info.confirmOverwrite(info.displayPath).then(function(action){
           if (action === 'diff') {
             info.displayDiff().then(doConfirm, reject);
           } else if (action === 'edit') {

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -30,7 +30,9 @@ module.exports = Task.extend({
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
-      dryRun: options.dryRun
+      dryRun: options.dryRun,
+      targetFiles: options.targetFiles,
+      rawArgs: options.rawArgs
     };
 
     if (isGitRepo(blueprintOption)) {

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -43,7 +43,7 @@ describe('Acceptance: ember destroy', function() {
   });
 
   function initApp() {
-    return ember(['init', 'my-app', '--skip-npm', '--skip-bower']);
+    return ember(['init', '--name=my-app', '--skip-npm', '--skip-bower']);
   }
 
   function generate(args) {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -40,7 +40,7 @@ describe('Acceptance: ember generate', function() {
   });
 
   function initApp() {
-    return ember(['init', 'my-app', '--skip-npm', '--skip-bower']);
+    return ember(['init', '--name=my-app', '--skip-npm', '--skip-bower']);
   }
 
   function generate(args) {

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -26,7 +26,7 @@ describe('Acceptance: ember help', function() {
     this.timeout(10000);
     var output = '';
 
-    return runCommand(ember, 'init', 'my-app', '--skip-npm', '--skip-bower', { verbose: false })
+    return runCommand(ember, 'init', '--name=my-app', '--skip-npm', '--skip-bower', { verbose: false })
       .then(function() {
         return runCommand(ember, 'generate', 'blueprint', 'component', { verbose: false });
       })

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -44,7 +44,7 @@ describe('Acceptance: ember destroy pod', function() {
   });
 
   function initApp() {
-    return ember(['init', 'my-app', '--skip-npm', '--skip-bower']);
+    return ember(['init', '--name=my-app', '--skip-npm', '--skip-bower']);
   }
 
   function generate(args) {

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -41,7 +41,7 @@ describe('Acceptance: ember generate pod', function() {
   });
 
   function initApp() {
-    return ember(['init', 'my-app', '--skip-npm', '--skip-bower']);
+    return ember(['init', '--name=my-app', '--skip-npm', '--skip-bower']);
   }
 
   function preGenerate(args) {

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -83,7 +83,7 @@ describe('init command', function() {
       settings: {}
     });
 
-    return command.validateAndRun(['provided-name'])
+    return command.validateAndRun(['--name=provided-name'])
       .catch(function(reason) {
         assert.equal(reason, 'Called run');
       });
@@ -171,7 +171,29 @@ describe('init command', function() {
       settings: {}
     });
 
-    return command.validateAndRun(['provided-name'])
+    return command.validateAndRun(['--name=provided-name'])
+      .catch(function(reason) {
+        assert.equal(reason, 'Called run');
+      });
+  });
+
+  it('Uses arguments to select files to init', function() {
+    tasks.InstallBlueprint = Task.extend({
+      run: function(blueprintOpts) {
+        assert.equal(blueprintOpts.blueprint, 'app');
+        return Promise.reject('Called run');
+      }
+    });
+
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { name: 'some-random-name'}),
+      tasks: tasks,
+      settings: {}
+    });
+
+    return command.validateAndRun(['package.json', '--name=provided-name'])
       .catch(function(reason) {
         assert.equal(reason, 'Called run');
       });
@@ -193,7 +215,7 @@ describe('init command', function() {
       settings: {}
     });
 
-    return command.validateAndRun(['provided-name'])
+    return command.validateAndRun(['--name=provided-name'])
       .catch(function(reason) {
         assert.equal(reason, 'Called run');
       });


### PR DESCRIPTION
Adds optional globbing functionality to `ember init` as described in #2156, and moves original functionality to `ember init --name=<app-name>`. 

In the current state of this PR, `ember init <glob-pattern>` ~~only accepts and applies a single glob pattern~~ accepts multiple raw args and joins them into one glob pattern. For instance `ember init foo.js bar.js package.json` would ~~only use "foo.js" and ignore the additional rawArgs~~ join the rawArgs together into `{foo.js,bar.js,package.json}`. ~~If desired, multiple patterns could be accepted, but would require additional work.~~ It should be noted that multiple files are technically already supported through glob patterns like `'{app/**,package.json}'` supported by the [minimatch library](https://github.com/isaacs/minimatch).

Direct paths also use the glob-pattern and will match with a small possibility of matching more than the intended path if the pattern is too general (i.e. "foo.js" vs "app/routes/foo.js"). 

Additionally, I had some difficulty with unquoted glob patterns with wildcards (i.e. "*_/_.js", would resolve the pattern upon parsing the rawArgs), and so quotes are required for patterns that aren't simple paths. 

The tests I've written so far are still lacking, would love some input or suggestions on what tests should be written to support this.
