### PR TITLE
[SPIKE] Detect and propagate file changes on rebuild.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -40,6 +40,7 @@ module.exports = Task.extend({
 
     this.mkdirp   = require('mkdirp');
     this.walkSync = require('walk-sync');
+    this._previousBuildStats = null;
   },
 
   canDeleteOutputPath: function(outputPath) {
@@ -86,6 +87,7 @@ module.exports = Task.extend({
   buildStats: function(directory) {
     var files = this.walkSync(directory);
     var stats = {};
+
     for (var i = 0, l = files.length; i < l; i++) {
       var relativePath = files[i];
       var fullPath = path.join(directory, relativePath);
@@ -102,9 +104,9 @@ module.exports = Task.extend({
     return stats;
   },
 
-  detectChangedFiles: function(current, rebuild) {
-    var currentBuildStats = this.buildStats(current);
-    var rebuildBuildStats = this.buildStats(rebuild);
+  detectChangedFiles: function(directory) {
+    var currentBuildStats = this._previousBuildStats || this.buildStats(this.outputPath);
+    var rebuildBuildStats = this.buildStats(directory);
 
     var changes = [];
     for (var relativePath in rebuildBuildStats) {
@@ -113,12 +115,13 @@ module.exports = Task.extend({
       }
     }
 
+    this._previousBuildStats = rebuildBuildStats;
     return changes;
   },
 
   processBuildResult: function(results) {
     var self = this;
-    var changedFiles = this.detectChangedFiles(this.outputPath, results.directory);
+    var changedFiles = this.detectChangedFiles(results.directory);
 
     return this.clearOutputPath()
       .then(function() {

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -6,6 +6,7 @@ var Promise     = require('../ext/promise');
 var rimraf      = Promise.denodeify(require('rimraf'));
 var ncp         = Promise.denodeify(require('ncp'));
 var Task        = require('./task');
+var crypto      = require('crypto');
 var SilentError = require('../errors/silent');
 
 var signalsTrapped = false;
@@ -37,7 +38,8 @@ module.exports = Task.extend({
     this.cleanupOnExit();
     this.trapSignals();
 
-    this.mkdirp = require('mkdirp');
+    this.mkdirp   = require('mkdirp');
+    this.walkSync = require('walk-sync');
   },
 
   canDeleteOutputPath: function(outputPath) {
@@ -81,14 +83,50 @@ module.exports = Task.extend({
     });
   },
 
+  buildStats: function(directory) {
+    var files = this.walkSync(directory);
+    var stats = {};
+    for (var i = 0, l = files.length; i < l; i++) {
+      var relativePath = files[i];
+      var fullPath = path.join(directory, relativePath);
+
+      if (relativePath.slice(-1) !== '/') {
+        var hash = crypto.createHash('md5')
+                         .update(fs.readFileSync(fullPath))
+                         .digest('hex');
+
+        stats[relativePath] = hash;
+      }
+    }
+
+    return stats;
+  },
+
+  detectChangedFiles: function(current, rebuild) {
+    var currentBuildStats = this.buildStats(current);
+    var rebuildBuildStats = this.buildStats(rebuild);
+
+    var changes = [];
+    for (var relativePath in rebuildBuildStats) {
+      if (currentBuildStats[relativePath] !== rebuildBuildStats[relativePath]) {
+        changes.push(relativePath);
+      }
+    }
+
+    return changes;
+  },
+
   processBuildResult: function(results) {
     var self = this;
+    var changedFiles = this.detectChangedFiles(this.outputPath, results.directory);
 
     return this.clearOutputPath()
       .then(function() {
         return self.copyToOutputPath(results.directory);
       })
       .then(function() {
+        results.outputChanges = changedFiles;
+
         return results;
       });
   },

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Promise     = require('../../ext/promise');
-var path        = require('path');
 var Task        = require('../../models/task');
 var SilentError = require('../../errors/silent');
 
@@ -57,17 +56,16 @@ module.exports = Task.extend({
   },
 
   didChange: function(results) {
-    var filePath = path.relative(this.project.root, results.filePath || '');
-
-    var canTrigger = this.project.liveReloadFilterPatterns.reduce(function(bool, pattern) {
-      bool = bool && !filePath.match(pattern);
-      return bool;
-    }, true);
-
-    if (canTrigger) {
+    var filterPatterns = this.project.liveReloadFilterPatterns;
+    var changes = (results.outputChanges || []).filter(function(file) {
+      return !file.match(/.css.map$/) && filterPatterns.reduce(function(bool, pattern) {
+        return bool && !file.match(pattern);
+      }, true);
+    });
+    if (changes.length) {
       this.liveReloadServer().changed({
         body: {
-          files: results.outputChanges
+          files: changes
         }
       });
 

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -67,7 +67,7 @@ module.exports = Task.extend({
     if (canTrigger) {
       this.liveReloadServer().changed({
         body: {
-          files: ['LiveReload files']
+          files: results.outputChanges
         }
       });
 

--- a/tests/fixtures/builder/first/output.css
+++ b/tests/fixtures/builder/first/output.css
@@ -1,0 +1,3 @@
+body {
+  content: 'Hello';
+}

--- a/tests/fixtures/builder/first/output.js
+++ b/tests/fixtures/builder/first/output.js
@@ -1,0 +1,1 @@
+var output = 'Hello';

--- a/tests/fixtures/builder/second/output.css
+++ b/tests/fixtures/builder/second/output.css
@@ -1,0 +1,3 @@
+body {
+  content: 'Hello';
+}

--- a/tests/fixtures/builder/second/output.js
+++ b/tests/fixtures/builder/second/output.js
@@ -1,0 +1,1 @@
+var output = 'World';

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -163,4 +163,43 @@ describe('models/builder.js', function() {
       });
     });
   });
+
+  describe('detectChangedFiles', function() {
+    beforeEach(function() {
+      tmpdir  = tmp.in(tmproot);
+
+      builder = new Builder({
+        outputPath: tmpdir,
+        setupBroccoliBuilder: function() { },
+        trapSignals: function() { },
+        cleanupOnExit: function() { },
+        project: new MockProject()
+      });
+    });
+
+    afterEach(function() {
+      return rimraf(tmproot);
+    });
+
+    it('compares new output directory with old', function() {
+      var buildResult = {directory: 'tests/fixtures/builder/first'};
+      return builder.processBuildResult(buildResult)
+        .then(function(results) {
+          assert(results.outputChanges.indexOf('output.js') !== -1, 'output.js is changed');
+          assert(results.outputChanges.indexOf('output.css') !== -1, 'output.css is changed');
+          return builder.processBuildResult(buildResult);
+        })
+        .then(function(results) {
+          assert(results.outputChanges.length === 0, 'no files are changed');
+          return builder.processBuildResult({
+            directory: 'tests/fixtures/builder/second'
+          });
+        })
+        .then(function(results) {
+          assert(results.outputChanges.indexOf('output.js') !== -1, 'output.js is changed');
+          assert.equal(results.outputChanges.length, 1, 'no other files are changed');
+        });
+    });
+  });
+
 });

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -105,7 +105,7 @@ describe('livereload-server', function() {
     });
 
     it('triggers the liverreload server of a change when no pattern matches', function() {
-      subject.didChange({filePath: ''});
+      subject.didChange({outputChanges: ['']});
       assert.equal(changedCount, 1);
       assert.equal(trackCount, 1);
     });
@@ -119,10 +119,45 @@ describe('livereload-server', function() {
       subject.project.liveReloadFilterPatterns = [filter];
 
       subject.didChange({
-        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.js'
+        outputChanges: ['test/fixtures/proxy/file-a.js']
       });
       assert.equal(changedCount, 0);
       assert.equal(trackCount, 0);
     });
   });
+
+  describe('watcher', function() {
+    var liveReloadServer;
+    var changedFiles;
+    var oldChanged;
+    var stubbedChanged = function(changed) {
+      changedFiles = changed.body.files;
+    };
+    var oldTrack;
+    var stubbedTrack = function() {};
+
+    beforeEach(function() {
+      liveReloadServer = subject.liveReloadServer();
+      changedFiles = null;
+      oldChanged = liveReloadServer.changed;
+      liveReloadServer.changed = stubbedChanged;
+
+      oldTrack = subject.analytics.track;
+      subject.analytics.track = stubbedTrack;
+    });
+
+    afterEach(function() {
+      liveReloadServer.changed = oldChanged;
+      subject.analytics.track = oldTrack;
+    });
+
+    it('reports which files have changed', function() {
+      var files = ['output.css'];
+      subject.didChange({
+        outputChanges: files
+      });
+      assert.equal(changedFiles[0], files[0]);
+    });
+  });
+
 });


### PR DESCRIPTION
This should make it possible to live-reload only changed output files.

Needs review + tests.

/cc @stefanpenner 