### PR TITLE
Add options aliases (shorthands) to command model

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -8,7 +8,7 @@ module.exports = {
   description: 'Generates a route and registers it with the router.',
 
   availableOptions: [
-    { name: 'type', values: ['route', 'resource'], default: 'route' }
+    { name: 'type', type: String, values: ['route', 'resource'], default: 'route', aliases:[{'route': 'route'}, {'resource': 'resource'}] }
   ],
 
   fileMapTokens: function() {

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -63,6 +63,8 @@ CLI.prototype.run = function(environment) {
       process.chdir(environment.project.root);
     }
 
+    command.beforeRun(commandArgs);
+
     return Promise.resolve(update).then(function() {
       return command.validateAndRun(commandArgs);
     }).then(function(exitCode) {

--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -8,12 +8,12 @@ module.exports = NewCommand.extend({
   description: 'Generates a new folder structure for building an addon, complete with test harness.',
 
   availableOptions: [
-    { name: 'dry-run', type: Boolean, default: false },
-    { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: path, default: 'addon' },
-    { name: 'skip-npm', type: Boolean, default: false },
-    { name: 'skip-bower', type: Boolean, default: false },
-    { name: 'skip-git', type: Boolean, default: false },
+    { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
+    { name: 'blueprint', type: path, default: 'addon', aliases: ['b'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
+    { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
   ],
 
   anonymousOptions: [

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -8,9 +8,9 @@ module.exports = Command.extend({
   description: 'Builds your app and places it into the output path (dist/ by default).',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
-    { name: 'output-path', type: path, default: 'dist/' },
-    { name: 'watch', type: Boolean, default: false }
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
+    { name: 'output-path', type: path, default: 'dist/', aliases: ['o'] },
+    { name: 'watch', type: Boolean, default: false, aliases: ['w'] }
   ],
 
   run: function(commandOptions) {

--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -13,9 +13,9 @@ module.exports = Command.extend({
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'dry-run', type: Boolean, default: false },
-    { name: 'verbose', type: Boolean, default: false },
-    { name: 'pod', type: Boolean, default: false }
+    { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
+    { name: 'pod', type: Boolean, default: false, aliases: ['p'] }
   ],
 
   anonymousOptions: [

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -17,14 +17,29 @@ module.exports = Command.extend({
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'dry-run', type: Boolean, default: false },
-    { name: 'verbose', type: Boolean, default: false },
-    { name: 'pod', type: Boolean, default: false }
+    { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
+    { name: 'pod', type: Boolean, default: false, aliases: ['p'] }
   ],
 
   anonymousOptions: [
     '<blueprint>'
   ],
+
+  beforeRun: function(rawArgs){
+    // merge in blueprint availableOptions
+    var blueprint;
+    var debug = require('debug')('ember-cli/commands/generate');
+
+    try{
+      blueprint = Blueprint.prototype.lookupBlueprint(rawArgs[0]);
+      this.registerOptions( blueprint );
+    }
+    catch(e) {
+      // ignore this error, invalid blueprints are handled in run
+      debug(e);
+    }
+  },
 
   run: function(commandOptions, rawArgs) {
     var blueprintName = rawArgs[0];
@@ -129,6 +144,18 @@ module.exports = Command.extend({
 
           if (opt.required) {
             output += chalk.cyan(' (Required)');
+          }
+
+          if (opt.aliases) {
+            output += chalk.grey(EOL + '          aliases: ' + opt.aliases.map(function(a) {
+              var key;
+              if (typeof a === 'string') {
+                return '-' + a + (opt.type === Boolean ? '' : ' <value>');
+              } else {
+                key = Object.keys(a)[0];
+                return  '-' + key + ' (--' + opt.name + '=' + a[key] + ')';
+              }
+            }).join(', '));
           }
 
           if (opt.description) {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -12,7 +12,7 @@ module.exports = Command.extend({
   aliases: [undefined, 'h', 'help', '-h', '--help'],
 
   availableOptions: [
-    { name: 'verbose', type: Boolean, default: false }
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] }
   ],
 
   anonymousOptions: [

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -14,12 +14,12 @@ module.exports = Command.extend({
   works: 'everywhere',
 
   availableOptions: [
-    { name: 'dry-run', type: Boolean, default: false },
-    { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: path },
-    { name: 'skip-npm', type: Boolean, default: false },
-    { name: 'skip-bower', type: Boolean, default: false },
-    { name: 'name', type: String, default: '' }
+    { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
+    { name: 'blueprint', type: path, aliases: ['b'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
+    { name: 'name', type: String, default: '', aliases: ['n'] }
   ],
 
   anonymousOptions: [

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -14,12 +14,12 @@ module.exports = Command.extend({
   works: 'outsideProject',
 
   availableOptions: [
-    { name: 'dry-run', type: Boolean, default: false },
-    { name: 'verbose', type: Boolean, default: false },
-    { name: 'blueprint', type: ['gitUrl', path], default: 'app' },
-    { name: 'skip-npm', type: Boolean, default: false },
-    { name: 'skip-bower', type: Boolean, default: false },
-    { name: 'skip-git', type: Boolean, default: false },
+    { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
+    { name: 'blueprint', type: ['gitUrl', path], default: 'app', aliases: ['b'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
+    { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
   ],
 
   anonymousOptions: [

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -10,14 +10,14 @@ module.exports = Command.extend({
   aliases: ['server', 's'],
 
   availableOptions: [
-    { name: 'port', type: Number, default: 4200 },
-    { name: 'host', type: String, default: '0.0.0.0' },
-    { name: 'proxy',  type: String },
-    { name: 'watcher',  type: String, default: 'events' },
-    { name: 'live-reload',  type: Boolean, default: true },
-    { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)'},
-    { name: 'environment', type: String, default: 'development' },
-    { name: 'output-path', type: path, default: 'dist/' }
+    { name: 'port', type: Number, default: 4200, aliases: ['p'] },
+    { name: 'host', type: String, default: '0.0.0.0', aliases: ['h'] },
+    { name: 'proxy',  type: String, aliases: ['pr','pxy'] },
+    { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },
+    { name: 'live-reload',  type: Boolean, default: true, aliases: ['lr'] },
+    { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)', aliases: ['lrp']},
+    { name: 'environment', type: String, default: 'development', aliases: ['e', {'dev' : 'development'}, {'prod' : 'production'}] },
+    { name: 'output-path', type: path, default: 'dist/', aliases: ['op', 'out'] }
   ],
 
   run: function(commandOptions) {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -13,13 +13,13 @@ module.exports = Command.extend({
   description: 'Runs your apps test suite.',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'test' },
-    { name: 'config-file', type: String,  default: './testem.json' },
-    { name: 'server',      type: Boolean, default: false},
-    { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.'},
-    { name: 'filter',      type: String,  description: 'A regex to filter tests ran'},
-    { name: 'module',      type: String,  description: 'The name of a test module to run'},
-    { name: 'watcher',     type: String,  default: 'events' },
+    { name: 'environment', type: String, default: 'test', aliases: ['e'] },
+    { name: 'config-file', type: String,  default: './testem.json', aliases: ['c', 'cf'] },
+    { name: 'server',      type: Boolean, default: false, aliases: ['s'] },
+    { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.', aliases: ['p'] },
+    { name: 'filter',      type: String,  description: 'A regex to filter tests ran', aliases: ['f'] },
+    { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
+    { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
   ],
 
   init: function() {

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -8,11 +8,18 @@ var getCallerFile = require('../utilities/get-caller-file');
 var isGitRepo     = require('../utilities/git-repo');
 var Promise       = require('../ext/promise');
 var defaults      = require('lodash-node/modern/objects/defaults');
+var assign        = require('lodash-node/modern/objects/assign');
+var pluck         = require('lodash-node/modern/collections/pluck');
+var union         = require('lodash-node/modern/arrays/union');
+var uniq          = require('lodash-node/modern/arrays/uniq');
+var where         = require('lodash-node/modern/collections/where');
+var reject        = require('lodash-node/modern/collections/reject');
 var EOL           = require('os').EOL;
 var CoreObject    = require('core-object');
 var debug         = require('debug')('ember-cli:command');
 var findKey       = require('lodash-node/modern/objects/findKey');
-var Watcher         = require('../models/watcher');
+var Watcher       = require('../models/watcher');
+var SilentError   = require('../errors/silent');
 
 var allowedWorkOptions = {
   insideProject: true,
@@ -20,11 +27,12 @@ var allowedWorkOptions = {
   everywhere: true
 };
 
+path.name = 'Path';
 // extend nopt to recognize 'gitUrl' as a type
 nopt.typeDefs.gitUrl = {
   type: 'gitUrl',
-  validate:  function(data, k, val){
-    if(isGitRepo(val)) {
+  validate: function(data, k, val) {
+    if (isGitRepo(val)) {
       data[k] = val;
       return true;
     } else {
@@ -53,29 +61,41 @@ function Command() {
   // Options properties
   this.availableOptions = this.availableOptions || [];
   this.anonymousOptions = this.anonymousOptions || [];
-
-  var self = this;
-  this.availableOptions.forEach(function(option) {
-    if (!option.name || !option.type) {
-      throw new Error('The command "' + self.name + '" has an option ' +
-                      'without the required type and name fields.');
-    }
-
-    if (option.name !== option.name.toLowerCase()) {
-      throw new Error('The "' + option.name + '" option\'s name of the "' +
-                       self.name + '" command contains a capital letter.');
-    }
-
-    option.key = camelize(option.name);
-    option.required = option.required || false;
-  });
+  this.registerOptions();
 }
+/*
+  Registers options with command. This method provides the ability to extend or override command options.
+  Expects an object containing anonymousOptions or availableOptions, which it will then merge with
+  existing availableOptions before building the optionsAliases which are used to define shorthands.
+*/
+Command.prototype.registerOptions = function(options) {
+  var extendedAvailableOptions = options && options.availableOptions || [];
+  var extendedAnonymousOptions = options && options.anonymousOptions || [];
+
+  this.anonymousOptions = union(this.anonymousOptions.slice(0), extendedAnonymousOptions);
+
+  // merge any availableOptions
+  this.availableOptions = union(this.availableOptions.slice(0), extendedAvailableOptions);
+
+  var optionKeys = uniq(pluck(this.availableOptions, 'name'));
+
+  optionKeys.map(this.mergeDuplicateOption.bind(this));
+
+  this.optionsAliases = this.optionsAliases || {};
+
+  this.availableOptions.map(this.validateOption.bind(this));
+};
 
 Command.__proto__ = CoreObject;
 
 Command.prototype.description = null;
 Command.prototype.works = 'insideProject';
 Command.prototype.constructor = Command;
+/*
+  Hook for extending a command before it is run in the cli.run command.
+  Most common use case would be to extend availableOptions.
+*/
+Command.prototype.beforeRun = function() {};
 
 Command.prototype.validateAndRun = function(args) {
   var commandOptions = this.parseArgs(args);
@@ -94,8 +114,112 @@ Command.prototype.validateAndRun = function(args) {
   }.bind(this));
 };
 
+Command.prototype.mergeDuplicateOption = function(key) {
+  var duplicateOptions, mergedOption, mergedAliases;
+  // get duplicates to merge
+  duplicateOptions = where(this.availableOptions, {'name': key});
+
+  if (duplicateOptions.length > 1) {
+    // TODO: warn on duplicates and overwriting
+    mergedAliases = [];
+
+    pluck(duplicateOptions, 'aliases').map(function(alias) {
+      alias.map(function(a) {
+        mergedAliases.push(a);
+      });
+    });
+
+    // merge duplicate options
+    mergedOption = assign.apply(null,duplicateOptions);
+
+    // replace aliases with unique aliases
+    mergedOption.aliases = uniq(mergedAliases, function(alias) {
+      return alias[Object.keys(alias)[0]];
+    });
+
+    // remove duplicates from options
+    this.availableOptions = reject(this.availableOptions, {'name': key});
+    this.availableOptions.push(mergedOption);
+  }
+};
+
+Command.prototype.validateOption = function(option) {
+  if (!option.name || !option.type) {
+    throw new Error('The command "' + this.name + '" has an option ' +
+                    'without the required type and name fields.');
+  }
+
+  if (option.name !== option.name.toLowerCase()) {
+    throw new Error('The "' + option.name + '" option\'s name of the "' +
+                     this.name + '" command contains a capital letter.');
+  }
+
+  option.key = camelize(option.name);
+  option.required = option.required || false;
+
+  if (option.aliases) {
+    return option.aliases.map(this.parseAlias.bind(this, option));
+  }
+  return false;
+};
+
+Command.prototype.parseAlias = function(option, alias) {
+  var aliasType = typeof alias;
+  var key, value, aliasValue;
+
+  if (validateAlias(alias, option.type)) {
+    if (aliasType === 'string') {
+      key = alias;
+      value = ['--' + option.key];
+    } else if (aliasType === 'object') {
+      key = Object.keys(alias)[0];
+      value = ['--' + option.key, alias[key]];
+    }
+  } else {
+    if (Array.isArray(alias)) {
+      aliasType = 'array';
+      aliasValue = alias.join(',');
+    } else {
+      aliasValue = alias;
+      try {
+        aliasValue = JSON.parse(alias);
+      }
+      catch(e) {
+        var debug = require('debug')('ember-cli/models/command');
+        debug(e);
+      }
+    }
+    throw new Error('The "' + aliasValue + '" [type:' + aliasType +
+      '] alias is not an acceptable value. It must be a string or single key' +
+      ' object with a string value (for example, "value" or { "key" : "value" }).');
+  }
+
+  if (!this.optionsAliases[key]) {
+    this.optionsAliases[key] = value;
+    return true;
+  } else {
+    if (value[0] !== this.optionsAliases[key][0]) {
+      throw new SilentError('The "' + key + '" alias is already in use by the "' + this.optionsAliases[key][0] +
+      '" option and cannot be used by the "' + value[0] + '" option. Please use a different alias.');
+    } else {
+      if (value[1] !== this.optionsAliases[key][1]) {
+        this.ui.writeLine(chalk.yellow('The "' + key + '" alias cannot be overridden. Please use a different alias.'));
+        // delete offending alias from options
+        var index = this.availableOptions.indexOf(option);
+        var aliasIndex = this.availableOptions[index].aliases.indexOf(alias);
+
+        if (this.availableOptions[index].aliases[aliasIndex]) {
+          delete this.availableOptions[index].aliases[aliasIndex];
+        }
+      }
+    }
+    return false;
+  }
+};
+
 Command.prototype.parseArgs = function(commandArgs) {
   var knownOpts       = {}; // Parse options
+  var shortHands      = {};
   var commandOptions  = {};
   var ui              = this.ui;
   var commandName     = this.name;
@@ -143,17 +267,21 @@ Command.prototype.parseArgs = function(commandArgs) {
     knownOpts[option.name] = option.type;
   });
 
-  parsedOptions = nopt(knownOpts, {}, commandArgs, 0);
+  for (var alias in this.optionsAliases){
+    shortHands[alias] = this.optionsAliases[alias];
+  }
+
+  parsedOptions = nopt(knownOpts, shortHands, commandArgs, 0);
 
   if (!this.availableOptions.every(assembleAndValidateOption)) {
     return null;
   }
 
   for (var key in parsedOptions) {
-    if(typeof parsedOptions[key] !== 'object') {
+    if (typeof parsedOptions[key] !== 'object') {
       commandOptions[camelize(key)] = parsedOptions[key];
     }
-    if(findKey(commandOptions, key) === undefined && key !== 'argv'){
+    if (findKey(commandOptions, key) === undefined && key !== 'argv') {
       this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not supported by the ' + this.name + ' command. ' +
                         'Run `ember ' + this.name + ' --help` for a list of supported options.'));
     }
@@ -223,6 +351,12 @@ Command.prototype.printBasicHelp = function() {
     this.availableOptions.forEach(function(option) {
       output += chalk.cyan('  --' + option.name);
 
+      if (option.type) {
+        output += chalk.cyan(' (' + (Array.isArray(option.type) ? option.type.map(function(a) {
+          return typeof a === 'string' ? a : a.name;
+        }).join(', ') : option.type.name) + ')');
+      }
+
       if (option.required) {
         output += chalk.cyan(' (Required)');
       }
@@ -233,6 +367,18 @@ Command.prototype.printBasicHelp = function() {
 
       if (option.description) {
         output += ' ' + option.description;
+      }
+
+      if (option.aliases) {
+        output += chalk.grey(EOL + '    aliases: ' + option.aliases.map(function(a) {
+          var key;
+          if (typeof a === 'string') {
+            return '-' + a + (option.type === Boolean ? '' : ' <value>');
+          } else {
+            key = Object.keys(a)[0];
+            return  '-' + key + ' (--' + option.name + '=' + a[key] + ')';
+          }
+        }).join(', '));
       }
 
       output += EOL;
@@ -251,3 +397,25 @@ Command.prototype.printBasicHelp = function() {
   @method printDetailedHelp
 */
 Command.prototype.printDetailedHelp = function() {};
+
+/*
+  Validates alias. Must be a string or single key object
+*/
+function validateAlias(alias, expectedType) {
+  var type  = typeof alias;
+
+  if (type === 'string') {
+    return true;
+  } else if (type === 'object') {
+
+    // no arrays, no multi-key objects
+    if (!Array.isArray(alias) && Object.keys(alias).length === 1) {
+      var valueType = typeof alias[Object.keys(alias)[0]];
+      if (valueType === expectedType.name.toLowerCase()) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -536,8 +536,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'foo']).then(function() {
       assertFile('app/adapters/foo.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
       assertFile('tests/unit/adapters/foo-test.js', {
@@ -556,8 +556,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'foo/bar']).then(function() {
       assertFile('app/adapters/foo/bar.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
     });
@@ -1106,6 +1106,14 @@ describe('Acceptance: ember generate', function() {
     return generate(['server']).then(function() {
       assertFile('server/index.js');
       assertFile('server/.jshintrc');
+    });
+  });
+
+  it('availableOptions work with aliases.', function() {
+    return generate(['route', 'foo', '-resource']).then(function() {
+      assertFile('app/router.js', {
+        contain: ["resource('foo')"]
+      });
     });
   });
 });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -787,8 +787,8 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'foo', '--pod']).then(function() {
       assertFile('app/foo/adapter.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
       assertFile('tests/unit/foo/adapter-test.js', {
@@ -807,8 +807,8 @@ describe('Acceptance: ember generate pod', function() {
     return generateWithPrefix(['adapter', 'foo', '--pod']).then(function() {
       assertFile('app/pods/foo/adapter.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
       assertFile('tests/unit/pods/foo/adapter-test.js', {
@@ -827,8 +827,8 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'foo/bar', '--pod']).then(function() {
       assertFile('app/foo/bar/adapter.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
     });
@@ -838,8 +838,8 @@ describe('Acceptance: ember generate pod', function() {
     return generateWithPrefix(['adapter', 'foo/bar', '--pod']).then(function() {
       assertFile('app/pods/foo/bar/adapter.js', {
         contains: [
-          "import DS from 'ember-data';",
-          "export default DS.RESTAdapter.extend({" + EOL + "});"
+          "import ApplicationAdapter from \'./application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
     });
@@ -1448,6 +1448,14 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['route', 'foo', '--dry-run', '--pod']).then(function() {
       assertFile('app/router.js', {
         doesNotContain: "route('foo')"
+      });
+    });
+  });
+
+  it('availableOptions work with aliases.', function() {
+    return generate(['route', 'foo', '-resource', '-p']).then(function() {
+      assertFile('app/router.js', {
+        contain: ["resource('foo')"]
       });
     });
   });

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -36,6 +36,7 @@ describe('generate command', function() {
   it('runs GenerateFromBlueprint with expected options', function() {
     return command.validateAndRun(['controller', 'foo'])
       .then(function(options) {
+        assert.equal(options.pod, false);
         assert.equal(options.dryRun, false);
         assert.equal(options.verbose, false);
         assert.deepEqual(options.args, ['controller', 'foo']);


### PR DESCRIPTION
### Overview

This PR adds support for command options aliases, as well as aliases for predefined options. See [#1675](https://github.com/stefanpenner/ember-cli/issues/1675) for more detail on the original issue.
### Leveraging nopt

The [nopt library](https://github.com/npm/nopt) being used to parse arguments automatically creates implicit aliases. This explains why `ember serve -po=3333` works, but `ember serve -p=3333` doesn't. It resolves to the minimum number of characters to identify the unique option.

Nopt also has the ability to map a shortcut to an option with a predefined value. I was thinking we could have a pattern where the aliases array could take either strings or objects, where objects would represent shortcuts with predefined values. For the build command, we could alias environment to predefined values, like `ember build -prod` (would resolve to `ember build --environment=production`):

```
availableOptions: [
    { name: 'environment', type: String, default: 'development' , aliases: ['e', {'stage': 'stage'}, {'prod': 'production' }]},
    { name: 'output-path', type: path, default: 'dist/' },
    { name: 'watch', type: Boolean, default: false }
  ]
```

So essentially we get explicit aliases for more complex needs, combined with the default implicit aliases that nopt defines.
### Extended options

Currently any options defined in a blueprint's [availableOptions hook](https://github.com/stefanpenner/ember-cli/blob/master/blueprints/route/index.js#L10) will [get merged in](https://github.com/stefanpenner/ember-cli/blob/master/lib/commands/generate.js#L108) so custom options can be added. This occurs after the initial processing of the command options, and so they currently don't work with the current approach. 
I'll need to accommodate this use case before it can be merged.
### Predefined aliases

With support for predefined aliases being added, we should probably take advantage of them for some more common use cases, such as `ember build --environment=production` could become `ember build -prod`.
Any suggestions on some predefined aliases we'd like to add to CLI would be welcomed.
### Other

I still need to write some tests to support these changes, so there's that too.
