### PR TITLE
Add on('error') handler to proxy blueprint.

### DIFF
--- a/blueprints/http-proxy/files/server/proxies/__name__.js
+++ b/blueprints/http-proxy/files/server/proxies/__name__.js
@@ -6,6 +6,10 @@ module.exports = function(app) {
   var proxy = require('http-proxy').createProxyServer({});
   var path = require('path');
 
+  proxy.on('error', function(err, req) {
+    console.error(err, req.url);
+  });
+
   app.use(proxyPath, function(req, res, next){
     // include root path in proxied request
     req.url = path.join(proxyPath, req.url);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -915,6 +915,10 @@ describe('Acceptance: ember generate', function() {
                   "  var proxy = require('http-proxy').createProxyServer({});" + EOL +
                   "  var path = require('path');" + EOL +
                   EOL +
+                  "  proxy.on('error', function(err, req) {" + EOL +
+                  "    console.error(err, req.url);" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use(proxyPath, function(req, res, next){" + EOL +
                   "    // include root path in proxied request" + EOL +
                   "    req.url = path.join(proxyPath, req.url);" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1272,6 +1272,10 @@ describe('Acceptance: ember generate pod', function() {
                   "  var proxy = require('http-proxy').createProxyServer({});" + EOL +
                   "  var path = require('path');" + EOL +
                   EOL +
+                  "  proxy.on('error', function(err, req) {" + EOL +
+                  "    console.error(err, req.url);" + EOL +
+                  "  });" + EOL +
+                  EOL +
                   "  app.use(proxyPath, function(req, res, next){" + EOL +
                   "    // include root path in proxied request" + EOL +
                   "    req.url = path.join(proxyPath, req.url);" + EOL +


### PR DESCRIPTION
If we don't handle this every time there is an error like ECONNRESET
then whole server get's killed which is really annoying.

Closes #2629 refs #1921
