### PR TITLE
[WIP] Refactor command model

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -9,6 +9,7 @@ var isGitRepo     = require('../utilities/git-repo');
 var Promise       = require('../ext/promise');
 var defaults      = require('lodash-node/modern/objects/defaults');
 var assign        = require('lodash-node/modern/objects/assign');
+var keys          = require('lodash-node/modern/objects/keys');
 var pluck         = require('lodash-node/modern/collections/pluck');
 var union         = require('lodash-node/modern/arrays/union');
 var uniq          = require('lodash-node/modern/arrays/uniq');
@@ -115,6 +116,18 @@ Command.prototype.validateAndRun = function(args) {
     return Promise.resolve();
   }
 
+  if (this.works === 'insideProject' && !this.isWithinProject) {
+    this.ui.writeLine('You have to be inside an ember-cli project in order to use ' +
+                        'the ' + chalk.green(this.name) + ' command.');
+    return Promise.resolve();
+  }
+
+  if (this.works === 'outsideProject' && this.isWithinProject) {
+    this.ui.writeLine('You cannot use the '+  chalk.green(this.name) +
+                        ' command inside an ember-cli project.');
+    return Promise.resolve();
+  }
+
   return Watcher.detectWatcher(this.ui, commandOptions.options).then(function(options) {
     return this.run(options, commandOptions.args);
   }.bind(this));
@@ -158,6 +171,50 @@ Command.prototype.mergeDuplicateOption = function(key) {
 };
 
 /*
+  Normalizes option, filling in implicit values
+  @method normalizeOption
+  @param {Object} option
+  @return {Object}
+*/
+Command.prototype.normalizeOption = function(option) {
+  option.key = camelize(option.name);
+  option.required = option.required || false;
+  return option;
+};
+
+/*
+  Assigns option
+  @method assignOption
+  @param {Object} option
+  @param {Object} parsedOptions
+  @param {Object} commandOptions
+  @return {Boolean}
+*/
+Command.prototype.assignOption = function(option, parsedOptions, commandOptions) {
+  var isValid = isValidParsedOption(option, parsedOptions[option.name]);
+  if (isValid) {
+    if (parsedOptions[option.name] === undefined) {
+      if (option.default !== undefined) {
+        commandOptions[option.key] = option.default;
+      }
+
+      if (this.settings[option.name] !== undefined) {
+        commandOptions[option.key] = this.settings[option.name];
+      } else if (this.settings[option.key] !== undefined) {
+        commandOptions[option.key] = this.settings[option.key];
+      }
+    } else {
+      commandOptions[option.key] = parsedOptions[option.name];
+      delete parsedOptions[option.name];
+    }
+  } else {
+    this.ui.writeLine('The specified command ' + chalk.green(this.name) +
+                     ' requires the option ' + chalk.green(option.name) + '.');
+  }
+  return isValid;
+};
+
+/*
   Validates option
   @method validateOption
   @param {Object} option
@@ -176,12 +233,11 @@ Command.prototype.validateOption = function(option) {
                      this.name + '" command contains a capital letter.');
   }
 
-  option.key = camelize(option.name);
-  option.required = option.required || false;
+  this.normalizeOption(option);
 
   if (option.aliases) {
     parsedAliases = option.aliases.map(this.parseAlias.bind(this, option));
-    return parsedAliases.map(this.validateAlias.bind(this, option)).indexOf(false) === -1;
+    return parsedAliases.map(this.assignAlias.bind(this, option)).indexOf(false) === -1;
   }
   return false;
 };
@@ -197,7 +253,7 @@ Command.prototype.parseAlias = function(option, alias) {
   var aliasType = typeof alias;
   var key, value, aliasValue;
 
-  if (validateAlias(alias, option.type)) {
+  if (isValidAlias(alias, option.type)) {
     if (aliasType === 'string') {
       key = alias;
       value = ['--' + option.key];
@@ -231,9 +287,17 @@ Command.prototype.parseAlias = function(option, alias) {
   };
 
 };
+Command.prototype.assignAlias = function(option, alias) {
+  var isValid = this.validateAlias(option, alias);
+
+  if (isValid) {
+    this.optionsAliases[alias.key] = alias.value;
+  }
+  return isValid;
+};
 
 /*
-  Validates and assigns alias value in optionsAliases
+  Validates alias value
   @method validateAlias
   @params {Object} alias
   @return {Boolean}
@@ -243,7 +307,6 @@ Command.prototype.validateAlias = function(option, alias) {
   var value = alias.value;
 
   if (!this.optionsAliases[key]) {
-    this.optionsAliases[key] = value;
     return true;
   } else {
     if (value[0] !== this.optionsAliases[key][0]) {
@@ -272,73 +335,35 @@ Command.prototype.validateAlias = function(option, alias) {
 */
 Command.prototype.parseArgs = function(commandArgs) {
   var knownOpts       = {}; // Parse options
-  var shortHands      = {};
   var commandOptions  = {};
-  var ui              = this.ui;
-  var commandName     = this.name;
-  var settings        = this.settings;
   var parsedOptions;
 
   var assembleAndValidateOption = function(option) {
-    if (parsedOptions[option.name] === undefined) {
-      if (option.default !== undefined) {
-        commandOptions[option.key] = option.default;
-      } else if (option.required) {
-        ui.writeLine('The specified command ' + chalk.green(commandName) +
-                     ' requires the option ' + chalk.green(option.name) + '.');
-        return false;
-      }
-
-      if (settings[option.name] !== undefined) {
-        commandOptions[option.key] = settings[option.name];
-      } else if (settings[option.key] !== undefined) {
-        commandOptions[option.key] = settings[option.key];
-      }
-    } else {
-      commandOptions[option.key] = parsedOptions[option.name];
-      delete parsedOptions[option.name];
-    }
-    return true;
+    return this.assignOption(option, parsedOptions, commandOptions);
   };
 
-  if (this.works === 'insideProject') {
-    if (!this.isWithinProject) {
-      this.ui.writeLine('You have to be inside an ember-cli project in order to use ' +
-                        'the ' + chalk.green(this.name) + ' command.');
-      return null;
-    }
-  }
-
-  if (this.works === 'outsideProject') {
-    if (this.isWithinProject) {
-      this.ui.writeLine('You cannot use the '+  chalk.green(this.name) +
-                        ' command inside an ember-cli project.');
-      return null;
-    }
-  }
-  this.availableOptions.forEach(function(option) {
-    knownOpts[option.name] = option.type;
-  });
-
-  for (var alias in this.optionsAliases){
-    shortHands[alias] = this.optionsAliases[alias];
-  }
-
-  parsedOptions = nopt(knownOpts, shortHands, commandArgs, 0);
-
-  if (!this.availableOptions.every(assembleAndValidateOption)) {
-    return null;
-  }
-
-  for (var key in parsedOptions) {
+  var validateParsed = function(key) {
     if (typeof parsedOptions[key] !== 'object') {
       commandOptions[camelize(key)] = parsedOptions[key];
     }
+
     if (findKey(commandOptions, key) === undefined && key !== 'argv') {
       this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not supported by the ' + this.name + ' command. ' +
                         'Run `ember ' + this.name + ' --help` for a list of supported options.'));
     }
+  };
+
+  this.availableOptions.forEach(function(option) {
+    knownOpts[option.name] = option.type;
+  });
+
+  parsedOptions = nopt(knownOpts, this.optionsAliases, commandArgs, 0);
+
+  if (!this.availableOptions.every(assembleAndValidateOption.bind(this))) {
+    return null;
   }
