### PR TITLE
[DOCS] Change order of components section

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -174,19 +174,6 @@ Adds bower components to development dependencies
 Normally you can leave the `Brocfile.js` as is. Only touch it if you need to customize the merging of trees for the addon and you understand how to use the [Brocfile API](https://www.npmjs.org/package/broccoli).
 
 ### Components
-In order to allow the consuming application to use the addon component without manual import statements, put the component under the `app/components` directory.
-
-{% highlight javascript %}
-// app/components/x-button.js
-
-import Ember from 'ember';
-import XButton from 'ember-x-button/components/x-button';
-
-export default XButton;
-{% endhighlight %}
-
-The code imports the component from the addon directory and exports it again. This setup allows others to modify the component by extending it while making the component available in the consuming applications namespace.
-
 The actual code for the addon goes in `addon/components/x-button.js`
 
 {% highlight javascript %}
@@ -204,6 +191,23 @@ export default Ember.Component.extend({
   }.on('willDestroyElement'),
 });
 {% endhighlight %}
+
+In order to allow the consuming application to use the addon component without manual import statements, put the component under the `app/components` directory.
+
+{% highlight javascript %}
+// app/components/x-button.js
+
+import Ember from 'ember';
+import XButton from 'ember-x-button/components/x-button';
+
+export default XButton;
+{% endhighlight %}
+
+The code imports the component from the addon directory and exports it again.
+This setup allows others to modify the component by extending it while making
+the component available in the consuming applications namespace. This means
+anyone who installs your `x-button` addon can start using the component in their
+templates with `{{x-button}}` without any extra configuration.
 
 ### Blueprints
 To create a blueprint, add a file `blueprints/x-button/index.js`. This follows the usual Ember blueprints naming conventions.


### PR DESCRIPTION
Change order of components section to make it clear that development should happen in the `addon` directory, while the component should be exposed in the `app` directory.

I think it is more clear if first you define your component `/addon`, and then you expose it in `/app`. Also added a line saying that by exporting it in `/app`, it is available automatically for whoever installs your addon.
