### PR TITLE
Exit with non-zero for unknown commands.

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -1,6 +1,7 @@
 'use strict';
 var chalk   = require('chalk');
 var Command = require('../models/command');
+var SilentError = require('../errors/silent');
 
 var UnknownCommand = Command.extend({
   printBasicHelp: function() {
@@ -8,9 +9,9 @@ var UnknownCommand = Command.extend({
   },
 
   validateAndRun: function() {
-    this.ui.writeLine('The specified command ' + chalk.green(this.commandName) +
-                      ' is invalid, for available options see ' +
-                      chalk.green('ember help') + '.');
+    throw new SilentError('The specified command ' + this.commandName +
+                          ' is invalid, for available options see ' +
+                          'ember help' + '.');
   }
 });
 

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -131,7 +131,8 @@ describe('cli/lookup-command.js', function() {
       ui: ui,
       project: project
     });
-    command.validateAndRun([]);
-    expect(ui.output).to.match(/command.*something-else.*is invalid/);
+    expect(function() {
+      command.validateAndRun([]);
+    }).to.throw(/command.*something-else.*is invalid/);
   });
 });


### PR DESCRIPTION
If you accidentally attempt to invoke a command that is not available you receive a nice warning message like the following:

```
The specified command asdfasdfasdf is invalid, for available options see ember help.
```

This comes from the `UnknownCommand` in `lib/cli/lookup-command.js` [here](https://github.com/stefanpenner/ember-cli/blob/master/lib/cli/lookup-command.js#L11).  Instead of using `this.ui.writeLine` we should throw a `SilentError`.
