### PR TITLE
Updates broccoli-asset-rev to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Add `outputPaths.app.html` option [#2523](https://github.com/stefanpenner/ember-cli/pull/2523)
 * [ENHANCEMENT] Allow multiple SASS/LESS files to be built by populating `outputPaths.app.css` option [#1888](https://github.com/stefanpenner/ember-cli/pull/1888)
 * [BUGFIX] Fix automatic generated model belongs-to and has-many relations to resolve test lookup. [#2351][https://github.com/stefanpenner/ember-cli/pull/2351]
+* [ENHANCEMENT] Update `broccoli-asset-rev` to 1.0.0. [#2535](https://github.com/stefanpenner/ember-cli/pull/2535)
 
 #### Applications
 * [BREAKING ENHANCEMENT] Replace `ember init appName` with `ember init --name=appName` to allow globbing support for `ember init` command. [#2197](https://github.com/stefanpenner/ember-cli/pull/2197)

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.3.1",
+    "broccoli-asset-rev": "^1.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-content-security-policy": "0.3.0",

--- a/tests/fixtures/dummy-project-outdated/package.json
+++ b/tests/fixtures/dummy-project-outdated/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.3.1",
+    "broccoli-asset-rev": "^1.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.5.0",
     "ember-cli": "0.0.1",
     "ember-cli-ember-data": "0.1.1",


### PR DESCRIPTION
broccoli-asset-rev now supports relative URLs. I hope that this alleviates any issues currently outstanding. I apologize about taking so long to get this fix out. I have no excuses, and I pledge to fix the next issue much faster!
