### PR TITLE
Watchman

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -37,7 +37,11 @@ module.exports = Task.extend({
 
   processAppMiddlewares: function(options) {
     if (this.project.has('./server')) {
-      this.project.require('./server')(this.app, options);
+      var server = this.project.require('./server');
+      if (typeof server !== 'function') {
+        throw new TypeError('ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
+      }
+      server(this.app, options);
     }
   },
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -37,6 +37,19 @@ describe('express-server', function() {
     } catch(err) { }
   });
 
+  describe('processAppMiddlewares', function() {
+    it('has a good error message if a file exists, but does not export a function', function() {
+      subject.project = {
+        has:     function() { return true; },
+        require: function() { return {};   }
+      };
+
+      assert.throws(function() {
+        subject.processAppMiddlewares();
+      }, TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
+    });
+  });
+
   describe('output', function() {
     it('with proxy', function() {
       return subject.start({


### PR DESCRIPTION
[fixes #2226]
- currently hard-coded to use watchman. It will only work on `*nix` and wont support windows.
- polling is currently entirely disabled so virtual box users will have issues.

To use:

use node `v0.11.x`

use this branch:

```
npm install --save-dev stefanpenner/ember-cli#watchman
```

 install watchman:

``` sh
brew install watchman
```

docs: https://facebook.github.io/watchman/
- [x] auto-detect either in broccoli-sane-watcher or sane itself
- [x] confirm this is good.
- [x] wait for sane to release
- [ ] release a new broccoli-sane-watcher
- [ ] ensure watchman's options.filter is exposed.
- [x] improve watchman detection, by parsing and validating the json output. `watchman version` returns json payload of the person which would allow us to use node-semver to ensure a valid and compliant version is used.
- [x] restore https://github.com/stefanpenner/ember-cli/tree/watchman-auto

``` js
{
  "version": "3.0.0"
}
```

Commenters reporting issues, please provide:

```
node version
watchman version
ember-cli version
OS version:
```
