### PR TITLE
Add test helper blueprint

### DIFF
--- a/blueprints/test-helper/files/tests/helpers/__name__.js
+++ b/blueprints/test-helper/files/tests/helpers/__name__.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerAsyncHelper('<%= camelizedModuleName %>', function(app) {
+
+});

--- a/blueprints/test-helper/index.js
+++ b/blueprints/test-helper/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates a test helper.'
+};

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1035,6 +1035,18 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('test-helper foo', function() {
+    return generate(['test-helper', 'foo']).then(function() {
+      assertFile('tests/helpers/foo.js', {
+        contains: "import Ember from 'ember';" + EOL +
+                  EOL +
+                  "export default Ember.Test.registerAsyncHelper('foo', function(app) {" + EOL +
+                  EOL +
+                  "});"
+      });
+    });
+  });
+
   it('correctly identifies the root of the project', function() {
     return initApp()
       .then(function() {


### PR DESCRIPTION
```
ember g test-helper routes-to
```

Will create a ``routesTo`` test helper.

---

This is my first cli PR. Let me know if I should be adding something
else in here. 

Do you guys unit test blueprints? I can add one, but it didn't look
like it was common/required. Also, by default this creates an async test
helper, which I think is right. However I can change/flag if required.
