### PR TITLE
vendorFiles should maintain its order even when it's overridden

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -32,6 +32,7 @@ var uglifyJavaScript = require('broccoli-uglify-js');
 var assign        = require('lodash-node/modern/objects/assign');
 var defaults      = require('lodash-node/modern/objects/defaults');
 var merge         = require('lodash-node/modern/objects/merge');
+var omit          = require('lodash-node/modern/objects/omit');
 var path          = require('path');
 var ES3SafeFilter = require('broccoli-es3-safe-recast');
 var Funnel        = require('broccoli-funnel');
@@ -118,7 +119,7 @@ function EmberApp(options) {
     vendorFiles: {}
   }, defaults);
 
-  this.vendorFiles = merge({
+  this.vendorFiles = omit(merge({
     'loader.js': this.options.loader,
     'jquery.js': this.bowerDirectory + '/jquery/dist/jquery.js',
     'handlebars.js': {
@@ -150,7 +151,9 @@ function EmberApp(options) {
         }
       }
     ]
-  }, options.vendorFiles, defaults);
+  }, options.vendorFiles), function(value) {
+    return value === null;
+  });
 
   this.options.trees = merge(this.options.trees, {
     app:       'app',

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -343,15 +343,36 @@ describe('broccoli/ember-app', function() {
         defaultVendorFiles);
     });
 
+    it('redefines a location of a vendor asset', function() {
+      emberApp = new EmberApp({
+        vendorFiles: {
+          'ember.js': 'vendor/ember.js'
+        }
+      });
+      assert.equal(emberApp.vendorFiles['ember.js'], 'vendor/ember.js');
+    });
+
     it('defines vendorFiles in order even when option for it is passed', function() {
       emberApp = new EmberApp({
         vendorFiles: {
-          'ember.js': 'ember.js'
+          'ember.js': 'vendor/ember.js'
         }
       });
       assert.deepEqual(
         Object.keys(emberApp.vendorFiles),
         defaultVendorFiles);
-    })
+    });
+
+    it('removes dependency in vendorFiles', function() {
+      emberApp = new EmberApp({
+        vendorFiles: {
+          'ember.js': null,
+          'handlebars.js': null
+        }
+      });
+      var vendorFiles = Object.keys(EmberApp);
+      assert.equal(vendorFiles.indexOf('ember.js'), -1);
+      assert.equal(vendorFiles.indexOf('handlebars.js'), -1);
+    });
   });
 });


### PR DESCRIPTION
We were overriding `vendorFiles`, and we encountered that when we tried to simply override the 'ember.js' file, it reordered the hash in having `ember.js` as a first import. This resulted in evaluation of ember before some of its dependencies.
