### PR TITLE
Validate NPM dependencies before build/serve/test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+!tests/fixtures/**/node_modules
 npm-debug.log
 tmp*
 _posts

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -14,13 +14,20 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions) {
-    var BuildTask = this.taskFor(commandOptions);
-    var buildTask = new BuildTask({
+    var options = {
       ui: this.ui,
       analytics: this.analytics,
       project: this.project
-    });
-    return buildTask.run(commandOptions);
+    };
+
+    var npmValidateTask = new this.tasks.NpmValidate(options);
+
+    return npmValidateTask.run(commandOptions)
+      .then(function() {
+        var BuildTask = this.taskFor(commandOptions);
+        var buildTask = new BuildTask(options);
+        return buildTask.run(commandOptions);
+      }.bind(this));
   },
 
   taskFor: function(options) {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -21,18 +21,28 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions) {
-    commandOptions = assign({}, commandOptions, {
-      liveReloadPort: commandOptions.liveReloadPort  || (commandOptions.port + 31529),
-      baseURL: this.project.config('development').baseURL || '/'
-    });
+    var project = this.project;
+    var tasks = this.tasks;
 
-    var ServeTask = this.tasks.Serve;
-    var serve = new ServeTask({
+    var options = {
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
-    });
+      project: project
+    };
 
-    return serve.run(commandOptions);
+    var npmValidateTask = new tasks.NpmValidate(options);
+
+    return npmValidateTask.run(commandOptions)
+      .then(function() {
+        commandOptions = assign({}, commandOptions, {
+          liveReloadPort: commandOptions.liveReloadPort || (commandOptions.port + 31529),
+          baseURL: project.config('development').baseURL || '/'
+        });
+
+        var ServeTask = tasks.Serve;
+        var serve = new ServeTask(options);
+
+        return serve.run(commandOptions);
+      });
   }
 });

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -66,31 +66,36 @@ module.exports = Command.extend({
       project: this.project
     };
 
-    if (commandOptions.server) {
-      options.builder = new Builder(testOptions);
+    var npmValidateTask = new this.tasks.NpmValidate(options);
 
-      var TestServerTask = this.tasks.TestServer;
-      var testServer     = new TestServerTask(options);
+    return npmValidateTask.run(commandOptions)
+      .then(function() {
+        if (commandOptions.server) {
+          options.builder = new Builder(testOptions);
 
-      testOptions.watcher = new Watcher(this.assign(options, {verbose: false}));
+          var TestServerTask = this.tasks.TestServer;
+          var testServer     = new TestServerTask(options);
 
-      return testServer.run(testOptions)
-        .finally(this.rmTmp.bind(this));
-    } else {
-      var TestTask  = this.tasks.Test;
-      var BuildTask = this.tasks.Build;
+          testOptions.watcher = new Watcher(this.assign(options, {verbose: false}));
 
-      var test  = new TestTask(options);
-      var build = new BuildTask(options);
+          return testServer.run(testOptions)
+            .finally(this.rmTmp.bind(this));
+        } else {
+          var TestTask  = this.tasks.Test;
+          var BuildTask = this.tasks.Build;
 
-      return build.run({
-          environment: commandOptions.environment,
-          outputPath: outputPath
-        })
-        .then(function() {
-          return test.run(testOptions);
-        })
-        .finally(this.rmTmp.bind(this));
-    }
+          var test  = new TestTask(options);
+          var build = new BuildTask(options);
+
+          return build.run({
+              environment: commandOptions.environment,
+              outputPath: outputPath
+            })
+            .then(function() {
+              return test.run(testOptions);
+            })
+            .finally(this.rmTmp.bind(this));
+        }
+      }.bind(this));
   }
 });

