### PR TITLE
[FEATURE] Adds a buildError hook

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -117,7 +117,11 @@ module.exports = Task.extend({
          return self.builder.build.apply(self.builder, args);
        })
       .then(this.processBuildResult.bind(this))
-      .then(this.processAddonBuildSteps.bind(this, 'postBuild'));
+      .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
+      .catch(function(error) {
+        this.processAddonBuildSteps('buildError', error);
+        throw error;
+      }.bind(this));
   },
 
   cleanup: function() {


### PR DESCRIPTION
`buildError` hook will be called on when an error occurs during the
`preBuild` or `postBuild` hooks for addons, or when `builder#build`
fails

/cc @rwjblue 
