### PR TITLE
Update docs to mention ember-cli-less add-on

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -53,11 +53,11 @@ All your preprocessed stylesheets will be compiled into one file and served at
 #### LESS
 
 To enable [LESS](http://lesscss.org/), you'll need to add
-[broccoli-less-single](https://github.com/gabrielgrant/broccoli-less-single) to
+[ember-cli-less](https://github.com/gdub22/ember-cli-less) to
 your NPM modules.
 
 {% highlight bash %}
-npm install --save-dev broccoli-less-single
+npm install --save-dev ember-cli-less
 {% endhighlight %}
 
 #### Sass


### PR DESCRIPTION
Enables passing options to LESS from your Brocfile.  Also produces css source maps in development.
https://github.com/gdub22/ember-cli-less
