### PR TITLE
Task for uninstalling Bower packages

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -835,6 +835,19 @@ Blueprint.prototype.addBowerPackagesToProject = function(packages, installOption
   });
 };
 
+Blueprint.prototype.removeBowerPackageFromProject = function(packageName) {
+  return this.removeBowerPackagesFromProject([packageName]);
+};
+
+Blueprint.prototype.removeBowerPackagesFromProject = function(packages) {
+  var task = this.taskFor('bower-uninstall');
+
+  return task.run({
+    verbose: true,
+    packages: packages
+  });
+};
+
 /*
   Used to retrieve a task with the given name. Passes the new task
   the standard information available (like `ui`, `analytics`, `project`, etc).

--- a/lib/tasks/bower-uninstall.js
+++ b/lib/tasks/bower-uninstall.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Runs `bower uninstall` in cwd
+
+var Promise = require('../ext/promise');
+var Task    = require('../models/task');
+
+module.exports = Task.extend({
+  init: function() {
+    this.bower = this.bower || require('bower');
+    this.bowerConfig = this.bowerConfig || require('bower-config');
+  },
+  // Options: Boolean verbose
+  run: function(options) {
+    var chalk            = require('chalk');
+    var bower            = this.bower;
+    var bowerConfig      = this.bowerConfig;
+    var ui               = this.ui;
+    var packages         = options.packages || [];
+    var uninstallOptions = { save: true };
+    var packageNames     = packages.join(', ');
+
+    ui.pleasantProgress.start(chalk.green('Uninstalling Bower packages: '+packageNames), chalk.green('.'));
+
+    var config = bowerConfig.read();
+    config.interactive = true;
+
+    return new Promise(function(resolve, reject) {
+        bower.commands.uninstall(packages, uninstallOptions, config) // Packages, options, config
+          .on('prompt', ui.prompt.bind(ui))
+          .on('error', reject)
+          .on('end', resolve);
+      })
+      .finally(function() { ui.pleasantProgress.stop(); })
+      .then(function() {
+        ui.writeLine(chalk.green('Bower packages uninstalled: '+packageNames));
+      });
+  }
+});

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -679,6 +679,80 @@ describe('Blueprint', function() {
     });
   });
 
+  describe('removeBowerPackageFromProject', function() {
+    var blueprint;
+    var ui;
+    var tmpdir;
+
+    beforeEach(function() {
+      tmpdir    = tmp.in(tmproot);
+      blueprint = new Blueprint(basicBlueprint);
+      ui        = new MockUI();
+    });
+
+    afterEach(function() {
+      return rimraf(tmproot);
+    });
+
+    it('passes a packages array for removeBowerPackagesFromProject', function() {
+      blueprint.removeBowerPackagesFromProject = function(packages) {
+        assert.deepEqual(packages, ['foo-bar']);
+      };
+
+      blueprint.removeBowerPackageFromProject('foo-bar');
+    });
+  });
+
+  describe('removeBowerPackagesFromProject', function() {
+    var blueprint;
+    var ui;
+    var tmpdir;
+    var BowerUninstallTask;
+    var taskNameLookedUp;
+
+    beforeEach(function() {
+      tmpdir    = tmp.in(tmproot);
+      blueprint = new Blueprint(basicBlueprint);
+      ui        = new MockUI();
+
+      blueprint.taskFor = function(name) {
+        taskNameLookedUp = name;
+
+        return new BowerUninstallTask();
+      };
+    });
+
+    afterEach(function() {
+      return rimraf(tmproot);
+    });
+
+    it('looks up the `bower-uninstall` task', function() {
+      BowerUninstallTask = Task.extend({
+        run: function() {}
+      });
+      blueprint.removeBowerPackagesFromProject([{name: 'foo-bar'}]);
+
+      assert.equal(taskNameLookedUp, 'bower-uninstall');
+    });
+
+    it('calls the task with the package names', function() {
+      var packages;
+
+      BowerUninstallTask = Task.extend({
+        run: function(options) {
+          packages = options.packages;
+        }
+      });
+
+      blueprint.removeBowerPackagesFromProject([
+        'foo-bar',
+        'bar-foo'
+      ]);
+
+      assert.deepEqual(packages, ['foo-bar', 'bar-foo']);
+    });
+  });
+
   describe('addBowerPackagesToProject', function() {
     var blueprint;
     var ui;


### PR DESCRIPTION
Managing bower components versions from ember-addons is currently not possible as ember-cli offers no way to alter once installed version. This PR introduces simple task for uninstalling bower dependencies (and removing them from bower.json) so they can be easly installed in another version (using bower-install task).

Using this task will allow authros of ember-addons to help their users to upgrade bower dependencies.

