### PR TITLE
Update upgrade section of docs

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -87,22 +87,69 @@ ember server
 
 ### Upgrading an Ember CLI App
 
-Use NPM to update to the latest released version of Ember CLI.
+Steps to upgrade to the latest version of Ember CLI are included with [each release](https://github.com/stefanpenner/ember-cli/releases), but these are the common steps one would follow to update Ember CLI using NPM from within your project directory.
 
-{% highlight bash %}
-npm install --save-dev ember-cli
-{% endhighlight %}
+#### Setup
 
-When you update to the latest version you may need to re-install files from the
-app blueprint and update Node NPM dependencies.
+1. Remove old global ember-cli
 
-{% highlight bash %}
-ember init
-{% endhighlight %}
+    {% highlight bash %}
+    npm uninstall -g ember-cli
+    {% endhighlight %}
 
-This will re-copy files from the project blueprint. You can choose to overwrite
-existing files or not. It will subsequently call `npm install` to update any
-changed dependencies.
+2. Clear NPM cache
+
+    {% highlight bash %}
+    npm cache clean
+    {% endhighlight %}
+
+3. Clear Bower cache
+
+    {% highlight bash %}
+    bower cache clean
+    {% endhighlight %}
+
+4. Install a new global ember-cli, replacing X.X.X with the version of ember-cli you want to install
+
+    {% highlight bash %}
+    npm install -g ember-cli@X.X.X
+    {% endhighlight %}
+    
+#### Project Update
+
+1. Delete temporary development folders
+
+    {% highlight bash %}
+    rm -rf node_modules bower_components dist tmp
+    {% endhighlight %}
+    
+2. Update your project's `package.json` file to use the latest version of ember-cli, replacing X.X.X with the version of ember-cli you want to install
+
+    {% highlight bash %}
+    npm install --save-dev ember-cli@X.X.X
+    {% endhighlight %}
+    
+3. Reinstall NPM dependencies
+
+    {% highlight bash %}
+    npm install
+    {% endhighlight %}
+    
+4. Reinstall Bower dependencies
+
+    {% highlight bash %}
+    bower install
+    {% endhighlight %}
+    
+5. Run the new project blueprint on your projects directory. Please follow the prompts, and review all changes (tip: you can see a diff by pressing d).
+
+    {% highlight bash %}
+    ember init
+    {% endhighlight %}
+
+The most common sources of upgrade pain are not clearing out old packages in Step 1 and missing a change in step 5.  Please review each change from Step 5 carefully to ensure you both have not missed a change from the upgrade and that you have not accidentally removed code you may have added to your project during your work.
+
+When the upgrade process has completed, you should be able to issue the `ember -v` command and see that the `version:` noted in the resulting output matches the version you just upgraded to.
 
 ### Using Ember CLI
 


### PR DESCRIPTION
Following up on #2241, this updates the upgrade section of the docs to both point to the release notes and include the steps that are generally suggested with each release.  I think the duplication is worth it in this case because it keeps the upgrade steps more self-contained with the main set of ember-cli docs, but if this proves problematic we could just keep the link to the release notes.
