### PR TITLE
Fix http-mock quotes

### DIFF
--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -4,7 +4,7 @@ module.exports = function(app) {
 
   <%= camelizedModuleName %>Router.get('/', function(req, res) {
     res.send({
-      "<%= dasherizedModuleName %>": []
+      '<%= dasherizedModuleName %>': []
     });
   });
 
@@ -14,16 +14,16 @@ module.exports = function(app) {
 
   <%= camelizedModuleName %>Router.get('/:id', function(req, res) {
     res.send({
-      "<%= dasherizedModuleName %>": {
-        "id": req.params.id
+      '<%= dasherizedModuleName %>': {
+        id: req.params.id
       }
     });
   });
 
   <%= camelizedModuleName %>Router.put('/:id', function(req, res) {
     res.send({
-      "<%= dasherizedModuleName %>": {
-        "id": req.params.id
+      '<%= dasherizedModuleName %>': {
+        id: req.params.id
       }
     });
   });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -857,7 +857,7 @@ describe('Acceptance: ember generate', function() {
                   EOL +
                   "  fooRouter.get('/', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": []" + EOL +
+                  "      'foo': []" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
@@ -867,16 +867,16 @@ describe('Acceptance: ember generate', function() {
                   EOL +
                   "  fooRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooRouter.put('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
@@ -906,7 +906,7 @@ describe('Acceptance: ember generate', function() {
                   EOL +
                   "  fooBarRouter.get('/', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": []" + EOL +
+                  "      'foo-bar': []" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
@@ -916,16 +916,16 @@ describe('Acceptance: ember generate', function() {
                   EOL +
                   "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo-bar': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooBarRouter.put('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo-bar': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1234,7 +1234,7 @@ describe('Acceptance: ember generate pod', function() {
                   EOL +
                   "  fooRouter.get('/', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": []" + EOL +
+                  "      'foo': []" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
@@ -1244,16 +1244,16 @@ describe('Acceptance: ember generate pod', function() {
                   EOL +
                   "  fooRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooRouter.put('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
@@ -1283,7 +1283,7 @@ describe('Acceptance: ember generate pod', function() {
                   EOL +
                   "  fooBarRouter.get('/', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": []" + EOL +
+                  "      'foo-bar': []" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
@@ -1293,16 +1293,16 @@ describe('Acceptance: ember generate pod', function() {
                   EOL +
                   "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo-bar': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooBarRouter.put('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
-                  "      \"foo-bar\": {" + EOL +
-                  "        \"id\": req.params.id" + EOL +
+                  "      'foo-bar': {" + EOL +
+                  "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
                   "  });" + EOL +


### PR DESCRIPTION
- use single-quotes in response data, since it's not json, but a js object.
- `id` shouldn't need quotes, since it's a valid js variable name and not dynamic.
