### PR TITLE
remove dead code

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -9,10 +9,6 @@ export default function startApp(attrs) {
   var attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Router.reopen({
-    location: 'none'
-  });
-
   Ember.run(function() {
     App = Application.create(attributes);
     App.setupForTesting();


### PR DESCRIPTION
The location property of the router already gets set in line 33 of
config/environment.js. Reopening the router and setting the property in
start-app.js does not have any effect.

It seems that this code should have been removed as part of commit 8158db
