### PR TITLE
Disable default lookup & active generation logging

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -21,10 +21,10 @@ module.exports = function(environment) {
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
-    ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    ENV.APP.LOG_VIEW_LOOKUPS = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
This logging can be useful for tracking down bugs, but both @wycats and I think this is overwhelming and confusing for new users, and also generates a ton of churn in the logs for larger apps.

Ideally, we can work with @teddyzeenny to allow users to enable and disable this functionality at runtime via the Inspector. In the interim, I think the best default is to leave these commented out so they're discoverable but off by default.
