### PR TITLE
Fix link to app/index.html from Layout table

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -138,7 +138,7 @@ changed dependencies.
  File/folder    | Purpose
  :------------- | :-------
  `app/app.js` | Your application's entry point. This is the module that is first executed.
- `app/index.html` | The only actual page of your single-page app! Includes dependencies and kickstarts your Ember application. See [app/index.html]((#appindexhtml)).
+ `app/index.html` | The only actual page of your single-page app! Includes dependencies and kickstarts your Ember application. See [app/index.html](#appindexhtml).
  `app/router.js` | Your route configuration. The routes defined here correspond to routes in `app/routes/`.
  `app/styles/` | Contains your stylesheets, whether SASS, LESS, Stylus, Compass, or plain CSS (though only one type is allowed, see [Asset Compilation](asset-compilation)). These are all compiled into `app.css`.
  `app/templates/` | Your Handlebars templates. These are compiled to `templates.js`. The templates are named the same as their filename, minus the extension (i.e. `templates/foo/bar.hbs` -> `foo/bar`).


### PR DESCRIPTION
Quick add on fix for #2392.  The link had double () around it which was causing it to not work.
