### PR TITLE
Remove path.join from urls, in response to #2796

### DIFF
--- a/blueprints/http-proxy/files/server/proxies/__name__.js
+++ b/blueprints/http-proxy/files/server/proxies/__name__.js
@@ -4,7 +4,6 @@ module.exports = function(app) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
   var proxy = require('http-proxy').createProxyServer({});
-  var path = require('path');
 
   proxy.on('error', function(err, req) {
     console.error(err, req.url);
@@ -12,7 +11,7 @@ module.exports = function(app) {
 
   app.use(proxyPath, function(req, res, next){
     // include root path in proxied request
-    req.url = path.join(proxyPath, req.url);
+    req.url = proxyPath + '/' + req.url;
     proxy.web(req, res, { target: '<%=proxyUrl %>' });
   });
 };

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -913,7 +913,6 @@ describe('Acceptance: ember generate', function() {
                   "  // For options, see:" + EOL +
                   "  // https://github.com/nodejitsu/node-http-proxy" + EOL +
                   "  var proxy = require('http-proxy').createProxyServer({});" + EOL +
-                  "  var path = require('path');" + EOL +
                   EOL +
                   "  proxy.on('error', function(err, req) {" + EOL +
                   "    console.error(err, req.url);" + EOL +
@@ -921,7 +920,7 @@ describe('Acceptance: ember generate', function() {
                   EOL +
                   "  app.use(proxyPath, function(req, res, next){" + EOL +
                   "    // include root path in proxied request" + EOL +
-                  "    req.url = path.join(proxyPath, req.url);" + EOL +
+                  "    req.url = proxyPath + '/' + req.url;" + EOL +
                   "    proxy.web(req, res, { target: 'http://localhost:5000' });" + EOL +
                   "  });" + EOL +
                   "};"

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1270,7 +1270,6 @@ describe('Acceptance: ember generate pod', function() {
                   "  // For options, see:" + EOL +
                   "  // https://github.com/nodejitsu/node-http-proxy" + EOL +
                   "  var proxy = require('http-proxy').createProxyServer({});" + EOL +
-                  "  var path = require('path');" + EOL +
                   EOL +
                   "  proxy.on('error', function(err, req) {" + EOL +
                   "    console.error(err, req.url);" + EOL +
@@ -1278,7 +1277,7 @@ describe('Acceptance: ember generate pod', function() {
                   EOL +
                   "  app.use(proxyPath, function(req, res, next){" + EOL +
                   "    // include root path in proxied request" + EOL +
-                  "    req.url = path.join(proxyPath, req.url);" + EOL +
+                  "    req.url = proxyPath + '/' + req.url;" + EOL +
                   "    proxy.web(req, res, { target: 'http://localhost:5000' });" + EOL +
                   "  });" + EOL +
                   "};"


### PR DESCRIPTION
WIP, tests still fail.

Getting `Object #<Object> has no method 'charAt'` for multiple tests in tests/unit/tasks/server/express-server-test.js