### PR TITLE
upgrade ember-cli-qunit and remove qunit divs

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-esnext": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.0",
+    "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.11",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -31,8 +31,6 @@
     </style>
   </head>
   <body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}


### PR DESCRIPTION
The latest ember-cli-qunit injects these in the contentFor('test-body') so they are not necessary any more.
refs https://github.com/jakecraige/ember-cli-qunit/pull/18

**do not merge** waiting on that PR to be merged and new version pushed to npm
