### PR TITLE
Adds default description to addon

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -14,6 +14,7 @@ module.exports = {
 
     delete contents.private;
     contents.name = this.project.name();
+    contents.description = this.description;
     contents.keywords = contents.keywords || [];
 
     if (contents.keywords.indexOf('ember-addon') === -1) {


### PR DESCRIPTION
This change will provide a default description to all addons. This will help prevent addons with missing descriptions which is really commong for ember addons in npmjs.org and emberaddons.com. When a module has no description npmjs.org will try to use the README.md which contains markdown and looks like garbage on both npmjs.org and emberaddons.com.
