### PR TITLE
Expose app.env before app instance creation

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -64,7 +64,7 @@ function EmberApp(options) {
     this.project.configPath = function() { return options.configPath; };
   }
 
-  this.env  = process.env.EMBER_ENV || 'development';
+  this.env  = EmberApp.env();
   this.name = options.name || this.project.name();
 
   this.registry = options.registry || p.setupRegistry(this);
@@ -208,6 +208,10 @@ function EmberApp(options) {
   this.populateLegacyFiles();
   this._notifyAddonIncluded();
 }
+
+EmberApp.env = function(){
+  return process.env.EMBER_ENV || 'development';
+};
 
 /**
   Provides a broccoli files concatenation filter that's configured


### PR DESCRIPTION
It's not currently possible to pass environment-dependent options to the `EmberApp` constructor in your Brocfile without duplicating the environment-detection logic, because the canonical environment detection happens after the instance is created.

This change exposes a "class method" instead, so you can say things like:

``` js
new EmberApp({
  someOption: EmberApp.env() === 'production' ? 'foo' : 'bar';
});
```
