### PR TITLE
Close #2350 Fixes generated model relationship tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,7 @@ module.exports = Task.extend({
     - file, folder and package names
     - CSS classes
     - HTML tags and attributes
+    - Model relationships
   - Camel case (`someThing`)
     - JavaScript (and JSON) properties and variables
   - Pascal case (`SomeThing`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-cli Changelog
 
+### Master
+
+* [BUGFIX] Fix automatic generated model belongs-to and has-many relations to resolve test lookup. [#2351][https://github.com/stefanpenner/ember-cli/pull/2351]
+
 ### 0.1.2
 
 #### Applications

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -24,9 +24,9 @@ module.exports = {
 
       if (/has-many/.test(dasherizedType)) {
         var camelizedNamePlural = inflection.pluralize(camelizedName);
-        attrs.push(camelizedNamePlural + ': ' + dsAttr(camelizedName, dasherizedType));
+        attrs.push(camelizedNamePlural + ': ' + dsAttr(dasherizedName, dasherizedType));
       } else {
-        attrs.push(camelizedName + ': ' + dsAttr(camelizedName, dasherizedType));
+        attrs.push(camelizedName + ': ' + dsAttr(dasherizedName, dasherizedType));
       }
 
       if (/has-many|belongs-to/.test(dasherizedType)) {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -202,7 +202,13 @@ describe('Acceptance: ember generate', function() {
       'bars:has-many',
       'baz:belongs-to',
       'echo:hasMany',
-      'bravo:belongs_to'
+      'bravo:belongs_to',
+      'foo-names:has-many',
+      'barName:has-many',
+      'bazName:belongs-to',
+      'test-name:belongs-to',
+      'echoName:hasMany',
+      'bravoName:belongs_to'
     ]).then(function() {
       assertFile('app/models/foo.js', {
         contains: [
@@ -214,11 +220,30 @@ describe('Acceptance: ember generate', function() {
           "bars: DS.hasMany('bar')",
           "baz: DS.belongsTo('baz')",
           "echos: DS.hasMany('echo')",
-          "bravo: DS.belongsTo('bravo')"
+          "bravo: DS.belongsTo('bravo')",
+          "fooNames: DS.hasMany('foo-name')",
+          "barNames: DS.hasMany('bar-name')",
+          "bazName: DS.belongsTo('baz-name')",
+          "testName: DS.belongsTo('test-name')",
+          "echoNames: DS.hasMany('echo-name')",
+          "bravoName: DS.belongsTo('bravo-name')"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
-        contains: "needs: ['model:bar', 'model:baz', 'model:echo', 'model:bravo']"
+        contains: [
+          "needs: [",
+          "'model:bar',",
+          "'model:baz',",
+          "'model:echo',",
+          "'model:bravo',",
+          "'model:foo-name',",
+          "'model:bar-name',",
+          "'model:baz-name',",
+          "'model:echo-name',",
+          "'model:test-name',",
+          "'model:bravo-name'",
+          "]"
+        ]
       });
     });
   });


### PR DESCRIPTION
This is one way of resolving this issue. The other would be to make the resolver allow for both cases in uses:[] which would probably be the better solution.
