### PR TITLE
Helpful cast if port is configured as string

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -22,7 +22,7 @@ module.exports = Command.extend({
 
   run: function(commandOptions) {
     commandOptions = assign({}, commandOptions, {
-      liveReloadPort: commandOptions.liveReloadPort  || (commandOptions.port + 31529),
+      liveReloadPort: commandOptions.liveReloadPort  || (parseInt(commandOptions.port, 10) + 31529),
       baseURL: this.project.config(commandOptions.environment).baseURL || '/'
     });
 


### PR DESCRIPTION
If someone makes the stupid mistake of setting the port as a string, e.g. `"4222"` instead of `4222` the live-reload port will be number-string concatenation, resulting in an attempt to connect to e.g. `422231529` instead of `35751` (4200+31529). I did this silly mistake, and thought we'd save others the trouble.

```
{
  /**
    Ember CLI sends analytics information by default. The data is completely
    anonymous, but there are times when you might want to disable this behavior.

    Setting `disableAnalytics` to true will prevent any data from being sent.
  */
  "disableAnalytics": false,
  "port": "4200" // silly mistake
}
```
