### PR TITLE
Fix robotstxt.org url

### DIFF
--- a/blueprints/app/files/public/robots.txt
+++ b/blueprints/app/files/public/robots.txt
@@ -1,3 +1,2 @@
-# robotstxt.org/
-
+# http://www.robotstxt.org
 User-agent: *


### PR DESCRIPTION
Looks like http://robotstxt.org does not resolve without www.
