### PR TITLE
Add ember-export-application-global to default app blueprint.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,6 +23,7 @@
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-content-security-policy": "0.2.0",
+    "ember-export-application-global": "^1.0.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.2.2",
     "ember-cli-qunit": "0.1.0",


### PR DESCRIPTION
From https://github.com/stefanpenner/ember-cli/pull/2183#issuecomment-58502411:

> > The addon solves my problem, but it also requires my knowledge of the addon's existence which seems like a lot to ask of new users.
> 
> Exactly, I think the cost/benefit trade-off here makes it clear we should include by default
