### PR TITLE
Add insecure-proxy option to `serve` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Master
 
+- [ENHANCEMENT] Add option `--insecure-proxy` to `serve` to allow for proxying
+  self signed SSL certificates.
+
 ### Applications
 ### Addons
 ### Blueprints

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -15,6 +15,7 @@ module.exports = Command.extend({
     { name: 'port', type: Number, default: 4200, aliases: ['p'] },
     { name: 'host', type: String, default: '0.0.0.0', aliases: ['h'] },
     { name: 'proxy',  type: String, aliases: ['pr','pxy'] },
+    { name: 'insecure-proxy', type: Boolean, default: false, description: 'Set false to proxy self-signed SSL certificates', aliases: ['inspr'] },
     { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },
     { name: 'live-reload',  type: Boolean, default: true, aliases: ['lr'] },
     { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)', aliases: ['lrp']},

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -13,6 +13,7 @@ ProxyServerAddon.prototype.serverMiddleware = function(options) {
     var proxy = require('http-proxy').createProxyServer({
       target: options.proxy,
       ws: true,
+      secure: !options.insecureProxy,
       changeOrigin: true
     });
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -196,6 +196,30 @@ describe('Unit: CLI', function() {
         });
       });
 
+      it('ember ' + command + ' --proxy https://localhost:3009/ --insecure-proxy', function () {
+        var server = stubRun('serve');
+
+        return ember([command, '--insecure-proxy']).then(function() {
+          expect(server.called).to.equal(1, 'expected the server command to be run');
+
+          var options = server.calledWith[0][0];
+
+          expect(options.insecureProxy).to.equal(true, 'correct `secure` option for http-proxy');
+        });
+      });
+
+      it('ember ' + command + ' --proxy https://localhost:3009/ --no-insecure-proxy', function () {
+        var server = stubRun('serve');
+
+        return ember([command, '--no-insecure-proxy']).then(function() {
+          expect(server.called).to.equal(1, 'expected the server command to be run');
+
+          var options = server.calledWith[0][0];
+
+          expect(options.insecureProxy).to.equal(false, 'correct `secure` option for http-proxy');
+        });
+      });
+
       it('ember ' + command + ' --watcher events', function() {
         var server = stubRun('serve');
 

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -75,6 +75,30 @@ describe('server command', function() {
     });
   });
 
+  it('has correct insecure proxy option', function() {
+    return new ServeCommand(options).validateAndRun([
+      '--insecure-proxy'
+    ]).then(function() {
+      var serveRun = tasks.Serve.prototype.run;
+      var ops = serveRun.calledWith[0][0];
+
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
+
+      expect(ops.insecureProxy).to.equal(true, 'has correct insecure proxy option');
+    });
+  });
+
+  it('has correct default value for insecure proxy', function() {
+    return new ServeCommand(options).validateAndRun().then(function() {
+      var serveRun = tasks.Serve.prototype.run;
+      var ops = serveRun.calledWith[0][0];
+
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
+
+      expect(ops.insecureProxy).to.equal(false, 'has correct insecure proxy option when not set');
+    });
+  });
+
   it('requires proxy URL to include protocol', function() {
     return new ServeCommand(options).validateAndRun([
       '--proxy', 'localhost:3000'


### PR DESCRIPTION
This adds an option to `serve` to allow for insecure proxying of self-signed or malformed SSL certs.

Use like this:
`ember server --proxy https://localhost:3009 --insecure-proxy`