--- a/lib/tasks/npm-validate.js
+++ b/lib/tasks/npm-validate.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var chalk         = require('chalk');
+var Promise       = require('../ext/promise');
+var Task          = require('../models/task');
+var isGitRepo     = require('../utilities/git-repo');
+var lookupVersion = require('../utilities/node-module-version');
+
+module.exports = Task.extend({
+  init: function() {
+    this.semver = this.semver || require('semver');
+  },
+
+  run: function() {
+    var merge = require('lodash-node/modern/objects/merge');
+    var pkg = this.project.pkg;
+    var deps = merge({}, pkg.dependencies, pkg.devDependencies);
+
+    return this.validateDependencies(deps);
+  },
+
+  validateDependencies: function(dependencies) {
+    var resolvedPackages = Object.keys(dependencies).map(function(name) {
+      return this.resolvePackage(name, dependencies[name]);
+    }, this);
+
+    var isUnsatisfied = function(pkg) {
+      return !!pkg.needUpdate;
+    };
+
+    return Promise.filter(resolvedPackages, isUnsatisfied)
+      .then(function(unsatisfiedPackages) {
+        if (unsatisfiedPackages.length === 0) {
+          return Promise.resolve();
+        } else {
+          this.reportUnsatisfiedPackages(unsatisfiedPackages);
+          return Promise.reject();
+        }
+      }.bind(this));
+  },
+
+  resolvePackage: function(name, version) {
+    return lookupVersion(this.project.root, name)
+      .then(function(versionInstalled) {
+        return {
+          name: name,
+          versionSpecified: version,
+          versionInstalled: versionInstalled,
+          needUpdate: this.updateRequired(name, version, versionInstalled)
+        };
+      }.bind(this));
+  },
+
+  updateRequired: function(name, version, versionInstalled) {
+    if (!versionInstalled) {
+      return true;
+    }
+
+    if (isGitRepo(version)) {
+      var parts = version.split('#');
+      if (parts.length === 2) {
+        version = this.semver.valid(parts[1]);
+        if (!version) {
+          return false;
+        }
+      }
+    }
+
+    if (!this.semver.validRange(version)) {
+      return false;
+    }
+
+    return !this.semver.satisfies(versionInstalled, version);
+  },
+
+  reportUnsatisfiedPackages: function(packages) {
+    var ui = this.ui;
+
+    ui.writeLine(chalk.red('The project has unsatisfied NPM dependencies. You may need to run `npm install`.'));
+    ui.writeLine('');
+
+    packages.map(function(pkg) {
+      ui.writeLine('Package: ' + chalk.cyan(pkg.name));
+      ui.writeLine(chalk.grey('  * Specified: ') + pkg.versionSpecified);
+      ui.writeLine(chalk.grey('  * Installed: ') + (pkg.versionInstalled || '(not installed)'));
+      ui.writeLine('');
+    });
+  }
+});

--- a/lib/utilities/node-module-version.js
+++ b/lib/utilities/node-module-version.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var fs        = require('fs');
+var path      = require('path');
+var Promise   = require('../ext/promise');
+var readFile  = Promise.denodeify(fs.readFile);
+
+module.exports = function(root, name) {
+  var nodePackage = path.join(root, 'node_modules', name, 'package.json');
+
+  return readFile(nodePackage, { encoding: 'utf8' })
+    .then(function(pkg) {
+      return JSON.parse(pkg).version;
+    }).catch(function() {
+      return null;
+    });
+};

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -129,7 +129,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = require(packageJsonPath);
+        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
         return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
@@ -154,7 +154,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/public-tree')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = require(packageJsonPath);
+        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
         return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
