### PR TITLE
Add description

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -1,6 +1,7 @@
 {
   "name": "<%= name %>",
   "version": "0.0.0",
+  "description": "Small description for <%= name %> goes here",
   "private": true,
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
No description truncates readmes on npm if the first part is a sentence/paragraph beyond a certain limit.
