### PR TITLE
Include Ember CLI and PhantomJS as "prerequisites" to the default app blueprint's README

### DIFF
--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -8,7 +8,10 @@ A short introduction of this app could easily go here.
 You will need the following things properly installed on your computer.
 
 * [Git](http://git-scm.com/)
-* [Node.js](http://nodejs.org/) (with NPM) and [Bower](http://bower.io/)
+* [Node.js](http://nodejs.org/) (with NPM)
+* [Bower](http://bower.io/)
+* [Ember CLI](http://www.ember-cli.com/)
+* [PhantomJS](http://phantomjs.org/)
 
 ## Installation
 


### PR DESCRIPTION
It may seem obvious, but given that the README is one of the first things someone new to an Ember project might see and given that it shows commands that depend on Ember CLI and on PhantomJS, it seems like both of these should be listed up-front in the "prerequisites" section.

(I didn't think this warranted updating the CHANGELOG, but I can if desired.)
