### PR TITLE
Check before outputting needs in model-test

### DIFF
--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -5,7 +5,7 @@ import {
 
 moduleForModel('<%= dasherizedModuleName %>', '<%= classifiedModuleName %>', {
   // Specify the other units that are required for this test.
-<%= needs %>
+<%= typeof needs !== 'undefined' ? needs : '' %>
 });
 
 test('it exists', function() {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -255,6 +255,21 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('model-test foo', function() {
+    return generate(['model-test', 'foo']).then(function() {
+      assertFile('tests/unit/models/foo-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForModel," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForModel('foo', 'Foo'"
+        ],
+        doesNotContain: 'needs'
+      });
+    });
+  });
+
   it('route foo', function() {
     return generate(['route', 'foo']).then(function() {
       assertFile('app/router.js', {


### PR DESCRIPTION
This is a simple fix for #2755, checking whether there’s a `needs` local before trying to print it.

The `model-test` blueprint will continue to ignore parameters passed in, like most of the other test blueprints.
