### PR TITLE
Debug-friendly minification defaults

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -106,7 +106,14 @@ function EmberApp(options) {
       enabled: !!isProduction,
       options: {
         mangle: true,
-        compress: true
+        compress: true,
+        // preserve newlines, to make debugging easier
+        // (with gzip the effect is negligible)
+        output: {
+          beautify: true,
+          indent_start: 0,
+          indent_level: 2
+        }
       }
     },
     loader: this.bowerDirectory + '/loader.js/loader.js',


### PR DESCRIPTION
Most apps will use Rollbar, TrackJS, etc. to get alerted on errors. Ember has great support for this setup via `Ember.onerror`. However, for error messages to be meaningful LFs are needed.

With gzip the extra LFs are < 10%, and it makes working with ember more pleasant for newcomers (I've helped people on irc who couldn't debug their app when errors occurred in production, and didn't know how to adjust this).

What do you think, does this sound like a good change?
