### PR TITLE
Update to Ember 1.8.0 by default.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.7.1",
+    "ember": "1.8.0",
     "ember-data": "1.0.0-beta.11",
     "ember-resolver": "~0.1.10",
     "loader.js": "stefanpenner/loader.js#1.0.1",


### PR DESCRIPTION
- http://emberjs.com/blog/2014/10/26/ember-1-8-0-released.html
- https://github.com/emberjs/ember.js/blob/v1.8.0/CHANGELOG.md
