### PR TITLE
Closes #1763 utilize ember server during testem run to get HTTP mocks

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -31,6 +31,9 @@ module.exports = function(environment) {
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'auto';
+    // ENV.mockApiEnabled = false;
+    // ENV.mockApiHost = '0.0.0.0';
+    // ENV.mockApiPort = 4200;
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -51,6 +51,13 @@ module.exports = Task.extend({
     options.ui          = this.ui;
     options.httpServer  = this.httpServer;
 
+    if (options.enabledInTest) {
+      this.app.all('/*', function(req, res, next) {
+        res.header('Access-Control-Allow-Origin', 'http://localhost:'+options.testRunnerPort);
+        next();
+      });
+    }
+
     this.processAppMiddlewares(options);
     this.processAddonMiddlewares(options);
 

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -4,27 +4,41 @@ var Task    = require('../models/task');
 var Promise = require('../ext/promise');
 var rimraf  = Promise.denodeify(require('rimraf'));
 var chalk   = require('chalk');
+var ExpressServer    = require('./server/express-server');
 
 module.exports = Task.extend({
   init: function() {
     this.testem = this.testem || new (require('testem'))();
   },
   run: function(options) {
+    var testemOptions = {
+      file: options.configFile,
+      port: options.port,
+      cwd: options.outputPath
+    };
+
     var ui = this.ui;
     var testem = this.testem;
+    var watcher = options.watcher;
 
     // The building has actually started already, but we want some output while we wait for the server
     ui.pleasantProgress.start(chalk.green('Building'), chalk.green('.'));
 
-    return new Promise(function() {
-      var testemOptions = {
-        file: options.configFile,
-        port: options.port,
-        cwd: options.outputPath
-      };
+    var expressServerOptions = {
+      enabledInTest: this.project.config('test').mockApiEnabled || false,
+      host: this.project.config('test').mockApiHost || '0.0.0.0',
+      port: this.project.config('test').mockApiPort || 4200,
+      baseURL: this.project.config('test').baseURL || '/',
+      testRunnerPort: options.port
+    };
 
-      var watcher = options.watcher;
-      var started = false;
+    var expressServer = new ExpressServer({
+      ui: this.ui,
+      project: this.project
+    });
+
+    var started = false;
+    return new Promise(function() {
 
       // Wait for a build and then either start or restart testem
       watcher.on('change', function() {
@@ -35,12 +49,23 @@ module.exports = Task.extend({
 
           ui.pleasantProgress.stop();
 
-          testem.startDev(testemOptions, function(code) {
-            rimraf(options.outputPath)
-              .finally(function() {
-                process.exit(code);
+          if (expressServerOptions.enabledInTest) {
+            expressServer.start(expressServerOptions).then(function(){
+              testem.startDev(testemOptions, function(code) {
+                rimraf(options.outputPath)
+                  .finally(function() {
+                    process.exit(code);
+                  });
               });
-          });
+            });
+          } else {
+            testem.startDev(testemOptions, function(code) {
+              rimraf(options.outputPath)
+                .finally(function() {
+                  process.exit(code);
+                });
+            });
+          }
         }
       });
     });

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -3,6 +3,7 @@
 var Task        = require('../models/task');
 var Promise     = require('../ext/promise');
 var SilentError = require('../errors/silent');
+var ExpressServer    = require('./server/express-server');
 
 module.exports = Task.extend({
   init: function() {
@@ -42,6 +43,26 @@ module.exports = Task.extend({
       middleware: this.addonMiddlewares()
     };
 
-    return this.invokeTestem(testemOptions);
+    var expressServerOptions = {
+      enabledInTest: this.project.config('test').mockApiEnabled || false,
+      host: this.project.config('test').mockApiHost || '0.0.0.0',
+      port: this.project.config('test').mockApiPort || 4200,
+      baseURL: this.project.config('test').baseURL || '/',
+      testRunnerPort: options.port
+    };
+
+    var expressServer = new ExpressServer({
+      ui: this.ui,
+      project: this.project
+    });
+
+    if (expressServerOptions.enabledInTest) {
+      var self = this;
+      return expressServer.start(expressServerOptions).then(function(){
+        return self.invokeTestem(testemOptions);
+      });
+    } else {
+      return this.invokeTestem(testemOptions);
+    }
   }
 });


### PR DESCRIPTION
- My take on #1423 (heavily based on the work of @dustinfarris )
- Test Environment determines if Express Server spins up (false by default)
- Sets Express Access-Control-Allow-Origin to test runner port for all requests
- Refactors `tasks/test-server.js` to feel a bit more like `tasks/test.js`

<3
