### PR TITLE
Allow production app testing.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -126,6 +126,10 @@ function EmberApp(options) {
       development: this.bowerDirectory + '/ember/ember.js',
       production:  this.bowerDirectory + '/ember/ember.prod.js'
     },
+    'ember-testing.js': [
+      this.bowerDirectory + '/ember/ember-testing.js',
+      { type: 'test' }
+    ],
     'app-shims.js': [
       this.bowerDirectory + '/ember-cli-shims/app-shims.js', {
         exports: {
@@ -150,6 +154,12 @@ function EmberApp(options) {
   }, options.vendorFiles), function(value) {
     return value === null;
   });
+
+  // this is needed to support versions of Ember older than
+  // 1.8.0 (when ember-testing.js was added to the deployment)
+  if (!fs.existsSync(this.vendorFiles['ember-testing.js'][0])) {
+    delete this.vendorFiles['ember-testing.js'];
+  }
 
   this.options.trees = merge(this.options.trees, {
     app:       'app',


### PR DESCRIPTION
Default support was broken by https://github.com/emberjs/ember.js/pull/9333, but a separate `ember-testing.js` file is now exported and can be used to test production builds as of https://github.com/emberjs/ember.js/pull/9411 (1.8.0+).
