### PR TITLE
app blueprint: don't trim whitespace from diffs

### DIFF
--- a/blueprints/app/files/.editorconfig
+++ b/blueprints/app/files/.editorconfig
@@ -29,5 +29,5 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[*.md]
+[*.{diff,md}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
With the current setting, editorconfig-compliant editors will remove trailing whitespace on `.diff` files - which means that solving a conflict with the `e` option (to edit the patch to be applied) becomes impractical.

I've stumbled on this while upgrading my ember-cli project, on the final `ember init` step.
