### PR TITLE
use addPackagesToProject instead of addPackageToProject in a Promise.all

### DIFF
--- a/blueprints/http-proxy/index.js
+++ b/blueprints/http-proxy/index.js
@@ -17,10 +17,10 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return Promise.all([
-      this.addPackageToProject('http-proxy', '^1.1.6'),
-      this.addPackageToProject('morgan', '^1.3.2'),
-      this.addPackageToProject('connect-restreamer', '^1.0.0')
+    return this.addPackagesToProject([
+      { name: 'http-proxy', target: '^1.1.6' },
+      { name: 'morgan', target: '^1.3.2' },
+      { name: 'connect-restreamer', target: '^1.0.0' }
     ]);
   }
 };


### PR DESCRIPTION
race conditions.. 

So turns our if you do more than 2 of our `addPackageToProject` it won't work. I'm guessing it's because we're trying to get npm to do all sorts of things at once. Using the `addPackagesToProject` works since it installs everything at once