+
+  keys(parsedOptions).map(validateParsed.bind(this));
 
   return {
     options: defaults(commandOptions, this.settings),
@@ -346,6 +371,9 @@ Command.prototype.parseArgs = function(commandArgs) {
   };
 };
 
+/*
+
+*/
 Command.prototype.run = function(commandArgs) {
   throw new Error('command must implement run' + commandArgs.toString());
 };
@@ -452,9 +480,26 @@ Command.prototype.printBasicHelp = function() {
 Command.prototype.printDetailedHelp = function() {};
 
 /*
+  Validates options parsed by nopt
+*/
+function isValidParsedOption(option, parsedOption) {
+  // option.name didn't parse
+  if (parsedOption === undefined) {
+    // no default
+    if (option.default === undefined) {
+      if (option.required) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/*
   Validates alias. Must be a string or single key object
 */
-function validateAlias(alias, expectedType) {
+function isValidAlias(alias, expectedType) {
   var type  = typeof alias;
 
   if (type === 'string') {

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -17,3 +17,6 @@ function MockUI() {
 
 MockUI.prototype = Object.create(UI.prototype);
 MockUI.prototype.constructor = MockUI;
+MockUI.prototype.clear = function(){
+  this.output = '';
+};

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -44,10 +44,23 @@ var OutsideProjectCommand = Command.extend({
 
 var OptionsAliasCommand = Command.extend({
   name: 'options-alias',
-  availableOptions: [
-    { name: 'taco', type: String, default: 'traditional', aliases:[{'hard-shell' : 'hard-shell'}, {'soft-shell' : 'soft-shell'}]},
-    { name: 'spicy', type: Boolean, default: true, aliases:[{'mild' : false}] }
-  ],
+  availableOptions: [{
+    name: 'taco',
+    type: String,
+    default: 'traditional',
+    aliases:[
+      {'hard-shell' : 'hard-shell'},
+      {'soft-shell' : 'soft-shell'}
+    ]
+  },
+  {
+    name: 'spicy',
+    type: Boolean,
+    default: true,
+    aliases:[
+      {'mild' : false}
+    ]
+  }],
   run: function() {}
 });
 
@@ -124,6 +137,7 @@ describe('models/command.js', function() {
   });
 
   it('parseArgs() should warn if an option is invalid.', function() {
+    ui.clear();
     new ServeCommand({
       ui: ui,
       analytics: analytics,
@@ -143,6 +157,7 @@ describe('models/command.js', function() {
   });
 
   it('validateAndRun() should print a message if a required option is missing.', function() {
+    ui.clear();
     return new DevelopEmberCLICommand({
       ui: ui,
       analytics: analytics,
@@ -212,38 +227,45 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var extendedAvailableOptions = [{ name: 'filling', type: String, default: 'adobada', aliases:[
-        {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
-        ]}];
+    var extendedAvailableOptions = [{
+      name: 'filling',
+      type: String,
+      default: 'adobada',
+      aliases:[
+        {'carne-asada' : 'carne-asada'},
+        {'carnitas' : 'carnitas' },
+        {'fish' : 'fish'}
+      ]
+    }];
 
     optionsAlias.registerOptions( { availableOptions : extendedAvailableOptions } );
     // defaults
     expect(optionsAlias.parseArgs([])).to.deep.equal({
-        options: {
-          taco: 'traditional',
-          spicy: true,
-          filling: 'adobada'
-        },
-        args: []
-      });
+      options: {
+        taco: 'traditional',
+        spicy: true,
+        filling: 'adobada'
+      },
+      args: []
+    });
     // shorthand
     expect(optionsAlias.parseArgs(['-carne'])).to.deep.equal({
-        options: {
-          taco: 'traditional',
-          spicy: true,
-          filling: 'carne-asada'
-        },
-        args: []
-      });
+      options: {
+        taco: 'traditional',
+        spicy: true,
+        filling: 'carne-asada'
+      },
+      args: []
+    });
     // last argument wins
     expect(optionsAlias.parseArgs(['-carne','-fish'])).to.deep.equal({
-        options: {
-          taco: 'traditional',
-          spicy: true,
-          filling: 'fish'
-        },
-        args: []
-      });
+      options: {
+        taco: 'traditional',
+        spicy: true,
+        filling: 'fish'
+      },
+      args: []
+    });
 
   });
 
@@ -254,14 +276,25 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var extendedAvailableOptions = [{ name: 'filling', type: String, default: 'adobada', aliases:[
-        {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
-        ]
-      }];
-    var duplicateExtendedAvailableOptions = [{ name: 'filling', type: String, default: 'carnitas', aliases:[
-         {'pollo-asado' : 'pollo-asado'}, {'carne-asada' : 'carne-asada'}
-        ]
-      }];
+    var extendedAvailableOptions = [{
+      name: 'filling',
+      type: String,
+      default: 'adobada',
+      aliases:[
+        {'carne-asada' : 'carne-asada'},
+        {'carnitas' : 'carnitas' },
+        {'fish' : 'fish'}
+      ]
+    }];
+    var duplicateExtendedAvailableOptions = [{
+      name: 'filling',
+      type: String,
+      default: 'carnitas',
+      aliases:[
+        {'pollo-asado' : 'pollo-asado'},
+        {'carne-asada' : 'carne-asada'}
+      ]
+    }];
 
     optionsAlias.registerOptions( { availableOptions : extendedAvailableOptions } );
     // default
@@ -312,16 +345,27 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var extendedAvailableOptions = [
-        { name: 'filling', type: String, default: 'adobada', aliases:[
-          {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
-          ]
-        },
-        { name: 'favorite', type: String, default: 'adobada', aliases:[
-          {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
-          ]
-        }
-        ];
+    var extendedAvailableOptions = [{
+        name: 'filling',
+        type: String,
+        default: 'adobada',
+        aliases:[
+          {'carne-asada' : 'carne-asada'},
+          {'carnitas' : 'carnitas' },
+          {'fish' : 'fish'}
+        ]
+      },
+      {
+        name: 'favorite',
+        type: String,
+        default: 'adobada',
+        aliases:[
+          {'carne-asada' : 'carne-asada'},
+          {'carnitas' : 'carnitas' },
+          {'fish' : 'fish'}
+        ]
+      }
+    ];
     var register = optionsAlias.registerOptions.bind(optionsAlias);
 
     optionsAlias.availableOptions = extendedAvailableOptions;
@@ -338,8 +382,15 @@ describe('models/command.js', function() {
       settings: {}
     });
     var extendedAvailableOptions = [
-        { name: 'spicy', type: Boolean, default: true, aliases:[{'mild' : true}] }
-      ];
+      {
+        name: 'spicy',
+        type: Boolean,
+        default: true,
+        aliases:[
+          {'mild' : true}
+        ]
+      }
+    ];
     optionsAlias.registerOptions( { availableOptions : extendedAvailableOptions });
     expect(ui.output).to.match(/The ".*" alias cannot be overridden. Please use a different alias./);
 
@@ -380,8 +431,15 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var option = { name: 'filling', type: String, key: 'filling', default: 'adobada', aliases:[
-        {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
+    var option = {
+      name: 'filling',
+      type: String,
+      key: 'filling',
+      default: 'adobada',
+      aliases:[
+        {'carne-asada' : 'carne-asada'},
+        {'carnitas' : 'carnitas' },
+        {'fish' : 'fish'}
       ]
     };
     var alias = {'carnitas' : 'carnitas' };
@@ -393,8 +451,14 @@ describe('models/command.js', function() {
   });
 
   it('validateOption() should validate options', function() {
-    var option = { name: 'filling', type: String, default: 'adobada', aliases:[
-        {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}
+    var option = {
+      name: 'filling',
+      type: String,
+      default: 'adobada',
+      aliases:[
+        {'carne-asada' : 'carne-asada'},
+        {'carnitas' : 'carnitas' },
+        {'fish' : 'fish'}
       ]
     };
     var dupe = { name: 'spicy', type: Boolean, default: true, aliases:[{'mild' : false}] };
@@ -425,7 +489,7 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var notype = { name: 'taco'};
+    var notype = { name: 'taco' };
     var noname = { type: Boolean };
 
     expect(optionsAlias.validateOption.bind(optionsAlias, notype)).to.throw('The command "options-alias" has an ' +
@@ -441,8 +505,14 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     });
-    var capital = { name: 'Taco', type: Boolean};
-    var camel = { name: 'tacoTown', type: Boolean };
+    var capital = {
+      name: 'Taco',
+      type: Boolean
+    };
+    var camel = {
+      name: 'tacoTown',
+      type: Boolean
+    };
 
     expect(optionsAlias.validateOption.bind(optionsAlias, capital)).to.throw('The "Taco" option\'s name of the "options-alias"' +
       ' command contains a capital letter.');
@@ -473,24 +543,40 @@ describe('models/command.js', function() {
     optionsAlias.availableOptions.push(duplicateExtendedAvailableOptions[0]);
 
     expect(optionsAlias.mergeDuplicateOption( 'filling' )).to.deep.equal([
-      { name: 'taco',
+      {
+        name: 'taco',
         type: String,
         default: 'traditional',
-        aliases: [ {'hard-shell' : 'hard-shell'}, {'soft-shell' : 'soft-shell'} ],
+        aliases: [
+          {'hard-shell' : 'hard-shell'},
+          {'soft-shell' : 'soft-shell'}
+        ],
         key: 'taco',
-        required: false },
-      { name: 'spicy',
+        required: false
+      },
+      {
+        name: 'spicy',
         type: Boolean,
         default: true,
-        aliases: [ {'mild' : false} ],
+        aliases: [
+          {'mild' : false}
+        ],
         key: 'spicy',
-        required: false },
-      { name: 'filling',
+        required: false
+      },
+      {
+        name: 'filling',
         type: String,
         default: 'carnitas',
-        aliases: [ {'carne-asada' : 'carne-asada'}, {'carnitas' : 'carnitas' }, {'fish' : 'fish'}, {'pollo-asado' : 'pollo-asado'} ],
+        aliases: [
+          {'carne-asada' : 'carne-asada'},
+          {'carnitas' : 'carnitas' },
+          {'fish' : 'fish'},
+          {'pollo-asado' : 'pollo-asado'}
+        ],
         key: 'filling',
-        required: false }
+        required: false
+      }
     ]);
   });
 


### PR DESCRIPTION
Doing some followup refactoring on the command shorthands PR and adding some additional unit tests. Some of the methods needed to be broken up further so they were more testable. Will be giving `parseArgs` the same treatment as well.

Also adding jsdocs to the command model.
