### PR TITLE
add .jshintrc files to addon blueprint

### DIFF
--- a/blueprints/addon/files/Brocfile.js
+++ b/blueprints/addon/files/Brocfile.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 /* global require, module */
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

--- a/blueprints/addon/files/index.js
+++ b/blueprints/addon/files/index.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 'use strict';
 
 module.exports = {

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -92,7 +92,6 @@ module.exports = {
   },
 
   fileMap: {
-    '^.jshintrc':   'tests/dummy/:path',
     '^app/.gitkeep': 'app/.gitkeep',
     '^app.*':        'tests/dummy/:path',
     '^config.*':     'tests/dummy/:path',


### PR DESCRIPTION
I felt that it would be helpful to have these already in place when making an addon. Since root is node-land I had to put a node .jshintrc in the root and override it with browser ones in app and addon.

I'm not sure if I did something bad with that change in `blueprints/addon/index.js`, but I needed it to ensure that the .jshintrc gets put in app.
