### PR TITLE
allowing isProduction to be passed in as an option to the build process

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -69,7 +69,7 @@ function EmberApp(options) {
 
   this.registry = options.registry || p.setupRegistry(this);
 
-  var isProduction = this.env === 'production';
+  var isProduction = options.isProduction || this.env === 'production';
 
   this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
   this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;


### PR DESCRIPTION
Here's my use case for this - I'd like to build a "staging" version of the app that is functionally identical to production, but points to a different url. I don't want to skip running minification/fingerprinting/WhatHaveYou but I don't want to run the risk of missing a setting. I'd rather just set an option at build time to ensure the production/staging builds are identical. 
