### PR TITLE
Fix resource generator ordering

### DIFF
--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -54,9 +54,10 @@ module.exports = {
 
     var routeOptions = merge({}, options, { type: 'resource' });
 
-    return Promise.all([
-      this._processBlueprint(type, 'model', modelOptions),
-      this._processBlueprint(type, 'route', routeOptions)
-    ]);
+    var self = this;
+    return this._processBlueprint(type, 'model', modelOptions)
+              .then(function() {
+                return self._processBlueprint(type, 'route', routeOptions);
+              });
   }
 };


### PR DESCRIPTION
We don't want to run promises simultaneously since we may end up with prompts
for existing files. Run back to back instead.
