### PR TITLE
allow app/templates to not exist when using pod structure

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -173,13 +173,13 @@ function EmberApp(options) {
 
     // these are contained within app/ no need to watch again
     styles:    unwatchedTree('app/styles'),
-    templates: unwatchedTree('app/templates'),
+    templates: fs.existsSync('app/templates') ? unwatchedTree('app/templates') : null,
 
     // do not watch vendor/ or bower's default directory by default
     bower: unwatchedTree(this.bowerDirectory),
     vendor: fs.existsSync('vendor') ? unwatchedTree('vendor') : null,
 
-    public:    fs.existsSync('public') ? 'public' : null
+    public: fs.existsSync('public') ? 'public' : null
   }, defaults);
 
   this.options.jshintrc = merge(this.options.jshintrc, {
@@ -388,8 +388,9 @@ EmberApp.prototype._processedAppTree = function() {
   @return
 */
 EmberApp.prototype._processedTemplatesTree = function() {
-  var addonTrees      = this.addonTreesFor('templates');
-  var mergedTemplates = mergeTrees(addonTrees.concat(this.trees.templates), {
+  var addonTrees = this.addonTreesFor('templates');
+  var mergedTrees = this.trees.templates ? addonTrees.concat(this.trees.templates) : addonTrees;
+  var mergedTemplates = mergeTrees(mergedTrees, {
     overwrite: true,
     description: 'TreeMerger (templates)'
   });

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -110,6 +110,20 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('without app/templates', function() {
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(450000);
+
+    return copyFixtureFiles('brocfile-tests/pods-templates')
+      .then(function(){
+        // remove ./app/templates
+        return rimraf(path.join(process.cwd(), 'app/templates'));
+      }).then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+      });
+  });
+
   it('using autoRun: true', function() {
     console.log('    running the slow end-to-end it will take some time');
 


### PR DESCRIPTION
When using the pod file structure, you won't necessarily need `./app/templates`. If you don't have it, ember-cli fails to build your app. This PR makes that path optional.

Before this change, the new test fails with:

```
Building
Building.
Build failed.

ENOENT, no such file or directory 'app/templates/'

Error: ENOENT, no such file or directory 'app/templates/'
```

After this change, the test passes.

Does this deserve a changelog entry? If so, I'll add it.
