### PR TITLE
Add --silent option for a quieter UI

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -20,8 +20,6 @@ function CLI(options) {
 module.exports = CLI;
 
 CLI.prototype.run = function(environment) {
-  this.ui.writeLine('version: ' + emberCLIVersion());
-
   return Promise.hash(environment).then(function(environment) {
     var args = environment.cliArgs.slice();
     var commandName = args.shift();
@@ -30,6 +28,12 @@ CLI.prototype.run = function(environment) {
     getOptionArgs('--verbose', commandArgs).forEach(function(arg){
       process.env['EMBER_VERBOSE_' + arg.toUpperCase()] = 'true';
     });
+
+    if (commandArgs.indexOf('--silent') !== -1) {
+      this.ui.setWriteLevel('ERROR');
+    }
+
+    this.ui.writeLine('version: ' + emberCLIVersion());
 
     var CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
       project: environment.project,

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -19,7 +19,7 @@ module.exports = Task.extend({
     var packages       = options.packages || [];
     var installOptions = options.installOptions || { save: true };
 
-    ui.pleasantProgress.start(chalk.green('Installing browser packages via Bower'), chalk.green('.'));
+    ui.startProgress(chalk.green('Installing browser packages via Bower'), chalk.green('.'));
 
     var config = bowerConfig.read();
     config.interactive = true;
@@ -31,7 +31,7 @@ module.exports = Task.extend({
           .on('error', reject)
           .on('end', resolve);
       })
-      .finally(function() { ui.pleasantProgress.stop(); })
+      .finally(function() { ui.stopProgress(); })
       .then(function() {
         ui.writeLine(chalk.green('Installed browser packages via Bower.'));
       });

--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -8,7 +8,7 @@ var Promise  = require('../ext/promise');
 
 module.exports = Task.extend({
   run: function(options) {
-    this.ui.pleasantProgress.start(
+    this.ui.startProgress(
       chalk.green('Building'), chalk.green('.')
     );
 

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -10,7 +10,7 @@ module.exports = Task.extend({
     var ui        = this.ui;
     var analytics = this.analytics;
 
-    ui.pleasantProgress.start(chalk.green('Building'), chalk.green('.'));
+    ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
     var builder = new Builder({
       ui: ui,
@@ -36,7 +36,7 @@ module.exports = Task.extend({
         });
       })
       .finally(function() {
-        ui.pleasantProgress.stop();
+        ui.stopProgress();
         return builder.cleanup();
       })
       .then(function() {

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -13,7 +13,7 @@ module.exports = Task.extend({
   },
   // Options: Boolean verbose
   run: function(options) {
-    this.ui.pleasantProgress.start(chalk.green('Installing packages for tooling via npm'), chalk.green('.'));
+    this.ui.startProgress(chalk.green('Installing packages for tooling via npm'), chalk.green('.'));
 
     var npmOptions = {
       loglevel: options.verbose ? 'verbose' : 'error',
@@ -53,7 +53,7 @@ module.exports = Task.extend({
   },
 
   finally: function() {
-    this.ui.pleasantProgress.stop();
+    this.ui.stopProgress();
     this.restoreLogger();
   },
 

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -23,7 +23,7 @@ module.exports = TestTask.extend({
     var self = this;
 
     // The building has actually started already, but we want some output while we wait for the server
-    ui.pleasantProgress.start(chalk.green('Building'), chalk.green('.'));
+    ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
     return new Promise(function() {
       var watcher = options.watcher;
@@ -36,7 +36,7 @@ module.exports = TestTask.extend({
         } else {
           started = true;
 
-          ui.pleasantProgress.stop();
+          ui.stopProgress();
           self.invokeTestem(options);
         }
       });

--- a/lib/tasks/update.js
+++ b/lib/tasks/update.js
@@ -42,14 +42,14 @@ module.exports = Task.extend({
   },
 
   runNpmUpdate: function(newestVersion) {
-    this.ui.pleasantProgress.start(chalk.green('Updating ember-cli'), chalk.green('.'));
+    this.ui.startProgress(chalk.green('Updating ember-cli'), chalk.green('.'));
 
     // first, run `npm install -g ember-cli`
     var npm = this.npm;
     var loadNPM = Promise.denodeify(npm.load);
 
     var stopProgress = (function() {
-      this.ui.pleasantProgress.stop();
+      this.ui.stopProgress();
     }.bind(this));
 
     var reportFailure = (function(reason) {

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -30,14 +30,49 @@ function UI(options) { // options === { inputStream, outputStream }
 
   // Input stream
   this.inputStream = options.inputStream;
+
+  this.writeLevel = options.writeLevel || 'INFO';
 }
 
-UI.prototype.write = function(data) { this.outputStream.write(data); };
+UI.prototype.write = function(data, writeLevel) {
+  if (this.writeLevelVisible(writeLevel)) {
+    this.outputStream.write(data);
+  }
+};
 
-UI.prototype.writeLine = function(data) { this.write(data + EOL); };
+UI.prototype.writeLine = function(data, writeLevel) {
+  if (this.writeLevelVisible(writeLevel)) {
+    this.write(data + EOL);
+  }
+};
 
 UI.prototype.writeError = function(error) {
   writeError(this, error);
+};
+
+/**
+  Sets the write level for the UI. Valid write levels are 'DEBUG', 'INFO', 
+  'WARNING', and 'ERROR'.
+
+  @method setWriteLevel
+  @param {String} level
+*/
+UI.prototype.setWriteLevel = function(level) {
+  if (Object.keys(this.WRITE_LEVELS).indexOf(level) === -1) {
+    throw new Error('Unknown write level. Valid values are \'DEBUG\', \'INFO\', \'WARNING\', and \'ERROR\'.');
+  }
+
+  this.writeLevel = level;
+};
+
+UI.prototype.startProgress = function(message, stepString) {
+  if (this.writeLevelVisible('INFO')) {
+    this.pleasantProgress.start(message, stepString);
+  }
+};
+
+UI.prototype.stopProgress = function(printWithFullStepString) {
+  this.pleasantProgress.stop(printWithFullStepString);
 };
 
 UI.prototype.prompt = function(questions, callback) {
@@ -66,4 +101,31 @@ UI.prototype.prompt = function(questions, callback) {
       new PromptExt(questions, resolve);
     });
   }
+};
+
+/**
+  @property WRITE_LEVELS
+  @private
+  @type Object
+*/
+UI.prototype.WRITE_LEVELS = {
+    'DEBUG': 1,
+    'INFO': 2,
+    'WARNING': 3,
+    'ERROR': 4
+};
+
+/**
+  Whether or not the specified write level should be printed by this UI.
+
+  @method writeLevelVisible
+  @private
+  @param {String} writeLevel
+  @return {Boolean}
+*/
+UI.prototype.writeLevelVisible = function(writeLevel) {
+  var levels = this.WRITE_LEVELS;
+  writeLevel = writeLevel || 'INFO';
+
+  return levels[writeLevel] >= levels[this.writeLevel];
 };


### PR DESCRIPTION
This addresses #2423.  Passing `--silent` to any command will set the UI will only write errors. This allows XML output from `ember test` to be captured in a file without any additional text (printed ember version, pleasent progress, etc.) 

To achieve this, I introduced the concept of a write level / log level to the UI object. `UI.write` and `UI.writeLine` now accept a second argument that is the write level. If the write level set for the UI is higher the write level passed to `UI.write`, nothing will be printed. By default, the write level for a `UI` object and for `UI.write` and `UI.writeLine` is `'INFO'`. The write levels, in order, are: `'DEBUG'`, `'INFO'`, `'WARNING'`, `'ERROR'`. 

This is my first time working in node / on ember-cli—if the implementation is off let me know how I can change it. I would be happy to add tests if all looks well.
