### PR TITLE
add Addon.prototype.isEnabled for an addon to exclude itself from the project

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -207,9 +207,15 @@ function EmberApp(options) {
 */
 EmberApp.prototype._notifyAddonIncluded = function() {
   this.initializeAddons();
-  this.project.addons.forEach(function(addon) {
-    if (addon.included) {
-      addon.included(this);
+  this.project.addons = this.project.addons.filter(function(addon) {
+    addon.app = this;
+
+    if (!addon.isEnabled || addon.isEnabled()) {
+      if (addon.included) {
+        addon.included(this);
+      }
+
+      return addon;
     }
   }, this);
 };

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -121,8 +121,7 @@ Addon.prototype._treeFor = function _treeFor(name) {
   return tree;
 };
 
-Addon.prototype.included = function(app) {
-  this.app = app;
+Addon.prototype.included = function(/* app */) {
 };
 
 Addon.prototype.includedModules = function() {
@@ -318,6 +317,10 @@ Addon.prototype.config = function (env, baseConfig) {
 
     return configGenerator(env, baseConfig);
   }
+};
+
+Addon.prototype.isEnabled = function() {
+  return true;
 };
 
 Addon.resolvePath = function(addon) {

--- a/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/index.js
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  name: 'ember-foo-env-addon',
+  isEnabled: function() {
+    return this.app.env === 'foo';
+  }
+};

--- a/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/package.json
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ember-foo-env-addon",
+  "private": true,
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  name: 'Ember Random Addon'
+};

--- a/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/package.json
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ember-random-addon",
+  "private": true,
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/fixtures/addon/env-addons/package.json
+++ b/tests/fixtures/addon/env-addons/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "env-addons",
+  "private": true,
+  "devDependencies": {
+    "ember-foo-env-addon": "latest",
+    "ember-random-addon": "latest"
+  }
+}
+

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -46,6 +46,22 @@ describe('broccoli/ember-app', function() {
       assert.equal(app.bowerDirectory, project.bowerDirectory);
       assert.equal(app.bowerDirectory, 'bower_components');
     });
+
+    describe('_nofifyAddonIncluded', function() {
+      beforeEach(function() {
+        project.initializeAddons = function() { };
+        project.addons = [{name: 'custom-addon'}];
+      });
+
+      it('should set the app on the addons', function() {
+        var app = new EmberApp({
+          project: project
+        });
+
+        var addon = project.addons[0];
+        assert.deepEqual(addon.app, app);
+      });
+    });
   });
 
   describe('contentFor', function() {
@@ -336,6 +352,35 @@ describe('broccoli/ember-app', function() {
 
         assert.equal(emberApp.toTree(), 'blap');
       });
+    });
+
+    describe('isEnabled is called properly', function() {
+      beforeEach(function() {
+        projectPath = path.resolve(__dirname, '../../fixtures/addon/env-addons');
+        var packageContents = require(path.join(projectPath, 'package.json'));
+        project = new Project(projectPath, packageContents);
+      });
+
+      afterEach(function() {
+        process.env.EMBER_ENV = undefined;
+      });
+
+      describe('with environment', function() {
+        it('development', function() {
+          process.env.EMBER_ENV = 'development';
+          emberApp = new EmberApp({ project: project });
+
+          assert.equal(emberApp.project.addons.length, 5);
+        });
+
+        it('foo', function() {
+          process.env.EMBER_ENV = 'foo';
+          emberApp = new EmberApp({ project: project });
+
+          assert.equal(emberApp.project.addons.length, 6);
+        });
+      });
+
     });
   });
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -215,11 +215,6 @@ describe('models/addon.js', function() {
         assert.equal(addon.project.name, project.name);
       });
 
-      it('sets the app if included', function() {
-        addon.included('app');
-        assert.equal(addon.app, 'app');
-      });
-
       it('generates a list of es6 modules to ignore', function() {
         assert.deepEqual(addon.includedModules(), {
           'ember-cli-generated-with-export/controllers/people': ['default'],
@@ -282,7 +277,7 @@ describe('models/addon.js', function() {
               return ['js'];
             }
           };
-          addon.included(app);
+          addon.app = app;
           var tree = addon.treeFor('addon');
           assert.equal(typeof tree.read, 'function');
         });


### PR DESCRIPTION
closes #2269 

addons can exclude themselves by implementing an isEnabled hook where they can access `this.app` to do whatever checks they want to.

I've also removed the requirement for settings this.app in the included hook. It always does it now.
