### PR TITLE
Removed App.reset() from the startApp helper (is not needed anymore)

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -15,7 +15,5 @@ export default function startApp(attrs) {
     App.injectTestHelpers();
   });
 
-  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
-
   return App;
 }


### PR DESCRIPTION
I've been using the same startApp helper for a while and found this reset isn't needed anymore (funny enough - the comment also said this)

Thanks again for running such a great project!

P.S. why is the below not needed in startApp anymore? **bonus question/answer**

``` js
Router.reopen({
  location: 'none'
});
```

P.P.S does ember-cli have a simple "lookup" helper (like Tom would show in private trainings)

The below was previously at the top of my startApp integration helper (if this isn't in ember-cli today ... should it/could it be added with a PR later or does it offer no value?)

``` js
var container;
Application.initializer({
  name: 'extractContainer',
  initialize: function(c) {
    container = c;
  }
});
Ember.Test.registerHelper('lookup', function(app, fullName) {
  return container.lookup(fullName);
});
```
