### PR TITLE
[BUGFIX] make application instances not use Pascal case

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('Acceptance: <%= classifiedModuleName %>', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -4,16 +4,16 @@ import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var App;
+  var application;
 
   var attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {
-    App = Application.create(attributes);
-    App.setupForTesting();
-    App.injectTestHelpers();
+    application = Application.create(attributes);
+    application.setupForTesting();
+    application.injectTestHelpers();
   });
 
-  return App;
+  return application;
 }

--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('Acceptance', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -2,16 +2,16 @@
 /* globals test, expect, equal, visit, andThen */
 
 import Ember from 'ember';
-import startApp    from '../helpers/start-app';
+import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('default-development - Integration', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -2,16 +2,16 @@
 /* globals test, expect, equal, visit, andThen */
 
 import Ember from 'ember';
-import startApp    from '../helpers/start-app';
+import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('pods based templates', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -2,16 +2,16 @@
 /* globals test, expect, equal, visit, andThen */
 
 import Ember from 'ember';
-import startApp    from '../helpers/start-app';
+import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('pods based templates', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -2,16 +2,16 @@
 /* globals test, expect, equal, visit, andThen */
 
 import Ember from 'ember';
-import startApp    from '../helpers/start-app';
+import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('wrapInEval in-app test', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 
-var App;
+var application;
 
 module('Acceptance: Foo', {
   setup: function() {
-    App = startApp();
+    application = startApp();
   },
   teardown: function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   }
 });
 


### PR DESCRIPTION
As per the style guide, instances should use camelCase.

_Edit_: This is my first PR. Being new to Ember I've noticed a few inconsistencies around app instances. `window.App = Ember.Application.create();` is often used, which is later `application` as an argument. I don't know if it should be 'app' or 'application' but I don't think it should be 'App'.
