### PR TITLE
Allow test framework addons to override query string.

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -50,6 +50,14 @@ module.exports = Command.extend({
     var tmpPath = this.quickTemp.makeOrRemake(this, '-customConfigFile');
     var customPath = path.join(tmpPath, 'testem.json');
     var originalContents = JSON.parse(fs.readFileSync(options.configFile, { encoding: 'utf8' }));
+
+    originalContents['test_page'] = originalContents['test_page'] + this.buildTestPageQueryString(options);
+    fs.writeFileSync(customPath, JSON.stringify(originalContents));
+
+    return customPath;
+  },
+
+  buildTestPageQueryString: function(options) {
     var params = [];
 
     if (options.module) {
@@ -60,9 +68,7 @@ module.exports = Command.extend({
       params.push('filter=' + options.filter);
     }
 
-    originalContents['test_page'] = originalContents['test_page'] + '?' + params.join('&');
-    fs.writeFileSync(customPath, JSON.stringify(originalContents));
-    return customPath;
+    return params.length ? '?' + params.join('&') : '';
   },
 
   run: function(commandOptions) {

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -167,6 +167,21 @@ describe('test command', function() {
       assert.ok(contents['test_page'].indexOf('bar') > -1);
     });
 
+    it('when module and filter option is present uses buildTestPageQueryString for test_page queryString', function() {
+      runOptions.filter = 'bar';
+      command.buildTestPageQueryString = function(options) {
+        assert.deepEqual(options, runOptions);
+
+        return '?blah=zorz';
+      };
+
+      var newPath = command._generateCustomConfigFile(runOptions);
+
+      var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
+
+      assert.ok(contents['test_page'].indexOf('?blah=zorz') > -1);
+    });
+
     it('new file returned contains the filter option value in test_page', function() {
       runOptions.filter = 'foo';
       var newPath = command._generateCustomConfigFile(runOptions);


### PR DESCRIPTION
Fix https://github.com/ember-cli/ember-cli/issues/2819.
