### PR TITLE
Add config property to use pods as default structure.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -328,7 +328,7 @@ Blueprint.prototype.install = function(options) {
   var verbose  = options.verbose;
   this.project = options.project;
   this.testing = options.testing;
-  this.pod     = options.pod;
+  this.pod     = this.project.config().usePodsByDefault ? !options.pod : options.pod;
   this.hasPath = hasPathToken(this.files());
 
   var actions = {
@@ -404,7 +404,7 @@ Blueprint.prototype.uninstall = function(options) {
   var dryRun      = options.dryRun;
   var verbose     = options.verbose;
   this.project    = options.project;
-  this.pod        = options.pod;
+  this.pod        = this.project.config().usePodsByDefault ? !options.pod : options.pod;
   this.hasPath    = hasPathToken(this.files());
 
   var actions = {


### PR DESCRIPTION
This PR adds a config property that inverts the meaning of the `--pod` flag. Current working name is `usePodsByDefault`, but the name is less important than the functionality. The basic result is that we no longer need to use `--pod` when generating and destroying blueprints.

```
// with `config.usePodsByDefault` set to true
// defaults to pod structure
ember g route taco
version: 0.1.2
installing
  create app/taco/route.js
  create app/taco/template.hbs
installing
  create tests/unit/routes/taco-test.js

// use `--pod` flag for type structure
ember g route taco --pod
version: 0.1.2
installing
  create app/routes/taco.js
  create app/templates/taco.hbs
installing
  create tests/unit/routes/taco-test.js
```

In blueprint install and uninstall, we check for the config property and return the inverse if `usePodsByDefault` is true.

I still need to write a couple tests, but I wanted to put this up in case there were objections or suggestions on the property name. I also wanted to make sure this was the right way to go about the change, since it does seem like it could lead to some confusion if someone wasn't aware of the config property and it was set somehow.

I was also wondering if the value should be added to the app blueprint config, set to false by default. 
