### PR TITLE
Ensure bower.json gets correct metadata

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -27,12 +27,24 @@ module.exports = {
     fs.writeFileSync(path.join(this.path, 'files', 'package.json'), JSON.stringify(contents, null, 2));
   },
 
+  generateBowerJson: function() {
+    var bowerPath = path.join(this._appBlueprint.path, 'files', 'bower.json');
+    var contents  = JSON.parse(fs.readFileSync(bowerPath, { encoding: 'utf8' }));
+
+    contents.name = this.project.name();
+
+    fs.writeFileSync(path.join(this.path, 'files', 'bower.json'), JSON.stringify(contents, null, 2));
+  },
+
   afterInstall: function() {
     var packagePath = path.join(this.path, 'files', 'package.json');
+    var bowerPath = path.join(this.path, 'files', 'bower.json');
 
-    if (fs.existsSync(packagePath)) {
-      fs.unlinkSync(packagePath);
-    }
+    [packagePath, bowerPath].forEach(function(filePath) {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    });
   },
 
   locals: function(options) {
@@ -64,6 +76,7 @@ module.exports = {
     var appFiles       = this._appBlueprint.files();
 
     this.generatePackageJson();
+    this.generateBowerJson();
 
     var addonFiles   = walkSync(path.join(this.path, 'files'));
 

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -85,15 +85,19 @@ describe('Acceptance: addon-smoke-test', function() {
     return tmp.teardown('./tmp');
   });
 
-  it('generates package.json with proper metadata', function() {
+  it('generates package.json and bower.json with proper metadata', function() {
     console.log('    running the slow end-to-end it will take some time');
 
-    var contents = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+    var packageContents = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
 
-    assert.equal(contents.name, addonName);
-    assert.equal(contents.private, undefined);
-    assert.deepEqual(contents.keywords, ['ember-addon']);
-    assert.deepEqual(contents['ember-addon'], { 'configPath': 'tests/dummy/config' });
+    assert.equal(packageContents.name, addonName);
+    assert.equal(packageContents.private, undefined);
+    assert.deepEqual(packageContents.keywords, ['ember-addon']);
+    assert.deepEqual(packageContents['ember-addon'], { 'configPath': 'tests/dummy/config' });
+
+    var bowerContents = JSON.parse(fs.readFileSync('bower.json', { encoding: 'utf8' }));
+
+    assert.equal(bowerContents.name, addonName);
   });
 
   it('ember addon foo, clean from scratch', function() {


### PR DESCRIPTION
It is debateable if the `name` property is even necessary, but in any
case it definitely shouldn't render as `dummy`.
