### PR TITLE
Prevent mangled POST bodies in http-proxy

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -18,7 +18,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "body-parser": "^1.2.0",
     "broccoli-asset-rev": "^1.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",

--- a/blueprints/http-mock/files/server/index.js
+++ b/blueprints/http-mock/files/server/index.js
@@ -1,24 +1,22 @@
+// To use it create some files under `routes/`
+// e.g. `server/routes/ember-hamsters.js`
+//
+// module.exports = function(app) {
+//   app.get('/ember-hamsters', function(req, res) {
+//     res.send('hello');
+//   });
+// };
+
 module.exports = function(app) {
   var globSync   = require('glob').sync;
-  var bodyParser = require('body-parser');
   var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
   var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
-
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({
-    extended: true
-  }));
 
   // Log proxy requests
   var morgan  = require('morgan');
   app.use(morgan('dev'));
 
   mocks.forEach(function(route) { route(app); });
-
-  // proxy expects a stream, but express will have turned
-  // the request stream into an object because bodyParser
-  // has run. We have to convert it back to stream:
-  // https://github.com/nodejitsu/node-http-proxy/issues/180
-  app.use(require('connect-restreamer')());
   proxies.forEach(function(route) { route(app); });
+
 };

--- a/blueprints/http-proxy/files/server/index.js
+++ b/blueprints/http-proxy/files/server/index.js
@@ -8,26 +8,15 @@
 // };
 
 module.exports = function(app) {
-  var bodyParser = require('body-parser');
   var globSync   = require('glob').sync;
   var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
   var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
-
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({
-    extended: true
-  }));
 
   // Log proxy requests
   var morgan  = require('morgan');
   app.use(morgan('dev'));
 
   mocks.forEach(function(route) { route(app); });
-
-  // proxy expects a stream, but express will have turned
-  // the request stream into an object because bodyParser
-  // has run. We have to convert it back to stream:
-  // https://github.com/nodejitsu/node-http-proxy/issues/180
-  app.use(require('connect-restreamer')());
   proxies.forEach(function(route) { route(app); });
+
 };

