### PR TITLE
Remove ember-cli-dependency-checker.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,7 +23,6 @@
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-dependency-checker": "0.0.6",
     "ember-cli-esnext": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",


### PR DESCRIPTION
I would like to bring this back, but at the moment it is causing our smoke tests to fail.

@quaertym - Please re-add once the issues have been addressed.
