### PR TITLE
Update broccoli-static-compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "broccoli-kitchen-sink-helpers": "0.2.5",
     "broccoli-merge-trees": "0.2.0",
     "broccoli-sane-watcher": "0.0.7",
-    "broccoli-static-compiler": "0.2.0",
+    "broccoli-static-compiler": "0.2.1",
     "broccoli-uglify-js": "0.1.3",
     "broccoli-unwatched-tree": "0.1.1",
     "broccoli-writer": "0.1.1",


### PR DESCRIPTION
Fixes a symlinking related regression that prevented the use of `destDir` of `/` without a `files` glob array.

Thanks to @linstula for pairing with me on the solution.
