### PR TITLE
[FEATURE] Allow addon commands to be classes

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -233,8 +233,13 @@ Project.prototype.addonCommands = function() {
   this.addons.forEach(function(addon){
     var includedCommands = (addon.includedCommands && addon.includedCommands()) || {};
     var addonCommands = {};
+
     for (var key in includedCommands) {
-      addonCommands[key] = Command.extend(includedCommands[key]);
+      if (typeof includedCommands[key] === 'function') {
+        addonCommands[key] = includedCommands[key];
+      } else {
+        addonCommands[key] = Command.extend(includedCommands[key]);
+      }
     }
     if(Object.keys(addonCommands).length) {
       commands[addon.name] = addonCommands;

--- a/tests/fixtures/addon/commands/addon-command-class.js
+++ b/tests/fixtures/addon/commands/addon-command-class.js
@@ -1,0 +1,17 @@
+var Command = require('../../../../lib/models/command');
+
+function Addon() {
+  this.name = "Ember CLI Addon Class Command Test"
+  return this;
+}
+
+Addon.prototype.includedCommands = function() {
+  return {
+    'ClassAddonCommand': Command.extend({
+      name: 'class-addon-command',
+      aliases: ['oac']
+    })
+  };
+}
+
+module.exports = Addon;

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -8,6 +8,7 @@ var Project       = require('../../../lib/models/project');
 var MockUI        = require('../../helpers/mock-ui');
 var AddonCommand  = require('../../fixtures/addon/commands/addon-command');
 var OtherCommand  = require('../../fixtures/addon/commands/other-addon-command');
+var ClassCommand  = require('../../fixtures/addon/commands/addon-command-class');
 
 var commands = {
   serve: Command.extend({
@@ -36,7 +37,7 @@ describe('cli/lookup-command.js', function() {
   var project = {
     isEmberCLIProject: function(){ return true; },
     initializeAddons: function() {
-      this.addons = [new AddonCommand(), new OtherCommand()];
+      this.addons = [new AddonCommand(), new OtherCommand(), new ClassCommand()];
     },
     addonCommands: Project.prototype.addonCommands,
     eachAddonCommand: Project.prototype.eachAddonCommand
@@ -102,6 +103,19 @@ describe('cli/lookup-command.js', function() {
     });
 
     expect(command.name).to.equal('other-addon-command');
+
+    Command = lookupCommand(commands, 'class-addon-command', [], {
+      project: project,
+      ui: ui
+    });
+
+    command = new Command({
+      ui: ui,
+      project: project
+    });
+
+    expect(command.name).to.equal('class-addon-command');
+
   });
 
   it('lookupCommand() should write out a warning when overriding a core command', function() {


### PR DESCRIPTION
I think it’s useful to be able to subclass existing commands in Ember CLI to roll your own.  For instance I want to subclass generate to take additional flags and do arbitrary work.