### PR TITLE
Docs: Removes Mentions of type option from Generators

### DIFF
--- a/_posts/2013-04-08-generators-and-blueprints.md
+++ b/_posts/2013-04-08-generators-and-blueprints.md
@@ -356,8 +356,7 @@ values when the `mapFile` method is called.
 
 Called before any of the template files are processed and receives
 the same arguments as `locals`. Typically used for validating any
-additional command line options. As an example, the `controller`
-blueprint validates its `--type` option in this hook.
+additional command line options.
 
 ### afterInstall & afterUninstall
 


### PR DESCRIPTION
The `--type` option is no longer supported by the `generate` command. This PR removes mentions of its use from the docs.
