### PR TITLE
Remove controller types.

### DIFF
--- a/blueprints/controller/files/app/__path__/__name__.js
+++ b/blueprints/controller/files/app/__path__/__name__.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
 
-export default Ember.<%= baseClass %>.extend({
+export default Ember.Controller.extend({
 });

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -1,36 +1,3 @@
-var SilentError = require('../../lib/errors/silent');
-var chalk       = require('chalk');
-
-var TYPE_MAP = {
-  array: 'ArrayController',
-  object: 'ObjectController',
-  basic: 'Controller'
-};
-
 module.exports = {
-  description: 'Generates a controller of the given type.',
-
-  availableOptions: [
-    { name: 'type', values: ['basic', 'object', 'array'], default: 'basic' }
-  ],
-
-  beforeInstall: function(options) {
-    var type = options.type;
-
-    if (type && !TYPE_MAP[type]) {
-      throw new SilentError('Unknown controller type "' + type + '". Should be "basic", "object", or "array".');
-    }
-
-    if (!type && !options.installingTest) {
-      this.ui.writeLine(chalk.yellow('Warning: no controller type was specified, defaulting to basic. Specify using --type=basic|object|array'));
-    }
-  },
-
-  locals: function(options) {
-    var baseClass = TYPE_MAP[options.type] || TYPE_MAP.basic;
-
-    return {
-      baseClass: baseClass
-    };
-  }
+  description: 'Generates a controller of the given type.'
 };

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -71,28 +71,6 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
-  it('controller foo --type=object', function() {
-    return generate(['controller', 'foo', '--type=object']).then(function() {
-      assertFile('app/controllers/foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ObjectController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
-  it('controller foo --type=array', function() {
-    return generate(['controller', 'foo', '--type=array']).then(function() {
-      assertFile('app/controllers/foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ArrayController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
   it('controller foo/bar', function() {
     return generate(['controller', 'foo/bar']).then(function() {
       assertFile('app/controllers/foo/bar.js', {

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -109,50 +109,6 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
-  it('controller foo --type=object --pod', function() {
-    return generate(['controller', 'foo', '--type=object', '--pod']).then(function() {
-      assertFile('app/foo/controller.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ObjectController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
-  it('controller foo --type=object --pod podModulePrefix', function() {
-    return generateWithPrefix(['controller', 'foo', '--type=object', '--pod']).then(function() {
-      assertFile('app/pods/foo/controller.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ObjectController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
-  it('controller foo --type=array --pod', function() {
-    return generate(['controller', 'foo', '--type=array', '--pod']).then(function() {
-      assertFile('app/foo/controller.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ArrayController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
-  it('controller foo --type=array --pod podModulePrefix', function() {
-    return generateWithPrefix(['controller', 'foo', '--type=array', '--pod']).then(function() {
-      assertFile('app/pods/foo/controller.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.ArrayController.extend({" + EOL + "});"
-        ]
-      });
-    });
-  });
-
   it('controller foo/bar --pod', function() {
     return generate(['controller', 'foo/bar', '--pod']).then(function() {
       assertFile('app/foo/bar/controller.js', {


### PR DESCRIPTION
In preparation for the coming deprecation in Ember of `Ember.ObjectController` and `Ember.ArrayController`. This will make future upgrades easier (users will not need to refactor away from proxying behavior).
