### PR TITLE
Adding app/index.html documentation

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -149,7 +149,7 @@ changed dependencies.
 
 #### `app/index.html`
 
-The `app/index.html` file lays the foundation for your actual single-page application.  This is where the basic DOM structure is layed out, the title attribute is set and stylesheet/javascript includes are done.  In addition to this, `app/index.html` includes multiple hooks - `{{content-for 'head'}}` and `{{content-for 'body'}}`- that can be used by [Add-ons](#add-ons) to inject content into your application's `head` or `body`.  These hooks need to be left in place for your application to function properly, but they can be safely ignored unless you are working directly with a particular add-on.
+The `app/index.html` file lays the foundation for your application.  This is where the basic DOM structure is laid out, the title attribute is set and stylesheet/javascript includes are done.  In addition to this, `app/index.html` includes multiple hooks - `{{content-for 'head'}}` and `{{content-for 'body'}}`- that can be used by [Add-ons](#add-ons) to inject content into your application's `head` or `body`.  These hooks need to be left in place for your application to function properly, but they can be safely ignored unless you are working directly with a particular add-on.
 
 ### Add-Ons
 


### PR DESCRIPTION
Trying to address #2388 and #2118, this is a starting point for expanded documentation of app/index.html to better explain what it does with particular emphasis on demystifying the content-for tags.  

I'm open to any feedback on content and/or location of this change, but I wanted to get something started so we can address some of the concerns people have been raising.
