### PR TITLE
Adds disable-analytics option to all commands

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -44,6 +44,27 @@ nopt.typeDefs.gitUrl = {
 
 module.exports = Command;
 
+function getAvailableOptions(availableOptions) {
+  var result  = {
+    name: 'disable-analytics',
+    type: Boolean,
+    default: false
+  };
+
+  var options = availableOptions;
+
+  if (!options) {
+    return [result];
+  } else {
+    var optionExists = where(options, {'name': 'disable-analytics'}).length;
+
+    if (!optionExists) {
+      options.push(result);
+    }
+    return options;
+  }
+}
+
 function Command() {
   CoreObject.apply(this, arguments);
 
@@ -60,7 +81,7 @@ function Command() {
   }
 
   // Options properties
-  this.availableOptions = this.availableOptions || [];
+  this.availableOptions = this._getAvailableOptions(this.availableOptions);
   this.anonymousOptions = this.anonymousOptions || [];
   this.registerOptions();
 }
@@ -92,6 +113,8 @@ Command.__proto__ = CoreObject;
 Command.prototype.description = null;
 Command.prototype.works = 'insideProject';
 Command.prototype.constructor = Command;
+Command.prototype._getAvailableOptions = getAvailableOptions;
+
 /*
   Hook for extending a command before it is run in the cli.run command.
   Most common use case would be to extend availableOptions.
@@ -100,6 +123,12 @@ Command.prototype.constructor = Command;
 */
 Command.prototype.beforeRun = function() {};
 
+Command.prototype._track = function(commandOptions, meta) {
+  if (commandOptions && commandOptions.options && !commandOptions.options.disableAnalytics) {
+    this.analytics.track(meta);
+  }
+};
+
 /*
   @method validateAndRun
   @return {Promise}
@@ -107,7 +136,7 @@ Command.prototype.beforeRun = function() {};
 Command.prototype.validateAndRun = function(args) {
   var commandOptions = this.parseArgs(args);
 
-  this.analytics.track({
+  this._track(commandOptions, {
     name:    'ember ',
     message: this.name
   });

--- a/lib/models/server-watcher.js
+++ b/lib/models/server-watcher.js
@@ -20,7 +20,7 @@ module.exports = Task.extend({
   didChange: function (filepath) {
     this.ui.writeLine('Server file changed: ' + filepath);
 
-    this.analytics.track({
+    this._track(this.options, {
       name: 'server file change',
       description: 'File changed: "' + filepath + '"'
     });
@@ -29,7 +29,7 @@ module.exports = Task.extend({
   didAdd: function (filepath) {
     this.ui.writeLine('Server file added: ' + filepath);
 
-    this.analytics.track({
+    this._track(this.options, {
       name: 'server file addition',
       description: 'File added: "' + filepath + '"'
     });
@@ -38,7 +38,7 @@ module.exports = Task.extend({
   didDelete: function (filepath) {
     this.ui.writeLine('Server file deleted: ' + filepath);
 
-    this.analytics.track({
+    this._track(this.options, {
       name: 'server file deletion',
       description: 'File deleted: "' + filepath + '"'
     });

--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -10,6 +10,24 @@ module.exports = Task;
 
 Task.__proto__ = CoreObject;
 
+Task.prototype._trackTiming = function(commandOptions, meta) {
+  if (commandOptions && !commandOptions.disableAnalytics) {
+    this.analytics.trackTiming(meta);
+  }
+};
+
+Task.prototype._trackError = function(commandOptions, meta) {
+  if (commandOptions && !commandOptions.disableAnalytics) {
+    this.analytics.trackError(meta);
+  }
+};
+
+Task.prototype._track = function(commandOptions, meta) {
+  if (commandOptions && !commandOptions.disableAnalytics) {
+    this.analytics.track(meta);
+  }
+};
+
 Task.prototype.run = function(/*options*/) {
   throw new Error('Task needs to have run() defined.');
 };

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -24,7 +24,7 @@ var Watcher = Task.extend({
   didError: function(error) {
     debug('didError %o', error);
     this.ui.writeError(error);
-    this.analytics.trackError({
+    this._trackError(this.options, {
       description: error && error.message
     });
   },
@@ -40,12 +40,12 @@ var Watcher = Task.extend({
     this.ui.writeLine('');
     this.ui.writeLine(chalk.green('Build successful - ' + Math.round(totalTime) + 'ms.'));
 
-    this.analytics.track({
+    this._track(this.options, {
       name:    'ember rebuild',
       message: 'broccoli rebuild time: ' + totalTime + 'ms'
     });
 
-    this.analytics.trackTiming({
+    this._trackTiming(this.options, {
       category: 'rebuild',
       variable: 'rebuild time',
       label:    'broccoli rebuild time',
@@ -60,6 +60,7 @@ var Watcher = Task.extend({
   off: function() {
     this.watcher.off.apply(this.watcher, arguments);
   },
+
   buildOptions: function() {
     var watcher = this.options && this.options.watcher;
 

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -74,7 +74,7 @@ module.exports = Task.extend({
         }
       });
 
-      this.analytics.track({
+      this._track(this.options, {
         name:    'broccoli watcher',
         message: 'live-reload'
       });
@@ -88,7 +88,7 @@ module.exports = Task.extend({
       }
     });
 
-    this.analytics.track({
+    this._track(this.options, {
       name:    'express server',
       message: 'live-reload'
     });

--- a/tests/unit/analytics-test.js
+++ b/tests/unit/analytics-test.js
@@ -21,7 +21,8 @@ beforeEach(function() {
   command = new FakeCommand({
     ui: new MockUI(),
     analytics: analytics,
-    project: { isEmberCLIProject: function(){ return true; }}
+    project: { isEmberCLIProject: function(){ return true; }},
+    settings: {}
   });
 });
 

--- a/tests/unit/commands/addon-test.js
+++ b/tests/unit/commands/addon-test.js
@@ -1,7 +1,8 @@
 'use strict';
-var expect         = require('chai').expect ;
+
+var expect         = require('chai').expect;
+var AddonCommand   = require('../../../lib/commands/addon');
 var commandOptions = require('../../factories/command-options');
-var AddonCommand     = require('../../../lib/commands/addon');
 
 describe('addon command', function() {
   var command, options;
@@ -17,6 +18,17 @@ describe('addon command', function() {
     });
 
     command = new AddonCommand(options);
+  });
+
+  it('should contain `disableAnalytics` option', function() {
+    expect(command.availableOptions.length).to.equal(7);
+    expect(command.availableOptions[6]).to.deep.equal({
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
   });
 
   it('doesn\'t allow to create an addon named `test`', function() {

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -49,6 +49,19 @@ describe('build command', function() {
     tasks.BuildWatch.prototype.run.restore();
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var buildCommand = new BuildCommand(options);
+
+    assert.equal(buildCommand.availableOptions.length, 4);
+    assert.deepEqual(buildCommand.availableOptions[3], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('Build task is provided with the project instance', function() {
     return new BuildCommand(options).validateAndRun([ ]).then(function() {
       var buildRun = tasks.Build.prototype.run;

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -33,6 +33,17 @@ describe('generate command', function() {
     }));
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    assert.equal(command.availableOptions.length, 4);
+    assert.deepEqual(command.availableOptions[3], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('runs DestroyFromBlueprint with expected options', function() {
     return command.validateAndRun(['controller', 'foo'])
       .then(function(options) {

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -33,6 +33,17 @@ describe('generate command', function() {
     }));
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    assert.equal(command.availableOptions.length, 4);
+    assert.deepEqual(command.availableOptions[3], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('runs GenerateFromBlueprint with expected options', function() {
     return command.validateAndRun(['controller', 'foo'])
       .then(function(options) {

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -36,6 +36,25 @@ describe('help command', function() {
     analytics = new MockAnalytics();
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var helpCommand = new HelpCommand({
+      ui: ui,
+      analytics: analytics,
+      commands: commands,
+      project: { isEmberCLIProject: function(){ return true; }},
+      settings: {}
+    });
+
+    expect(helpCommand.availableOptions.length).to.equal(2);
+    expect(helpCommand.availableOptions[1]).to.deep.equal({
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('should generate complete help output, including aliases', function() {
     return new HelpCommand({
       ui: ui,

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -28,6 +28,25 @@ describe('init command', function() {
     InitCommand = require('../../../lib/commands/init');
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { name: 'test'}),
+      tasks: tasks,
+      settings: {}
+    });
+
+    assert.equal(command.availableOptions.length, 7);
+    assert.deepEqual(command.availableOptions[6], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('doesn\'t allow to create an application named `test`', function() {
     var command = new InitCommand({
       ui: ui,

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -21,6 +21,17 @@ describe('new command', function() {
     command = new NewCommand(options);
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    assert.equal(command.availableOptions.length, 7);
+    assert.deepEqual(command.availableOptions[6], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('doesn\'t allow to create an application named `test`', function() {
     return command.validateAndRun(['test']).then(function() {
       assert.ok(false, 'should have rejected with an application name of test');

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -35,6 +35,19 @@ describe('server command', function() {
     tasks.Serve.prototype.run.restore();
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var serveCommand = new ServeCommand(options);
+
+    assert.equal(serveCommand.availableOptions.length, 9);
+    assert.deepEqual(serveCommand.availableOptions[8], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('has correct options', function() {
     return new ServeCommand(options).validateAndRun([
       '--port', '4000'

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -41,6 +41,19 @@ describe('test command', function() {
     testServerRun = tasks.TestServer.prototype.run;
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var testCommand = new TestCommand(options);
+
+    assert.equal(testCommand.availableOptions.length, 8);
+    assert.deepEqual(testCommand.availableOptions[7], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('builds and runs test', function() {
     return new TestCommand(options).validateAndRun([]).then(function() {
       assert.equal(buildRun.called, 1, 'expected build task to be called once');

--- a/tests/unit/commands/update-test.js
+++ b/tests/unit/commands/update-test.js
@@ -34,6 +34,34 @@ describe('update command', function() {
     };
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    var updateChecker = new UpdateChecker(ui, {
+      checkForUpdates: true
+    }, '100.0.0');
+
+    updateChecker.checkNPM = function() {
+      return Promise.resolve('0.0.1');
+    };
+
+    var updateCommand = new UpdateCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      tasks: tasks,
+      updateChecker: updateChecker,
+      environment: { }
+    });
+
+    assert.equal(updateCommand.availableOptions.length, 1);
+    assert.deepEqual(updateCommand.availableOptions[0], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('says \'you have the latest version\' if no update is needed', function() {
     var updateChecker = new UpdateChecker(ui, {
       checkForUpdates: true
@@ -49,7 +77,8 @@ describe('update command', function() {
       project: project,
       tasks: tasks,
       updateChecker: updateChecker,
-      environment: { }
+      environment: { },
+      settings: {}
     }).validateAndRun([]).then(function() {
       assert.include(ui.output, 'You have the latest version of ember-cli');
     });
@@ -70,7 +99,8 @@ describe('update command', function() {
       project: project,
       tasks: tasks,
       updateChecker: updateChecker,
-      environment: { }
+      environment: { },
+      settings: {}
     }).validateAndRun([]).then(function() {
       assert(updateTaskWasRun, 'update task should have been run');
     });

--- a/tests/unit/commands/version-test.js
+++ b/tests/unit/commands/version-test.js
@@ -26,6 +26,17 @@ describe('version command', function() {
     command = new VersionCommand(options);
   });
 
+  it('should contain `disableAnalytics` option', function() {
+    assert.equal(command.availableOptions.length, 2);
+    assert.deepEqual(command.availableOptions[1], {
+      key: 'disableAnalytics',
+      type: Boolean,
+      name: 'disable-analytics',
+      required: false,
+      default: false
+    });
+  });
+
   it('reports node and npm versions', function() {
     return command.validateAndRun().then(function() {
       var lines = ui.output.split(EOL);

--- a/tests/unit/models/server-watcher-test.js
+++ b/tests/unit/models/server-watcher-test.js
@@ -21,7 +21,8 @@ describe('Server Watcher', function() {
     subject = new ServerWatcher({
       ui: ui,
       analytics: analytics,
-      watcher: watcher
+      watcher: watcher,
+      options: {}
     });
   });
 

--- a/tests/unit/models/task-test.js
+++ b/tests/unit/models/task-test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var Task          = require('../../../lib/models/task');
+var MockUI        = require('../../helpers/mock-ui');
+var MockAnalytics = require('../../helpers/mock-analytics');
+var assert        = require('assert');
+
+var FakeTask = Task.extend({
+  run: function(commandOptions /*, rawArgs*/) {
+    this._track(commandOptions, {
+      name: 'foo',
+      message: 'bar'
+    });
+  }
+});
+
+describe('models/task.js', function() {
+  var ui;
+  var analytics;
+  var project;
+
+  before(function() {
+    ui = new MockUI();
+    analytics = new MockAnalytics();
+    project = { isEmberCLIProject: function(){ return true; }};
+  });
+
+  it('should call track functions by default', function() {
+    var l = analytics.tracks.length;
+
+    var task = new FakeTask({
+      ui: ui,
+      project: project,
+      analytics: analytics
+    });
+
+    task.run({
+      disableAnalytics: false
+    });
+
+    assert.equal(l + 1, analytics.tracks.length);
+  });
+  it('should not call track functions if --disable-analytics=true', function() {
+    var l = analytics.tracks.length;
+
+    var task = new FakeTask({
+      ui: ui,
+      project: project,
+      analytics: analytics
+    });
+
+    task.run({
+      disableAnalytics: true
+    });
+
+    assert.equal(l, analytics.tracks.length);
+  });
+});

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -26,7 +26,8 @@ describe('Watcher', function() {
       ui: ui,
       analytics: analytics,
       builder: builder,
-      watcher: watcher
+      watcher: watcher,
+      options: {}
     });
   });
 
@@ -97,6 +98,35 @@ describe('Watcher', function() {
     });
   });
 
+  describe('watcher:change --disable-analytics', function() {
+    var tracksLength, timingsLength;
+
+    before(function() {
+      tracksLength  = analytics.tracks.length;
+      timingsLength = analytics.trackTimings.length;
+
+      subject.options.disableAnalytics = true;
+    });
+
+    after(function() {
+      subject.options.disableAnalytics = false;
+    });
+
+    beforeEach(function() {
+      watcher.emit('change', {
+        totalTime: 12344000000
+      });
+    });
+
+    it('does not track events if --disable-analytics=true', function() {
+      assert.equal(analytics.tracks.length, tracksLength);
+    });
+
+    it('does not track timings if --disable-analytics=true', function() {
+      assert.equal(analytics.trackTimings.length, timingsLength);
+    });
+  });
+
   describe('watcher:error', function() {
     it('tracks errors', function() {
       watcher.emit('error', {
@@ -158,6 +188,31 @@ describe('Watcher', function() {
 
       assert.equal(outs[0], chalk.red('File: someFile (24:80)'));
       assert.equal(outs[1], chalk.red('buildFailed'));
+    });
+  });
+
+  describe('watcher:error --disable-analytics', function() {
+    var trackErrorsLength;
+
+    before(function() {
+      trackErrorsLength = analytics.trackErrors.length;
+
+      subject.options.disableAnalytics = true;
+    });
+
+    after(function() {
+      subject.options.disableAnalytics = false;
+    });
+
+    beforeEach(function() {
+      watcher.emit('error', {
+        message: 'foo',
+        stack: new Error().stack
+      });
+    });
+
+    it('does not track errors if --disable-analytics=true', function() {
+      assert.equal(analytics.trackErrors.length, trackErrorsLength);
     });
   });
 

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -23,6 +23,7 @@ describe('livereload-server', function() {
     subject = new LiveReloadServer({
       ui: ui,
       watcher: watcher,
+      options: {},
       expressServer: expressServer,
       analytics: { trackError: function() { } },
       project: {


### PR DESCRIPTION
Fixes #1835

- [x] add `disableAnalytics` option to `models/command`
- [x] `models/command` tests
- [x] add tests for other commands
- [x] make sure to pass `disableAnalytics` option to tasks
