### PR TITLE
Configure broccoli to use os.tmpdir

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -8,6 +8,7 @@ var ncp         = Promise.denodeify(require('ncp'));
 var Task        = require('./task');
 var SilentError = require('../errors/silent');
 var chalk       = require('chalk');
+var os          = require('os');
 
 var signalsTrapped = false;
 
@@ -18,7 +19,9 @@ module.exports = Task.extend({
 
     var broccoli = require('broccoli');
     this.tree    = broccoli.loadBrocfile();
-    this.builder = new broccoli.Builder(this.tree);
+    this.builder = new broccoli.Builder(this.tree, {
+      tmpRoot: path.join(os.tmpdir(), 'ember-cli')
+    });
   },
 
   trapSignals: function() {


### PR DESCRIPTION
Not ready yet, obviously needs tests and such, but want to get feedback on approach.  This PR depends on: 
https://github.com/broccolijs/broccoli/pull/224

An example of how a plugin can be modified to make use of the provided tmpDir is here:

https://github.com/rwjblue/broccoli-funnel/pull/7

The nice thing about this is its not all or nothing. Nothing changes unless a plugin opts in. 