### PR TITLE
Use project.root as process.cwd(), so files aren't generated in wrong pl...

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -55,6 +55,10 @@ CLI.prototype.run = function(environment) {
       update = a.checkForUpdates();
     }
 
+    if(!this.testing) {
+      process.chdir(environment.project.root);
+    }
+
     return Promise.resolve(update).then(function() {
       return command.validateAndRun(commandArgs);
     });


### PR DESCRIPTION
...aces

I followed the @rwjblue advice and used the `process.chdir` to use the project root.
Unfortunately the test suite use `process.cwd()` to navigate to tmp dirs, so I end up using `this.testing` flag, this seems a little hacky, but I didn't find a better way to handle this problem :(.

Closes #2364 
