### PR TITLE
add .npmignore to addon blueprint

### DIFF
--- a/blueprints/addon/files/.npmignore
+++ b/blueprints/addon/files/.npmignore
@@ -1,0 +1,12 @@
+bower_components/
+tests/
+
+.bowerrc
+.editorconfig
+.ember-cli
+.travis.yml
+.npmignore
+**/.gitkeep
+bower.json
+Brocfile.js
+testem.json


### PR DESCRIPTION
Having an `.npmignore` in your addons directory can reduce the size of the packaged and published node module considerably. For example: In case of the [ember-cli-i18n addon](https://github.com/dockyard/ember-cli-i18n), the size of the tgz file build with the `.npmignore` in this PR is only 1.5% of the one build without the `.npmignore`.

I'm not sure if calling `tar` (line 204 in the test) without any checks is such a good idea...The test probably fails on Windows. What do you think about this?

This resolves issue #2640 

