### PR TITLE
.bowerrc directory pointed at bower_components instead of vendor.

### DIFF
--- a/blueprints/app/files/.bowerrc
+++ b/blueprints/app/files/.bowerrc
@@ -1,4 +1,4 @@
 {
-  "directory": "bower_components",
+  "directory": "vendor",
   "analytics": false
 }


### PR DESCRIPTION
small mistake fix.
