### PR TITLE
Adjust podModulePrefix example to be less confusing

### DIFF
--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -271,8 +271,8 @@ Rather than hold your resource folders on the root of your app you can define a 
 // config/environment.js
 module.exports = function(environment) {
   var ENV = {
-    modulePrefix: 'app',
-    podModulePrefix: 'app/pods' // directory where resolver will look for your resource files
+    modulePrefix: 'my-new-app',
+    podModulePrefix: 'my-new-app/pods' // namespaced directory where resolver will look for your resource files
     environment: environment,
     baseURL: '/',
     locationType: 'auto',


### PR DESCRIPTION
Just helped a user on IRC with this, and have tripped over it myself in the past.  

Have made it more clear in the docs that the modulePrefix and podModulePrefix are using the resovler namespace, and not the literal directory structure.
