### PR TITLE
Give anonymous modules named variables in files

### DIFF
--- a/blueprints/component/files/app/__path__/__name__.js
+++ b/blueprints/component/files/app/__path__/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+var <%= classifiedModuleName %>Component = Ember.Component.extend({
 });
+
+export default <%= classifiedModuleName %>Component;

--- a/blueprints/controller/files/app/__path__/__name__.js
+++ b/blueprints/controller/files/app/__path__/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+var <%= classifiedModuleName %>Controller = Ember.Controller.extend({
 });
+
+export default <%= classifiedModuleName %>Controller;

--- a/blueprints/mixin/files/app/mixins/__name__.js
+++ b/blueprints/mixin/files/app/mixins/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+var <%= classifiedModuleName %>Mixin = Ember.Mixin.create({
 });
+
+export default <%= classifiedModuleName %>Mixin;

--- a/blueprints/route/files/app/__path__/__name__.js
+++ b/blueprints/route/files/app/__path__/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+var <%= classifiedModuleName %>Route = Ember.Route.extend({
 });
+
+export default <%= classifiedModuleName %>Route;

--- a/blueprints/service/files/app/services/__name__.js
+++ b/blueprints/service/files/app/services/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Object.extend({
+var <%= classifiedModuleName %>Service = Ember.Object.extend({
 });
+
+export default <%= classifiedModuleName %>Service;

--- a/blueprints/view/files/app/__path__/__name__.js
+++ b/blueprints/view/files/app/__path__/__name__.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.View.extend({
+var <%= classifiedModuleName %>View = Ember.View.extend({
 });
+
+export default <%= classifiedModuleName %>View;


### PR DESCRIPTION
Now that pods are officially the “best” way to organize Ember projects,
it can get really confusing to have 25 files named “model.js” open. This
pull request adds variable names to the component, controller, mixin,
route, service, and view blueprints so that simply having the file open
reveals the name of the module that you are editing.
