### PR TITLE
short-circuit failure in build task when calling test task

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -95,7 +95,10 @@ module.exports = Command.extend({
           environment: commandOptions.environment,
           outputPath: outputPath
         })
-        .then(function() {
+        .then(function(exitCode) {
+          if (exitCode) {
+            return exitCode;
+          }
           return test.run(testOptions);
         })
         .finally(this.rmTmp.bind(this));


### PR DESCRIPTION
When calling `ember test`, a failure in `ember build` will cause the process to hang. This PR short circuits the process on a failure of `ember build`, which returns an `exitCode`.

```
$ ember test
version: 0.1.2-shortcircuit-build-test-d631211121
Build failed.
ENOENT, no such file or directory 'app/styles/'
Error: ENOENT, no such file or directory 'app/styles/'
    at Object.fs.lstatSync (fs.js:690:18)
    at symlinkOrCopySync (/home/smassa/source/ember-cli/node_modules/symlink-or-copy/index.js:19:12)
    at CustomStaticCompiler.StaticCompiler._copy (/home/smassa/source/ember-cli/node_modules/broccoli-static-compiler/index.js:59:3)
    at /home/smassa/source/ember-cli/node_modules/broccoli-static-compiler/index.js:25:12
    at $$$internal$$tryCatch (/home/smassa/source/broccoli/node_modules/rsvp/dist/rsvp.js:470:16)
    at $$$internal$$invokeCallback (/home/smassa/source/broccoli/node_modules/rsvp/dist/rsvp.js:482:17)
    at $$$internal$$publish (/home/smassa/source/broccoli/node_modules/rsvp/dist/rsvp.js:453:11)
    at $$rsvp$asap$$flush (/home/smassa/source/broccoli/node_modules/rsvp/dist/rsvp.js:1531:9)
    at process._tickCallback (node.js:419:13)

***HANGS HERE***
```
