### PR TITLE
add .jshintrc file for in-repo addons

### DIFF
--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -1,9 +1,20 @@
 var fs   = require('fs-extra');
 var path = require('path');
 var stringUtil = require('../../lib/utilities/string');
+var Blueprint = require('../../lib/models/blueprint');
 
 module.exports = {
   description: 'The blueprint for addon in repo ember-cli addons.',
+
+  beforeInstall: function(options) {
+    var libBlueprint = Blueprint.lookup('lib', {
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+
+    return libBlueprint.install(options);
+  },
 
   afterInstall: function(options) {
     var packagePath = path.join(this.project.root, 'package.json');

--- a/blueprints/lib/files/lib/.jshintrc
+++ b/blueprints/lib/files/lib/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "browser": false
+}

--- a/blueprints/lib/index.js
+++ b/blueprints/lib/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description: 'Generates a lib directory for in-repo addons.',
+
+  normalizeEntityName: function(name) { return name; }
+};

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1065,6 +1065,8 @@ describe('Acceptance: ember generate', function() {
           '"' + path.normalize('lib/foo-bar').replace('\\', '\\\\') + '"'
         ]
       });
+
+      assertFile('lib/.jshintrc');
     });
   });
 
@@ -1080,6 +1082,12 @@ describe('Acceptance: ember generate', function() {
       assertFile('app/router.js', {
         contain: ["resource('foo')"]
       });
+    });
+  });
+
+  it('lib', function() {
+    return generate(['lib']).then(function() {
+      assertFile('lib/.jshintrc');
     });
   });
 });


### PR DESCRIPTION
This addon adds a node .jshintrc file to the `/lib` folder so that in-repo addons are treated as being in node-land. Currently jshint uses the .jshintrc in the app's root, which is for the browser.

I used the same technique as for http-mocks/proxies: adding an intermediate blueprint called `lib` that creates `/lib/.jshintrc`, and installing that blueprint in the `beforeInstall` hook of the `in-repo-addon` blueprint.

The .jshintrc itself is pretty barebones, just indicating that it is a node environment. Let me know if you'd like me to add any other directives.
