### PR TITLE
Remove repository field from blueprint's package.json

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "https://github.com/stefanpenner/ember-cli",
+  "repository": "",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
It should be specified by user.
