### PR TITLE
Fix gitignore in app blueprint

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -6,7 +6,7 @@
 
 # dependencies
 /node_modules
-/bower_components/*
+/bower_components
 
 # misc
 /.sass-cache


### PR DESCRIPTION
The line for `bower_components` should not end in `/*` or, the pattern matches files underneath `bower_components` but not the `bower_components` directory itself. This breaks `git-clean` and, contradicts the pattern for `node_modules`, which is correct. See: http://git-scm.com/docs/gitignore.