--- a/blueprints/http-proxy/index.js
+++ b/blueprints/http-proxy/index.js
@@ -19,8 +19,7 @@ module.exports = {
   afterInstall: function() {
     return this.addPackagesToProject([
       { name: 'http-proxy', target: '^1.1.6' },
-      { name: 'morgan', target: '^1.3.2' },
-      { name: 'connect-restreamer', target: '^1.0.0' }
+      { name: 'morgan', target: '^1.3.2' }
     ]);
   }
 };

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -75,7 +75,6 @@ describe('Acceptance: blueprint smoke tests', function() {
         var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
 
         assert(packageJson.devDependencies['http-proxy']);
-        assert(packageJson.devDependencies['connect-restreamer']);
         assert(packageJson.devDependencies['morgan']);
       });
   });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -839,30 +839,7 @@ describe('Acceptance: ember generate', function() {
     this.timeout(10000);
     return generate(['http-mock', 'foo']).then(function() {
       assertFile('server/index.js', {
-        contains:"module.exports = function(app) {" + EOL +
-                 "  var globSync   = require('glob').sync;" + EOL +
-                 "  var bodyParser = require('body-parser');" + EOL +
-                 "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                 "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                 EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains:"mocks.forEach(function(route) { route(app); });"
       });
       assertFile('server/mocks/foo.js', {
         contains: "module.exports = function(app) {" + EOL +
@@ -911,30 +888,7 @@ describe('Acceptance: ember generate', function() {
   it('http-mock foo-bar', function() {
     return generate(['http-mock', 'foo-bar']).then(function() {
       assertFile('server/index.js', {
-        contains: "module.exports = function(app) {" + EOL +
-                  "  var globSync   = require('glob').sync;" + EOL +
-                  "  var bodyParser = require('body-parser');" + EOL +
-                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains: "mocks.forEach(function(route) { route(app); });"
       });
       assertFile('server/mocks/foo-bar.js', {
         contains: "module.exports = function(app) {" + EOL +
@@ -983,30 +937,7 @@ describe('Acceptance: ember generate', function() {
   it('http-proxy foo', function() {
     return generate(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
       assertFile('server/index.js', {
-        contains: "module.exports = function(app) {" + EOL +
-                  "  var bodyParser = require('body-parser');" + EOL +
-                  "  var globSync   = require('glob').sync;" + EOL +
-                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains: "proxies.forEach(function(route) { route(app); });"
       });
       assertFile('server/proxies/foo.js', {
         contains: "var proxyPath = '/foo';" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1215,30 +1215,7 @@ describe('Acceptance: ember generate pod', function() {
   it('http-mock foo --pod', function() {
     return generate(['http-mock', 'foo', '--pod']).then(function() {
       assertFile('server/index.js', {
-        contains:"module.exports = function(app) {" + EOL +
-                 "  var globSync   = require('glob').sync;" + EOL +
-                 "  var bodyParser = require('body-parser');" + EOL +
-                 "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                 "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                 EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains:"mocks.forEach(function(route) { route(app); });"
       });
       assertFile('server/mocks/foo.js', {
         contains: "module.exports = function(app) {" + EOL +
@@ -1287,30 +1264,7 @@ describe('Acceptance: ember generate pod', function() {
   it('http-mock foo-bar --pod', function() {
     return generate(['http-mock', 'foo-bar', '--pod']).then(function() {
       assertFile('server/index.js', {
-        contains: "module.exports = function(app) {" + EOL +
-                  "  var globSync   = require('glob').sync;" + EOL +
-                  "  var bodyParser = require('body-parser');" + EOL +
-                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains: "mocks.forEach(function(route) { route(app); });"
       });
       assertFile('server/mocks/foo-bar.js', {
         contains: "module.exports = function(app) {" + EOL +
@@ -1359,30 +1313,7 @@ describe('Acceptance: ember generate pod', function() {
   it('http-proxy foo --pod', function() {
     return generate(['http-proxy', 'foo', 'http://localhost:5000', '--pod']).then(function() {
       assertFile('server/index.js', {
-        contains: "module.exports = function(app) {" + EOL +
-                  "  var bodyParser = require('body-parser');" + EOL +
-                  "  var globSync   = require('glob').sync;" + EOL +
-                  "  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  "  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);" + EOL +
-                  EOL +
-                  "  app.use(bodyParser.json());" + EOL +
-                  "  app.use(bodyParser.urlencoded({" + EOL +
-                  "    extended: true" + EOL +
-                  "  }));" + EOL +
-                  EOL +
-                  "  // Log proxy requests" + EOL +
-                  "  var morgan  = require('morgan');" + EOL +
-                  "  app.use(morgan('dev'));" + EOL +
-                  EOL +
-                  "  mocks.forEach(function(route) { route(app); });" + EOL +
-                  EOL +
-                  "  // proxy expects a stream, but express will have turned" + EOL +
-                  "  // the request stream into an object because bodyParser" + EOL +
-                  "  // has run. We have to convert it back to stream:" + EOL +
-                  "  // https://github.com/nodejitsu/node-http-proxy/issues/180" + EOL +
-                  "  app.use(require('connect-restreamer')());" + EOL +
-                  "  proxies.forEach(function(route) { route(app); });" + EOL +
-                  "};"
+        contains: "proxies.forEach(function(route) { route(app); });"
       });
       assertFile('server/proxies/foo.js', {
         contains: "var proxyPath = '/foo';" + EOL +


### PR DESCRIPTION
This closes #1921. 

`connect-restreamer` is fundamentally nuts and rather fragile. It tries to reserialize the already-parsed body, but it doesn't take into account what format was originally used. Thankfully we can just avoid the issue entirely by putting `http-proxy` ahead of `bodyParser`.

People who have already run the proxy generator probably need to be warned that they won't benefit from this bugfix. (IMO this kind of code really shouldn't be in blueprints in the first place.)
