### PR TITLE
Add watch ENOSPC workaround instructions for Arch-based systems in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ This problem will be corrected in future releases. The following line is a worka
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
+For Arch Linux or Manjaro Linux, in order for the parameters to be loaded at boot, the kernel sysctl parameters have to be saved in a drop-in directory instead of `sysctl.conf`.
+
+```sh
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/99-sysctl.conf && sudo sysctl --system
+```
+
 ## Inline Documentation
 
 Use `npm run docs` to build HTML and JSON documentation with YUIDoc and place it in `docs/build/`. Please help by improving this documentation.


### PR DESCRIPTION
This adds workaround instructions for #1054 for Arch-based systems to the README.

According to the [Arch Wiki](https://wiki.archlinux.org/index.php/Sysctl) systemd no longer loads sysctl kernel parameters in `/etc/sysctl.conf` and instead requires them to be in a file in  `/etc/sysctl.d/` or `/usr/lib/sysctl.d/`.

While the already provided command brings immediate results even on Arch, the parameters are not loaded anymore after a reboot. `sudo sysctl -p` whould have to be run after each boot. If they are in one of the drop-in directories they will be loaded by systemd automatically.
