### PR TITLE
Ensure that addon build hooks are called in the proper order.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -106,8 +106,16 @@ module.exports = Task.extend({
   },
 
   build: function() {
-    return this.builder.build.apply(this.builder, arguments)
-      .then(this.processAddonBuildSteps.bind(this, 'preBuild'))
+    var self = this;
+    var args = [];
+    for (var i = 0, l = arguments.length; i < l; i++) {
+      args.push(arguments[i]);
+    }
+
+    return this.processAddonBuildSteps('preBuild')
+       .then(function() {
+         return self.builder.build.apply(self.builder, args);
+       })
       .then(this.processBuildResult.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'));
   },


### PR DESCRIPTION
Prior to this change, `preBuild` was actually being called **after** the Broccoli build completed (but before the tmp directory was copied to `--output-path`).  Clearly this is incorrect.

/cc @rondale-sc @danmcclain
