### PR TITLE
Add validation for command options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Applications
 * [BREAKING ENHANCEMENT] Replace `ember init appName` with `ember init --name=appName` to allow globbing support for `ember init` command. [#2197](https://github.com/stefanpenner/ember-cli/pull/2197)
+* [ENHANCEMENT] Commands will warn when invalid options are passed. [#2482](https://github.com/stefanpenner/ember-cli/pull/2482)
 
 #### Addons
 * [ENHANCEMENT] Addons can implement a preBuild hook. [#2411](https://github.com/stefanpenner/ember-cli/pull/2411)

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -11,6 +11,7 @@ var defaults      = require('lodash-node/modern/objects/defaults');
 var EOL           = require('os').EOL;
 var CoreObject    = require('core-object');
 var debug         = require('debug')('ember-cli:command');
+var findKey       = require('lodash-node/modern/objects/findKey');
 
 var allowedWorkOptions = {
   insideProject: true,
@@ -146,6 +147,10 @@ Command.prototype.parseArgs = function(commandArgs) {
   for (var key in parsedOptions) {
     if(typeof parsedOptions[key] !== 'object') {
       commandOptions[camelize(key)] = parsedOptions[key];
+    }
+    if(findKey(commandOptions, key) === undefined && key !== 'argv'){
+      this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not supported by the ' + this.name + ' command. ' +
+                        'Run `ember ' + this.name + ' --help` for a list of supported options.'));
     }
   }
 

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -114,6 +114,16 @@ describe('models/command.js', function() {
     });
   });
 
+  it('parseArgs() should warn if an option is invalid.', function() {
+    new ServeCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      settings: config.getAll()
+    }).parseArgs(['foo', '--envirmont', 'production']);
+    expect(ui.output).to.match(/The option '--envirmont' is not supported by the serve command. Run `ember serve --help` for a list of supported options./);
+  });
+
   it('validateAndRun() should print a message if a required option is missing.', function() {
     new DevelopEmberCLICommand({
       ui: ui,


### PR DESCRIPTION
This PR fixes [issue #2299](https://github.com/stefanpenner/ember-cli/issues/2299). The command model now parses the command options and will throw a warning if the option does not exist in the `knownOptions` hash. For example:

```
ember serve --envirnment=production
version: 0.1.2
The option '--envirnment' is not supported by the serve command. Run `ember serve --help` for a list of supported options.
Livereload server on port 35729
Serving on http://0.0.0.0:4200/
```
