### PR TITLE
Enable properly nested addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Applications
 ### Addons
+* [ENHANCEMENT] Addons can now use nested addons. This enables things like addons using their own preprocessors. [#2354](https://github.com/stefanpenner/ember-cli/issues/2354)
+
 ### Blueprints
 
 ### 0.1.7

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -236,18 +236,18 @@ EmberApp.prototype.concatFiles = function(tree, options) {
   @private
 */
 EmberApp.prototype._notifyAddonIncluded = function() {
+  var self = this;
   this.initializeAddons();
-  this.project.addons = this.project.addons.filter(function(addon) {
-    addon.app = this;
 
-    if (!addon.isEnabled || addon.isEnabled()) {
-      if (addon.included) {
-        addon.included(this);
-      }
+  this.project.addonGraph.topsort(function(vertex) {
+    var addon        = vertex.value.addon;
+    var parentAddon  = vertex.value.parentAddon;
+    var target       = parentAddon || self;
 
-      return addon;
+    if (addon.included) {
+      addon.included(target);
     }
-  }, this);
+  });
 };
 
 /**

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -20,7 +20,7 @@ function Project(root, pkg) {
   debug('init root: %s', root);
   this.root          = root;
   this.pkg           = pkg;
-  this.addonPackages = {};
+  this.addonGraph    = new DAG();
   this.liveReloadFilterPatterns = [];
   this.setupBowerDirectory();
 }
@@ -166,28 +166,29 @@ Project.prototype.buildAddonPackages = function() {
   this.discoverAddons(this.root, this.pkg, false);
 };
 
-Project.prototype.discoverAddons = function(root, pkg, excludeDevDeps) {
+Project.prototype.discoverAddons = function(root, pkg, excludeDevDeps, parentAddonName) {
   Object.keys(this.dependencies(pkg, excludeDevDeps)).forEach(function(name) {
     if (name !== 'ember-cli') {
       var addonPath = path.join(root, 'node_modules', name);
-      this.addIfAddon(addonPath);
+      this.addIfAddon(addonPath, parentAddonName);
     }
   }, this);
 
   if (pkg['ember-addon'] && pkg['ember-addon'].paths) {
     pkg['ember-addon'].paths.forEach(function(addonPath) {
       addonPath = path.join(root, addonPath);
-      this.addIfAddon(addonPath);
+      this.addIfAddon(addonPath, parentAddonName);
     }, this);
   }
 };
 
-Project.prototype.addIfAddon = function(addonPath) {
+Project.prototype.addIfAddon = function(addonPath, parentAddonName) {
   var pkgPath = path.join(addonPath, 'package.json');
   debug('attemping to add: %s',  addonPath);
 
   if (fs.existsSync(pkgPath)) {
     var addonPkg = require(pkgPath);
+    var addonName = addonPkg.name + '@' + addonPkg.version;
     var keywords = addonPkg.keywords || [];
     debug(' - module found: %s', addonPkg.name);
 
@@ -195,11 +196,11 @@ Project.prototype.addIfAddon = function(addonPath) {
 
     if (keywords.indexOf('ember-addon') > -1) {
       debug(' - is addon, adding...');
-      this.discoverAddons(addonPath, addonPkg, true);
-      this.addonPackages[addonPkg.name] = {
+      this.addonGraph.addEdges(addonName, {
         path: addonPath,
         pkg: addonPkg
-      };
+      }, null, parentAddonName);
+      this.discoverAddons(addonPath, addonPkg, true, addonName);
     } else {
       debug(' - no ember-addon keyword, not including.');
     }
@@ -214,25 +215,38 @@ Project.prototype.initializeAddons = function() {
 
   debug('initializeAddons for: %s', this.name());
 
-  var project         = this;
-  var graph           = new DAG();
-  var addon, emberAddonConfig;
+  var project                    = this;
+  var addonDependencyOrderGraph  = new DAG();
 
   this.buildAddonPackages();
 
-  for (var name in this.addonPackages) {
-    addon            = this.addonPackages[name];
-    emberAddonConfig = addon.pkg['ember-addon'];
+  this.addonGraph.topsort(function(vertex) {
+    var addonLookup = vertex.value;
+    var addonConfig = addonLookup.pkg['ember-addon'];
+    var AddonClass = Addon.lookup(addonLookup);
+    var parentAddonVertex = vertex.incoming[vertex.incomingNames[0]];
+    var parentAddon, addon;
 
-    graph.addEdges(name, addon, emberAddonConfig.before, emberAddonConfig.after);
-  }
+    if (parentAddonVertex) {
+      parentAddon = parentAddonVertex.value.addon;
+    }
 
-  this.addons = [];
-  graph.topsort(function (vertex) {
-    var addon           = vertex.value;
-    if (addon) {
-      var AddonConstructor = Addon.lookup(addon);
-      project.addons.push(new AddonConstructor(project));
+    addon = new AddonClass(project);
+    vertex.value.addon = addon;
+    vertex.value.parentAddon = parentAddon;
+    addonDependencyOrderGraph.addEdges(vertex.name, vertex.value, addonConfig.before, addonConfig.after);
+  });
+
+  project.addons = [];
+  addonDependencyOrderGraph.topsort(function(vertex) {
+    if (vertex.value) {
+      var addon = vertex.value.addon;
+      var parentAddon = vertex.value.parentAddon;
+
+      if (!parentAddon) {
+        var AddonConstructor = Addon.lookup(addon);
+        project.addons.push(new AddonConstructor(project));
+      }
     }
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -268,6 +268,32 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('nested addons', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return copyFixtureFiles('brocfile-tests/nested-addons')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = require(packageJsonPath);
+        packageJson['ember-addon'] = {
+          paths: ['./lib/test-addon']
+        };
+
+        fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        // No need to positively assert the result below - the fixture that is being built contains
+        // an import that attempts to import the result of the preprocessor, which will fail if the
+        // preprocessor fails to run. Essentially, the successful build is our assertion here.
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .catch(function(e) {
+        assert(!e, 'nested addon build failed');
+      });
+  });
+
   it('specifying custom output paths works properly', function() {
     this.timeout(100000);
 

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -9,14 +9,12 @@
   },
   "devDependencies": {
     "ember-cli": "latest",
-    "ember-random-addon": "latest",
-    "ember-non-root-addon": "latest",
-    "ember-generated-with-export-addon": "latest",
+    "ember-contains-nested-addon": "latest",
     "ember-generated-no-export-addon": "latest",
-    "non-ember-thingy": "latest",
     "ember-before-blueprint-addon": "latest",
     "ember-after-blueprint-addon": "latest",
-    "ember-devDeps-addon": "latest"
+    "ember-devDeps-addon": "latest",
+    "ember-non-root-addon": "latest",
+    "non-ember-thingy": "latest"
   }
 }
-

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/addon/routes/application.test
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/addon/routes/application.test
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  test: 'processed with nested preprocessor'
+});

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/app/routes/application.js
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/app/routes/application.js
@@ -1,0 +1,3 @@
+import ApplicationRoute from 'test-addon/routes/application';
+
+export default ApplicationRoute;

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/index.js
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'test-addon'
+};

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/lib/ember-test-preprocessor/index.js
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/lib/ember-test-preprocessor/index.js
@@ -1,0 +1,23 @@
+var Filter = require('broccoli-filter');
+
+module.exports = {
+  name: 'test-preprocessor',
+  included: function(app) {
+    app.registry.add('js', {
+      name: 'test-preprocessor',
+      ext: 'test',
+      toTree: function(tree, inputPath, outputPath) {
+        // This faked out preprocessor doesn't touch the file contents - it
+        // just rewrites .test to .js, but otherwise leaves the file intact
+        var preprocessor = new Filter(tree, {
+          extensions: ['test'],
+          targetExtension: 'js',
+          srcDir: inputPath,
+          destDir: outputPath
+        });
+        preprocessor.processString = function(string) { return string };
+        return preprocessor
+      }
+    });
+  }
+};

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/lib/ember-test-preprocessor/package.json
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/lib/ember-test-preprocessor/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ember-test-preprocessor",
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/package.json
+++ b/tests/fixtures/brocfile-tests/nested-addons/lib/test-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-addon",
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "paths": ["./lib/ember-test-preprocessor"]
+  }
+}
+

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -209,7 +209,7 @@ describe('broccoli/ember-app', function() {
         };
 
         project.initializeAddons = function() {
-          this.addons = [ addon ];
+          this.addonGraph.map('test-addon', { addon: addon });
         };
 
         emberApp = new EmberApp({
@@ -218,6 +218,30 @@ describe('broccoli/ember-app', function() {
 
         expect(true, called);
         expect(passedApp).to.equal(emberApp);
+      });
+
+      it('included hook is passed the parentAddon, if present', function() {
+        var called = false;
+        var parentAddon = {
+          name: 'parent-addon'
+        };
+        var passedApp;
+
+        addon = {
+          included: function(app) { called = true; passedApp = app; },
+          treeFor: function() { }
+        };
+
+        project.initializeAddons = function() {
+          this.addonGraph.map('test-addon', { addon: addon, parentAddon: parentAddon });
+        };
+
+        emberApp = new EmberApp({
+          project: project
+        });
+
+        assert.ok(called);
+        assert.equal(passedApp, parentAddon);
       });
 
       it('does not throw an error if the addon does not implement `included`', function() {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -130,7 +130,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon no-export', function() {
       before(function() {
-        addon = project.addons[7];
+        addon = project.addons[5];
       });
 
       it('sets it\'s project', function() {


### PR DESCRIPTION
See #2354 for context.

This adds a `parentAddon` context for any nested addons included in a project. The `parentAddon` is supplied to each child addon on the addon instance as well as passed into the `included` hook.

The child addon is then free to determine if it should modify the `parentAddon` or the `app` from within the `included` hook.

This enables addons to have their own isolated dependencies which don't interfere with the root app's preprocessors. I.e. I can write my addon in Coffeescript, and the parent app doesn't need to depend on the Coffeescript addon directly.