### PR TITLE
Add podModulePrefix to app blueprint

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -3,6 +3,7 @@
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: '<%= modulePrefix %>',
+    podModulePrefix: '<%= modulePrefix %>/pods',
     environment: environment,
     baseURL: '/',
     locationType: 'auto',


### PR DESCRIPTION
This provides a nice default for people transitioning to the pods structure as
well as makes this option known.

This may not be wanted, but it's something I am using on my apps so I figured
it may be useful for others.
