### PR TITLE
Add "ws: true" to create http proxy server option to support proxying websockets.

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -6,18 +6,32 @@ function ProxyServerAddon(project) {
 }
 
 ProxyServerAddon.prototype.serverMiddleware = function(options) {
-  var app = options.app;
+  var app = options.app, server = options.options.httpServer;
   options = options.options;
 
   if (options.proxy) {
     var urlOpts = require('url').parse(options.proxy);
-    var proxy   = require('proxy-middleware');
+    var proxy   = require('http-proxy').createProxyServer({
+      target: {
+        host: urlOpts.hostname,
+        port: urlOpts.port
+      },
+      ws: true
+    });
+
     var morgan  = require('morgan');
 
     options.ui.writeLine('Proxying to ' + options.proxy);
 
+    server.on('upgrade', function (req, socket, head) {
+      options.ui.writeLine('Proxying websocket to ' + req.url);
+      proxy.ws(req, socket, head);
+    });
+
     app.use(morgan('dev'));
-    app.use(proxy(urlOpts));
+    app.use(function(req, res) {
+      return proxy.web(req, res);
+    });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     "through": "^2.3.4",
     "tiny-lr": "0.1.4",
     "walk-sync": "0.1.3",
-    "yam": "0.0.17"
+    "yam": "0.0.17",
+    "http-proxy": "^1.6.2"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
I have tested, it cannot proxy websockets request to remote server.
According node-http-proxy doc https://github.com/nodejitsu/node-http-proxy#proxying-websockets, I think "ws: true" is required for supporting websocket.
