### PR TITLE
Fixes #2692: Generator places new routes in the wrong location if the ro...

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -123,8 +123,8 @@ function addRouteToRouter(name, options) {
   switch (type) {
   case 'route':
     newContent = oldContent.replace(
-      /(map\(function\(\) {[\s\S]+)}\)/,
-      "$1  this.route('" + name + "');" + EOL + "})"
+      /map\(function\(\)(\s+|){(.|)(([\s\S]+?))(\s|)?/,
+      "map(function() {" + EOL + "  this.route('" + name + "');" + EOL + "$1"
     );
     break;
   case 'resource':
@@ -132,13 +132,13 @@ function addRouteToRouter(name, options) {
 
     if (plural === name) {
       newContent = oldContent.replace(
-        /(map\(function\(\) {[\s\S]+)}\)/,
-        "$1  this.resource('" + name + "', function() { });" + EOL + "})"
+        /map\(function\(\)(\s+|){(.|)(([\s\S]+?))(\s|)?/,
+        "map(function() {" + EOL + "  this.resource('" + name + "', function() { });" + EOL + "$1"
       );
     } else {
       newContent = oldContent.replace(
-        /(map\(function\(\) {[\s\S]+)}\)/,
-        "$1  this.resource('" + name + "', { path: '" + plural + "/:" + name + "_id' }, function() { });" + EOL + "})"
+        /map\(function\(\)(\s+|){(.|)(([\s\S]+?))(\s|)?/,
+        "map(function() {" + EOL + "  this.resource('" + name + "', { path: '" + plural + "/:" + name + "_id' }, function() { });" + EOL + "$1"
       );
     }
     break;

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -366,6 +366,25 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  // Issue #2692: Generator inserts routes outside Router.map if the Router is reopened
+  it('routes are not placed outside Router.map when the router is reopened', function() {
+    // Bypassing generate() to override default functionality
+    return initApp().then(function() {
+      return fs.appendFile('app/router.js', EOL + 'Router.reopen({});');
+    })
+    .then(function() {
+      return ember(['generate', 'route', 'foo']);
+    })
+    .then(function() {
+      assertFile('app/router.js', {
+        // A malformed regex would insert `this.route('foo'` instead of `this.route('foo');`
+        contains: "this.route('foo');",
+        // If the new route exists but was placed outside the Router.map(), it should remain empty
+        doesNotContain: "Router.map(function() {" + EOL + "});"
+      });
+    });
+  });
+
   it('template foo', function() {
     return generate(['template', 'foo']).then(function() {
       assertFile('app/templates/foo.hbs');


### PR DESCRIPTION
...uter has been reopened
#2692: Regex match and replace function has been modified so that new

routes are placed at the top of the Router.map(), which eliminates the
possibility of potentially valid code or useful comments breaking the
functionality of the generate command.

Failing test was created to demonstrate the issue. Now passes with 0
regressions.
