### PR TITLE
Allow filtering tests run through testem.

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -4,6 +4,9 @@ var Command   = require('../models/command');
 var Watcher   = require('../models/watcher');
 var Builder   = require('../models/builder');
 
+var fs = require('fs');
+var path = require('path');
+
 module.exports = Command.extend({
   name: 'test',
   aliases: ['test', 't'],
@@ -14,6 +17,7 @@ module.exports = Command.extend({
     { name: 'config-file', type: String,  default: './testem.json' },
     { name: 'server',      type: Boolean, default: false},
     { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.'},
+    { name: 'filter',      type: String,  description: 'A regex to filter tests ran'},
   ],
 
   init: function() {
@@ -31,13 +35,29 @@ module.exports = Command.extend({
 
   rmTmp: function() {
     this.quickTemp.remove(this, '-testsDist');
+    this.quickTemp.remove(this, '-customConfigFile');
+  },
+
+  _generateCustomConfigFile: function(options) {
+    if (!options.filter) { return options.configFile; }
+
+    var tmpPath = this.quickTemp.makeOrRemake(this, '-customConfigFile');
+    var customPath = path.join(tmpPath, 'testem.json');
+    var originalContents = JSON.parse(fs.readFileSync(options.configFile, { encoding: 'utf8' }));
+
+    originalContents['test_page'] = originalContents['test_page'] + '?filter=' + options.filter;
+
+    fs.writeFileSync(customPath, JSON.stringify(originalContents));
+
+    return customPath;
   },
 
   run: function(commandOptions) {
     var outputPath  = this.tmp();
     var testOptions = this.assign({}, commandOptions, {
       outputPath: outputPath,
-      project: this.project
+      project: this.project,
+      configFile: this._generateCustomConfigFile(commandOptions)
     });
 
     var options = {
@@ -54,7 +74,8 @@ module.exports = Command.extend({
 
       testOptions.watcher = new Watcher(this.assign(options, {verbose: false}));
 
-      return testServer.run(testOptions);
+      return testServer.run(testOptions)
+        .finally(this.rmTmp.bind(this));
     } else {
       var TestTask  = this.tasks.Test;
       var BuildTask = this.tasks.Build;

--- a/tests/fixtures/tasks/default-testem-config/testem.json
+++ b/tests/fixtures/tasks/default-testem-config/testem.json
@@ -1,0 +1,11 @@
+{
+  "framework": "qunit",
+  "test_page": "tests/index.html",
+  "launch_in_ci": [
+    "PhantomJS"
+  ],
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ]
+}


### PR DESCRIPTION
Adds `--filter` command line option to `ember test` and `ember test --server`. The `filter` parameter is used by QUnit to filter based on module name and test description.

Closes #2175.
