### PR TITLE
Properly handle `ember.js` -> `ember.debug.js`.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -130,7 +130,7 @@ function EmberApp(options) {
       production:  this.bowerDirectory + '/handlebars/handlebars.runtime.js'
     },
     'ember.js': {
-      development: this.bowerDirectory + '/ember/ember.js',
+      development: this.bowerDirectory + '/ember/ember.debug.js',
       production:  this.bowerDirectory + '/ember/ember.prod.js'
     },
     'ember-testing.js': [
@@ -166,6 +166,13 @@ function EmberApp(options) {
   // 1.8.0 (when ember-testing.js was added to the deployment)
   if (!fs.existsSync(this.vendorFiles['ember-testing.js'][0])) {
     delete this.vendorFiles['ember-testing.js'];
+  }
+
+  // in Ember 1.10 and higher `ember.js` is deprecated in favor of
+  // the more aptly named `ember.debug.js`.
+  var emberFiles = this.vendorFiles['ember.js'];
+  if (typeof emberFiles === 'object' && !fs.existsSync(emberFiles.development)) {
+    emberFiles.development = this.bowerDirectory + '/ember/ember.js';
   }
 
   this.options.trees = merge(this.options.trees, {


### PR DESCRIPTION
For reference: 

https://github.com/emberjs/ember.js/issues/9830
https://github.com/emberjs/ember.js/pull/9845
