### PR TITLE
Update docs to mention `included` addon hook

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -147,6 +147,23 @@ module.exports = {
 };
 {% endhighlight %}
 
+During the build process, the `included` hook on your addon will be called, allowing you to perform setup logic or modify the app or including addon:
+
+{% highlight javascript %}
+// index.js
+module.exports = {
+  name: 'my-addon',
+  included: function(app, parentAddon) {
+    var target = (parentAddon || app);
+    // Now you can modify the app / parentAddon. For example, if you wanted
+    // to include a custom preprocessor, you could add it to the target's
+    // registry:
+    //
+    //     target.registry.add('js', myPreprocessor);
+  }
+};
+{% endhighlight %}
+
 ### Managing addon dependencies
 Install your client side dependencies via Bower.
 Here we install a fictional bower dependency `x-button`:


### PR DESCRIPTION
Sorry for the double PR, not sure if there is a cleaner way to do this. This is this docs update for #2381.

Includes a brief demonstration of using `included` to inject your own preprocessor into the app or parentAddon.
