### PR TITLE
Remove less from initial registry.

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -9,7 +9,6 @@ module.exports.setupRegistry = function(app) {
 
   registry.add('css', 'broccoli-sass', ['scss', 'sass']);
   registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);
-  registry.add('css', 'broccoli-less-single', 'less');
   registry.add('css', 'broccoli-stylus-single', 'styl');
 
   registry.add('minify-css', 'broccoli-csso', null);


### PR DESCRIPTION
Now it should be pulled in from ember-cli-less.
