### PR TITLE
Automated npm/browserify/cjs loader

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -189,6 +189,7 @@ function EmberApp(options) {
   }, defaults);
 
   this.importWhitelist         = {};
+  this.importWhitelistFilters  = [];
   this.legacyFilesToAppend     = [];
   this.vendorStaticStyles      = [];
   this.otherAssetPaths         = [];
@@ -665,7 +666,7 @@ EmberApp.prototype.javascript = function() {
 
   var es6 = compileES6(applicationJs, {
     loaderFile: 'vendor/ember-cli/loader.js',
-    ignoredModules: Object.keys(this.importWhitelist),
+    ignoredModules: this._isIgnoredModule.bind(this),
     inputFiles: [
       this.name + '/**/*.js'
     ],
@@ -697,6 +698,26 @@ EmberApp.prototype.javascript = function() {
     return vendorAndApp;
   }
 };
+
+/**
+  @method _isIgnoredModule
+  @private
+  @return {Boolean}
+*/
+EmberApp.prototype._isIgnoredModule = function(moduleName) {
+  var filters = this.importWhitelistFilters;
+  var len     = filters.length;
+
+  if (len > 0) {
+    for (var i=0; i<len; i++){
+      if (filters[i](moduleName)){
+        return true;
+      }
+    }
+  }
+  return this.importWhitelist[moduleName];
+};
+
 
 /**
   @method styles

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "broccoli-clean-css": "0.2.0",
     "broccoli-concat": "0.0.12",
     "broccoli-es3-safe-recast": "1.0.0",
-    "broccoli-es6-concatenator": "0.1.10",
+    "broccoli-es6-concatenator": "0.1.11",
     "broccoli-filter": "0.1.7",
     "broccoli-funnel": "0.1.5",
     "broccoli-jshint": "0.5.3",


### PR DESCRIPTION
This closes #2283. 

It extends the ember-cli addon API in two ways:
- I've added a new `'js'` type of `postprocessTree`. This was suggested by @rwjblue and it nicely solves this particular problem, while being generally useful for other addons.
- addons can use `app.importWhitelistFilters` to register filters that determine which module names should be ignored by the es6 concatenator.

With these extensions, my new [ember-browserify](https://github.com/ef4/ember-browserify) addon can do the actual work of finding & packaging npm modules.

Remaining issues before this is ready to merge:
- [ ] Get a PR into broccoli-es6-concatenator (https://github.com/ef4/broccoli-es6-concatenator/compare/joliss:master...master)
