### PR TITLE
Remove duplicate writeError.

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -41,7 +41,6 @@ module.exports = Task.extend({
 
     // Reload on file changes
     this.watcher.on('change', this.didChange.bind(this));
-    this.watcher.on('error',  this.didError.bind(this));
 
     // Start LiveReload server
     return this.listen(options.liveReloadPort)
@@ -77,13 +76,5 @@ module.exports = Task.extend({
         message: 'live-reload'
       });
     }
-  },
-
-  didError: function(error) {
-    this.ui.writeError(error);
-    this.analytics.trackError({
-      description: error.message + ' ' + error.stack,
-      isFatal:     false
-    });
   }
 });

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -6,8 +6,6 @@ var MockUI           = require('../../../helpers/mock-ui');
 var net              = require('net');
 var EOL              = require('os').EOL;
 var path             = require('path');
-var chalk            = require('chalk');
-var BuildError       = require('../../../helpers/build-error');
 var MockWatcher      = require('../../../helpers/mock-watcher');
 
 describe('livereload-server', function() {
@@ -125,57 +123,6 @@ describe('livereload-server', function() {
       });
       assert.equal(changedCount, 0);
       assert.equal(trackCount, 0);
-    });
-
-    it('emits without error.file', function() {
-      subject.didError(new BuildError({
-        file: 'someFile',
-        message: 'buildFailed'
-      }));
-
-      var outs = ui.output.split(EOL);
-
-      assert.equal(outs[0], chalk.red('File: someFile'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
-    });
-
-    it('emits with error.file with error.line without err.col', function() {
-      subject.didError(new BuildError({
-        file: 'someFile',
-        line: 24,
-        message: 'buildFailed'
-      }));
-
-      var outs = ui.output.split(EOL);
-
-      assert.equal(outs[0], chalk.red('File: someFile (24)'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
-    });
-
-    it('emits with error.file without error.line with err.col', function() {
-      subject.didError(new BuildError({
-        file: 'someFile',
-        col: 80,
-        message: 'buildFailed'
-      }));
-      var outs = ui.output.split(EOL);
-
-      assert.equal(outs[0], chalk.red('File: someFile'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
-    });
-
-    it('emits with error.file with error.line with err.col', function() {
-      subject.didError(new BuildError({
-        file: 'someFile',
-        line: 24,
-        col: 80,
-        message: 'buildFailed'
-      }));
-
-      var outs = ui.output.split(EOL);
-
-      assert.equal(outs[0], chalk.red('File: someFile (24:80)'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
     });
   });
 });


### PR DESCRIPTION
Both the livereload server and the watcher were listening to the `watcher`'s `error` event which caused the same error to be printed twice.

The `didError` in `livereload-server` is superfluous (it cannot run without `wacther` running and `watcher` already has a `didError` that does the right thing).

Copies tests added in #2246, into the watcher models tests.