@@ -201,7 +201,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/jshint-addon')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = require(packageJsonPath);
+        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
         packageJson['ember-addon'] = {
           paths: ['./lib/ember-random-thing']
         };

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-random-addon/package.json
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-random-addon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ember-random-addon",
+  "version": "0.0.1",
   "private": true,
   "keywords": [
     "ember-addon"

--- a/tests/fixtures/brocfile-tests/jshint-addon/lib/ember-random-thing/package.json
+++ b/tests/fixtures/brocfile-tests/jshint-addon/lib/ember-random-thing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ember-random-thing",
+  "version": "0.0.1",
   "keywords": [
     "ember-addon"
   ]

--- a/tests/fixtures/brocfile-tests/public-tree/node_modules/ember-random-addon/package.json
+++ b/tests/fixtures/brocfile-tests/public-tree/node_modules/ember-random-addon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ember-random-addon",
+  "version": "0.0.1",
   "private": true,
   "keywords": [
     "ember-addon"

--- a/tests/fixtures/project-npm-validate/node_modules/ember-cli/package.json
+++ b/tests/fixtures/project-npm-validate/node_modules/ember-cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli",
+  "version": "1.2.3"
+}

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -3,6 +3,7 @@
 var assert         = require('../../helpers/assert');
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
+var Promise        = require('../../../lib/ext/promise');
 var Task           = require('../../../lib/models/task');
 
 describe('build command', function() {
@@ -16,6 +17,8 @@ describe('build command', function() {
 
   beforeEach(function() {
     tasks = {
+      NpmValidate: Task.extend(),
+
       Build: Task.extend({
         init: function() {
           buildTaskInstance = this;
@@ -34,6 +37,7 @@ describe('build command', function() {
       settings: {}
     });
 
+    stub(tasks.NpmValidate.prototype, 'run', Promise.resolve());
     stub(tasks.Build.prototype, 'run');
     stub(tasks.BuildWatch.prototype, 'run');
   });
@@ -45,25 +49,37 @@ describe('build command', function() {
   });
 
   afterEach(function() {
+    tasks.NpmValidate.prototype.run.restore();
     tasks.Build.prototype.run.restore();
     tasks.BuildWatch.prototype.run.restore();
   });
 
+  it('invokes the NpmValidate task', function() {
+    new BuildCommand(options).validateAndRun([ ])
+      .then(function() {
+        var npmValidate = tasks.NpmValidate.prototype.run;
+
+        assert.equal(npmValidate.called, 1, 'expected run to be called once');
+      });
+  });
+
   it('Build task is provided with the project instance', function() {
-    new BuildCommand(options).validateAndRun([ ]);
+    new BuildCommand(options).validateAndRun([ ])
+      .then(function() {
+        var buildRun = tasks.Build.prototype.run;
 
-    var buildRun = tasks.Build.prototype.run;
-
-    assert.equal(buildRun.called, 1, 'expected run to be called once');
-    assert.equal(buildTaskInstance.project, options.project, 'has correct project instance');
+        assert.equal(buildRun.called, 1, 'expected run to be called once');
+        assert.equal(buildTaskInstance.project, options.project, 'has correct project instance');
+      });
   });
 
   it('BuildWatch task is provided with the project instance', function() {
-    new BuildCommand(options).validateAndRun([ '--watch' ]);
+    new BuildCommand(options).validateAndRun([ '--watch' ])
+      .then(function() {
+        var buildWatchRun = tasks.BuildWatch.prototype.run;
 
-    var buildWatchRun = tasks.BuildWatch.prototype.run;
-
-    assert.equal(buildWatchRun.called, 1, 'expected run to be called once');
-    assert.equal(buildWatchTaskInstance.project, options.project, 'has correct project instance');
+        assert.equal(buildWatchRun.called, 1, 'expected run to be called once');
+        assert.equal(buildWatchTaskInstance.project, options.project, 'has correct project instance');
+      });
   });
 });

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -3,6 +3,7 @@
 var assert         = require('../../helpers/assert');
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
+var Promise        = require('../../../lib/ext/promise');
 var Task           = require('../../../lib/models/task');
 
 describe('server command', function() {
@@ -16,6 +17,7 @@ describe('server command', function() {
 
   beforeEach(function() {
     tasks = {
+      NpmValidate: Task.extend(),
       Serve: Task.extend()
     };
 
@@ -24,6 +26,7 @@ describe('server command', function() {
       settings: {}
     });
 
+    stub(tasks.NpmValidate.prototype, 'run', Promise.resolve());
     stub(tasks.Serve.prototype, 'run');
   });
 
@@ -32,46 +35,53 @@ describe('server command', function() {
   });
 
   afterEach(function() {
+    tasks.NpmValidate.prototype.run.restore();
     tasks.Serve.prototype.run.restore();
   });
 
   it('has correct options', function() {
-    new ServeCommand(options).validateAndRun([
-      '--port', '4000'
-    ]);
+    new ServeCommand(options).validateAndRun(['--port', '4000'])
+      .then(function() {
+        var serveRun = tasks.Serve.prototype.run;
+        var ops = serveRun.calledWith[0][0];
 
-    var serveRun = tasks.Serve.prototype.run;
-    var ops = serveRun.calledWith[0][0];
+        assert.equal(serveRun.called, 1, 'expected run to be called once');
 
-    assert.equal(serveRun.called, 1, 'expected run to be called once');
-
-    assert.equal(ops.port,           4000,      'has correct port');
-    assert.equal(ops.liveReloadPort, 35529,     'has correct liveReload port');
+        assert.equal(ops.port,           4000,      'has correct port');
+        assert.equal(ops.liveReloadPort, 35529,     'has correct liveReload port');
+      });
   });
 
   it('has correct liveLoadPort', function() {
-    new ServeCommand(options).validateAndRun([
-      '--live-reload-port', '4001'
-    ]);
+    new ServeCommand(options).validateAndRun(['--live-reload-port', '4001'])
+      .then(function() {
+        var serveRun = tasks.Serve.prototype.run;
+        var ops = serveRun.calledWith[0][0];
 
-    var serveRun = tasks.Serve.prototype.run;
-    var ops = serveRun.calledWith[0][0];
+        assert.equal(serveRun.called, 1, 'expected run to be called once');
 
-    assert.equal(serveRun.called, 1, 'expected run to be called once');
-
-    assert.equal(ops.liveReloadPort, 4001,     'has correct liveReload port');
+        assert.equal(ops.liveReloadPort, 4001,     'has correct liveReload port');
+      });
   });
-  
+
   it('has correct proxy', function() {
-    new ServeCommand(options).validateAndRun([
-      '--proxy', 'http://localhost:3000/'
-    ]);
+    new ServeCommand(options).validateAndRun(['--proxy', 'http://localhost:3000/'])
+      .then(function() {
+        var serveRun = tasks.Serve.prototype.run;
+        var ops = serveRun.calledWith[0][0];
 
-    var serveRun = tasks.Serve.prototype.run;
-    var ops = serveRun.calledWith[0][0];
+        assert.equal(serveRun.called, 1, 'expected run to be called once');
 
-    assert.equal(serveRun.called, 1, 'expected run to be called once');
+        assert.equal(ops.proxy, 'http://localhost:3000/', 'has correct port');
+      });
+  });
 
-    assert.equal(ops.proxy, 'http://localhost:3000/', 'has correct port');
+  it('invokes the NpmValidate task', function() {
+    new ServeCommand(options).validateAndRun()
+      .then(function() {
+        var npmValidate = tasks.NpmValidate.prototype.run;
+
+        assert.equal(npmValidate.called, 1, 'expected run to be called once');
+      });
   });
 });

--- a/tests/unit/tasks/npm-validate-test.js
+++ b/tests/unit/tasks/npm-validate-test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var assert          = require('../../helpers/assert');
+var MockUI          = require('../../helpers/mock-ui');
+var NpmValidateTask = require('../../../lib/tasks/npm-validate');
+
+describe('npm-validate', function() {
+  var createTask = function(dependencies, devDependencies) {
+    return new NpmValidateTask({
+      ui: new MockUI(),
+      project: {
+        root: 'tests/fixtures/project-npm-validate',
+        pkg: {
+          dependencies: dependencies,
+          devDependencies: devDependencies
+        }
+      }
+    });
+  };
+
+  var error = 'The project has unsatisfied NPM dependencies';
+
+  var assertResolved = function(task) {
+    return task.run()
+      .catch(function() {})
+      .finally(function() {
+        assert.notInclude(task.ui.output, error);
+      });
+  };
+
+  var assertRejected = function(task) {
+    var error = 'The project has unsatisfied NPM dependencies';
+    return task.run()
+      .catch(function() {})
+      .finally(function() {
+        assert.include(task.ui.output, error);
+      });
+  };
+
+  describe('reports an error', function() {
+    it('when the specified package is not installed', function() {
+      var task = createTask({ 'foo': '0.1.1' }, { 'ember-cli': '1.2.3' });
+      return assertRejected(task);
+    });
+
+    it('when the installed package does not match the version specified', function() {
+      var task = createTask({ 'ember-cli': '0.1.1' });
+      return assertRejected(task);
+    });
+
+    it('when the installed package does not satisfy the version range specified', function() {
+      var task = createTask({ 'ember-cli': '>1.3.2 <=2.3.4' });
+      return assertRejected(task);
+    });
+
+    it('when the installed package is not compatible with the version specified', function() {
+      var task = createTask({ 'ember-cli': '0.2.x' });
+      return assertRejected(task);
+    });
+
+    it('when the version specified is a Git repo with a semver tag and there is a version mismatch', function() {
+      var task = createTask({ 'ember-cli': 'git://github.com/stefanpenner/ember-cli.git#v0.1.0' });
+      return assertRejected(task);
+    });
+  });
+
+  describe('does not report an error', function() {
+    it('when the installed package matches the version specified', function() {
+      var task = createTask({ 'ember-cli': '1.2.3' });
+      return assertResolved(task);
+    });
+
+    it('when the installed package satisfies the version range specified', function() {
+      var task = createTask({ 'ember-cli': '>1.0.0' });
+      return assertResolved(task);
+    });
+
+    it('when the installed package is compatible with the version specified', function() {
+      var task = createTask({ 'ember-cli': '^1.2.0' });
+      return assertResolved(task);
+    });
+
+    it('when the version specified is a URL', function() {
+      var task = createTask({ 'ember-cli': 'http://ember-cli.com/ember-cli.tar.gz' });
+      return assertResolved(task);
+    });
+
+    it('when the version specified is a Git repo with a non-semver tag', function() {
+      var task = createTask({ 'ember-cli': 'git://github.com/stefanpenner/ember-cli.git#master' });
+      return assertResolved(task);
+    });
+
+    it('when the version specified is a local path', function() {
+      var task = createTask({ 'ember-cli': '~/projects/ember-cli' });
+      return assertResolved(task);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the infamous NPM dependency issue mentioned in several places, including [here](https://github.com/stefanpenner/ember-cli/issues/253) and again recently [here](https://github.com/stefanpenner/ember-cli/issues/2192).

The changes involve introducing a new task, `NpmValidate`, to the existing `Build`, `Serve`, and `Test` commands. If a dependency is listed in `package.json` but is not installed or the version installed is incorrect, ember-cli halts the builds with an error message.

I haven't done the Bower side of things (it can be a separate PR), but I wanted to get some feedback on the approach before going all the way.

Thanks!
