### PR TITLE
Set locationType to none in tests

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -30,7 +30,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';
-    ENV.locationType = 'auto';
+    ENV.locationType = 'none';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1000,7 +1000,7 @@ function calculateBaseTag(config){
   var baseURL      = cleanBaseURL(config.baseURL);
   var locationType = config.locationType;
 
-  if (locationType === 'hash' || locationType === 'none') {
+  if (locationType === 'hash') {
     return '';
   }
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -151,19 +151,19 @@ describe('broccoli/ember-app', function() {
         assert(actual.indexOf(expected) > -1);
       });
 
+      it('includes the `base` tag in `head` if locationType is none (testem requirement)', function() {
+        config.locationType = 'none';
+        config.baseURL = '/';
+        var expected = '<base href="/">';
+        var actual = emberApp.contentFor(config, defaultMatch, 'head');
+
+        assert(actual.indexOf(expected) > -1);
+      });
+
       it('does not include the `base` tag in `head` if locationType is hash', function() {
         config.locationType = 'hash';
         config.baseURL = '/foo/bar';
         var expected = '<base href="/foo/bar/">';
-        var actual = emberApp.contentFor(config, defaultMatch, 'head');
-
-        assert(actual.indexOf(expected) === -1);
-      });
-
-      it('does not include the `base` tag in `head` if locationType is none', function() {
-        config.locationType = 'none';
-        config.baseURL = '/';
-        var expected = '<base href="/">';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
         assert(actual.indexOf(expected) === -1);


### PR DESCRIPTION
Fixes #2559
- Tests should not affect the url so router location should be `none`
- Testem requires a base URL

Previously we were [setting location to `auto`](https://github.com/teddyzeenny/ember-cli/blob/master/blueprints/app/files/config/environment.js#L32-L33) in test environment so that we get a `<base>` tag during build (which testem needs), and then setting it back to `none` in the `startApp` helper before running the tests. But that last step [was removed](https://github.com/stefanpenner/ember-cli/commit/3568d60d745bd7e3f3672819c85c51918690c6c8), which caused the tests to run with location `auto`, which breaks reloads.

It might be a bit confusing to set `locationType:'auto'` in `environment.js` just to get a `<base>` tag, when actually the tests would run with `locationType: 'none'`.  So I just set location to `none` and added a `<base>` tag anyway.

@rwjblue is it safe to set a `<base>` tag in location `none` or was https://github.com/stefanpenner/ember-cli/commit/de7c6bce2cf6c9d271b2ccc23a2872a4bcff6bc5 fixing a previous issue?
