### PR TITLE
Quick fix for cut-off navigation

### DIFF
--- a/assets/styles/ecli.scss
+++ b/assets/styles/ecli.scss
@@ -357,8 +357,11 @@ body {
       padding-left: 0;padding-right: 0;
       .affix {
         top: 0;
+        bottom: 0;
         left: 0;
         width: 25%;
+        overflow-y: auto;
+        overflow-x: hidden;
       }
     }
     .main {


### PR DESCRIPTION
The better alternative would be to have the "Back To Top" button fixed to the top, and the rest of the side nav scrolling.

The issue: 
![screen shot 2014-10-20 at 10 21 20 am](https://cloud.githubusercontent.com/assets/34726/4702610/69b62dc4-5864-11e4-9187-a96350acdf13.png)
