### PR TITLE
Use the Ember.Applications container for initializer tests.

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -6,8 +6,8 @@ var container, application;
 module('<%= classifiedModuleName %>Initializer', {
   setup: function() {
     Ember.run(function() {
-      container = new Ember.Container();
       application = Ember.Application.create();
+      container = application.__container__;
       application.deferReadiness();
     });
   }


### PR DESCRIPTION
Without this change, the `application` and `container` instances are not associated with each other AT ALL.

If I am testing an initializer's function that uses the established public API's `application.register` and `application.inject` then I should be able to confirm that things are setup properly via a lookup.
