### PR TITLE
Add installOptions to bower-install task options

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -777,16 +777,17 @@ Blueprint.prototype.addPackagesToProject = function(packages) {
   @method addBowerPackageToProject
   @param {String} packageName
   @param {String} target
+  @param {Object} installOptions
   @return {Promise}
 */
-Blueprint.prototype.addBowerPackageToProject = function(packageName, target) {
+Blueprint.prototype.addBowerPackageToProject = function(packageName, target, installOptions) {
   var packageObject = {name: packageName};
 
   if (target) {
     packageObject.target = target;
   }
 
-  return this.addBowerPackagesToProject([packageObject]);
+  return this.addBowerPackagesToProject([packageObject], installOptions);
 };
 
 /*
@@ -801,9 +802,10 @@ Blueprint.prototype.addBowerPackageToProject = function(packageName, target) {
 
   @method addBowerPackagesToProject
   @param {Array} packages
+  @param {Object} installOptions
   @return {Promise}
 */
-Blueprint.prototype.addBowerPackagesToProject = function(packages) {
+Blueprint.prototype.addBowerPackagesToProject = function(packages, installOptions) {
   var task = this.taskFor('bower-install');
   var packageNamesAndVersions = [];
 
@@ -819,7 +821,8 @@ Blueprint.prototype.addBowerPackagesToProject = function(packages) {
 
   return task.run({
     verbose: true,
-    packages: packageNamesAndVersions
+    packages: packageNamesAndVersions,
+    installOptions: installOptions
   });
 };
 

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -12,11 +12,12 @@ module.exports = Task.extend({
   },
   // Options: Boolean verbose
   run: function(options) {
-    var chalk       = require('chalk');
-    var bower       = this.bower;
-    var bowerConfig = this.bowerConfig;
-    var ui          = this.ui;
-    var packages    = options.packages || [];
+    var chalk          = require('chalk');
+    var bower          = this.bower;
+    var bowerConfig    = this.bowerConfig;
+    var ui             = this.ui;
+    var packages       = options.packages || [];
+    var installOptions = options.installOptions || { save: true };
 
     ui.pleasantProgress.start(chalk.green('Installing browser packages via Bower'), chalk.green('.'));
 
@@ -24,7 +25,7 @@ module.exports = Task.extend({
     config.interactive = true;
 
     return new Promise(function(resolve, reject) {
-        bower.commands.install(packages, { save: true }, config) // Packages, options, config
+        bower.commands.install(packages, installOptions, config) // Packages, options, config
           .on('log', logBowerMessage)
           .on('prompt', ui.prompt.bind(ui))
           .on('error', reject)


### PR DESCRIPTION
This is based on the @rwjblue 's comment in https://github.com/stefanpenner/ember-cli/pull/1942. This commit allows blueprints to add bower packages to devDependencies section in addition to dependencies by passing the `{ save-dev: true }`. The default option is `{ save: true }` so it is backwards compatible.
