### PR TITLE
App.import should throw exception when someone passes a bad type

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -890,8 +890,10 @@ EmberApp.prototype.import = function(asset, options) {
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if(options.type === 'vendor') {
       this.legacyFilesToAppend.push(assetPath);
-    } else {
+    } else if (options.type === 'test' ) {
       this.legacyTestFilesToAppend.push(assetPath);
+    } else {
+      throw new Error( 'You must pass either `vendor` or `test` for options.type in your call to `app.import` for file: '+basename );
     }
 
     this.importWhitelist = assign(this.importWhitelist, options.exports || {});

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -196,6 +196,31 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('app.import fails when options.type is not `vendor` or `test`', function(){
+    console.log('    running the slow end-to-end it will take some time');
+
+    this.timeout(100000);
+
+    return copyFixtureFiles('brocfile-tests/app-import')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        packageJson.devDependencies['ember-bad-addon'] = 'latest';
+
+        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
+          verbose: true
+        });
+      })
+      .then(function() {
+        assert( false, 'Build passed when it should have failed!' );
+      }, function() {
+        assert.ok( true, 'Build failed with invalid options type.' );
+      });
+  });
+
   it('addons can have a public tree that is merged and returned namespaced by default', function() {
     console.log('    running the slow end-to-end it will take some time');
 

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  name: 'Ember Random Addon',
+
+  included: function included(app) {
+    this._super.included(app);
+
+    app.import('vendor/ember-random-addon/file-to-import.js', { type: 'jabascript' });
+
+  }
+};

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/package.json
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-bad-addon",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/vendor/ember-bad-addon/file-to-import.js
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/vendor/ember-bad-addon/file-to-import.js
@@ -1,0 +1,1 @@
+//example javascript to import


### PR DESCRIPTION
<strangelooper> rwjblue it doesn't look like the code is checking for anything other than if(options.type === 'vendor')  the else statement stuffs your asset into legacyTestFilesToAppend
<rwjblue> yes, I know
<rwjblue> I'm saying it should
<strangelooper> oh, want me to make a pr with `else if( options.type === 'test' ){`'  ?
<strangelooper> :-)
<rwjblue> yes, then error in the final `else` case
<strangelooper> cool
