### PR TITLE
Remove testing note about podModulePrefix

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -29,8 +29,6 @@ acceptance/integration tests using the new [ember-testing package](http://ianpet
 
 Test filenames should be suffixed with `-test.js` in order to run.
 
-If you are using Pods to organize your application, be sure to add your `podModulePrefix` to the [test resolver](https://github.com/stefanpenner/ember-app-kit/blob/master/tests/helpers/resolver.js) namespace.
-
 If you have manually set the locationType in your environment.js to `hash` or `none` you need to update your `tests/index.html` to have absolute paths (`/assets/vendor.css` and `/testem.js` vs the default relative paths).
 
 ### CI Mode with Testem


### PR DESCRIPTION
Since it's already being pulled in from the config.
