### PR TITLE
WIP - Detected failed test run

### DIFF
--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -122,6 +122,23 @@ describe('Acceptance: smoke-test', function() {
       });
   });
 
+  it.only('ember test tells you when an error occurred', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return copyFixtureFiles('smoke-tests/syntax-error')
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test')
+          .then(function(result) {
+            assert(false, 'should have rejected with a failing test');
+          })
+          .catch(function(result) {
+            assert.equal(result.output.indexOf('No tests were ran, please ensure that you have a test launcher (e.g. PhantomJS) enabled.\n'), -1);
+          });
+      });
+  }).only;
+
   it('ember new foo, build production and verify fingerprint', function() {
     console.log('    running the slow fingerprint it will take some time');
 

--- a/tests/fixtures/smoke-tests/syntax-error/app/app.js
+++ b/tests/fixtures/smoke-tests/syntax-error/app/app.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import Resolver from 'ember/resolver';
+import loadInitializers from 'ember/load-initializers';
+import config from './config/environment';
+
+Ember.MODEL_FACTORY_INJECTIONS = true;
+var badJuju = JSON.parse('{"bad":"this juju",}');
+
+var App = Ember.Application.extend({
+  modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
+  juju:badJuju,
+  Resolver: Resolver
+});
+
+loadInitializers(App, config.modulePrefix);
+
+export default App;

--- a/tests/fixtures/smoke-tests/syntax-error/tests/acceptance/some-test.js
+++ b/tests/fixtures/smoke-tests/syntax-error/tests/acceptance/some-test.js
@@ -1,0 +1,20 @@
+import Ember from "ember";
+import { test } from 'ember-qunit';
+import startApp from '../helpers/start-app';
+var App;
+
+module('An Integration test', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, App.destroy);
+  }
+});
+
+test("Page contents", function() {
+  expect(2);
+  visit('/').then(function() {
+    equal(find('.ember-application').length, 1, "Page contains application");
+  });
+});


### PR DESCRIPTION
closes #2142 **WORK IN PROGRESS**

I'm working on this but rather than just changing the message I'ld like to actually display the error('s) that occurred (if any). As you can see in the fixture I've created, the case I'm testing for is a syntax error which isn't caught at build time (a malformed JSON string). 

I'm running into a bit of an issue because testem doesn't report this as an "error" (but rather just as 0 tests being run). I'm guessing this is because the error occurs before the testing code started..  In https://github.com/airportyh/testem/blob/master/assets/phantom.js I see that there's also no 'error' hook attached to the page in phantom so unless I'm missing something, I guess I'll have to open a PR with testem? Can you confirm this @stefanpenner  or @rwjblue ?

Also: If that's the case, would you still like a PR where I append something like "Make sure that no errors occurred by running the tests in you browser with ember test --server" to the "No tests were run" eror?
