### PR TITLE
Add bowerDependencies() to Project

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -128,6 +128,14 @@ Project.prototype.dependencies = function(pkg) {
   return assign({}, pkg['devDependencies'], pkg['dependencies']);
 };
 
+Project.prototype.bowerDependencies = function(bower) {
+  if (!bower) {
+    var bowerPath = path.join(this.root, 'bower.json');
+    bower = (fs.existsSync(bowerPath)) ? require(bowerPath) : {};
+  }
+  return assign({}, bower['devDependencies'], bower['dependencies']);
+};
+
 Project.prototype.buildAddonPackages = function() {
   if (!this.root) { return; }
 

--- a/tests/fixtures/addon/simple/bower.json
+++ b/tests/fixtures/addon/simple/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-project",
+  "dependencies": {
+    "handlebars": "~1.3.0",
+    "jquery": "^1.11.1",
+    "ember": "1.7.0",
+    "ember-data": "1.0.0-beta.10",
+    "ember-resolver": "~0.1.7",
+    "loader.js": "stefanpenner/loader.js#1.0.1",
+    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
+    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
+    "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2"
+  },
+  "devDependencies": {
+    "ember-qunit": "0.1.8",
+    "ember-qunit-notifications": "0.0.4",
+    "qunit": "~1.15.0"
+  }
+}

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -159,6 +159,25 @@ describe('models/project.js', function() {
       assert.deepEqual(project.dependencies(), expected);
     });
 
+    it('returns a listing of all dependencies in the projects bower.json', function() {
+      var expected = {
+        'handlebars': '~1.3.0',
+        'jquery': '^1.11.1',
+        'ember': '1.7.0',
+        'ember-data': '1.0.0-beta.10',
+        'ember-resolver': '~0.1.7',
+        'loader.js': 'stefanpenner/loader.js#1.0.1',
+        'ember-cli-shims': 'stefanpenner/ember-cli-shims#0.0.3',
+        'ember-cli-test-loader': 'rwjblue/ember-cli-test-loader#0.0.4',
+        'ember-load-initializers': 'stefanpenner/ember-load-initializers#0.0.2',
+        'ember-qunit': '0.1.8',
+        'ember-qunit-notifications': '0.0.4',
+        'qunit': '~1.15.0'
+      };
+
+      assert.deepEqual(project.bowerDependencies(), expected);
+    });
+
     it('returns a listing of all ember-cli-addons', function() {
       var expected = [
         'tests-server-middleware',


### PR DESCRIPTION
I have added `bowerDependencies()` to Project model. `dependencies()` was implemented for NPM before and for symmetry I added this. I also selfishly need this for [quaertym/ember-cli-dependency-checker](https://github.com/quaertym/ember-cli-dependency-checker) and thought it might be useful for other addon developers.
