### PR TITLE
Replace incompatible markdown fenced blocks with liquid syntax

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -64,9 +64,9 @@ npm ERR! github.com[0: 192.30.252.129]: errno=Connection timed out
 
 This is not a `ember-cli` issue _per se_, but here's a workaround. You can configure `git` to make the translation:
 
-```bash
+{% highlight bash %}
 git config --global url."https://".insteadOf git://
-```
+{% endhighlight %}
 
 ### Usage with Sublime Text
 

--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -60,13 +60,13 @@ the CSP in report-only mode.
 The following is a simple deployment with https using nginx.  Http just redirects to the https server here.  Don't forget to include your ssl keys in your config.
 
 Before deployment make sure you run this command to populate the dist directory:
-```
+
+{% highlight bash %}
 ember build --environment="production"
-```
+{% endhighlight %}
 
 #### File: nginx.conf
 
-```
     ## Nginx Production Https Ember Server Configuration
 
     ## https site##
@@ -110,4 +110,3 @@ ember build --environment="production"
         add_header Strict-Transport-Security max-age=2592000;
         rewrite ^/.*$ https://$host$request_uri? permanent;
     }
-```

--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -32,9 +32,8 @@ It is now also possible to override command line options by creating a file in y
 
 For example, a common desire is to [change the port](http://stackoverflow.com/questions/24003944/save-port-number-for-ember-cli-in-a-config-file) that ember-cli serves the app from. It's possible to pass the port number directly to ember server in the command line, e.g. `ember serve --port 8080`. If you wish to make this change a permanent configuration change, make the `.ember-cli` file and add the options you wish to pass to the server in a hash.
 
-```json
+{% highlight javascript %}
 {
   "port": 8080
 }
-```
-
+{% endhighlight %}

--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -188,9 +188,9 @@ Optionally, you may specify whether your `ember-addon` must run `"before"` or `"
 Install your client side dependencies via Bower.
 Here we install a fictional bower dependency `x-button`:
 
-```
+{% highlight bash %}
 bower install --save-dev x-button
-```
+{% endhighlight %}
 
 Adds bower components to development dependencies
 

--- a/_posts/2013-04-12-ember-data.md
+++ b/_posts/2013-04-12-ember-data.md
@@ -89,9 +89,9 @@ up to a live API, it's wise to be testing your adapters from the onset.
 
 To create a mock for a `posts` API endpoint, use
 
-```
+{% highlight bash %}
 ember g http-mock posts
-```
+{% endhighlight %}
 
 A basic [ExpressJS](http://expressjs.com/) server will be scaffolded for
 your endpoint under `/your-app/server/mocks/posts.js`. Once you add the 


### PR DESCRIPTION
At some point I think it'd be worth changing jekyll's markdown interpreter to `redcarpet` so that fenced blocks can be used like normal, but that's a much larger job.
