### PR TITLE
Add `storeConfigInMeta` option.

### DIFF
--- a/lib/broccoli/app-config-from-meta.js
+++ b/lib/broccoli/app-config-from-meta.js
@@ -1,0 +1,14 @@
+/* jshint ignore:start */
+
+try {
+  var metaName = prefix + '/config/environment';
+  var rawConfig = Ember['default'].$('meta[name="' + metaName + '"]').attr('content');
+  var config = JSON.parse(unescape(rawConfig));
+
+  return { 'default': config };
+}
+catch(err) {
+  throw new Error('Could not read config from meta tag with name "' + metaName + '".');
+}
+
+/* jshint ignore:end */

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,16 +1,7 @@
 /* jshint ignore:start */
 
 define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
-  try {
-    var metaName = '{{MODULE_PREFIX}}/config/environment';
-    var rawConfig = Ember['default'].$('meta[name="' + metaName + '"]').attr('content');
-    var config = JSON.parse(unescape(rawConfig));
-
-    return { 'default': config };
-  }
-  catch(err) {
-    throw new Error('Could not read config from meta tag with name "' + metaName + '".');
-  }
+  {{content-for 'config-module'}}
 });
 
 if (runningTests) {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -86,6 +86,7 @@ function EmberApp(options) {
   this.options = merge(options, {
     es3Safe: true,
     wrapInEval: !isProduction,
+    storeConfigInMeta: true,
     outputPaths: {
       app: {
         css: '/assets/' + this.name + '.css',
@@ -907,8 +908,19 @@ EmberApp.prototype.contentFor = function(config, match, type) {
   if (type === 'head') {
     content.push(calculateBaseTag(config));
 
-    content.push('<meta name="' + config.modulePrefix + '/config/environment" ' +
-                 'content="' + escape(JSON.stringify(config)) + '">');
+    if (this.options.storeConfigInMeta) {
+      content.push('<meta name="' + config.modulePrefix + '/config/environment" ' +
+                   'content="' + escape(JSON.stringify(config)) + '">');
+    }
+  }
+
+  if (type === 'config-module') {
+    if (this.options.storeConfigInMeta) {
+      content.push('var prefix = \'' + config.modulePrefix + '\';');
+      content.push(fs.readFileSync(path.join(__dirname, 'app-config-from-meta.js')));
+    } else {
+      content.push('return { \'default\': ' + JSON.stringify(config) + '};');
+    }
   }
 
   content = this.project.addons.reduce(function(content, addon) {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var fs       = require('fs');
 var path     = require('path');
 var Project  = require('../../../lib/models/project');
 var EmberApp = require('../../../lib/broccoli/ember-app');
@@ -96,13 +97,24 @@ describe('broccoli/ember-app', function() {
     });
 
     describe('contentFor("head")', function() {
-      it('includes the `meta` tag in `head`', function() {
+      it('includes the `meta` tag in `head` by default', function() {
         var escapedConfig = escape(JSON.stringify(config));
         var metaExpected = '<meta name="cool-foo/config/environment" ' +
                            'content="' + escapedConfig + '">';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
         assert(actual.indexOf(metaExpected) > -1);
+      });
+
+      it('does not include the `meta` tag in `head` if storeConfigInMeta is false', function() {
+        emberApp.options.storeConfigInMeta = false;
+
+        var escapedConfig = escape(JSON.stringify(config));
+        var metaExpected = '<meta name="cool-foo/config/environment" ' +
+                           'content="' + escapedConfig + '">';
+        var actual = emberApp.contentFor(config, defaultMatch, 'head');
+
+        assert(actual.indexOf(metaExpected) === -1);
       });
 
       it('includes the `base` tag in `head` if locationType is auto', function() {
@@ -130,6 +142,26 @@ describe('broccoli/ember-app', function() {
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
         assert(actual.indexOf(expected) === -1);
+      });
+    });
+
+    describe('contentFor("config-module")', function() {
+      it('includes the meta gathering snippet by default', function() {
+        var metaSnippetPath = path.join(__dirname, '..','..','..','lib','broccoli','app-config-from-meta.js');
+        var expected = fs.readFileSync(metaSnippetPath);
+
+        var actual = emberApp.contentFor(config, defaultMatch, 'config-module');
+
+        assert(actual.indexOf(expected) > -1);
+      });
+
+      it('includes the raw config if storeConfigInMeta is false', function() {
+        emberApp.options.storeConfigInMeta = false;
+
+        var expected = JSON.stringify(config);
+        var actual = emberApp.contentFor(config, defaultMatch, 'config-module');
+
+        assert(actual.indexOf(expected) > -1);
       });
     });
 


### PR DESCRIPTION
Allows opting out of using `<meta>` tag in `head` section for configuration.
- If set to `true` the calculated config will be stored in a `<meta>` tag in `index.html`.
- If set to `false` the calculated config will be stored in the final `my-app-name.js` file.

Defaults to `true`.

Closes https://github.com/stefanpenner/ember-cli/issues/2184.
