### PR TITLE
watch Brocfile.js and ./server for changes and restart local server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 #### Tasks
 * [ENHANCEMENT] `ember test --server` now invokes testem middleware, the same as `ember test`
+* [ENHANCEMENT] `ember serve` now watches the `Brocfile.js` file and `./server` directory (if it exists) and restarts the server on changes
 
 ### 0.1.2
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var cluster         = require('cluster');
 var chalk           = require('chalk');
 var lookupCommand   = require('./lookup-command');
 var Promise         = require('../ext/promise');
@@ -20,7 +21,9 @@ function CLI(options) {
 module.exports = CLI;
 
 CLI.prototype.run = function(environment) {
-  this.ui.writeLine('version: ' + emberCLIVersion());
+  if (cluster.isMaster) {
+    this.ui.writeLine('version: ' + emberCLIVersion());
+  }
 
   return Promise.hash(environment).then(function(environment) {
     var args = environment.cliArgs.slice();

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var cluster          = require('cluster');
+var watch            = require('watch');
+var fs               = require('fs');
 var LiveReloadServer = require('./server/livereload-server');
 var ExpressServer    = require('./server/express-server');
 var Promise          = require('../ext/promise');
@@ -7,41 +10,79 @@ var Task             = require('../models/task');
 var Watcher          = require('../models/watcher');
 var Builder          = require('../models/builder');
 
+var watchServer = function(project){
+  var worker;
+
+  cluster.on('exit', function() {
+    // only restart if we killed the process
+    if (worker.suicide === true) {
+      worker = cluster.fork();
+    }
+  });
+
+  worker = cluster.fork();
+
+  var projectRoot = project.root;
+  var brocfilePath = projectRoot + '/Brocfile.js';
+  fs.watchFile(brocfilePath, {interval: 1500}, function(){
+    worker.kill();
+  });
+
+  var serverPath = projectRoot + '/server';
+  if (fs.existsSync(serverPath)) {
+    watch.watchTree(serverPath, function(){
+      worker.kill();
+    });
+  }
+
+  return new Promise(function(){
+    // hang until the user exits.
+  });
+};
+
+var serveApp = function(app, options){
+  var builder = new Builder({
+    outputPath: options.outputPath,
+    project: app.project,
+    environment: options.environment
+  });
+
+  var watcher = new Watcher({
+    ui: app.ui,
+    builder: builder,
+    analytics: app.analytics,
+    options: options
+  });
+
+  var expressServer = new ExpressServer({
+    ui: app.ui,
+    project: app.project,
+    watcher: watcher
+  });
+
+  var liveReloadServer = new LiveReloadServer({
+    ui: app.ui,
+    analytics: app.analytics,
+    project: app.project,
+    watcher: watcher
+  });
+
+  return Promise.all([
+      liveReloadServer.start(options),
+      expressServer.start(options)
+    ]).then(function() {
+      return new Promise(function() {
+        // hang until the user exits.
+      });
+    });
+};
+
 module.exports = Task.extend({
   run: function(options) {
-    var builder = new Builder({
-      outputPath: options.outputPath,
-      project: this.project,
-      environment: options.environment
-    });
-
-    var watcher = new Watcher({
-      ui: this.ui,
-      builder: builder,
-      analytics: this.analytics,
-      options: options
-    });
-
-    var expressServer = new ExpressServer({
-      ui: this.ui,
-      project: this.project,
-      watcher: watcher
-    });
-
-    var liveReloadServer = new LiveReloadServer({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-      watcher: watcher
-    });
-
-    return Promise.all([
-        liveReloadServer.start(options),
-        expressServer.start(options)
-      ]).then(function() {
-        return new Promise(function() {
-          // hang until the user exits.
-        });
-      });
+    if (cluster.isMaster) {
+      return watchServer(this.project);
+    } else {
+      return serveApp(this, options);
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "through": "^2.3.4",
     "tiny-lr": "0.1.4",
     "walk-sync": "0.1.3",
+    "watch": "0.13.0",
     "yam": "0.0.17"
   },
   "devDependencies": {


### PR DESCRIPTION
This uses [watch](https://github.com/mikeal/watch) to watch the `./server` directory (if it exists) for changes. It uses [fs.watchFile](http://nodejs.org/docs/latest/api/fs.html#fs_fs_watchfile_filename_options_listener) to watch the `Brocfile.js` file because the `watch` package can't watch just a single file. I found [fs.watch](http://nodejs.org/docs/latest/api/fs.html#fs_fs_watch_filename_options_listener) to not always work on my Ubuntu-based system.

On any change, it restarts the local server that's serving the app and handling the http-mocks and http-proxies. The result is very nice. I tested this with an actual app and was very pleased.

I'm more than happy to change how the file watching is happening. I'm happy to add a test for this, but I'm not sure how I would do that.

---

Implements https://github.com/stefanpenner/ember-cli/issues/2004
