### PR TITLE
Fail if --proxy URL doesn't include protocol.

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,8 +1,10 @@
 'use strict';
 
-var path    = require('path');
-var assign  = require('lodash-node/modern/objects/assign');
-var Command = require('../models/command');
+var assign      = require('lodash-node/modern/objects/assign');
+var path        = require('path');
+var Command     = require('../models/command');
+var Promise     = require('../ext/promise');
+var SilentError = require('../errors/silent');
 
 module.exports = Command.extend({
   name: 'serve',
@@ -25,6 +27,14 @@ module.exports = Command.extend({
       liveReloadPort: commandOptions.liveReloadPort  || (parseInt(commandOptions.port, 10) + 31529),
       baseURL: this.project.config(commandOptions.environment).baseURL || '/'
     });
+
+    if (commandOptions.proxy) {
+      if (!commandOptions.proxy.match(/^(http:|https:)/)) {
+        var message = 'You need to include a protocol with the proxy URL.\nTry --proxy http://' + commandOptions.proxy;
+
+        return Promise.reject(new SilentError(message));
+      }
+    }
 
     var ServeTask = this.tasks.Serve;
     var serve = new ServeTask({

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -75,6 +75,23 @@ describe('server command', function() {
     });
   });
 
+  it('requires proxy URL to include protocol', function() {
+    return new ServeCommand(options).validateAndRun([
+      '--proxy', 'localhost:3000'
+    ]).then(function() {
+      assert.ok(
+        false,
+        'it rejects when proxy URL doesn\'t include protocol'
+      );
+    })
+    .catch(function(error) {
+      assert.equal(
+        error.message,
+        'You need to include a protocol with the proxy URL.\nTry --proxy http://localhost:3000'
+      );
+    });
+  });
+
   it('uses baseURL of correct environment', function() {
     options.project.config = function(env) {
       return { baseURL: env };


### PR DESCRIPTION
Closes #2834 

I was thinking about using url.parse('foo').protocol, but the following `localhost:3000` takes localhost as the procotol which actually fails. So a quick regex does the job.
