### PR TITLE
Mention the possibility of top-level errors until testem reports this

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
     return new Promise(function(resolve, reject) {
       testem.startCI(testemOptions, function(exitCode) {
         if (!testem.app.reporter.total) {
-          reject(new SilentError('No tests were ran, please ensure that you have a test launcher (e.g. PhantomJS) enabled.'));
+          reject(new SilentError('No tests were ran, please check whether any errors occurred in the page (ember test --server) and ensure that you have a test launcher (e.g. PhantomJS) enabled.'));
         }
 
         resolve(exitCode);


### PR DESCRIPTION
closes #2142 

Changed message

> No tests were ran, please ensure that you have a test launcher (e.g. PhantomJS) enabled.

To

> No tests were ran, please check whether any errors occurred in the page (ember test --server) and ensure that you have a test launcher (e.g. PhantomJS) enabled.

I'm working on airportyh/testem#416 to actually let Testem display top level errors in CI mode.
