### PR TITLE
Give clear error when failing to read config from meta

### DIFF
--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,11 +1,16 @@
 /* jshint ignore:start */
 
 define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
-  var metaName = '{{MODULE_PREFIX}}/config/environment';
-  var rawConfig = Ember['default'].$('meta[name="' + metaName + '"]').attr('content');
-  var config = JSON.parse(unescape(rawConfig));
+  try {
+    var metaName = '{{MODULE_PREFIX}}/config/environment';
+    var rawConfig = Ember['default'].$('meta[name="' + metaName + '"]').attr('content');
+    var config = JSON.parse(unescape(rawConfig));
 
-  return { 'default': config };
+    return { 'default': config };
+  }
+  catch(err) {
+    throw new Error('Could not read config from meta tag with name "' + metaName + '".');
+  }
 });
 
 if (runningTests) {


### PR DESCRIPTION
closes #2218 

To be honest, I don't know how to test for this considering the fact that top-level errors are not caught by testem CI mode (which is something I'm working on).
