### PR TITLE
Unify using chai.expect

### DIFF
--- a/tests/unit/analytics-test.js
+++ b/tests/unit/analytics-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert  = require('../helpers/assert');
+var expect  = require('chai').expect;
 var Command = require('../../lib/models/command');
 var MockUI = require('../helpers/mock-ui');
 var command;
@@ -32,7 +32,7 @@ afterEach(function() {
 describe('analytics', function() {
   it('track gets invoked on command.validateAndRun()', function() {
     return command.validateAndRun([]).then(function() {
-      assert.ok(called, 'expected analytics.track to be called');
+      expect(called, 'expected analytics.track to be called');
     });
   });
 });

--- a/tests/unit/blueprints/component-test.js
+++ b/tests/unit/blueprints/component-test.js
@@ -1,28 +1,27 @@
 'use strict';
 
 var Blueprint = require('../../../lib/models/blueprint');
-var assert    = require('assert');
+var expect    = require('chai').expect;
 
 describe('blueprint - component', function(){
   describe('entityName', function(){
     it('throws error when hyphen is not present', function(){
       var blueprint = Blueprint.lookup('component');
 
-      assert.throws(function(){
+      expect(function() {
         var nonConformantComponentName = 'form';
         blueprint.normalizeEntityName(nonConformantComponentName);
-      }, /must have a hyphen/);
+      }).to.throw(/must have a hyphen/);
     });
 
 
     it('keeps existing behavior by calling Blueprint.normalizeEntityName', function(){
       var blueprint = Blueprint.lookup('component');
 
-      assert.throws(function(){
+      expect(function() {
         var nonConformantComponentName = 'x-form/';
         blueprint.normalizeEntityName(nonConformantComponentName);
-      }, /trailing slash/);
-
+      }).to.throw(/trailing slash/);
     });
   });
 });

--- a/tests/unit/broccoli/config-loader-test.js
+++ b/tests/unit/broccoli/config-loader-test.js
@@ -5,7 +5,7 @@ var path         = require('path');
 var ConfigLoader = require('../../../lib/broccoli/broccoli-config-loader');
 var Project      = require('../../../lib/models/project');
 var Promise      = require('../../../lib/ext/promise');
-var assert       = require('assert');
+var expect       = require('chai').expect;
 var root         = process.cwd();
 var tmp          = require('tmp-sync');
 var tmproot      = path.join(root, 'tmp');
@@ -64,8 +64,8 @@ describe('broccoli/broccoli-config-loader', function() {
       configLoader.updateCache(tmpSrcDir, tmpDestDir2);
       var updatedConfig = fs.readFileSync(path.join(tmpDestDir2, 'environments', 'development.json'), { encoding: 'utf8' });
 
-      assert.notEqual(originalConfig, updatedConfig);
-      assert(updatedConfig.match(/blammo/));
+      expect(originalConfig).to.not.equal(updatedConfig);
+      expect(true, updatedConfig.match(/blammo/));
     });
   });
 
@@ -73,16 +73,16 @@ describe('broccoli/broccoli-config-loader', function() {
     it('writes the current environments file', function() {
       configLoader.updateCache(tmpSrcDir, tmpDestDir);
 
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
+      expect(true, fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
+      expect(true, fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
     });
 
     it('does not generate test environment files if testing is disabled', function() {
       options.tests = false;
       configLoader.updateCache(tmpSrcDir, tmpDestDir);
 
-      assert(fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
-      assert(!fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
+      expect(true, fs.existsSync(path.join(tmpDestDir, 'environments', 'development.json')));
+      expect(true, !fs.existsSync(path.join(tmpDestDir, 'environments', 'test.json')));
     });
   });
 });

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -6,7 +6,7 @@ var fs       = require('fs');
 var path     = require('path');
 var Project  = require('../../../lib/models/project');
 var EmberApp = require('../../../lib/broccoli/ember-app');
-var assert   = require('assert');
+var expect   = require('chai').expect;
 var stub     = require('../../helpers/stub').stub;
 
 describe('broccoli/ember-app', function() {
@@ -35,7 +35,7 @@ describe('broccoli/ember-app', function() {
         configPath: 'custom config path'
       });
 
-      assert.equal(project.configPath(), 'custom config path');
+      expect(project.configPath()).to.equal('custom config path');
     });
 
     it('should set bowerDirectory for app', function() {
@@ -43,8 +43,8 @@ describe('broccoli/ember-app', function() {
         project: project
       });
 
-      assert.equal(app.bowerDirectory, project.bowerDirectory);
-      assert.equal(app.bowerDirectory, 'bower_components');
+      expect(app.bowerDirectory).to.equal(project.bowerDirectory);
+      expect(app.bowerDirectory).to.equal('bower_components');
     });
 
     describe('_nofifyAddonIncluded', function() {
@@ -59,7 +59,7 @@ describe('broccoli/ember-app', function() {
         });
 
         var addon = project.addons[0];
-        assert.deepEqual(addon.app, app);
+        expect(addon.app).to.deep.equal(app);
       });
     });
   });
@@ -97,9 +97,9 @@ describe('broccoli/ember-app', function() {
 
         var actual = emberApp.contentFor(config, defaultMatch, 'foo');
 
-        assert.deepEqual(calledConfig, config);
-        assert.equal(calledType, 'foo');
-        assert.equal(actual, 'blammo');
+        expect(calledConfig).to.deep.equal(config);
+        expect(calledType).to.equal('foo');
+        expect(actual).to.equal('blammo');
       });
 
       it('calls `contentFor` on each addon', function() {
@@ -117,7 +117,7 @@ describe('broccoli/ember-app', function() {
 
         var actual = emberApp.contentFor(config, defaultMatch, 'foo');
 
-        assert.equal(actual, 'blammo\nblahzorz');
+        expect(actual).to.equal('blammo\nblahzorz');
       });
     });
 
@@ -128,7 +128,7 @@ describe('broccoli/ember-app', function() {
                            'content="' + escapedConfig + '" />';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
-        assert(actual.indexOf(metaExpected) > -1);
+        expect(true, actual.indexOf(metaExpected) > -1);
       });
 
       it('does not include the `meta` tag in `head` if storeConfigInMeta is false', function() {
@@ -139,7 +139,7 @@ describe('broccoli/ember-app', function() {
                            'content="' + escapedConfig + '" />';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
-        assert(actual.indexOf(metaExpected) === -1);
+        expect(true, actual.indexOf(metaExpected) === -1);
       });
 
       it('includes the `base` tag in `head` if locationType is auto', function() {
@@ -148,7 +148,7 @@ describe('broccoli/ember-app', function() {
         var expected = '<base href="/" />';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
-        assert(actual.indexOf(expected) > -1);
+        expect(true, actual.indexOf(expected) > -1);
       });
 
       it('includes the `base` tag in `head` if locationType is none (testem requirement)', function() {
@@ -157,7 +157,7 @@ describe('broccoli/ember-app', function() {
         var expected = '<base href="/" />';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
-        assert(actual.indexOf(expected) > -1);
+        expect(true, actual.indexOf(expected) > -1);
       });
 
       it('does not include the `base` tag in `head` if locationType is hash', function() {
@@ -166,7 +166,7 @@ describe('broccoli/ember-app', function() {
         var expected = '<base href="/foo/bar/" />';
         var actual = emberApp.contentFor(config, defaultMatch, 'head');
 
-        assert(actual.indexOf(expected) === -1);
+        expect(true, actual.indexOf(expected) === -1);
       });
     });
 
@@ -177,7 +177,7 @@ describe('broccoli/ember-app', function() {
 
         var actual = emberApp.contentFor(config, defaultMatch, 'config-module');
 
-        assert(actual.indexOf(expected) > -1);
+        expect(true, actual.indexOf(expected) > -1);
       });
 
       it('includes the raw config if storeConfigInMeta is false', function() {
@@ -186,14 +186,14 @@ describe('broccoli/ember-app', function() {
         var expected = JSON.stringify(config);
         var actual = emberApp.contentFor(config, defaultMatch, 'config-module');
 
-        assert(actual.indexOf(expected) > -1);
+        expect(true, actual.indexOf(expected) > -1);
       });
     });
 
     it('has no default value other than `head`', function() {
-      assert.equal(emberApp.contentFor(config, defaultMatch, 'foo'), '');
-      assert.equal(emberApp.contentFor(config, defaultMatch, 'body'), '');
-      assert.equal(emberApp.contentFor(config, defaultMatch, 'blah'), '');
+      expect(emberApp.contentFor(config, defaultMatch, 'foo')).to.equal('');
+      expect(emberApp.contentFor(config, defaultMatch, 'body')).to.equal('');
+      expect(emberApp.contentFor(config, defaultMatch, 'blah')).to.equal('');
     });
   });
 
@@ -216,8 +216,8 @@ describe('broccoli/ember-app', function() {
           project: project
         });
 
-        assert.ok(called);
-        assert.equal(passedApp, emberApp);
+        expect(true, called);
+        expect(passedApp).to.equal(emberApp);
       });
 
       it('does not throw an error if the addon does not implement `included`', function() {
@@ -227,14 +227,11 @@ describe('broccoli/ember-app', function() {
           this.addons = [ addon ];
         };
 
-        assert.doesNotThrow(
-          function() {
-            emberApp = new EmberApp({
-              project: project
-            });
-          },
-          /addon must implement the `included`/
-        );
+        expect(function() {
+          emberApp = new EmberApp({
+            project: project
+          });
+        }).to.not.throw(/addon must implement the `included`/);
       });
     });
 
@@ -256,7 +253,7 @@ describe('broccoli/ember-app', function() {
           project: project
         });
 
-        assert.deepEqual(emberApp.addonTreesFor('blah'), []);
+        expect(emberApp.addonTreesFor('blah')).to.deep.equal([]);
       });
 
       it('addonTreesFor calls treesFor on the addon', function() {
@@ -273,8 +270,8 @@ describe('broccoli/ember-app', function() {
           return 'blazorz';
         };
 
-        assert.deepEqual(emberApp.addonTreesFor('blah'), ['blazorz']);
-        assert.equal(actualTreeName, 'blah');
+        expect(emberApp.addonTreesFor('blah')).to.deep.equal(['blazorz']);
+        expect(actualTreeName).to.equal('blah');
       });
 
       it('addonTreesFor does not throw an error if treeFor is not defined', function() {
@@ -284,12 +281,9 @@ describe('broccoli/ember-app', function() {
           project: project
         });
 
-        assert.doesNotThrow(
-          function() {
-            emberApp.addonTreesFor('blah');
-          },
-          /addon must implement the `treeFor`/
-        );
+        expect(function() {
+          emberApp.addonTreesFor('blah');
+        }).not.to.throw(/addon must implement the `treeFor`/);
       });
 
       describe('addonTreesFor is called properly', function() {
@@ -304,21 +298,21 @@ describe('broccoli/ember-app', function() {
         it('_processedVendorTree calls addonTreesFor', function() {
           emberApp._processedVendorTree();
 
-          assert.equal(addonTreesForStub.calledWith[0][0], 'addon');
-          assert.equal(addonTreesForStub.calledWith[1][0], 'vendor');
+          expect(addonTreesForStub.calledWith[0][0]).to.equal('addon');
+          expect(addonTreesForStub.calledWith[1][0]).to.equal('vendor');
         });
 
         it('_processedAppTree calls addonTreesFor', function() {
           emberApp._processedAppTree();
 
-          assert.equal(addonTreesForStub.calledWith[0][0], 'app');
+          expect(addonTreesForStub.calledWith[0][0]).to.equal('app');
         });
 
         it('styles calls addonTreesFor', function() {
           var trees = emberApp.styles();
 
-          assert.equal(addonTreesForStub.calledWith[0][0], 'styles');
-          assert(trees.inputTrees[0].inputTree.inputTrees.indexOf('batman') !== -1, 'contains addon tree');
+          expect(addonTreesForStub.calledWith[0][0]).to.equal('styles');
+          expect(true, trees.inputTrees[0].inputTree.inputTrees.indexOf('batman') !== -1, 'contains addon tree');
         });
       });
     });
@@ -343,14 +337,14 @@ describe('broccoli/ember-app', function() {
         stub(emberApp, 'toArray', []);
         stub(addon, 'postprocessTree', 'derp');
 
-        assert.equal(emberApp.toTree(), 'derp');
+        expect(emberApp.toTree()).to.equal('derp');
       });
 
       it('calls addonPostprocessTree', function() {
         stub(emberApp, 'toArray', []);
         stub(emberApp, 'addonPostprocessTree', 'blap');
 
-        assert.equal(emberApp.toTree(), 'blap');
+        expect(emberApp.toTree()).to.equal('blap');
       });
     });
 
@@ -370,14 +364,14 @@ describe('broccoli/ember-app', function() {
           process.env.EMBER_ENV = 'development';
           emberApp = new EmberApp({ project: project });
 
-          assert.equal(emberApp.project.addons.length, 5);
+          expect(emberApp.project.addons.length).to.equal(5);
         });
 
         it('foo', function() {
           process.env.EMBER_ENV = 'foo';
           emberApp = new EmberApp({ project: project });
 
-          assert.equal(emberApp.project.addons.length, 6);
+          expect(emberApp.project.addons.length).to.equal(6);
         });
       });
 
@@ -389,13 +383,13 @@ describe('broccoli/ember-app', function() {
       emberApp = new EmberApp({
       });
       emberApp.import('vendor/moment.js', {type: 'vendor'});
-      assert.equal(emberApp.legacyFilesToAppend.indexOf('vendor/moment.js'), emberApp.legacyFilesToAppend.length - 1);
+      expect(emberApp.legacyFilesToAppend.indexOf('vendor/moment.js')).to.equal(emberApp.legacyFilesToAppend.length - 1);
     });
     it('prepends dependencies', function() {
       emberApp = new EmberApp({
       });
       emberApp.import('vendor/es5-shim.js', {type: 'vendor', prepend: true});
-      assert.equal(emberApp.legacyFilesToAppend.indexOf('vendor/es5-shim.js'), 0);
+      expect(emberApp.legacyFilesToAppend.indexOf('vendor/es5-shim.js')).to.equal(0);
     });
   });
 
@@ -407,9 +401,7 @@ describe('broccoli/ember-app', function() {
 
     it('defines vendorFiles by default', function() {
       emberApp = new EmberApp();
-      assert.deepEqual(
-        Object.keys(emberApp.vendorFiles),
-        defaultVendorFiles);
+      expect(Object.keys(emberApp.vendorFiles)).to.deep.equal(defaultVendorFiles);
     });
 
     it('redefines a location of a vendor asset', function() {
@@ -418,7 +410,7 @@ describe('broccoli/ember-app', function() {
           'ember.js': 'vendor/ember.js'
         }
       });
-      assert.equal(emberApp.vendorFiles['ember.js'], 'vendor/ember.js');
+      expect(emberApp.vendorFiles['ember.js']).to.equal('vendor/ember.js');
     });
 
     it('defines vendorFiles in order even when option for it is passed', function() {
@@ -427,9 +419,7 @@ describe('broccoli/ember-app', function() {
           'ember.js': 'vendor/ember.js'
         }
       });
-      assert.deepEqual(
-        Object.keys(emberApp.vendorFiles),
-        defaultVendorFiles);
+      expect(Object.keys(emberApp.vendorFiles)).to.deep.equal(defaultVendorFiles);
     });
 
     it('removes dependency in vendorFiles', function() {
@@ -440,8 +430,8 @@ describe('broccoli/ember-app', function() {
         }
       });
       var vendorFiles = Object.keys(EmberApp);
-      assert.equal(vendorFiles.indexOf('ember.js'), -1);
-      assert.equal(vendorFiles.indexOf('handlebars.js'), -1);
+      expect(vendorFiles.indexOf('ember.js')).to.equal(-1);
+      expect(vendorFiles.indexOf('handlebars.js')).to.equal(-1);
     });
   });
 });

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var EOL      = require('os').EOL;
-var assert   = require('../../helpers/assert');
+var expect   = require('chai').expect;
 var stub     = require('../../helpers/stub').stub;
 var MockUI   = require('../../helpers/mock-ui');
 var MockAnalytics   = require('../../helpers/mock-analytics');
@@ -66,24 +66,23 @@ afterEach(function() {
 });
 
 function assertVersion(string, message) {
-  assert(/version:\s\d+\.\d+\.\d+/.test(string), message ||
-         ('expected version, got: ' + string));
+  expect(true, /version:\s\d+\.\d+\.\d+/.test(string), message || ('expected version, got: ' + string));
 }
 
 describe('Unit: CLI', function() {
   this.timeout(10000);
   it('exists', function() {
-    assert(CLI);
+    expect(true, CLI);
   });
 
   it('ember', function() {
     var help = stubValidateAndRun('help');
 
     return ember().then(function() {
-      assert.equal(help.called, 1, 'expected help to be called once');
+      expect(help.called).to.equal(1, 'expected help to be called once');
       var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
-      assert.equal(output.length, 1, 'expected no extra output');
+      expect(output.length).to.equal(1, 'expected no extra output');
     });
   });
 
@@ -93,10 +92,10 @@ describe('Unit: CLI', function() {
         var help = stubValidateAndRun('help');
 
         return ember([command]).then(function() {
-          assert.equal(help.called, 1, 'expected help to be called once');
+          expect(help.called).to.equal(1, 'expected help to be called once');
           var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
-          assert.equal(output.length, 1, 'expected no extra output');
+          expect(output.length).to.equal(1, 'expected no extra output');
         });
       });
 
@@ -105,12 +104,12 @@ describe('Unit: CLI', function() {
         var newCommand = stubValidateAndRun('new');
 
         return ember(['new', command]).then(function() {
-          assert.equal(help.called, 1, 'expected help to be called once');
+          expect(help.called).to.equal(1, 'expected help to be called once');
           var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
-          assert.equal(output.length, 1, 'expected no extra output');
+          expect(output.length).to.equal(1, 'expected no extra output');
 
-          assert.equal(newCommand.called, 0, 'expected the new command to never be called');
+          expect(newCommand.called).to.equal(0, 'expected the new command to never be called');
         });
       });
     });
@@ -123,8 +122,8 @@ describe('Unit: CLI', function() {
       return ember([command]).then(function() {
         var output = ui.output.trim().split(EOL);
         assertVersion(output[0]);
-        assert.equal(output.length, 1, 'expected no extra output');
-        assert.equal(version.called, 1, 'expected version to be called once');
+        expect(output.length).to.equal(1, 'expected no extra output');
+        expect(version.called).to.equal(1, 'expected version to be called once');
       });
     });
   });
@@ -135,15 +134,15 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command]).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
           var options = server.calledWith[0][0];
           if (/win\d+/.test(process.platform) || options.watcher === 'watchman') {
-            assert.equal(output.length, 1, 'expected no extra output');
+            expect(output.length).to.equal(1, 'expected no extra output');
           } else {
-            assert.equal(output.length, 2, 'expected no extra output');
+            expect(output.length).to.equal(2, 'expected no extra output');
           }
         });
       });
@@ -152,11 +151,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command, '--port',  '9999']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert.equal(options.port, 9999, 'expected port 9999, was ' + options.port);
+          expect(options.port).to.equal(9999, 'expected port 9999, was ' + options.port);
         });
       });
 
@@ -164,11 +163,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember(['server', '--host', 'localhost']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert.equal(options.host, 'localhost', 'correct localhost');
+          expect(options.host).to.equal('localhost', 'correct localhost');
         });
       });
 
@@ -176,12 +175,12 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command, '--port', '9292',  '--host',  'localhost']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert.equal(options.host, 'localhost', 'correct localhost');
-          assert.equal(options.port, '9292', 'correct localhost');
+          expect(options.host).to.equal('localhost', 'correct localhost');
+          expect(options.port).to.equal(9292, 'correct port');
         });
       });
 
@@ -189,11 +188,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command, '--proxy', 'http://localhost:3000/']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert.equal(options.proxy, 'http://localhost:3000/', 'correct proxy url');
+          expect(options.proxy).to.equal('http://localhost:3000/', 'correct proxy url');
         });
       });
 
@@ -201,11 +200,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command, '--watcher', 'events']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert(/node|events|watchman/.test(options.watcher), 'correct watcher type');
+          expect(true, /node|events|watchman/.test(options.watcher), 'correct watcher type');
         });
       });
 
@@ -213,11 +212,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command, '--watcher', 'polling']).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert.equal(options.watcher, 'polling', 'correct watcher type');
+          expect(options.watcher).to.equal('polling', 'correct watcher type');
         });
       });
 
@@ -225,11 +224,11 @@ describe('Unit: CLI', function() {
         var server = stubRun('serve');
 
         return ember([command]).then(function() {
-          assert.equal(server.called, 1, 'expected the server command to be run');
+          expect(server.called).to.equal(1, 'expected the server command to be run');
 
           var options = server.calledWith[0][0];
 
-          assert(/node|events|watchman/.test(options.watcher), 'correct watcher type');
+          expect(true, /node|events|watchman/.test(options.watcher), 'correct watcher type');
         });
       });
 
@@ -238,11 +237,11 @@ describe('Unit: CLI', function() {
           var server = stubRun('serve');
 
           return ember([command, '--environment', env]).then(function() {
-            assert.equal(server.called, 1, 'expected the server command to be run');
+            expect(server.called).to.equal(1, 'expected the server command to be run');
 
             var options = server.calledWith[0][0];
 
-            assert.equal(options.environment, env, 'correct environment');
+            expect(options.environment).to.equal(env, 'correct environment');
           });
         });
       });
@@ -253,9 +252,9 @@ describe('Unit: CLI', function() {
           process.env.EMBER_ENV='production';
 
           return ember([command, '--environment', env]).then(function() {
-            assert.equal(server.called, 1, 'expected the server command to be run');
+            expect(server.called).to.equal(1, 'expected the server command to be run');
 
-            assert.equal(process.env.EMBER_ENV, 'production', 'uses EMBER_ENV over environment');
+            expect(process.env.EMBER_ENV).to.equal('production', 'uses EMBER_ENV over environment');
           });
         });
       });
@@ -267,9 +266,9 @@ describe('Unit: CLI', function() {
           process.env.EMBER_ENV=env;
 
           return ember([command]).then(function() {
-            assert.equal(server.called, 1, 'expected the server command to be run');
+            expect(server.called).to.equal(1, 'expected the server command to be run');
 
-            assert.equal(process.env.EMBER_ENV, env, 'correct environment');
+            expect(process.env.EMBER_ENV).to.equal(env, 'correct environment');
           });
         });
       });
@@ -282,20 +281,20 @@ describe('Unit: CLI', function() {
         var generate = stubRun('generate');
 
         return ember([command, 'foo', 'bar', 'baz']).then(function() {
-          assert.equal(generate.called, 1, 'expected the generate command to be run');
+          expect(generate.called).to.equal(1, 'expected the generate command to be run');
 
           var args = generate.calledWith[0][1];
 
-          assert.deepEqual(args, ['foo', 'bar', 'baz']);
+          expect(args).to.deep.equal(['foo', 'bar', 'baz']);
 
           var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
 
           var options = generate.calledWith[0][0];
           if (/win\d+/.test(process.platform) || options.watcher === 'watchman') {
-            assert.equal(output.length, 1, 'expected no extra output');
+            expect(output.length).to.equal(1, 'expected no extra output');
           } else {
-            assert.equal(output.length, 2, 'expected no extra output');
+            expect(output.length).to.equal(2, 'expected no extra output');
           }
         });
       });
@@ -308,7 +307,7 @@ describe('Unit: CLI', function() {
         var init = stubValidateAndRun('init');
 
         return ember([command]).then(function() {
-          assert.equal(init.called, 1, 'expected the init command to be run');
+          expect(init.called).to.equal(1, 'expected the init command to be run');
         });
       });
 
@@ -318,17 +317,17 @@ describe('Unit: CLI', function() {
         return ember([command, 'my-blog']).then(function() {
           var args = init.calledWith[0][1];
 
-          assert.equal(init.called, 1, 'expected the init command to be run');
-          assert.deepEqual(args, ['my-blog'], 'expect first arg to be the app name');
+          expect(init.called).to.equal(1, 'expected the init command to be run');
+          expect(args).to.deep.equal(['my-blog'], 'expect first arg to be the app name');
 
           var output = ui.output.trim().split(EOL);
           assertVersion(output[0]);
 
           var options = init.calledWith[0][0];
           if (/win\d+/.test(process.platform) || options.watcher === 'watchman') {
-            assert.equal(output.length, 1, 'expected no extra output');
+            expect(output.length).to.equal(1, 'expected no extra output');
           } else {
-            assert.equal(output.length, 2, 'expected no extra output');
+            expect(output.length).to.equal(2, 'expected no extra output');
           }
         });
       });
@@ -342,7 +341,7 @@ describe('Unit: CLI', function() {
       var newCommand = stubRun('new');
 
       return ember(['new']).then(function() {
-        assert.equal(newCommand.called, 1, 'expected the new command to be run');
+        expect(newCommand.called).to.equal(1, 'expected the new command to be run');
       });
     });
 
@@ -352,10 +351,10 @@ describe('Unit: CLI', function() {
       var newCommand = stubRun('new');
 
       return ember(['new', 'MyApp']).then(function() {
-        assert.equal(newCommand.called, 1, 'expected the new command to be run');
+        expect(newCommand.called).to.equal(1, 'expected the new command to be run');
         var args = newCommand.calledWith[0][1];
 
-        assert.deepEqual(args, ['MyApp']);
+        expect(args).to.deep.equal(['MyApp']);
       });
     });
   });
@@ -365,7 +364,7 @@ describe('Unit: CLI', function() {
       var update = stubRun('update');
 
       return ember(['update']).then(function() {
-        assert.equal(update.called, 1, 'expected the update command to be run');
+        expect(update.called).to.equal(1, 'expected the update command to be run');
       });
     });
   });
@@ -375,10 +374,10 @@ describe('Unit: CLI', function() {
       var build = stubRun('build');
 
       return ember(['build']).then(function() {
-        assert.equal(build.called, 1, 'expected the build command to be run');
+        expect(build.called).to.equal(1, 'expected the build command to be run');
 
         var options = build.calledWith[0][0];
-        assert.equal(options.watch, false, 'expected the default watch flag to be false');
+        expect(options.watch).to.equal(false, 'expected the default watch flag to be false');
       });
     });
 
@@ -387,7 +386,7 @@ describe('Unit: CLI', function() {
 
       return ember(['build', '--watch']).then(function() {
         var options = build.calledWith[0][0];
-        assert.equal(options.watch, true, 'expected the watch flag to be true');
+        expect(options.watch).to.equal(true, 'expected the watch flag to be true');
       });
     });
 
@@ -396,11 +395,11 @@ describe('Unit: CLI', function() {
         var build = stubRun('build');
 
         return ember(['build', '--environment', env]).then(function() {
-          assert.equal(build.called, 1, 'expected the build command to be run');
+          expect(build.called).to.equal(1, 'expected the build command to be run');
 
           var options = build.calledWith[0][0];
 
-          assert.equal(options.environment, env, 'correct environment');
+          expect(options.environment).to.equal(env, 'correct environment');
         });
       });
     });
@@ -412,9 +411,9 @@ describe('Unit: CLI', function() {
         process.env.EMBER_ENV = 'production';
 
         return ember(['build', '--environment', env]).then(function() {
-          assert.equal(build.called, 1, 'expected the build command to be run');
+          expect(build.called).to.equal(1, 'expected the build command to be run');
 
-          assert.equal(process.env.EMBER_ENV, 'production', 'uses EMBER_ENV over environment');
+          expect(process.env.EMBER_ENV).to.equal('production', 'uses EMBER_ENV over environment');
         });
       });
     });
@@ -426,9 +425,9 @@ describe('Unit: CLI', function() {
         process.env.EMBER_ENV=env;
 
         return ember(['build']).then(function() {
-          assert.equal(build.called, 1, 'expected the build command to be run');
+          expect(build.called).to.equal(1, 'expected the build command to be run');
 
-          assert.equal(process.env.EMBER_ENV, env, 'correct environment');
+          expect(process.env.EMBER_ENV).to.equal(env, 'correct environment');
         });
       });
     });
@@ -439,12 +438,12 @@ describe('Unit: CLI', function() {
     var serve = stubValidateAndRun('serve');
 
     return ember(['serve']).then(function() {
-      assert.equal(help.called, 0, 'expected the help command NOT to be run');
-      assert.equal(serve.called, 1,  'expected the serve command to be run');
+      expect(help.called).to.equal(0, 'expected the help command NOT to be run');
+      expect(serve.called).to.equal(1, 'expected the serve command to be run');
 
       var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
-      assert.equal(output.length, 1, 'expected no extra output');
+      expect(output.length).to.equal(1, 'expected no extra output');
     });
   });
 
@@ -453,17 +452,17 @@ describe('Unit: CLI', function() {
     var serve = stubValidateAndRun('serve');
 
     return ember(['serve', 'lorem', 'ipsum', 'dolor', '--flag1=one']).then(function() {
-      var args= serve.calledWith[0][0].cliArgs;
+      var args = serve.calledWith[0][0].cliArgs;
 
-      assert.equal(help.called, 0, 'expected the help command NOT to be run');
-      assert.equal(serve.called, 1,  'expected the foo command to be run');
-      assert.deepEqual(args, ['serve', 'lorem', 'ipsum', 'dolor'], 'expects correct arguments');
+      expect(help.called).to.equal(0, 'expected the help command NOT to be run');
+      expect(serve.called).to.equal(1, 'expected the foo command to be run');
+      expect(args).to.deep.equal(['serve', 'lorem', 'ipsum', 'dolor'], 'expects correct arguments');
 
-      assert.equal(serve.calledWith[0].length, 2, 'expect foo to receive a total of 4 args');
+      expect(serve.calledWith[0].length).to.equal(2, 'expect foo to receive a total of 4 args');
 
       var output = ui.output.trim().split(EOL);
       assertVersion(output[0]);
-      assert.equal(output.length, 1, 'expected no extra output');
+      expect(output.length).to.equal(1, 'expected no extra output');
     });
   });
 
@@ -472,8 +471,8 @@ describe('Unit: CLI', function() {
 
     return ember(['unknownCommand']).then(function() {
       var output = ui.output.trim().split(EOL);
-      assert(/The specified command .*unknownCommand.* is invalid/.test(output[1]), 'expected an invalid command message');
-      assert.equal(help.called, 0, 'expected the help command to be run');
+      expect(true, /The specified command .*unknownCommand.* is invalid/.test(output[1]), 'expected an invalid command message');
+      expect(help.called).to.equal(0, 'expected the help command to be run');
     });
   });
 
@@ -486,7 +485,7 @@ describe('Unit: CLI', function() {
 
         var options = build.calledWith[0][1].cliOptions;
 
-        assert.equal(options.output, process.cwd());
+        expect(options.output).to.equal(process.cwd());
       });
     });
   });
@@ -501,9 +500,9 @@ describe('Unit: CLI', function() {
     it('tracks the command that was run', function() {
 
       return ember(['build']).then(function() {
-        assert.ok(track.called);
-        assert.equal(track.calledWith[0][1], 'ember');
-        assert.equal(track.calledWith[0][2], 'build');
+        expect(true, track.called);
+        expect(track.calledWith[0][1]).to.equal('ember');
+        expect(track.calledWith[0][2]).to.equal('build');
       });
     });
 
@@ -512,9 +511,9 @@ describe('Unit: CLI', function() {
 
         var args = JSON.parse(track.calledWith[1][0]);
 
-        assert.ok(track.called);
-        assert.equal(args[0], 'production');
-        assert.equal(args[1].output, '/blah');
+        expect(true, track.called);
+        expect(args[0]).to.equal('production');
+        expect(args[1].output).to.equal('/blah');
       });
     });
   });
@@ -533,22 +532,22 @@ describe('Unit: CLI', function() {
 
         it('sets process.env.EMBER_VERBOSE_${NAME} for each space delimited option', function() {
           return verboseCommand(['fake_option_1', 'fake_option_2']).then(function() {
-            assert(process.env.EMBER_VERBOSE_FAKE_OPTION_1,  'expected it to be true');
-            assert(process.env.EMBER_VERBOSE_FAKE_OPTION_2,  'expected it to be true');
+            expect(true, process.env.EMBER_VERBOSE_FAKE_OPTION_1,  'expected it to be true');
+            expect(true, process.env.EMBER_VERBOSE_FAKE_OPTION_2,  'expected it to be true');
           });
         });
 
         it('ignores verbose options after --', function() {
           return verboseCommand(['fake_option_1', '--fake-option', 'fake_option_2']).then(function() {
-            assert(process.env.EMBER_VERBOSE_FAKE_OPTION_1,  'expected it to be true');
-            assert(!process.env.EMBER_VERBOSE_FAKE_OPTION_2,  'expected it to be false');
+            expect(true, process.env.EMBER_VERBOSE_FAKE_OPTION_1,   'expected it to be true');
+            expect(false, !process.env.EMBER_VERBOSE_FAKE_OPTION_2, 'expected it to be false');
           });
         });
 
         it('ignores verbose options after -', function() {
           return verboseCommand(['fake_option_1', '-f', 'fake_option_2']).then(function() {
-            assert(process.env.EMBER_VERBOSE_FAKE_OPTION_1,  'expected it to be true');
-            assert(!process.env.EMBER_VERBOSE_FAKE_OPTION_2,  'expected it to be false');
+            expect(true, process.env.EMBER_VERBOSE_FAKE_OPTION_1,  'expected it to be true');
+            expect(false, !process.env.EMBER_VERBOSE_FAKE_OPTION_2,  'expected it to be false');
           });
         });
       });

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var Task           = require('../../../lib/models/task');
@@ -53,8 +53,8 @@ describe('build command', function() {
     return new BuildCommand(options).validateAndRun([ ]).then(function() {
       var buildRun = tasks.Build.prototype.run;
 
-      assert.equal(buildRun.called, 1, 'expected run to be called once');
-      assert.equal(buildTaskInstance.project, options.project, 'has correct project instance');
+      expect(buildRun.called).to.equal(1, 'expected run to be called once');
+      expect(buildTaskInstance.project).to.equal(options.project, 'has correct project instance');
     });
   });
 
@@ -62,8 +62,8 @@ describe('build command', function() {
     return new BuildCommand(options).validateAndRun([ '--watch' ]).then(function() {
       var buildWatchRun = tasks.BuildWatch.prototype.run;
 
-      assert.equal(buildWatchRun.called, 1, 'expected run to be called once');
-      assert.equal(buildWatchTaskInstance.project, options.project, 'has correct project instance');
+      expect(buildWatchRun.called).to.equal(1, 'expected run to be called once');
+      expect(buildWatchTaskInstance.project).to.equal(options.project, 'has correct project instance');
     });
   });
 });

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -3,7 +3,7 @@
 var DestroyCommand  = require('../../../lib/commands/destroy');
 var Promise         = require('../../../lib/ext/promise');
 var Task            = require('../../../lib/models/task');
-var assert          = require('../../helpers/assert');
+var expect          = require('chai').expect;
 var commandOptions  = require('../../factories/command-options');
 
 describe('generate command', function() {
@@ -36,19 +36,19 @@ describe('generate command', function() {
   it('runs DestroyFromBlueprint with expected options', function() {
     return command.validateAndRun(['controller', 'foo'])
       .then(function(options) {
-        assert.equal(options.dryRun, false);
-        assert.equal(options.verbose, false);
-        assert.deepEqual(options.args, ['controller', 'foo']);
+        expect(options.dryRun, false);
+        expect(options.verbose, false);
+        expect(options.args).to.deep.equal(['controller', 'foo']);
       });
   });
 
   it('complains if no entity name is given', function() {
     return command.validateAndRun(['controller'])
       .then(function() {
-        assert.ok(false, 'should not have called run');
+        expect(false, 'should not have called run');
       })
       .catch(function(error) {
-        assert.equal(error.message,
+        expect(error.message).to.equal(
             'The `ember destroy` command requires an ' +
             'entity name to be specified. ' +
             'For more details, use `ember help`.');
@@ -58,10 +58,10 @@ describe('generate command', function() {
   it('complains if no blueprint name is given', function() {
     return command.validateAndRun([])
       .then(function() {
-        assert.ok(false, 'should not have called run');
+        expect(false, 'should not have called run');
       })
       .catch(function(error) {
-        assert.equal(error.message,
+        expect(error.message).to.equal(
             'The `ember destroy` command requires a ' +
             'blueprint name to be specified. ' +
             'For more details, use `ember help`.');

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -3,7 +3,7 @@
 var GenerateCommand = require('../../../lib/commands/generate');
 var Promise         = require('../../../lib/ext/promise');
 var Task            = require('../../../lib/models/task');
-var assert          = require('../../helpers/assert');
+var expect          = require('chai').expect;
 var commandOptions  = require('../../factories/command-options');
 
 describe('generate command', function() {
@@ -36,20 +36,20 @@ describe('generate command', function() {
   it('runs GenerateFromBlueprint with expected options', function() {
     return command.validateAndRun(['controller', 'foo'])
       .then(function(options) {
-        assert.equal(options.pod, false);
-        assert.equal(options.dryRun, false);
-        assert.equal(options.verbose, false);
-        assert.deepEqual(options.args, ['controller', 'foo']);
+        expect(options.pod, false);
+        expect(options.dryRun, false);
+        expect(options.verbose, false);
+        expect(options.args).to.deep.equal(['controller', 'foo']);
       });
   });
 
   it('complains if no blueprint name is given', function() {
     return command.validateAndRun([])
       .then(function() {
-        assert.ok(false, 'should not have called run');
+        expect(false, 'should not have called run');
       })
       .catch(function(error) {
-        assert.equal(error.message,
+        expect(error.message).to.equal(
             'The `ember generate` command requires a ' +
             'blueprint name to be specified. ' +
             'For more details, use `ember help`.');

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path          = require('path');
-var assert        = require('../../helpers/assert');
+var expect        = require('chai').expect;
 var MockUI        = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
 var Promise       = require('../../../lib/ext/promise');
@@ -38,17 +38,17 @@ describe('init command', function() {
     });
 
     return command.validateAndRun([]).then(function() {
-      assert.ok(false, 'should have rejected with an application name of test');
+      expect(false, 'should have rejected with an application name of test');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `test`.');
+      expect(error.message).to.equal('We currently do not support a name of `test`.');
     });
   });
 
   it('Uses the name of the closest project to when calling installBlueprint', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.rawName, 'some-random-name');
+        expect(blueprintOpts.rawName).to.equal('some-random-name');
         return Promise.reject('Called run');
       }
     });
@@ -63,14 +63,14 @@ describe('init command', function() {
 
     return command.validateAndRun([])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('Uses the provided app name over the closest found project', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.rawName, 'provided-name');
+        expect(blueprintOpts.rawName).to.equal('provided-name');
         return Promise.reject('Called run');
       }
     });
@@ -85,7 +85,7 @@ describe('init command', function() {
 
     return command.validateAndRun(['--name=provided-name'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
@@ -93,7 +93,7 @@ describe('init command', function() {
   it('Uses process.cwd if no package is found when calling installBlueprint', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.rawName, path.basename(process.cwd()));
+        expect(blueprintOpts.rawName).to.equal(path.basename(process.cwd()));
         return Promise.reject('Called run');
       }
     });
@@ -107,14 +107,14 @@ describe('init command', function() {
 
     return command.validateAndRun([])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('doesn\'t use --dry-run or any other command option as the name', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.rawName, 'some-random-name');
+        expect(blueprintOpts.rawName).to.equal('some-random-name');
         return Promise.reject('Called run');
       }
     });
@@ -129,14 +129,14 @@ describe('init command', function() {
 
     return command.validateAndRun(['--dry-run'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('doesn\'t use . as the name', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.rawName, 'some-random-name');
+        expect(blueprintOpts.rawName).to.equal('some-random-name');
         return Promise.reject('Called run');
       }
     });
@@ -151,14 +151,14 @@ describe('init command', function() {
 
     return command.validateAndRun(['.'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('Uses the "app" blueprint by default', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.blueprint, 'app');
+        expect(blueprintOpts.blueprint).to.equal('app');
         return Promise.reject('Called run');
       }
     });
@@ -173,14 +173,14 @@ describe('init command', function() {
 
     return command.validateAndRun(['--name=provided-name'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('Uses arguments to select files to init', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.blueprint, 'app');
+        expect(blueprintOpts.blueprint).to.equal('app');
         return Promise.reject('Called run');
       }
     });
@@ -195,14 +195,14 @@ describe('init command', function() {
 
     return command.validateAndRun(['package.json', '--name=provided-name'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 
   it('Uses the "addon" blueprint for addons', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
-        assert.equal(blueprintOpts.blueprint, 'addon');
+        expect(blueprintOpts.blueprint).to.equal('addon');
         return Promise.reject('Called run');
       }
     });
@@ -217,7 +217,7 @@ describe('init command', function() {
 
     return command.validateAndRun(['--name=provided-name'])
       .catch(function(reason) {
-        assert.equal(reason, 'Called run');
+        expect(reason).to.equal('Called run');
       });
   });
 });

--- a/tests/unit/commands/install-addon-test.js
+++ b/tests/unit/commands/install-addon-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-addon');
@@ -81,13 +81,13 @@ describe('install:addon command', function() {
 
   it('initializes npm install and generate blueprint task with ui, project and analytics', function() {
     return command.validateAndRun(['ember-data']).then(function() {
-      assert.ok(npmInstance.ui, 'ui was set');
-      assert.ok(npmInstance.project, 'project was set');
-      assert.ok(npmInstance.analytics, 'analytics was set');
+      expect(npmInstance.ui, 'ui was set');
+      expect(npmInstance.project, 'project was set');
+      expect(npmInstance.analytics, 'analytics was set');
 
-      assert.ok(generateBlueprintInstance.ui, 'ui was set');
-      assert.ok(generateBlueprintInstance.project, 'project was set');
-      assert.ok(generateBlueprintInstance.analytics, 'analytics was set');
+      expect(generateBlueprintInstance.ui, 'ui was set');
+      expect(generateBlueprintInstance.project, 'project was set');
+      expect(generateBlueprintInstance.analytics, 'analytics was set');
     });
   });
 
@@ -95,9 +95,9 @@ describe('install:addon command', function() {
     it('runs the npm install task with given name and save-dev true', function() {
       return command.validateAndRun(['ember-data']).then(function() {
         var npmRun = tasks.NpmInstall.prototype.run;
-        assert.equal(npmRun.called, 1, 'expected npm install run was called once');
+        expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
 
-        assert.deepEqual(npmRun.calledWith[0][0], {
+        expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: ['ember-data'],
           'save-dev': true
         }, 'expected npm install called with given name and save-dev true');
@@ -107,8 +107,8 @@ describe('install:addon command', function() {
     it('runs the packae name blueprint task with given name and args', function() {
       return command.validateAndRun(['ember-data']).then(function() {
         var generateRun = tasks.GenerateFromBlueprint.prototype.run;
-        assert.equal(generateRun.calledWith[0][0].ignoreMissingMain, true);
-        assert.deepEqual(generateRun.calledWith[0][0].args, [
+        expect(generateRun.calledWith[0][0].ignoreMissingMain, true);
+        expect(generateRun.calledWith[0][0].args).to.deep.equal([
           'ember-data'
         ], 'expected generate blueprint called with correct args');
       });
@@ -117,8 +117,8 @@ describe('install:addon command', function() {
     it('runs the defaultBlueprint task with given github/name and args', function() {
       return command.validateAndRun(['ember-cli-cordova', 'com.ember.test']).then(function() {
         var generateRun = tasks.GenerateFromBlueprint.prototype.run;
-        assert.equal(generateRun.calledWith[0][0].ignoreMissingMain, true);
-        assert.deepEqual(generateRun.calledWith[0][0].args, [
+        expect(generateRun.calledWith[0][0].ignoreMissingMain, true);
+        expect(generateRun.calledWith[0][0].args).to.deep.equal([
           'cordova-starter-kit', 'com.ember.test'
         ], 'expected generate blueprint called with correct args');
       });
@@ -127,8 +127,8 @@ describe('install:addon command', function() {
     it('runs the package name blueprint task when given github/name and args', function() {
       return command.validateAndRun(['ember-cli/ember-cli-qunit']).then(function() {
         var generateRun = tasks.GenerateFromBlueprint.prototype.run;
-        assert.equal(generateRun.calledWith[0][0].ignoreMissingMain, true);
-        assert.deepEqual(generateRun.calledWith[0][0].args, [
+        expect(generateRun.calledWith[0][0].ignoreMissingMain, true);
+        expect(generateRun.calledWith[0][0].args).to.deep.equal([
           'ember-cli-qunit'
         ], 'expected generate blueprint called with correct args');
       });
@@ -136,11 +136,12 @@ describe('install:addon command', function() {
 
     it('gives helpful message if it can\'t find the addon', function() {
       return command.validateAndRun(['unknown-addon']).then(function() {
-        assert.ok(false, 'should reject with error');
+        expect(false, 'should reject with error');
       }).catch(function(err) {
-        assert.equal(err.message, [
-          'Install failed. Could not find addon with name: unknown-addon'
-        ], 'expected error to have helpful message');
+        expect(err.message).to.equal(
+          'Install failed. Could not find addon with name: unknown-addon',
+          'expected error to have helpful message'
+        );
       });
     });
   });

--- a/tests/unit/commands/install-bower-test.js
+++ b/tests/unit/commands/install-bower-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-bower');
@@ -45,9 +45,9 @@ describe('install:bower command', function() {
 
   it('initializes bower task with ui, project and analytics', function() {
     return command.validateAndRun([]).then(function() {
-      assert.ok(bowerInstance.ui, 'ui was set');
-      assert.ok(bowerInstance.project, 'project was set');
-      assert.ok(bowerInstance.analytics, 'analytics was set');
+      expect(bowerInstance.ui, 'ui was set');
+      expect(bowerInstance.project, 'project was set');
+      expect(bowerInstance.analytics, 'analytics was set');
     });
   });
 
@@ -55,8 +55,8 @@ describe('install:bower command', function() {
     it('runs the bower install task with no packages and save true', function() {
       return command.validateAndRun([]).then(function() {
         var bowerRun = tasks.BowerInstall.prototype.run;
-        assert.equal(bowerRun.called, 1, 'expected bower install run was called once');
-        assert.deepEqual(bowerRun.calledWith[0][0], {
+        expect(bowerRun.called).to.equal(1, 'expected bower install run was called once');
+        expect(bowerRun.calledWith[0][0]).to.deep.equal({
           packages: [],
           installOptions: { save: true }
         }, 'expected bower install called with no packages and save true');
@@ -68,8 +68,8 @@ describe('install:bower command', function() {
     it('runs the bower install task with given packages and save true', function() {
       return command.validateAndRun(['moment', 'lodash']).then(function() {
         var bowerRun = tasks.BowerInstall.prototype.run;
-        assert.equal(bowerRun.called, 1, 'expected bower install run was called once');
-        assert.deepEqual(bowerRun.calledWith[0][0], {
+        expect(bowerRun.called).to.equal(1, 'expected bower install run was called once');
+        expect(bowerRun.calledWith[0][0]).to.deep.equal({
           packages: ['moment', 'lodash'],
           installOptions: { save: true }
         }, 'expected bower install called with given packages and save true');

--- a/tests/unit/commands/install-npm-test.js
+++ b/tests/unit/commands/install-npm-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-npm');
@@ -45,9 +45,9 @@ describe('install:npm command', function() {
 
   it('initializes npm task with ui, project and analytics', function() {
     return command.validateAndRun([]).then(function() {
-      assert.ok(npmInstance.ui, 'ui was set');
-      assert.ok(npmInstance.project, 'project was set');
-      assert.ok(npmInstance.analytics, 'analytics was set');
+      expect(npmInstance.ui, 'ui was set');
+      expect(npmInstance.project, 'project was set');
+      expect(npmInstance.analytics, 'analytics was set');
     });
   });
 
@@ -55,8 +55,8 @@ describe('install:npm command', function() {
     it('runs the npm install task with no packages and save-dev true', function() {
       return command.validateAndRun([]).then(function() {
         var npmRun = tasks.NpmInstall.prototype.run;
-        assert.equal(npmRun.called, 1, 'expected npm install run was called once');
-        assert.deepEqual(npmRun.calledWith[0][0], {
+        expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
+        expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: [],
           'save-dev': true
         }, 'expected npm install called with no packages and save-dev true');
@@ -68,8 +68,8 @@ describe('install:npm command', function() {
     it('runs the npm install task with given packages', function() {
       return command.validateAndRun(['moment', 'lodash']).then(function() {
         var npmRun = tasks.NpmInstall.prototype.run;
-        assert.equal(npmRun.called, 1, 'expected npm install run was called once');
-        assert.deepEqual(npmRun.calledWith[0][0], {
+        expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
+        expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: ['moment', 'lodash'],
           'save-dev': true
         }, 'expected npm install called with given packages and save-dev true');

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install');
@@ -55,37 +55,37 @@ describe('install command', function() {
   it('runs the bower install task and npm install task', function() {
     return command.validateAndRun([]).then(function() {
       var bowerRun = tasks.BowerInstall.prototype.run;
-      assert.equal(bowerRun.called, 1, 'expected bower install run was called once');
-      assert.deepEqual(bowerRun.calledWith[0][0], {}, 'expected bower install called with empty options');
+      expect(bowerRun.called).to.equal(1, 'expected bower install run was called once');
+      expect(bowerRun.calledWith[0][0]).to.deep.equal({}, 'expected bower install called with empty options');
 
       var npmRun = tasks.NpmInstall.prototype.run;
-      assert.equal(npmRun.called, 1, 'expected npm install run was called once');
-      assert.deepEqual(npmRun.calledWith[0][0], {}, 'expected npm install called with empty options');
+      expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
+      expect(npmRun.calledWith[0][0]).to.deep.equal({}, 'expected npm install called with empty options');
     });
   });
 
   it('initializes npm task with ui, project and analytics', function() {
     return command.validateAndRun([]).then(function() {
-      assert.ok(npmInstance.ui, 'ui was set');
-      assert.ok(npmInstance.project, 'project was set');
-      assert.ok(npmInstance.analytics, 'analytics was set');
+      expect(npmInstance.ui, 'ui was set');
+      expect(npmInstance.project, 'project was set');
+      expect(npmInstance.analytics, 'analytics was set');
     });
   });
 
   it('initializes bower task with ui, project and analytics', function() {
     return command.validateAndRun([]).then(function() {
-      assert.ok(bowerInstance.ui, 'ui was set');
-      assert.ok(bowerInstance.project, 'project was set');
-      assert.ok(bowerInstance.analytics, 'analytics was set');
+      expect(bowerInstance.ui, 'ui was set');
+      expect(bowerInstance.project, 'project was set');
+      expect(bowerInstance.analytics, 'analytics was set');
     });
   });
 
   it('warns when passing args', function() {
     return command.validateAndRun(['moment']).then(function() {
-      assert.ok(false, 'should have rejected with a warning');
+      expect(false, 'should have rejected with a warning');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'The `install` command does not take any arguments. You must use `install:npm` or `install:bower` to install a specific package.');
+      expect(error.message).to.equal('The `install` command does not take any arguments. You must use `install:npm` or `install:bower` to install a specific package.');
     });
   });
 });

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var commandOptions = require('../../factories/command-options');
 var NewCommand     = require('../../../lib/commands/new');
 
@@ -23,55 +23,55 @@ describe('new command', function() {
 
   it('doesn\'t allow to create an application named `test`', function() {
     return command.validateAndRun(['test']).then(function() {
-      assert.ok(false, 'should have rejected with an application name of test');
+      expect(false, 'should have rejected with an application name of test');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `test`.');
+      expect(error.message).to.equal('We currently do not support a name of `test`.');
     });
   });
 
   it('doesn\'t allow to create an application named `ember`', function() {
     return command.validateAndRun(['ember']).then(function() {
-      assert.ok(false, 'should have rejected with an application name of test');
+      expect(false, 'should have rejected with an application name of test');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `ember`.');
+      expect(error.message).to.equal('We currently do not support a name of `ember`.');
     });
   });
 
   it('doesn\'t allow to create an application named `vendor`', function() {
     return command.validateAndRun(['vendor']).then(function() {
-      assert.ok(false, 'should have rejected with an application name of `vendor`');
+      expect(false, 'should have rejected with an application name of `vendor`');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `vendor`.');
+      expect(error.message).to.equal('We currently do not support a name of `vendor`.');
     });
   });
 
   it('doesn\'t allow to create an application with a period in the name', function() {
     return command.validateAndRun(['zomg.awesome']).then(function() {
-      assert.ok(false, 'should have rejected with period in the application name');
+      expect(false, 'should have rejected with period in the application name');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `zomg.awesome`.');
+      expect(error.message).to.equal('We currently do not support a name of `zomg.awesome`.');
     });
   });
 
   it('doesn\'t allow to create an application with a name beginning with a number', function() {
     return command.validateAndRun(['123-my-bagel']).then(function() {
-      assert.ok(false, 'should have rejected with a name beginning with a number');
+      expect(false, 'should have rejected with a name beginning with a number');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'We currently do not support a name of `123-my-bagel`.');
+      expect(error.message).to.equal('We currently do not support a name of `123-my-bagel`.');
     });
   });
 
   it('shows a suggestion messages when the application name is a period', function() {
     return command.validateAndRun(['.']).then(function() {
-      assert.ok(false, 'should have rejected with a name `.`');
+      expect(false, 'should have rejected with a name `.`');
     })
     .catch(function(error) {
-      assert.equal(error.message, 'Trying to generate an application structure on this folder? Use `ember init` instead.');
+      expect(error.message).to.equal('Trying to generate an application structure on this folder? Use `ember init` instead.');
     });
   });
 

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var Task           = require('../../../lib/models/task');
@@ -42,10 +42,10 @@ describe('server command', function() {
       var serveRun = tasks.Serve.prototype.run;
       var ops = serveRun.calledWith[0][0];
 
-      assert.equal(serveRun.called, 1, 'expected run to be called once');
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
-      assert.equal(ops.port,           4000,      'has correct port');
-      assert.equal(ops.liveReloadPort, 35529,     'has correct liveReload port');
+      expect(ops.port).to.equal(4000,            'has correct port');
+      expect(ops.liveReloadPort).to.equal(35529, 'has correct liveReload port');
     });
   });
 
@@ -56,9 +56,9 @@ describe('server command', function() {
       var serveRun = tasks.Serve.prototype.run;
       var ops = serveRun.calledWith[0][0];
 
-      assert.equal(serveRun.called, 1, 'expected run to be called once');
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
-      assert.equal(ops.liveReloadPort, 4001,     'has correct liveReload port');
+      expect(ops.liveReloadPort).to.equal(4001, 'has correct liveReload port');
     });
   });
 
@@ -69,9 +69,9 @@ describe('server command', function() {
       var serveRun = tasks.Serve.prototype.run;
       var ops = serveRun.calledWith[0][0];
 
-      assert.equal(serveRun.called, 1, 'expected run to be called once');
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
-      assert.equal(ops.proxy, 'http://localhost:3000/', 'has correct port');
+      expect(ops.proxy).to.equal('http://localhost:3000/', 'has correct port');
     });
   });
 
@@ -79,14 +79,10 @@ describe('server command', function() {
     return new ServeCommand(options).validateAndRun([
       '--proxy', 'localhost:3000'
     ]).then(function() {
-      assert.ok(
-        false,
-        'it rejects when proxy URL doesn\'t include protocol'
-      );
+      expect(false, 'it rejects when proxy URL doesn\'t include protocol');
     })
     .catch(function(error) {
-      assert.equal(
-        error.message,
+      expect(error.message).to.equal(
         'You need to include a protocol with the proxy URL.\nTry --proxy http://localhost:3000'
       );
     });
@@ -103,7 +99,7 @@ describe('server command', function() {
       var serveRun = tasks.Serve.prototype.run;
       var ops = serveRun.calledWith[0][0];
 
-      assert.equal(ops.baseURL, 'test', 'Uses the correct environment.');
+      expect(ops.baseURL).to.equal('test', 'Uses the correct environment.');
     });
   });
 });

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var commandOptions = require('../../factories/command-options');
 var stub           = require('../../helpers/stub').stub;
 var Promise        = require('../../../lib/ext/promise');
@@ -43,8 +43,8 @@ describe('test command', function() {
 
   it('builds and runs test', function() {
     return new TestCommand(options).validateAndRun([]).then(function() {
-      assert.equal(buildRun.called, 1, 'expected build task to be called once');
-      assert.equal(testRun.called, 1,  'expected test task to be called once');
+      expect(buildRun.called).to.equal(1, 'expected build task to be called once');
+      expect(testRun.called).to.equal(1,  'expected test task to be called once');
     });
   });
 
@@ -53,10 +53,10 @@ describe('test command', function() {
       var buildOptions = buildRun.calledWith[0][0];
       var testOptions  = testRun.calledWith[0][0];
 
-      assert.equal(buildOptions.environment, 'test', 'has correct env');
-      assert.ok(buildOptions.outputPath,     'has outputPath');
-      assert.equal(testOptions.configFile,   './testem.json', 'has config file');
-      assert.equal(testOptions.port,         7357, 'has config file');
+      expect(buildOptions.environment).to.equal('test', 'has correct env');
+      expect(buildOptions.outputPath,                   'has outputPath');
+      expect(testOptions.configFile).to.equal('./testem.json', 'has config file');
+      expect(testOptions.port).to.equal(7357, 'has config file');
     });
   });
 
@@ -64,7 +64,7 @@ describe('test command', function() {
     return new TestCommand(options).validateAndRun(['--config-file=some-random/path.json']).then(function() {
       var testOptions  = testRun.calledWith[0][0];
 
-      assert.equal(testOptions.configFile, 'some-random/path.json');
+      expect(testOptions.configFile).to.equal('some-random/path.json');
     });
   });
 
@@ -72,7 +72,7 @@ describe('test command', function() {
     return new TestCommand(options).validateAndRun(['--port=5678']).then(function() {
       var testOptions  = testRun.calledWith[0][0];
 
-      assert.equal(testOptions.port, 5678);
+      expect(testOptions.port).to.equal(5678);
     });
   });
 
@@ -86,7 +86,7 @@ describe('test command', function() {
       return new TestCommand(options).validateAndRun(['--server']).then(function() {
         var testOptions  = testServerRun.calledWith[0][0];
 
-        assert.equal(testOptions.watcher.verbose, false);
+        expect(testOptions.watcher.verbose, false);
       });
     });
 
@@ -94,7 +94,7 @@ describe('test command', function() {
       return new TestCommand(options).validateAndRun(['--server', '--watcher=polling']).then(function() {
         var testOptions  = testServerRun.calledWith[0][0];
 
-        assert.equal(testOptions.watcher.options.watcher, 'polling');
+        expect(testOptions.watcher.options.watcher).to.equal('polling');
       });
     });
   });
@@ -119,14 +119,14 @@ describe('test command', function() {
     it('should return a valid path', function() {
       var newPath = command._generateCustomConfigFile(runOptions);
 
-      assert.ok(fs.existsSync(newPath));
+      expect(fs.existsSync(newPath));
     });
 
     it('should return the original path if filter or module isn\'t present', function() {
       var originalPath = runOptions.configFile;
       var newPath = command._generateCustomConfigFile(runOptions);
 
-      assert.equal(newPath, originalPath);
+      expect(newPath).to.equal(originalPath);
     });
 
     it('when module and filter option is present the new file path returned exists', function() {
@@ -135,8 +135,8 @@ describe('test command', function() {
       runOptions.filter = 'bar';
       var newPath = command._generateCustomConfigFile(runOptions);
 
-      assert.notEqual(newPath, originalPath);
-      assert.ok(fs.existsSync(newPath), 'file should exist');
+      expect(newPath).to.not.equal(originalPath);
+      expect(fs.existsSync(newPath), 'file should exist');
     });
 
     it('when filter option is present the new file path returned exists', function() {
@@ -144,8 +144,8 @@ describe('test command', function() {
       runOptions.filter = 'foo';
       var newPath = command._generateCustomConfigFile(runOptions);
 
-      assert.notEqual(newPath, originalPath);
-      assert.ok(fs.existsSync(newPath), 'file should exist');
+      expect(newPath).to.not.equal(originalPath);
+      expect(fs.existsSync(newPath), 'file should exist');
     });
 
     it('when module option is present the new file path returned exists', function() {
@@ -153,8 +153,8 @@ describe('test command', function() {
       runOptions.module = 'fooModule';
       var newPath = command._generateCustomConfigFile(runOptions);
 
-      assert.notEqual(newPath, originalPath);
-      assert.ok(fs.existsSync(newPath), 'file should exist');
+      expect(newPath).to.not.equal(originalPath);
+      expect(fs.existsSync(newPath), 'file should exist');
     });
 
     it('when provided filter and module the new file returned contains the both option values in test_page', function() {
@@ -163,14 +163,14 @@ describe('test command', function() {
       var newPath = command._generateCustomConfigFile(runOptions);
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
-      assert.ok(contents['test_page'].indexOf('fooModule') > -1);
-      assert.ok(contents['test_page'].indexOf('bar') > -1);
+      expect(contents['test_page'].indexOf('fooModule') > -1);
+      expect(contents['test_page'].indexOf('bar') > -1);
     });
 
     it('when module and filter option is present uses buildTestPageQueryString for test_page queryString', function() {
       runOptions.filter = 'bar';
       command.buildTestPageQueryString = function(options) {
-        assert.deepEqual(options, runOptions);
+        expect(options).to.deep.equal(runOptions);
 
         return '?blah=zorz';
       };
@@ -179,7 +179,7 @@ describe('test command', function() {
 
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
-      assert.ok(contents['test_page'].indexOf('?blah=zorz') > -1);
+      expect(contents['test_page'].indexOf('?blah=zorz') > -1);
     });
 
     it('new file returned contains the filter option value in test_page', function() {
@@ -187,7 +187,7 @@ describe('test command', function() {
       var newPath = command._generateCustomConfigFile(runOptions);
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
-      assert.ok(contents['test_page'].indexOf('foo') > -1);
+      expect(contents['test_page'].indexOf('foo') > -1);
     });
 
     it('new file returned contains the module option value in test_page', function() {
@@ -195,7 +195,7 @@ describe('test command', function() {
       var newPath = command._generateCustomConfigFile(runOptions);
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
-      assert.ok(contents['test_page'].indexOf('fooModule') > -1);
+      expect(contents['test_page'].indexOf('fooModule') > -1);
     });
   });
 });

--- a/tests/unit/commands/update-test.js
+++ b/tests/unit/commands/update-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert        = require('../../helpers/assert');
+var expect        = require('chai').expect;
 var MockUI        = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
 var Task          = require('../../../lib/models/task');
@@ -51,7 +51,7 @@ describe('update command', function() {
       updateChecker: updateChecker,
       environment: { }
     }).validateAndRun([]).then(function() {
-      assert.include(ui.output, 'You have the latest version of ember-cli');
+      expect(ui.output).to.include('You have the latest version of ember-cli');
     });
   });
 
@@ -72,7 +72,7 @@ describe('update command', function() {
       updateChecker: updateChecker,
       environment: { }
     }).validateAndRun([]).then(function() {
-      assert(updateTaskWasRun, 'update task should have been run');
+      expect(updateTaskWasRun, 'update task should have been run');
     });
   });
 });

--- a/tests/unit/commands/version-test.js
+++ b/tests/unit/commands/version-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var commandOptions = require('../../factories/command-options');
 var VersionCommand = require('../../../lib/commands/version');
 var MockUI         = require('../../helpers/mock-ui');
@@ -29,17 +29,17 @@ describe('version command', function() {
   it('reports node and npm versions', function() {
     return command.validateAndRun().then(function() {
       var lines = ui.output.split(EOL);
-      assert(someLineStartsWith(lines, 'node:'), 'contains the version of node');
-      assert(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
+      expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
+      expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
     });
   });
 
   it('supports a --verbose flag', function() {
     return command.validateAndRun(['--verbose']).then(function() {
       var lines = ui.output.split(EOL);
-      assert(someLineStartsWith(lines, 'node:'), 'contains the version of node');
-      assert(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
-      assert(someLineStartsWith(lines, 'v8:'), 'contains the version of v8');
+      expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
+      expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
+      expect(someLineStartsWith(lines, 'v8:'), 'contains the version of v8');
     });
   });
 

--- a/tests/unit/errors/silent-test.js
+++ b/tests/unit/errors/silent-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
 var SilentError = require('../../../lib/errors/silent');
-var assert      = require('../../helpers/assert');
+var expect      = require('chai').expect;
 
 describe('SilentError', function() {
   var error;
 
   it('should suppress the stack trace by default', function() {
     error = new SilentError();
-    assert(error.suppressStacktrace, 'suppressesStacktrace should be true');
+    expect(error.suppressStacktrace, 'suppressesStacktrace should be true');
   });
 
   describe('with EMBER_VERBOSE_ERRORS set', function() {
@@ -19,13 +19,13 @@ describe('SilentError', function() {
     it('should suppress stack when true', function() {
       process.env.EMBER_VERBOSE_ERRORS = 'true';
       error = new SilentError();
-      assert(!error.suppressStacktrace, 'suppressesStacktrace should be false');
+      expect(!error.suppressStacktrace, 'suppressesStacktrace should be false');
     });
 
     it('shouldn\'t suppress stack when false', function() {
       process.env.EMBER_VERBOSE_ERRORS = 'false';
       error = new SilentError();
-      assert(error.suppressStacktrace, 'suppressesStacktrace should be true');
+      expect(error.suppressStacktrace, 'suppressesStacktrace should be true');
     });
   });
 });

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -5,7 +5,7 @@ var path    = require('path');
 var Project = require('../../../lib/models/project');
 var Addon   = require('../../../lib/models/addon');
 var Promise = require('../../../lib/ext/promise');
-var assert  = require('assert');
+var expect  = require('chai').expect;
 var rimraf  = Promise.denodeify(require('rimraf'));
 var tmp     = require('tmp-sync');
 
@@ -50,16 +50,16 @@ describe('models/addon.js', function() {
       var first = new FirstAddon(project);
       var second = new SecondAddon(project);
 
-      assert.equal(first.treePaths.vendor, 'blazorz');
-      assert.equal(second.treePaths.vendor, 'blammo');
+      expect(first.treePaths.vendor).to.equal('blazorz');
+      expect(second.treePaths.vendor).to.equal('blammo');
     });
 
     it('modifying a treeForMethod does not affect other addons', function() {
       var first = new FirstAddon(project);
       var second = new SecondAddon(project);
 
-      assert.equal(first.treeForMethods.public, 'huzzah!');
-      assert.equal(second.treeForMethods.public, 'boooo');
+      expect(first.treeForMethods.public).to.equal('huzzah!');
+      expect(second.treeForMethods.public).to.equal('boooo');
     });
   });
 
@@ -78,19 +78,19 @@ describe('models/addon.js', function() {
     it('adds .js if not present', function() {
       addon.pkg['ember-addon']['main'] = 'index';
       var resolvedFile = path.basename(Addon.resolvePath(addon));
-      assert.equal(resolvedFile, 'index.js');
+      expect(resolvedFile).to.equal('index.js');
     });
 
     it('doesn\'t add .js if it is .js', function() {
       addon.pkg['ember-addon']['main'] = 'index.js';
       var resolvedFile = path.basename(Addon.resolvePath(addon));
-      assert.equal(resolvedFile, 'index.js');
+      expect(resolvedFile).to.equal('index.js');
     });
 
     it('doesn\'t add .js if it has another extension', function() {
       addon.pkg['ember-addon']['main'] = 'index.coffee';
       var resolvedFile = path.basename(Addon.resolvePath(addon));
-      assert.equal(resolvedFile, 'index.coffee');
+      expect(resolvedFile).to.equal('index.coffee');
     });
   });
 
@@ -109,15 +109,15 @@ describe('models/addon.js', function() {
       });
 
       it('sets it\'s project', function() {
-        assert.equal(addon.project.name, project.name);
+        expect(addon.project.name).to.equal(project.name);
       });
 
       it('sets the root', function() {
-        assert.notEqual(addon.root, undefined);
+        expect(addon.root).to.not.equal(undefined);
       });
 
       it('sets the pkg', function() {
-        assert.notEqual(addon.pkg, undefined);
+        expect(addon.pkg).to.not.equal(undefined);
       });
 
       describe('custom treeFor methods', function() {
@@ -129,7 +129,7 @@ describe('models/addon.js', function() {
           };
 
           addon.treeFor('app');
-          assert(called);
+          expect(called);
         });
 
         it('can define treeForStyles', function() {
@@ -140,7 +140,7 @@ describe('models/addon.js', function() {
           };
 
           addon.treeFor('styles');
-          assert(called);
+          expect(called);
         });
 
         it('can define treeForVendor', function() {
@@ -151,7 +151,7 @@ describe('models/addon.js', function() {
           };
 
           addon.treeFor('vendor');
-          assert(called);
+          expect(called);
         });
 
         it('can define treeForTemplates', function() {
@@ -162,7 +162,7 @@ describe('models/addon.js', function() {
           };
 
           addon.treeFor('templates');
-          assert(called);
+          expect(called);
         });
 
         it('can define treeForPublic', function() {
@@ -173,7 +173,7 @@ describe('models/addon.js', function() {
           };
 
           addon.treeFor('public');
-          assert(called);
+          expect(called);
         });
       });
 
@@ -181,27 +181,27 @@ describe('models/addon.js', function() {
         it('app', function() {
           var tree = addon.treeFor('app');
 
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('styles', function() {
           var tree = addon.treeFor('styles');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('templates', function() {
           var tree = addon.treeFor('templates');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('vendor', function() {
           var tree = addon.treeFor('vendor');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('public', function() {
           var tree = addon.treeFor('public');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
       });
     });
@@ -216,11 +216,11 @@ describe('models/addon.js', function() {
       });
 
       it('sets it\'s project', function() {
-        assert.equal(addon.project.name, project.name);
+        expect(addon.project.name).to.equal(project.name);
       });
 
       it('generates a list of es6 modules to ignore', function() {
-        assert.deepEqual(addon.includedModules(), {
+        expect(addon.includedModules()).to.deep.equal({
           'ember-cli-generated-with-export/controllers/people': ['default'],
           'ember-cli-generated-with-export/mixins/thing': ['default']
         });
@@ -229,7 +229,7 @@ describe('models/addon.js', function() {
       it('generates a list of es6 modules to ignore with custom modulePrefix', function() {
         addon.modulePrefix = 'custom-addon';
 
-        assert.deepEqual(addon.includedModules(), {
+        expect(addon.includedModules()).to.deep.equal({
           'custom-addon/controllers/people': ['default'],
           'custom-addon/mixins/thing': ['default']
         });
@@ -238,32 +238,32 @@ describe('models/addon.js', function() {
       });
 
       it('sets the root', function() {
-        assert.notEqual(addon.root, undefined);
+        expect(addon.root).to.not.equal(undefined);
       });
 
       it('sets the pkg', function() {
-        assert.notEqual(addon.pkg, undefined);
+        expect(addon.pkg).to.not.equal(undefined);
       });
 
       describe('trees for it\'s treePaths', function() {
         it('app', function() {
           var tree = addon.treeFor('app');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('styles', function() {
           var tree = addon.treeFor('styles');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('templates', function() {
           var tree = addon.treeFor('templates');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('vendor', function() {
           var tree = addon.treeFor('vendor');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
 
         it('addon', function() {
@@ -287,7 +287,7 @@ describe('models/addon.js', function() {
           };
           addon.app = app;
           var tree = addon.treeFor('addon');
-          assert.equal(typeof tree.read, 'function');
+          expect(typeof tree.read).to.equal('function');
         });
       });
     });
@@ -295,10 +295,9 @@ describe('models/addon.js', function() {
     it('must define a `name` property', function() {
       var Foo = Addon.extend({ root: 'foo' });
 
-      assert.throws(function() {
+      expect(function() {
         new Foo(project);
-      },
-      /An addon must define a `name` property./ );
+      }).to.throw(/An addon must define a `name` property./);
     });
 
     describe('isDevelopingAddon', function() {
@@ -315,19 +314,19 @@ describe('models/addon.js', function() {
       it('returns true when `EMBER_ADDON_ENV` is set to development', function() {
         process.env.EMBER_ADDON_ENV = 'development';
 
-        assert(addon.isDevelopingAddon());
+        expect(addon.isDevelopingAddon());
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {
         delete process.env.EMBER_ADDON_ENV;
 
-        assert(!addon.isDevelopingAddon());
+        expect(!addon.isDevelopingAddon());
       });
 
       it('returns false when `EMBER_ADDON_ENV` is something other than `development`', function() {
         process.env.EMBER_ADDON_ENV = 'production';
 
-        assert(!addon.isDevelopingAddon());
+        expect(!addon.isDevelopingAddon());
       });
     });
 
@@ -337,7 +336,7 @@ describe('models/addon.js', function() {
 
         var tree = addon.treeGenerator('foo/bar');
 
-        assert.equal(tree, 'foo/bar');
+        expect(tree).to.equal('foo/bar');
       });
 
       it('uses unwatchedTree when not developing the addon itself', function() {
@@ -345,7 +344,7 @@ describe('models/addon.js', function() {
 
         var tree = addon.treeGenerator('foo/bar');
 
-        assert.equal(tree.read(), 'foo/bar');
+        expect(tree.read()).to.equal('foo/bar');
       });
     });
 
@@ -365,7 +364,7 @@ describe('models/addon.js', function() {
       it('returns undefined if the `blueprint` folder does not exist', function() {
         var returnedPath = addon.blueprintsPath();
 
-        assert.equal(returnedPath, undefined);
+        expect(returnedPath).to.equal(undefined);
       });
 
       it('returns blueprint path if the folder exists', function() {
@@ -374,7 +373,7 @@ describe('models/addon.js', function() {
 
         var returnedPath = addon.blueprintsPath();
 
-        assert.equal(returnedPath, blueprintsDir);
+        expect(returnedPath).to.equal(blueprintsDir);
       });
     });
 
@@ -383,7 +382,7 @@ describe('models/addon.js', function() {
         addon.root = path.join(fixturePath, 'no-config');
         var result = addon.config();
 
-        assert.equal(result, undefined);
+        expect(result).to.equal(undefined);
       });
 
       it('returns blueprint path if the folder exists', function() {
@@ -392,7 +391,7 @@ describe('models/addon.js', function() {
 
         addon.config('development', appConfig);
 
-        assert.equal(appConfig.addon, 'with-config');
+        expect(appConfig.addon).to.equal('with-config');
       });
     });
   });

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -5,7 +5,7 @@ var Blueprint         = require('../../../lib/models/blueprint');
 var Task              = require('../../../lib/models/task');
 var MockProject       = require('../../helpers/mock-project');
 var MockUI            = require('../../helpers/mock-ui');
-var assert            = require('assert');
+var expect            = require('chai').expect;
 var path              = require('path');
 var glob              = require('glob');
 var walkSync          = require('walk-sync');
@@ -32,13 +32,6 @@ var basicBlueprintFiles = [
   'test.txt'
 ];
 
-assert.match = function(actual, matcher) {
-  assert(matcher.test(actual), 'expected: ' +
-                                actual +
-                                ' to match ' +
-                                matcher);
-};
-
 describe('Blueprint', function() {
   beforeEach(function() {
     Blueprint.ignoredFiles = defaultIgnoredFiles;
@@ -47,13 +40,13 @@ describe('Blueprint', function() {
   describe('.mapFile', function() {
     it('replaces all occurences of __name__ with module name',function(){
       var path = Blueprint.prototype.mapFile('__name__/__name__-controller.js',{dasherizedModuleName: 'my-blueprint'});
-      assert.equal(path,'my-blueprint/my-blueprint-controller.js');
+      expect(path).to.equal('my-blueprint/my-blueprint-controller.js');
 
       path = Blueprint.prototype.mapFile('__name__/controller.js',{dasherizedModuleName: 'my-blueprint'});
-      assert.equal(path,'my-blueprint/controller.js');
+      expect(path).to.equal('my-blueprint/controller.js');
 
       path = Blueprint.prototype.mapFile('__name__/__name__.js',{dasherizedModuleName: 'my-blueprint'});
-      assert.equal(path,'my-blueprint/my-blueprint.js');
+      expect(path).to.equal('my-blueprint/my-blueprint.js');
     });
     it('accepts locals.fileMap with multiple mappings',function(){
       var locals = {};
@@ -65,10 +58,10 @@ describe('Blueprint', function() {
       };
 
       var path = Blueprint.prototype.mapFile('__name__/__type____plural__.js',locals);
-      assert.equal(path,'user/controller.js');
+      expect(path).to.equal('user/controller.js');
 
       path = Blueprint.prototype.mapFile('__path__/__name__/__type__.js',locals);
-      assert.equal(path,'pods/users/user/controller.js');
+      expect(path).to.equal('pods/users/user/controller.js');
     });
   });
   describe('.fileMapTokens', function() {
@@ -82,7 +75,7 @@ describe('Blueprint', function() {
         };
       };
       var tokens = blueprint._fileMapTokens();
-      assert.equal(tokens.__foo__(), 'foo');
+      expect(tokens.__foo__()).to.equal('foo');
     });
   });
   describe('.generateFileMap', function() {
@@ -104,7 +97,7 @@ describe('Blueprint', function() {
         __test__: 'foo-baz-test'
       };
 
-      assert.deepEqual( fileMap, expected );
+      expect(fileMap).to.deep.equal(expected);
     });
   });
   describe('.lookup', function() {
@@ -112,9 +105,9 @@ describe('Blueprint', function() {
       var expectedClass = require(basicBlueprint);
       var blueprint = Blueprint.lookup(basicBlueprint);
 
-      assert.equal(blueprint.name, 'basic');
-      assert.equal(blueprint.path, basicBlueprint);
-      assert(blueprint instanceof expectedClass);
+      expect(blueprint.name).to.equal('basic');
+      expect(blueprint.path).to.equal(basicBlueprint);
+      expect(blueprint instanceof expectedClass).to.equal(true);
     });
 
     it('finds blueprints within given lookup paths', function() {
@@ -123,9 +116,9 @@ describe('Blueprint', function() {
         paths: [fixtureBlueprints]
       });
 
-      assert.equal(blueprint.name, 'basic');
-      assert.equal(blueprint.path, basicBlueprint);
-      assert(blueprint instanceof expectedClass);
+      expect(blueprint.name).to.equal('basic');
+      expect(blueprint.path).to.equal(basicBlueprint);
+      expect(blueprint instanceof expectedClass).to.equal(true);
     });
 
     it('finds blueprints in the ember-cli package', function() {
@@ -134,9 +127,9 @@ describe('Blueprint', function() {
 
       var blueprint = Blueprint.lookup('app');
 
-      assert.equal(blueprint.name, 'app');
-      assert.equal(blueprint.path, expectedPath);
-      assert(blueprint instanceof expectedClass);
+      expect(blueprint.name).to.equal('app');
+      expect(blueprint.path).to.equal(expectedPath);
+      expect(blueprint instanceof expectedClass).to.equal(true);
     });
 
     it('can instantiate a blueprint that exports an object instead of a constructor', function() {
@@ -144,14 +137,14 @@ describe('Blueprint', function() {
         paths: [fixtureBlueprints]
       });
 
-      assert.equal(blueprint.woot, 'someValueHere');
-      assert(blueprint instanceof Blueprint);
+      expect(blueprint.woot).to.equal('someValueHere');
+      expect(blueprint instanceof Blueprint).to.equal(true);
     });
 
     it('throws an error if no blueprint is found', function() {
-      assert.throws(function() {
+      expect(function() {
         Blueprint.lookup('foo');
-      }, 'Unknown blueprint: foo');
+      }).to.throw('Unknown blueprint: foo');
     });
 
     it('returns undefined if no blueprint is found and ignoredMissing is passed', function() {
@@ -159,7 +152,7 @@ describe('Blueprint', function() {
         ignoreMissing: true
       });
 
-      assert.equal(blueprint, undefined);
+      expect(blueprint).to.equal(undefined);
     });
   });
 
@@ -188,18 +181,18 @@ describe('Blueprint', function() {
         }]
       };
 
-      assert.deepEqual(actual[0], expected[0]);
+      expect(actual[0]).to.deep.equal(expected[0]);
     });
   });
 
   it('exists', function() {
     var blueprint = new Blueprint(basicBlueprint);
-    assert(blueprint);
+    expect(!!blueprint).to.equal(true);
   });
 
   it('derives name from path', function() {
     var blueprint = new Blueprint(basicBlueprint);
-    assert.equal(blueprint.name, 'basic');
+    expect(blueprint.name).to.equal('basic');
   });
 
   describe('basic blueprint installation', function() {
@@ -226,22 +219,22 @@ describe('Blueprint', function() {
     });
 
     it('installs basic files', function() {
-      assert(blueprint);
+      expect(!!blueprint).to.equal(true);
 
       return blueprint.install(options)
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
           var output = ui.output.trim().split(EOL);
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /create.* .ember-cli/);
-          assert.match(output.shift(), /create.* .gitignore/);
-          assert.match(output.shift(), /create.* bar/);
-          assert.match(output.shift(), /create.* foo.txt/);
-          assert.match(output.shift(), /create.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/create.* .ember-cli/);
+          expect(output.shift()).to.match(/create.* .gitignore/);
+          expect(output.shift()).to.match(/create.* bar/);
+          expect(output.shift()).to.match(/create.* foo.txt/);
+          expect(output.shift()).to.match(/create.* test.txt/);
+          expect(output.length).to.equal(0);
 
-          assert.deepEqual(actualFiles, basicBlueprintFiles);
+          expect(actualFiles).to.deep.equal(basicBlueprintFiles);
         });
     });
 
@@ -251,13 +244,13 @@ describe('Blueprint', function() {
           var output = ui.output.trim().split(EOL);
           ui.output = '';
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /create.* \.ember-cli/);
-          assert.match(output.shift(), /create.* \.gitignore/);
-          assert.match(output.shift(), /create.* bar/);
-          assert.match(output.shift(), /create.* foo.txt/);
-          assert.match(output.shift(), /create.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/create.* .ember-cli/);
+          expect(output.shift()).to.match(/create.* .gitignore/);
+          expect(output.shift()).to.match(/create.* bar/);
+          expect(output.shift()).to.match(/create.* foo.txt/);
+          expect(output.shift()).to.match(/create.* test.txt/);
+          expect(output.length).to.equal(0);
 
           return blueprint.install(options);
         })
@@ -265,15 +258,15 @@ describe('Blueprint', function() {
           var actualFiles = walkSync(tmpdir).sort();
           var output = ui.output.trim().split(EOL);
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /identical.* \.ember-cli/);
-          assert.match(output.shift(), /identical.* \.gitignore/);
-          assert.match(output.shift(), /identical.* bar/);
-          assert.match(output.shift(), /identical.* foo.txt/);
-          assert.match(output.shift(), /identical.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/identical.* .ember-cli/);
+          expect(output.shift()).to.match(/identical.* .gitignore/);
+          expect(output.shift()).to.match(/identical.* bar/);
+          expect(output.shift()).to.match(/identical.* foo.txt/);
+          expect(output.shift()).to.match(/identical.* test.txt/);
+          expect(output.length).to.equal(0);
 
-          assert.deepEqual(actualFiles, basicBlueprintFiles);
+          expect(actualFiles).to.deep.equal(basicBlueprintFiles);
         });
     });
 
@@ -283,13 +276,13 @@ describe('Blueprint', function() {
           var output = ui.output.trim().split(EOL);
           ui.output = '';
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /create.* \.ember-cli/);
-          assert.match(output.shift(), /create.* \.gitignore/);
-          assert.match(output.shift(), /create.* bar/);
-          assert.match(output.shift(), /create.* foo.txt/);
-          assert.match(output.shift(), /create.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/create.* .ember-cli/);
+          expect(output.shift()).to.match(/create.* .gitignore/);
+          expect(output.shift()).to.match(/create.* bar/);
+          expect(output.shift()).to.match(/create.* foo.txt/);
+          expect(output.shift()).to.match(/create.* test.txt/);
+          expect(output.length).to.equal(0);
           var blueprintNew = new Blueprint(basicNewBlueprint);
 
           ui.waitForPrompt().then(function(){
@@ -306,18 +299,18 @@ describe('Blueprint', function() {
           // Prompts contain \n EOL
           // Split output on \n since it will have the same affect as spliting on OS specific EOL
           var output = ui.output.trim().split('\n');
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /Overwrite.*foo.*\?/); // Prompt
-          assert.match(output.shift(), /Overwrite.*foo.*No, skip/);
-          assert.match(output.shift(), /Overwrite.*test.*\?/); // Prompt
-          assert.match(output.shift(), /Overwrite.*test.*Yes, overwrite/);
-          assert.match(output.shift(), /identical.* \.ember-cli/);
-          assert.match(output.shift(), /identical.* \.gitignore/);
-          assert.match(output.shift(), /skip.* foo.txt/);
-          assert.match(output.shift(), /overwrite.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/Overwrite.*foo.*\?/); // Prompt
+          expect(output.shift()).to.match(/Overwrite.*foo.*No, skip/);
+          expect(output.shift()).to.match(/Overwrite.*test.*\?/); // Prompt
+          expect(output.shift()).to.match(/Overwrite.*test.*Yes, overwrite/);
+          expect(output.shift()).to.match(/identical.* \.ember-cli/);
+          expect(output.shift()).to.match(/identical.* \.gitignore/);
+          expect(output.shift()).to.match(/skip.* foo.txt/);
+          expect(output.shift()).to.match(/overwrite.* test.txt/);
+          expect(output.length).to.equal(0);
 
-          assert.deepEqual(actualFiles, basicBlueprintFiles);
+          expect(actualFiles).to.deep.equal(basicBlueprintFiles);
         });
     });
 
@@ -334,11 +327,11 @@ describe('Blueprint', function() {
             }).sort();
           var output = ui.output.trim().split(EOL);
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /create.* foo.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/create.* foo.txt/);
+          expect(output.length).to.equal(0);
 
-          assert.deepEqual(actualFiles, globFiles);
+          expect(actualFiles).to.deep.equal(globFiles);
         });
     });
 
@@ -355,12 +348,12 @@ describe('Blueprint', function() {
             }).sort();
           var output = ui.output.trim().split(EOL);
 
-          assert.match(output.shift(), /^installing/);
-          assert.match(output.shift(), /create.* foo.txt/);
-          assert.match(output.shift(), /create.* test.txt/);
-          assert.equal(output.length, 0);
+          expect(output.shift()).to.match(/^installing/);
+          expect(output.shift()).to.match(/create.* foo.txt/);
+          expect(output.shift()).to.match(/create.* test.txt/);
+          expect(output.length).to.equal(0);
 
-          assert.deepEqual(actualFiles, globFiles);
+          expect(actualFiles).to.deep.equal(globFiles);
         });
     });
 
@@ -375,13 +368,13 @@ describe('Blueprint', function() {
             var output = ui.output.trim().split(EOL);
             ui.output = '';
 
-            assert.match(output.shift(), /^installing/);
-            assert.match(output.shift(), /create.* \.ember-cli/);
-            assert.match(output.shift(), /create.* \.gitignore/);
-            assert.match(output.shift(), /create.* bar/);
-            assert.match(output.shift(), /create.* foo.txt/);
-            assert.match(output.shift(), /create.* test.txt/);
-            assert.equal(output.length, 0);
+            expect(output.shift()).to.match(/^installing/);
+            expect(output.shift()).to.match(/create.* .ember-cli/);
+            expect(output.shift()).to.match(/create.* .gitignore/);
+            expect(output.shift()).to.match(/create.* bar/);
+            expect(output.shift()).to.match(/create.* foo.txt/);
+            expect(output.shift()).to.match(/create.* test.txt/);
+            expect(output.length).to.equal(0);
 
             var blueprintNew = new Blueprint(basicNewBlueprint);
 
@@ -401,43 +394,42 @@ describe('Blueprint', function() {
             // Prompts contain \n EOL
             // Split output on \n since it will have the same affect as spliting on OS specific EOL
             var output = ui.output.trim().split('\n');
-            assert.match(output.shift(), /^installing/);
-            assert.match(output.shift(), /Overwrite.*test.*\?/); // Prompt
-            assert.match(output.shift(), /Overwrite.*test.*No, skip/);
-            assert.match(output.shift(), /identical.* \.ember-cli/);
-            assert.match(output.shift(), /identical.* \.gitignore/);
-            assert.match(output.shift(), /skip.* test.txt/);
-            assert.equal(output.length, 0);
+            expect(output.shift()).to.match(/^installing/);
+            expect(output.shift()).to.match(/Overwrite.*test.*\?/); // Prompt
+            expect(output.shift()).to.match(/Overwrite.*test.*No, skip/);
+            expect(output.shift()).to.match(/identical.* \.ember-cli/);
+            expect(output.shift()).to.match(/identical.* \.gitignore/);
+            expect(output.shift()).to.match(/skip.* test.txt/);
+            expect(output.length).to.equal(0);
 
-            assert.deepEqual(actualFiles, basicBlueprintFiles);
+            expect(actualFiles).to.deep.equal(basicBlueprintFiles);
           });
       });
     });
 
     it('throws error when there is a trailing forward slash in entityName', function(){
       options.entity = { name: 'foo/' };
-      assert.throws(function(){
+      expect(function() {
         blueprint.install(options);
-      }, /You specified "foo\/", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
+      }).to.throw(/You specified "foo\/", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
 
       options.entity = { name: 'foo\\' };
-      assert.throws(function(){
+      expect(function() {
         blueprint.install(options);
-      }, /You specified "foo\\", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
+      }).to.throw(/You specified "foo\\", but you can't use a trailing slash as an entity name with generators. Please re-run the command with "foo"./);
 
       options.entity = { name: 'foo' };
-      assert.doesNotThrow(function(){
+      expect(function() {
         blueprint.install(options);
-      });
+      }).not.to.throw();
     });
 
     it('throws error when an entityName is not provided', function(){
       options.entity = { };
-      assert.throws(function(){
+      expect(function() {
         blueprint.install(options);
-      }, SilentError, /'The `ember generate` command requires an entity name to be specified./);
+      }).to.throw(SilentError, /The `ember generate` command requires an entity name to be specified./);
     });
-
 
     it('calls normalizeEntityName hook during install', function(done){
       blueprint.normalizeEntityName = function(){ done(); };
@@ -453,14 +445,14 @@ describe('Blueprint', function() {
           .then(function() {
             var actualFiles = walkSync(tmpdir).sort();
 
-            assert.deepEqual(actualFiles, basicBlueprintFiles);
+            expect(actualFiles).to.deep.equal(basicBlueprintFiles);
           });
     });
 
     it('calls normalizeEntityName before locals hook is called', function(done) {
       blueprint.normalizeEntityName = function(){ return 'foo'; };
       blueprint.locals = function(options) {
-        assert.equal(options.entity.name, 'foo');
+        expect(options.entity.name).to.equal('foo');
         done();
       };
       options.entity = { name: 'bar' };
@@ -485,7 +477,7 @@ describe('Blueprint', function() {
 
     it('passes a packages array for addPackagesToProject', function() {
       blueprint.addPackagesToProject = function(packages) {
-        assert.deepEqual(packages, [{name: 'foo-bar'}]);
+        expect(packages).to.deep.equal([{name: 'foo-bar'}]);
       };
 
       blueprint.addPackageToProject('foo-bar');
@@ -493,7 +485,7 @@ describe('Blueprint', function() {
 
     it('passes a packages array with target for addPackagesToProject', function() {
       blueprint.addPackagesToProject = function(packages) {
-        assert.deepEqual(packages, [{name: 'foo-bar', target: '^123.1.12'}]);
+        expect(packages).to.deep.equal([{name: 'foo-bar', target: '^123.1.12'}]);
       };
 
       blueprint.addPackageToProject('foo-bar', '^123.1.12');
@@ -530,7 +522,7 @@ describe('Blueprint', function() {
 
       blueprint.addPackagesToProject([{name: 'foo-bar'}]);
 
-      assert.equal(taskNameLookedUp, 'npm-install');
+      expect(taskNameLookedUp).to.equal('npm-install');
     });
 
     it('calls the task with package names', function() {
@@ -547,7 +539,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo'}
       ]);
 
-      assert.deepEqual(packages, ['foo-bar', 'bar-foo']);
+      expect(packages).to.deep.equal(['foo-bar', 'bar-foo']);
     });
 
     it('calls the task with package names and versions', function() {
@@ -564,7 +556,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo', target: '0.0.7'}
       ]);
 
-      assert.deepEqual(packages, ['foo-bar@^123.1.12', 'bar-foo@0.0.7']);
+      expect(packages).to.deep.equal(['foo-bar@^123.1.12', 'bar-foo@0.0.7']);
     });
 
     it('writes information to the ui log for a single package', function() {
@@ -577,7 +569,7 @@ describe('Blueprint', function() {
 
       var output = ui.output.trim();
 
-      assert.match(output, /install package.*foo-bar/);
+      expect(output).to.match(/install package.*foo-bar/);
     });
 
     it('writes information to the ui log for multiple packages', function() {
@@ -591,7 +583,7 @@ describe('Blueprint', function() {
 
       var output = ui.output.trim();
 
-      assert.match(output, /install packages.*foo-bar, bar-foo/);
+      expect(output).to.match(/install packages.*foo-bar, bar-foo/);
     });
 
     it('does not error if ui is not present', function() {
@@ -604,7 +596,7 @@ describe('Blueprint', function() {
 
       var output = ui.output.trim();
 
-      assert(!output.match(/install package.*foo-bar/));
+      expect(output).to.not.match(/install package.*foo-bar/);
     });
 
     it('runs task with --save-dev', function() {
@@ -621,7 +613,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo', target: '0.0.7'}
       ]);
 
-      assert(saveDev);
+      expect(!!saveDev).to.equal(true);
     });
 
     it('does not use verbose mode with the task', function() {
@@ -638,7 +630,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo', target: '0.0.7'}
       ]);
 
-      assert(!verbose);
+      expect(verbose).to.equal(false);
     });
   });
 
@@ -667,7 +659,7 @@ describe('Blueprint', function() {
 
     it('passes a packages array for addBowerPackagesToProject', function() {
       blueprint.addBowerPackagesToProject = function(packages) {
-        assert.deepEqual(packages, [{name: 'foo-bar'}]);
+        expect(packages).to.deep.equal([{name: 'foo-bar'}]);
       };
 
       blueprint.addBowerPackageToProject('foo-bar');
@@ -675,7 +667,7 @@ describe('Blueprint', function() {
 
     it('passes a packages array with target for addBowerPackagesToProject', function() {
       blueprint.addBowerPackagesToProject = function(packages) {
-        assert.deepEqual(packages, [{name: 'foo-bar', target: '1.0.0'}]);
+        expect(packages).to.deep.equal([{name: 'foo-bar', target: '1.0.0'}]);
       };
 
       blueprint.addBowerPackageToProject('foo-bar', '1.0.0');
@@ -711,7 +703,7 @@ describe('Blueprint', function() {
       });
       blueprint.addBowerPackagesToProject([{name: 'foo-bar'}]);
 
-      assert.equal(taskNameLookedUp, 'bower-install');
+      expect(taskNameLookedUp).to.equal('bower-install');
     });
 
     it('calls the task with the package names', function() {
@@ -728,7 +720,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo'}
       ]);
 
-      assert.deepEqual(packages, ['foo-bar', 'bar-foo']);
+      expect(packages).to.deep.equal(['foo-bar', 'bar-foo']);
     });
 
     it('uses the provided target (version, range, sha, etc)', function() {
@@ -745,7 +737,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo', target: '0.7.0'}
       ]);
 
-      assert.deepEqual(packages, ['foo-bar#~1.0.0', 'bar-foo#0.7.0']);
+      expect(packages).to.deep.equal(['foo-bar#~1.0.0', 'bar-foo#0.7.0']);
     });
 
     it('uses uses verbose mode with the task', function() {
@@ -762,7 +754,7 @@ describe('Blueprint', function() {
         {name: 'bar-foo', target: '0.7.0'}
       ]);
 
-      assert(verbose);
+      expect(verbose).to.equal(true);
     });
   });
 
@@ -797,10 +789,10 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert(contents.indexOf(toInsert) > -1, 'contents were inserted');
-          assert.equal(result.originalContents, '', 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
-          assert.equal(contents, result.contents, 'returned object should contain contents');
+          expect(contents.indexOf(toInsert) > -1).to.equal(true, 'contents were inserted');
+          expect(result.originalContents).to.equal('', 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
+          expect(contents).to.equal(result.contents, 'returned object should contain contents');
         });
     });
 
@@ -815,9 +807,9 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, originalContent + toInsert, 'inserted contents should be appended to original');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
+          expect(contents).to.equal(originalContent + toInsert, 'inserted contents should be appended to original');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         });
     });
 
@@ -831,8 +823,8 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, toInsert, 'contents should be unchanged');
-          assert(!result.inserted, 'inserted should indicate that the file was not modified');
+          expect(contents).to.equal(toInsert, 'contents should be unchanged');
+          expect(result.inserted).to.equal(false, 'inserted should indicate that the file was not modified');
         });
     });
 
@@ -846,8 +838,8 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, toInsert + toInsert, 'contents should be unchanged');
-          assert(result.inserted, 'inserted should indicate that the file was not modified');
+          expect(contents).to.equal(toInsert + toInsert, 'contents should be unchanged');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was not modified');
         });
     });
 
@@ -865,10 +857,10 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, [line1, line2, toInsert, line3].join(EOL),
+          expect(contents).to.equal([line1, line2, toInsert, line3].join(EOL),
                        'inserted contents should be inserted after the `after` value');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         });
     });
 
@@ -886,10 +878,10 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, [line1, line2, toInsert, line2, line3].join(EOL),
+          expect(contents).to.equal([line1, line2, toInsert, line2, line3].join(EOL),
                        'inserted contents should be inserted after the `after` value');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         });
     });
 
@@ -907,10 +899,10 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, [line1, toInsert, line2, line3].join(EOL),
+          expect(contents).to.equal([line1, toInsert, line2, line3].join(EOL),
                        'inserted contents should be inserted before the `before` value');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         });
     });
 
@@ -928,10 +920,10 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, [line1, toInsert, line2, line2, line3].join(EOL),
+          expect(contents).to.equal([line1, toInsert, line2, line2, line3].join(EOL),
                        'inserted contents should be inserted after the `after` value');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(result.inserted, 'inserted should indicate that the file was modified');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         });
     });
 
@@ -947,9 +939,9 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, originalContent, 'original content is unchanged');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(!result.inserted, 'inserted should indicate that the file was not modified');
+          expect(contents).to.equal(originalContent, 'original content is unchanged');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(false, 'inserted should indicate that the file was not modified');
         });
     });
 
@@ -964,9 +956,9 @@ describe('Blueprint', function() {
         .then(function(result) {
           var contents = fs.readFileSync(path.join(project.root, filename), { encoding: 'utf8' });
 
-          assert.equal(contents, originalContent, 'original content is unchanged');
-          assert.equal(result.originalContents, originalContent, 'returned object should contain original contents');
-          assert(!result.inserted, 'inserted should indicate that the file was not modified');
+          expect(contents).to.equal(originalContent, 'original content is unchanged');
+          expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+          expect(result.inserted).to.equal(false, 'inserted should indicate that the file was not modified');
         });
     });
 
@@ -1002,13 +994,13 @@ describe('Blueprint', function() {
     it('can lookup other Blueprints from the project blueprintLookupPaths', function() {
       var result = blueprint.lookupBlueprint('basic_2');
 
-      assert.equal(result.description, 'Another basic blueprint');
+      expect(result.description).to.equal('Another basic blueprint');
     });
 
     it('can find internal blueprints', function() {
       var result = blueprint.lookupBlueprint('controller');
 
-      assert.equal(result.description, 'Generates a controller.');
+      expect(result.description).to.equal('Generates a controller.');
     });
   });
 });

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -6,7 +6,7 @@ var Builder         = require('../../../lib/models/builder');
 var BuildCommand    = require('../../../lib/commands/build');
 var commandOptions  = require('../../factories/command-options');
 var touch           = require('../../helpers/file-utils').touch;
-var assert          = require('assert');
+var expect          = require('chai').expect;
 var Promise         = require('../../../lib/ext/promise');
 var stub            = require('../../helpers/stub').stub;
 var MockProject     = require('../../helpers/mock-project');
@@ -40,7 +40,7 @@ describe('models/builder.js', function() {
 
       return builder.copyToOutputPath('tests/fixtures/blueprints/basic_2')
         .then(function() {
-          assert(fs.existsSync(path.join(builder.outputPath, 'files', 'foo.txt')));
+          expect(fs.existsSync(path.join(builder.outputPath, 'files', 'foo.txt'))).to.equal(true);
         });
     });
   });
@@ -65,8 +65,8 @@ describe('models/builder.js', function() {
 
     return builder.clearOutputPath()
       .then(function() {
-        assert(!fs.existsSync(firstFile));
-        assert(!fs.existsSync(secondFile));
+        expect(fs.existsSync(firstFile)).to.equal(false);
+        expect(fs.existsSync(secondFile)).to.equal(false);
       });
   });
 
@@ -93,7 +93,7 @@ describe('models/builder.js', function() {
 
       return builder.clearOutputPath()
         .catch(function(error) {
-          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
+          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
 
@@ -104,7 +104,7 @@ describe('models/builder.js', function() {
 
       return builder.clearOutputPath()
         .catch(function(error) {
-          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
+          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
 
@@ -115,7 +115,7 @@ describe('models/builder.js', function() {
 
       return builder.clearOutputPath()
         .catch(function(error) {
-          assert.equal(error.message, 'Using a build destination path of `' + outputPath + '` is not supported.');
+          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
         });
     });
   });
@@ -168,7 +168,7 @@ describe('models/builder.js', function() {
       var preBuild = stub(addon, 'preBuild', Promise.resolve());
 
       return builder.build().then(function() {
-        assert.equal(preBuild.called, 1, 'expected preBuild to be called');
+        expect(preBuild.called).to.equal(1, 'expected preBuild to be called');
       });
     });
 
@@ -176,14 +176,14 @@ describe('models/builder.js', function() {
       var postBuild = stub(addon, 'postBuild');
 
       return builder.build().then(function() {
-        assert.equal(postBuild.called, 1, 'expected postBuild to be called');
-        assert.equal(postBuild.calledWith[0][0], buildResults, 'expected postBuild to be called with the results');
+        expect(postBuild.called).to.equal(1, 'expected postBuild to be called');
+        expect(postBuild.calledWith[0][0]).to.equal(buildResults, 'expected postBuild to be called with the results');
       });
     });
 
     it('hooks are called in the right order', function() {
       return builder.build().then(function() {
-        assert.deepEqual(hooksCalled, ['preBuild', 'build', 'postBuild']);
+        expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'postBuild']);
       });
     });
 
@@ -202,9 +202,9 @@ describe('models/builder.js', function() {
       };
 
       return builder.build().then(function() {
-        assert(false, 'should not succeed');
+        expect(false, 'should not succeed');
       }).catch(function() {
-        assert.equal(receivedBuildError, thrownBuildError);
+        expect(receivedBuildError).to.equal(thrownBuildError);
       });
     });
 
@@ -216,9 +216,9 @@ describe('models/builder.js', function() {
       };
 
       return builder.build().then(function() {
-        assert(false, 'should not succeed');
+        expect(false, 'should not succeed');
       }).catch(function() {
-        assert.deepEqual(hooksCalled, ['preBuild', 'buildError']);
+        expect(hooksCalled).to.deep.equal(['preBuild', 'buildError']);
       });
     });
 
@@ -230,9 +230,9 @@ describe('models/builder.js', function() {
       };
 
       return builder.build().then(function() {
-        assert(false, 'should not succeed');
+        expect(false, 'should not succeed');
       }).catch(function() {
-        assert.deepEqual(hooksCalled, ['preBuild', 'build', 'buildError']);
+        expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'buildError']);
       });
     });
 
@@ -244,9 +244,9 @@ describe('models/builder.js', function() {
       };
 
       return builder.build().then(function() {
-        assert(false, 'should not succeed');
+        expect(false, 'should not succeed');
       }).catch(function() {
-        assert.deepEqual(hooksCalled, ['preBuild', 'build', 'postBuild', 'buildError']);
+        expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'postBuild', 'buildError']);
       });
     });
   });

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert    = require('../../helpers/assert');
+var expect    = require('chai').expect;
 var MockUI    = require('../../helpers/mock-ui');
 var FileInfo  = require('../../../lib/models/file-info');
 var path      = require('path');
@@ -48,7 +48,7 @@ describe('Unit - FileInfo', function(){
     var fileInfo = new FileInfo(validOptions);
 
     return fileInfo.render().then(function(output){
-      assert.equal(output.trim(), 'Howdy Billy',
+      expect(output.trim()).to.equal('Howdy Billy',
         'expects the template to have been run');
     });
   });
@@ -61,8 +61,7 @@ describe('Unit - FileInfo', function(){
     var fileInfo = new FileInfo(validOptions);
 
     return fileInfo.render().then(function(output){
-      assert(output,
-        'expects the file to be processed without error');
+      expect(!!output, 'expects the file to be processed without error').to.equal(true);
     });
   });
 
@@ -74,13 +73,13 @@ describe('Unit - FileInfo', function(){
       return fileInfo.displayDiff();
     }).then(function(){
       var output = ui.output.trim().split(EOL);
-      assert.equal(output.shift(), 'Index: ' + testOutputPath);
-      assert.match(output.shift(), /=+/);
-      assert.match(output.shift(), /---/);
-      assert.match(output.shift(), /\+{3}/);
-      assert.match(output.shift(), /.*/);
-      assert.match(output.shift(), /\+Howdy Billy/);
-      assert.match(output.shift(), /-Something Old/);
+      expect(output.shift()).to.equal('Index: ' + testOutputPath);
+      expect(output.shift()).to.match(/=+/);
+      expect(output.shift()).to.match(/---/);
+      expect(output.shift()).to.match(/\+{3}/);
+      expect(output.shift()).to.match(/.*/);
+      expect(output.shift()).to.match(/\+Howdy Billy/);
+      expect(output.shift()).to.match(/-Something Old/);
     });
   });
 
@@ -93,8 +92,8 @@ describe('Unit - FileInfo', function(){
 
     return fileInfo.confirmOverwrite().then(function(action){
       var output = ui.output.trim().split(EOL);
-      assert.match(output.shift(), /Overwrite.*\?/);
-      assert.equal(action, 'overwrite');
+      expect(output.shift()).to.match(/Overwrite.*\?/);
+      expect(action).to.equal('overwrite');
     });
   });
 
@@ -107,8 +106,8 @@ describe('Unit - FileInfo', function(){
 
     return fileInfo.confirmOverwrite().then(function(action){
       var output = ui.output.trim().split(EOL);
-      assert.match(output.shift(), /Overwrite.*\?/);
-      assert.equal(action, 'skip');
+      expect(output.shift()).to.match(/Overwrite.*\?/);
+      expect(action).to.equal('skip');
     });
   });
 
@@ -121,8 +120,8 @@ describe('Unit - FileInfo', function(){
 
     return fileInfo.confirmOverwrite().then(function(action){
       var output = ui.output.trim().split(EOL);
-      assert.match(output.shift(), /Overwrite.*\?/);
-      assert.equal(action, 'diff');
+      expect(output.shift()).to.match(/Overwrite.*\?/);
+      expect(action).to.equal('diff');
     });
   });
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -6,7 +6,7 @@ var Addon   = require('../../../lib/models/addon');
 var stub    = require('../../helpers/stub').stub;
 var tmp     = require('../../helpers/tmp');
 var touch   = require('../../helpers/file-utils').touch;
-var assert  = require('../../helpers/assert');
+var expect  = require('chai').expect;
 
 var emberCLIVersion = require('../../../lib/utilities/ember-cli-version');
 
@@ -39,7 +39,7 @@ describe('models/project.js', function() {
 
     it('config() finds and requires config/environment', function() {
       project.config('development');
-      assert.equal(called, true);
+      expect(called).to.equal(true);
     });
 
     it('configPath() returns tests/dummy/config/environment', function() {
@@ -51,7 +51,7 @@ describe('models/project.js', function() {
 
       var expected = path.normalize('tests/dummy/config/environment');
 
-      assert.equal(project.configPath(), expected);
+      expect(project.configPath()).to.equal(expected);
     });
 
     it('calls getAddonsConfig', function() {
@@ -64,7 +64,7 @@ describe('models/project.js', function() {
       };
 
       project.config('development');
-      assert.equal(addonConfigCalled, true);
+      expect(addonConfigCalled).to.equal(true);
     });
 
     it('returns getAddonsConfig result when configPath is not present', function() {
@@ -79,7 +79,7 @@ describe('models/project.js', function() {
           };
 
           var actual = project.config('development');
-          assert.deepEqual(actual, expected);
+          expect(actual).to.deep.equal(expected);
         });
     });
 
@@ -116,7 +116,7 @@ describe('models/project.js', function() {
         };
 
         var actual = project.config('development');
-        assert.deepEqual(actual, expected);
+        expect(actual).to.deep.equal(expected);
       });
 
       it('getAddonsConfig does NOT override project config', function() {
@@ -132,7 +132,7 @@ describe('models/project.js', function() {
         addon1Config.foo = 'NO!!!!!!';
 
         var actual = project.config('development');
-        assert.deepEqual(actual, expected);
+        expect(actual).to.deep.equal(expected);
       });
     });
   });
@@ -159,7 +159,7 @@ describe('models/project.js', function() {
         'something-else': 'latest'
       };
 
-      assert.deepEqual(project.dependencies(), expected);
+      expect(project.dependencies()).to.deep.equal(expected);
     });
 
     it('returns a listing of all dependencies in the projects bower.json', function() {
@@ -178,7 +178,7 @@ describe('models/project.js', function() {
         'qunit': '~1.15.0'
       };
 
-      assert.deepEqual(project.bowerDependencies(), expected);
+      expect(project.bowerDependencies()).to.deep.equal(expected);
     });
 
     it('returns a listing of all ember-cli-addons', function() {
@@ -192,31 +192,31 @@ describe('models/project.js', function() {
       ];
 
       project.buildAddonPackages();
-      assert.deepEqual(Object.keys(project.addonPackages), expected);
+      expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
     });
 
     it('returns an instance of the addon', function() {
       var addons = project.addons;
 
-      assert.equal(addons[6].name, 'Ember Non Root Addon');
+      expect(addons[6].name).to.equal('Ember Non Root Addon');
     });
 
     it('addons get passed the project instance', function() {
       var addons = project.addons;
 
-      assert.equal(addons[1].project, project);
+      expect(addons[1].project).to.equal(project);
     });
 
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       var addons = project.addons;
 
-      assert.equal(addons[8].name, 'Ember Random Addon');
+      expect(addons[8].name).to.equal('Ember Random Addon');
     });
 
     it('returns the default blueprints path', function() {
       var expected = project.root + path.normalize('/blueprints');
 
-      assert.equal(project.localBlueprintLookupPath(), expected);
+      expect(project.localBlueprintLookupPath()).to.equal(expected);
     });
 
     it('returns a listing of all addon blueprints paths ordered by last loaded', function() {
@@ -229,7 +229,7 @@ describe('models/project.js', function() {
       // the first found addon blueprint should be the last one defined
       var expected = loadedBlueprintPaths.reverse();
 
-      assert.deepEqual(project.addonBlueprintLookupPaths(), expected);
+      expect(project.addonBlueprintLookupPaths()).to.deep.equal(expected);
     });
 
     it('returns a listing of all blueprints paths', function() {
@@ -240,7 +240,7 @@ describe('models/project.js', function() {
         project.root + path.normalize('/node_modules/ember-before-blueprint-addon/blueprints')
       ];
 
-      assert.deepEqual(project.blueprintLookupPaths(), expected);
+      expect(project.blueprintLookupPaths()).to.deep.equal(expected);
     });
 
     it('returns an empty list of blueprint paths if outside a project', function() {
@@ -248,21 +248,21 @@ describe('models/project.js', function() {
         return false;
       };
 
-      assert.deepEqual(project.blueprintLookupPaths(), []);
+      expect(project.blueprintLookupPaths()).to.deep.equal([]);
     });
 
     it('returns an instance of an addon with an object export', function() {
       var addons = project.addons;
 
-      assert.ok(addons[4] instanceof Addon);
-      assert.equal(addons[4].name, 'Ember CLI Generated with export');
+      expect(addons[4] instanceof Addon).to.equal(true);
+      expect(addons[4].name).to.equal('Ember CLI Generated with export');
     });
 
     it('returns an instance of a generated addon with no export', function() {
       var addons = project.addons;
 
-      assert.ok(addons[5] instanceof Addon);
-      assert.equal(addons[5].name, '(generated ember-generated-no-export-addon addon)');
+      expect(addons[5] instanceof Addon).to.equal(true);
+      expect(addons[5].name).to.equal('(generated ember-generated-no-export-addon addon)');
     });
 
     it('adds the project itself if it is an addon', function() {
@@ -278,7 +278,7 @@ describe('models/project.js', function() {
 
       project.buildAddonPackages();
 
-      assert.ok(added);
+      expect(added);
     });
 
 
@@ -304,15 +304,15 @@ describe('models/project.js', function() {
     });
 
     it('sets _addonsInitialized to false', function() {
-      assert.equal(project._addonsInitialized, false);
+      expect(project._addonsInitialized).to.equal(false);
     });
 
     it('reloads the package', function() {
-      assert(Project.prototype.reloadPkg.called, 'reloadPkg was called');
+      expect(Project.prototype.reloadPkg.called, 'reloadPkg was called');
     });
 
     it('initializes the addons', function() {
-      assert(Project.prototype.initializeAddons.called, 'initialize addons was called');
+      expect(Project.prototype.initializeAddons.called, 'initialize addons was called');
     });
   });
 
@@ -334,13 +334,13 @@ describe('models/project.js', function() {
     it('reloads the package from disk', function() {
       project.reloadPkg();
 
-      assert.notDeepEqual(oldPkg, project.pkg);
+      expect(oldPkg).to.not.deep.equal(project.pkg);
     });
   });
 
   describe('emberCLIVersion', function() {
     it('should return the same value as the utlity function', function() {
-      assert.equal(project.emberCLIVersion(), emberCLIVersion());
+      expect(project.emberCLIVersion()).to.equal(emberCLIVersion());
     });
   });
 
@@ -357,7 +357,7 @@ describe('models/project.js', function() {
         keywords: [ 'ember-addon' ]
       };
 
-      assert.equal(project.isEmberCLIAddon(), true);
+      expect(project.isEmberCLIAddon()).to.equal(true);
     });
 
     it('should return false if `ember-addon` is not included in keywords', function() {
@@ -365,7 +365,7 @@ describe('models/project.js', function() {
         keywords: [ ]
       };
 
-      assert.equal(project.isEmberCLIAddon(), false);
+      expect(project.isEmberCLIAddon()).to.equal(false);
     });
   });
 
@@ -391,52 +391,52 @@ describe('models/project.js', function() {
 
     it('should call initialize addons', function() {
       project.findAddonByName('foo');
-      assert.ok(project.initializeAddons.called, 'should have called initializeAddons');
+      expect(project.initializeAddons.called, 'should have called initializeAddons');
     });
 
     it('should return the foo addon from name', function() {
       var addon = project.findAddonByName('foo');
-      assert.equal(addon.name, 'foo', 'should have found the foo addon');
+      expect(addon.name).to.equal('foo', 'should have found the foo addon');
     });
 
     it('should return the bar-pkg addon from package name', function() {
       var addon = project.findAddonByName('bar-pkg');
-      assert.equal(addon.pkg.name, 'bar-pkg', 'should have found the bar-pkg addon');
+      expect(addon.pkg.name).to.equal('bar-pkg', 'should have found the bar-pkg addon');
     });
 
     it('should return undefined if adddon doesn\'t exist', function() {
       var addon = project.findAddonByName('not-an-addon');
-      assert.equal(addon, undefined, 'not found addon should be undefined');
+      expect(addon).to.equal(undefined, 'not found addon should be undefined');
     });
   });
 
   describe('bowerDirectory', function() {
     it('should be initialized in constructor', function() {
-      assert.equal(project.bowerDirectory, 'bower_components');
+      expect(project.bowerDirectory).to.equal('bower_components');
     });
 
     it('should be set to directory property in .bowerrc', function() {
       projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/bowerrc-with-directory');
       project = new Project(projectPath, {});
-      assert.equal(project.bowerDirectory, 'vendor');
+      expect(project.bowerDirectory).to.equal('vendor');
     });
 
     it('should default to ‘bower_components’ unless directory property is set in .bowerrc', function() {
       projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/bowerrc-without-directory');
       project = new Project(projectPath, {});
-      assert.equal(project.bowerDirectory, 'bower_components');
+      expect(project.bowerDirectory).to.equal('bower_components');
     });
 
     it('should default to ‘bower_components’ if .bowerrc is not present', function() {
       projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/no-bowerrc');
       project = new Project(projectPath, {});
-      assert.equal(project.bowerDirectory, 'bower_components');
+      expect(project.bowerDirectory).to.equal('bower_components');
     });
 
     it('should default to ‘bower_components’ if .bowerrc json is invalid', function() {
       projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/invalid-bowerrc');
       project = new Project(projectPath, {});
-      assert.equal(project.bowerDirectory, 'bower_components');
+      expect(project.bowerDirectory).to.equal('bower_components');
     });
   });
 });

--- a/tests/unit/models/server-watcher-test.js
+++ b/tests/unit/models/server-watcher-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert = require('assert');
+var expect = require('chai').expect;
 var EOL = require('os').EOL;
 var MockUI = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
@@ -28,17 +28,17 @@ describe('Server Watcher', function() {
   describe('watcher strategy selection', function() {
     it('selects the events-based watcher by default', function () {
       subject.options = null;
-      assert.ok(!subject.polling());
+      expect(!!subject.polling()).to.equal(false);
     });
 
     it('selects the events-based watcher when given events watcher option', function () {
       subject.options = { watcher: 'events' };
-      assert.ok(!subject.polling());
+      expect(!!subject.polling()).to.equal(false);
     });
 
     it('selects the polling watcher when given polling watcher option', function () {
       subject.options = { watcher: 'polling' };
-      assert.ok(subject.polling());
+      expect(!!subject.polling());
     });
   });
 
@@ -48,11 +48,11 @@ describe('Server Watcher', function() {
     });
 
     it('logs that the file was changed', function() {
-      assert.equal(ui.output, 'Server file changed: foo.txt' + EOL);
+      expect(ui.output).to.equal('Server file changed: foo.txt' + EOL);
     });
 
     it('tracks changes', function() {
-      assert.deepEqual(analytics.tracks, [{
+      expect(analytics.tracks).to.deep.equal([{
         name: 'server file change',
         description: 'File changed: "foo.txt"'
       }]);
@@ -65,11 +65,11 @@ describe('Server Watcher', function() {
     });
 
     it('logs that the file was added', function() {
-      assert.equal(ui.output, 'Server file added: foo.txt' + EOL);
+      expect(ui.output).to.equal('Server file added: foo.txt' + EOL);
     });
 
     it('tracks additions', function() {
-      assert.deepEqual(analytics.tracks, [{
+      expect(analytics.tracks).to.deep.equal([{
         name: 'server file addition',
         description: 'File added: "foo.txt"'
       }]);
@@ -82,11 +82,11 @@ describe('Server Watcher', function() {
     });
 
     it('logs that the file was deleted', function() {
-      assert.equal(ui.output, 'Server file deleted: foo.txt' + EOL);
+      expect(ui.output).to.equal('Server file deleted: foo.txt' + EOL);
     });
 
     it('tracks deletions', function() {
-      assert.deepEqual(analytics.tracks, [{
+      expect(analytics.tracks).to.deep.equal([{
         name: 'server file deletion',
         description: 'File deleted: "foo.txt"'
       }]);

--- a/tests/unit/models/update-checker-test.js
+++ b/tests/unit/models/update-checker-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert        = require('../../helpers/assert');
+var expect        = require('chai').expect;
 var MockUI        = require('../../helpers/mock-ui');
 var UpdateChecker = require('../../../lib/models/update-checker');
 var Promise       = require('../../../lib/ext/promise');
@@ -42,7 +42,7 @@ describe('Update Checker', function() {
     };
 
     return updateChecker.checkForUpdates().then(function(updateInfo) {
-      assert.isFalse(updateInfo.updateNeeded, 'updateNeeded should be false');
+      expect(updateInfo.updateNeeded).to.equal(false, 'updateNeeded should be false');
     });
   });
 
@@ -66,7 +66,7 @@ describe('Update Checker', function() {
     };
 
     return updateChecker.checkForUpdates().then(function() {
-      assert.include(ui.output, 'A new version of ember-cli is available');
+      expect(ui.output).to.include('A new version of ember-cli is available');
     });
   });
 
@@ -93,7 +93,7 @@ describe('Update Checker', function() {
     };
 
     return updateChecker.checkForUpdates().then(function() {
-      assert.isFalse(npmCalled, 'NPM should not be called if the last check was less than a day ago');
+      expect(npmCalled).to.equal(false, 'NPM should not be called if the last check was less than a day ago');
     });
   });
 
@@ -107,8 +107,8 @@ describe('Update Checker', function() {
 
     var now = new Date().getTime();
 
-    assert.equal(updateChecker.versionConfig.store.newestVersion, '1000.0.0', 'should store newest version in configstore');
-    assert.closeTo(updateChecker.versionConfig.store.lastVersionCheckAt, now, 100, 'should store lastVersionCheckAt in configstore');
+    expect(updateChecker.versionConfig.store.newestVersion).to.equal('1000.0.0', 'should store newest version in configstore');
+    expect(updateChecker.versionConfig.store.lastVersionCheckAt).to.be.closeTo(now, 100, 'should store lastVersionCheckAt in configstore');
   });
 
 });

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert = require('assert');
+var expect = require('chai').expect;
 
 var MockUI = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
@@ -34,7 +34,7 @@ describe('Watcher', function() {
     it('selects the events-based watcher by default', function () {
       subject.options = null;
 
-      assert.deepEqual(subject.buildOptions(), {
+      expect(subject.buildOptions()).to.deep.equal({
         verbose: true,
         poll: false,
         watchman: false,
@@ -47,7 +47,7 @@ describe('Watcher', function() {
         watcher: 'events'
       };
 
-      assert.deepEqual(subject.buildOptions(), {
+      expect(subject.buildOptions()).to.deep.equal({
         verbose: true,
         poll: false,
         watchman: true,
@@ -60,7 +60,7 @@ describe('Watcher', function() {
         watcher: 'polling'
       };
 
-      assert.deepEqual(subject.buildOptions(), {
+      expect(subject.buildOptions()).to.deep.equal({
         verbose: true,
         poll: true,
         watchman: false,
@@ -77,14 +77,14 @@ describe('Watcher', function() {
     });
 
     it('tracks events', function() {
-      assert.deepEqual(analytics.tracks, [{
+      expect(analytics.tracks).to.deep.equal([{
         name: 'ember rebuild',
         message: 'broccoli rebuild time: 12344ms'
       }]);
     });
 
     it('tracks timings', function() {
-      assert.deepEqual(analytics.trackTimings, [{
+      expect(analytics.trackTimings).to.deep.equal([{
         category: 'rebuild',
         variable: 'rebuild time',
         label:    'broccoli rebuild time',
@@ -93,7 +93,7 @@ describe('Watcher', function() {
     });
 
     it('logs that the build was successful', function() {
-      assert.equal(ui.output, EOL + chalk.green('Build successful - 12344ms.') + EOL);
+      expect(ui.output).to.equal(EOL + chalk.green('Build successful - 12344ms.') + EOL);
     });
   });
 
@@ -104,7 +104,7 @@ describe('Watcher', function() {
         stack: new Error().stack
       });
 
-      assert.deepEqual(analytics.trackErrors, [{
+      expect(analytics.trackErrors).to.deep.equal([{
         description: 'foo'
       }]);
     });
@@ -117,8 +117,8 @@ describe('Watcher', function() {
 
       var outs = ui.output.split(EOL);
 
-      assert.equal(outs[0], chalk.red('File: someFile'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
+      expect(outs[0]).to.equal(chalk.red('File: someFile'));
+      expect(outs[1]).to.equal(chalk.red('buildFailed'));
     });
 
     it('emits with error.file with error.line without err.col', function() {
@@ -130,8 +130,8 @@ describe('Watcher', function() {
 
       var outs = ui.output.split(EOL);
 
-      assert.equal(outs[0], chalk.red('File: someFile (24)'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
+      expect(outs[0]).to.equal(chalk.red('File: someFile (24)'));
+      expect(outs[1]).to.equal(chalk.red('buildFailed'));
     });
 
     it('emits with error.file without error.line with err.col', function() {
@@ -142,8 +142,8 @@ describe('Watcher', function() {
       }));
       var outs = ui.output.split(EOL);
 
-      assert.equal(outs[0], chalk.red('File: someFile'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
+      expect(outs[0]).to.equal(chalk.red('File: someFile'));
+      expect(outs[1]).to.equal(chalk.red('buildFailed'));
     });
 
     it('emits with error.file with error.line with err.col', function() {
@@ -156,8 +156,8 @@ describe('Watcher', function() {
 
       var outs = ui.output.split(EOL);
 
-      assert.equal(outs[0], chalk.red('File: someFile (24:80)'));
-      assert.equal(outs[1], chalk.red('buildFailed'));
+      expect(outs[0]).to.equal(chalk.red('File: someFile (24:80)'));
+      expect(outs[1]).to.equal(chalk.red('buildFailed'));
     });
   });
 
@@ -174,11 +174,11 @@ describe('Watcher', function() {
     });
 
     it('log that the build was green', function() {
-      assert(/Build successful./.test(ui.output), 'has successful build output');
+      expect(ui.output).to.match(/Build successful./, 'has successful build output');
     });
 
     it('keep tracking analytics', function() {
-      assert.deepEqual(analytics.tracks, [{
+      expect(analytics.tracks).to.deep.equal([{
         name: 'ember rebuild',
         message: 'broccoli rebuild time: 12344ms'
       }]);

--- a/tests/unit/package/dependency-version-test.js
+++ b/tests/unit/package/dependency-version-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert = require('../../helpers/assert');
+var expect = require('chai').expect;
 var semver = require('semver');
 
 function assertVersionLock(_deps) {
@@ -11,7 +11,7 @@ function assertVersionLock(_deps) {
         semver.valid(deps[name]) &&
         semver.gtr('1.0.0', deps[name])) {
       // only valid if the version is fixed
-      assert(semver.valid(deps[name]), '"' + name + '" has a valid version');
+      expect(semver.valid(deps[name]), '"' + name + '" has a valid version');
     }
   });
 }

--- a/tests/unit/preprocessors/javascript-test.js
+++ b/tests/unit/preprocessors/javascript-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
-var preprocessJs   = require('../../../lib/preprocessors').preprocessJs;
+var expect       = require('chai').expect;
+var preprocessJs = require('../../../lib/preprocessors').preprocessJs;
 
 var registry, plugins;
 
@@ -36,7 +36,7 @@ describe('preprocessJs', function() {
       registry: registry
     });
 
-    assert.deepEqual(pluginsCalled, ['foo', 'bar']);
+    expect(pluginsCalled).to.deep.equal(['foo', 'bar']);
   });
 
   it('passes the previously returned value into the next plugin', function() {
@@ -56,7 +56,7 @@ describe('preprocessJs', function() {
       registry: registry
     });
 
-    assert.deepEqual(treeValues, ['app', 'foo']);
-    assert.equal(output, 'bar');
+    expect(treeValues).to.deep.equal(['app', 'foo']);
+    expect(output).to.equal('bar');
   });
 });

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assign         = require('lodash-node/modern/objects/assign');
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var PluginRegistry = require('../../../lib/preprocessors/registry');
 
 var pkg, registry, app;
@@ -28,37 +28,37 @@ describe('Plugin Loader', function() {
   it('returns array of one plugin when only one', function() {
     var plugins = registry.load('css');
 
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-sass');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-sass');
   });
 
   it('returns the correct list of plugins when there are more than one', function() {
     registry.availablePlugins['broccoli-ruby-sass'] = 'latest';
     var plugins = registry.load('css');
 
-    assert.equal(plugins.length, 2);
-    assert.equal(plugins[0].name, 'broccoli-sass');
-    assert.equal(plugins[1].name, 'broccoli-ruby-sass');
+    expect(plugins.length).to.equal(2);
+    expect(plugins[0].name).to.equal('broccoli-sass');
+    expect(plugins[1].name).to.equal('broccoli-ruby-sass');
   });
 
   it('returns plugin of the correct type', function() {
     registry.add('js', 'broccoli-coffee');
     var plugins = registry.load('js');
 
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-coffee');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-coffee');
   });
 
   it('returns plugin that was in dependencies', function() {
     registry.add('template', 'broccoli-emblem');
     var plugins = registry.load('template');
-    assert.equal(plugins[0].name, 'broccoli-emblem');
+    expect(plugins[0].name).to.equal('broccoli-emblem');
   });
 
   it('returns null when no plugin available for type', function() {
     registry.add('blah', 'not-available');
     var plugins = registry.load('blah');
-    assert.equal(plugins.length, 0);
+    expect(plugins.length).to.equal(0);
   });
 
   it('returns the configured extension for the plugin', function() {
@@ -66,7 +66,7 @@ describe('Plugin Loader', function() {
     registry.availablePlugins = { 'broccoli-less-single': 'latest' };
     var plugins = registry.load('css');
 
-    assert.equal(plugins[0].ext, 'less');
+    expect(plugins[0].ext).to.equal('less');
   });
 
   it('can specify fallback extensions', function() {
@@ -74,15 +74,15 @@ describe('Plugin Loader', function() {
     var plugins = registry.load('css');
     var plugin  = plugins[0];
 
-    assert.equal(plugin.ext[0], 'scss');
-    assert.equal(plugin.ext[1], 'sass');
+    expect(plugin.ext[0]).to.equal('scss');
+    expect(plugin.ext[1]).to.equal('sass');
   });
 
   it('provides the application name to each plugin', function() {
     registry.add('js', 'broccoli-coffee');
     var plugins = registry.load('js');
 
-    assert.equal(plugins[0].applicationName, 'some-application-name');
+    expect(plugins[0].applicationName).to.equal('some-application-name');
   });
 
   it('adds a plugin directly if it is provided', function() {
@@ -91,7 +91,7 @@ describe('Plugin Loader', function() {
     registry.add('js', randomPlugin);
     var registered = registry.registry['js'];
 
-    assert.equal(registered[0], randomPlugin);
+    expect(registered[0]).to.equal(randomPlugin);
   });
 
   it('returns plugins added manually even if not present in package deps', function() {
@@ -100,7 +100,7 @@ describe('Plugin Loader', function() {
     registry.add('foo', randomPlugin);
     var plugins = registry.load('foo');
 
-    assert.equal(plugins[0], randomPlugin);
+    expect(plugins[0]).to.equal(randomPlugin);
   });
 
   describe('extensionsForType', function() {
@@ -108,20 +108,20 @@ describe('Plugin Loader', function() {
 
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['css', 'scss', 'sass']);
+      expect(extensions).to.deep.equal(['css', 'scss', 'sass']);
     });
 
     it('can handle mixed array and non-array extensions', function() {
       registry.add('css', 'broccoli-foo', 'foo');
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['css', 'scss', 'sass', 'foo']);
+      expect(extensions).to.deep.equal(['css', 'scss', 'sass', 'foo']);
     });
   });
 
   describe('adds a plugin directly if it is provided', function() {
     it('returns an empty array if called on an unknown type', function() {
-      assert.deepEqual(registry.registeredForType('foo'), []);
+      expect(registry.registeredForType('foo')).to.deep.equal([]);
     });
 
     it('returns the current array if type is found', function() {
@@ -129,7 +129,7 @@ describe('Plugin Loader', function() {
 
       registry.registry['foo'] = fooArray;
 
-      assert.equal(registry.registeredForType('foo'), fooArray);
+      expect(registry.registeredForType('foo')).to.deep.equal(fooArray);
     });
   });
 
@@ -138,8 +138,8 @@ describe('Plugin Loader', function() {
     registry.remove('css', 'broccoli-sass');
 
     var plugins = registry.load('css');
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-ruby-sass');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-ruby-sass');
   });
 
   it('allows removal of plugin added as instantiated objects', function() {
@@ -149,11 +149,11 @@ describe('Plugin Loader', function() {
     registry.add('foo', randomPlugin);
 
     plugins = registry.load('foo');
-    assert.equal(plugins[0], randomPlugin); // precondition
+    expect(plugins[0]).to.equal(randomPlugin); // precondition
 
     registry.remove('foo', randomPlugin);
 
     plugins = registry.load('foo');
-    assert.equal(plugins.length, 0);
+    expect(plugins.length).to.equal(0);
   });
 });

--- a/tests/unit/preprocessors/style-plugin-test.js
+++ b/tests/unit/preprocessors/style-plugin-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
+var expect      = require('chai').expect;
 var StylePlugin = require('../../../lib/preprocessors/style-plugin');
 
 describe('Style Plugin', function(){
@@ -16,22 +16,22 @@ describe('Style Plugin', function(){
       plugin = new StylePlugin('california-stylesheets', 'cass', options);
     });
     it('sets type', function(){
-      assert.equal(plugin.type, 'css');
+      expect(plugin.type).to.equal('css');
     });
     it('sets name', function(){
-      assert.equal(plugin.name, 'california-stylesheets');
+      expect(plugin.name).to.equal('california-stylesheets');
     });
     it('sets ext', function(){
-      assert.equal(plugin.ext, 'cass');
+      expect(plugin.ext).to.equal('cass');
     });
     it('sets options', function(){
-      assert.equal(plugin.options, options);
+      expect(plugin.options).to.equal(options);
     });
     it('sets registry', function(){
-      assert.equal(plugin.registry, 'some/registry');
+      expect(plugin.registry).to.equal('some/registry');
     });
     it('sets applicationName', function(){
-      assert.equal(plugin.applicationName, 'some/application');
+      expect(plugin.applicationName).to.equal('some/application');
     });
   });
 });

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert            = require('../../../helpers/assert');
+var expect            = require('chai').expect;
 var ExpressServer     = require('../../../../lib/tasks/server/express-server');
 var Promise           = require('../../../../lib/ext/promise');
 var MockUI            = require('../../../helpers/mock-ui');
@@ -53,9 +53,9 @@ describe('express-server', function() {
         require: function() { return {};   }
       };
 
-      assert.throws(function() {
+      expect(function() {
         subject.processAppMiddlewares();
-      }, TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
+      }).to.throw(TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
     });
   });
 
@@ -68,9 +68,9 @@ describe('express-server', function() {
         baseURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[1], 'Serving on http://0.0.0.0:1337/');
-        assert.deepEqual(output[0], 'Proxying to http://localhost:3001/');
-        assert.deepEqual(output.length, 2, 'expected only two lines of output');
+        expect(output[1]).to.equal('Serving on http://0.0.0.0:1337/');
+        expect(output[0]).to.equal('Proxying to http://localhost:3001/');
+        expect(output.length).to.equal(2, 'expected only two lines of output');
       });
     });
 
@@ -81,8 +81,8 @@ describe('express-server', function() {
         baseURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/');
-        assert.deepEqual(output.length, 1, 'expected only one line of output');
+        expect(output[0]).to.equal('Serving on http://0.0.0.0:1337/');
+        expect(output.length).to.equal(1, 'expected only one line of output');
       });
     });
 
@@ -93,8 +93,8 @@ describe('express-server', function() {
         baseURL: '/foo'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/foo/');
-        assert.deepEqual(output.length, 1, 'expected only one line of output');
+        expect(output[0]).to.equal('Serving on http://0.0.0.0:1337/foo/');
+        expect(output.length).to.equal(1, 'expected only one line of output');
       });
     });
 
@@ -107,14 +107,14 @@ describe('express-server', function() {
         port: '1337'
       })
         .then(function() {
-          assert(false, 'should have rejected');
+          expect(false, 'should have rejected');
         })
         .catch(function(reason) {
-          assert.equal(reason, 'Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
+          expect(reason).to.equal('Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
         })
-          .finally(function() {
-            preexistingServer.close(done);
-          });
+        .finally(function() {
+          preexistingServer.close(done);
+        });
     });
   });
 
@@ -141,13 +141,13 @@ describe('express-server', function() {
             .get('/foo')
             .set('accept', 'application/json, */*')
             .expect(function(res) {
-              assert.equal(res.text, expected);
+              expect(res.text).to.equal(expected);
             })
             .end(function(err) {
               if (err) {
                 return done(err);
               }
-              assert(!proxy.called);
+              expect(proxy.called).to.equal(false);
               done();
             });
         });
@@ -171,7 +171,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(!proxy.called);
+            expect(proxy.called).to.equal(false);
             if (responseCallback) { responseCallback(response); }
             done();
           });
@@ -183,7 +183,7 @@ describe('express-server', function() {
 
       it('bypasses proxy for files that exist', function(done) {
         bypassTest(subject.app, '/test-file.txt', done, function(response) {
-          assert.equal(response.text.trim(), 'some contents');
+          expect(response.text.trim()).to.equal('some contents');
         });
       });
 
@@ -196,9 +196,9 @@ describe('express-server', function() {
               return done(err);
             }
 
-            assert(proxy.called, 'proxy receives the request');
-            assert.equal(proxy.lastReq.method, method.toUpperCase());
-            assert.equal(proxy.lastReq.url, url);
+            expect(proxy.called, 'proxy receives the request');
+            expect(proxy.lastReq.method).to.equal(method.toUpperCase());
+            expect(proxy.lastReq.url).to.equal(url);
             done();
           });
       }
@@ -223,7 +223,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(proxy.called, 'proxy receives the request');
+            expect(proxy.called, 'proxy receives the request');
             done();
           });
       });
@@ -253,9 +253,9 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(nockProxy.called, 'proxy receives the request');
-            assert.equal(nockProxy.method, method.toUpperCase());
-            assert.equal(nockProxy.url, url);
+            expect(nockProxy.called, 'proxy receives the request');
+            expect(nockProxy.method).to.equal(method.toUpperCase());
+            expect(nockProxy.url).to.equal(url);
             done();
           });
       }
@@ -343,7 +343,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(nockProxy.called, 'proxy receives the request');
+            expect(nockProxy.called, 'proxy receives the request');
             done();
           });
       });
@@ -453,7 +453,7 @@ describe('express-server', function() {
             request(subject.app)
             .get('/test-file.txt')
             .end(function(err, response) {
-              assert.equal(response.text.trim(), 'some contents');
+              expect(response.text.trim()).to.equal('some contents');
               done();
             });
           });
@@ -470,7 +470,7 @@ describe('express-server', function() {
                   return done(err);
                 }
 
-                assert.equal(response.text.trim(), 'some other content');
+                expect(response.text.trim()).to.equal('some other content');
 
                 done();
               });
@@ -488,7 +488,7 @@ describe('express-server', function() {
                   return done(err);
                 }
 
-                assert.equal(response.text.trim(), 'some other content');
+                expect(response.text.trim()).to.equal('some other content');
 
                 done();
               });
@@ -511,7 +511,7 @@ describe('express-server', function() {
           host:  '0.0.0.0',
           port: '1337'
         }).then(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
     });
@@ -543,8 +543,8 @@ describe('express-server', function() {
           host:  '0.0.0.0',
           port: '1337'
         }).then(function() {
-          assert.equal(firstCalls, 1);
-          assert.equal(secondCalls, 1);
+          expect(firstCalls).to.equal(1);
+          expect(secondCalls).to.equal(1);
         });
       });
 
@@ -556,8 +556,8 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(firstCalls, 2);
-          assert.equal(secondCalls, 2);
+          expect(firstCalls).to.equal(2);
+          expect(secondCalls).to.equal(2);
         });
       });
     });
@@ -583,8 +583,8 @@ describe('express-server', function() {
         };
 
         return subject.start(realOptions).then(function() {
-          assert(passedOptions === realOptions);
-          assert.equal(calls, 1);
+          expect(passedOptions === realOptions).to.equal(true);
+          expect(calls).to.equal(1);
         });
       });
 
@@ -603,10 +603,10 @@ describe('express-server', function() {
             return subject.restartHttpServer();
           })
           .then(function() {
-            assert(subject.app);
-            assert.notEqual(originalApp, subject.app);
-            assert(passedOptions === realOptions);
-            assert.equal(calls, 2);
+            expect(subject.app);
+            expect(originalApp).to.not.equal(subject.app);
+            expect(passedOptions === realOptions).to.equal(true);
+            expect(calls).to.equal(2);
           });
       });
 
@@ -623,7 +623,7 @@ describe('express-server', function() {
         };
 
         return subject.start(realOptions).then(function() {
-          assert(!!passedOptions.httpServer.listen);
+          expect(!!passedOptions.httpServer.listen);
         });
       });
     });
@@ -640,7 +640,7 @@ describe('express-server', function() {
           port: '1337'
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
 
@@ -656,7 +656,7 @@ describe('express-server', function() {
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
           subject.serverWatcher.emit('change', 'bar.txt');
-          assert.equal(calls, 2);
+          expect(calls).to.equal(2);
         });
       });
     });
@@ -669,13 +669,13 @@ describe('express-server', function() {
         };
 
         subject.scheduleServerRestart();
-        assert.equal(calls, 0);
+        expect(calls).to.equal(0);
         setTimeout(function() {
-          assert.equal(calls, 0);
+          expect(calls).to.equal(0);
           subject.scheduleServerRestart();
         }, 50);
         setTimeout(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
           done();
         }, 175);
       });
@@ -695,11 +695,11 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(ui.output, EOL + chalk.green('Server restarted.') + EOL + EOL);
-          assert(subject.httpServer, 'HTTP server exists');
-          assert.notEqual(subject.httpServer, originalHttpServer, 'HTTP server has changed');
-          assert(subject.app, 'App exists');
-          assert.notEqual(subject.app, originalApp, 'App has changed');
+          expect(ui.output).to.equal(EOL + chalk.green('Server restarted.') + EOL + EOL);
+          expect(subject.httpServer, 'HTTP server exists');
+          expect(subject.httpServer).to.not.equal(originalHttpServer, 'HTTP server has changed');
+          expect(!!subject.app).to.equal(true, 'App exists');
+          expect(subject.app).to.not.equal(originalApp, 'App has changed');
         });
       });
 
@@ -721,10 +721,10 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert(subject.httpServer, 'HTTP server exists');
-          assert.notEqual(subject.httpServer, originalHttpServer, 'HTTP server has changed');
-          assert(subject.app, 'App exists');
-          assert.notEqual(subject.app, originalApp, 'App has changed');
+          expect(!!subject.httpServer).to.equal(true, 'HTTP server exists');
+          expect(subject.httpServer).to.not.equal(originalHttpServer, 'HTTP server has changed');
+          expect(!!subject.app).to.equal(true, 'App exists');
+          expect(subject.app).to.not.equal(originalApp, 'App has changed');
         });
       });
 
@@ -740,7 +740,7 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
     });

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert            = require('../../../helpers/assert');
+var expect            = require('chai').expect;
 var LiveReloadServer  = require('../../../../lib/tasks/server/livereload-server');
 var MockUI            = require('../../../helpers/mock-ui');
 var MockExpressServer = require('../../../helpers/mock-express-server');
@@ -46,8 +46,8 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: false
       }).then(function(output) {
-        assert.equal(output, 'Livereload server manually disabled.');
-        assert(!subject._liveReloadServer);
+        expect(output).to.equal('Livereload server manually disabled.');
+        expect(!!subject._liveReloadServer).to.equal(false);
       });
     });
 
@@ -56,7 +56,7 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: true
       }).then(function() {
-        assert.equal(ui.output, 'Livereload server on port 1337' + EOL);
+        expect(ui.output).to.equal('Livereload server on port 1337' + EOL);
       });
     });
 
@@ -69,7 +69,7 @@ describe('livereload-server', function() {
           liveReload: true
         })
         .catch(function(reason) {
-          assert.equal(reason, 'Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
+          expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
         })
         .finally(function() {
           preexistingServer.close(done);
@@ -89,7 +89,7 @@ describe('livereload-server', function() {
           liveReload: true
         }).then(function () {
           expressServer.emit('restart');
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
     });
   });
@@ -127,8 +127,8 @@ describe('livereload-server', function() {
 
     it('triggers the liverreload server of a change when no pattern matches', function() {
       subject.didChange({filePath: ''});
-      assert.equal(changedCount, 1);
-      assert.equal(trackCount, 1);
+      expect(changedCount).to.equal(1);
+      expect(trackCount).to.equal(1);
     });
 
     it('does not trigger livereoad server of a change when there is a pattern match', function() {
@@ -142,8 +142,8 @@ describe('livereload-server', function() {
       subject.didChange({
         filePath: '/home/user/my-project/test/fixtures/proxy/file-a.js'
       });
-      assert.equal(changedCount, 0);
-      assert.equal(trackCount, 0);
+      expect(changedCount).to.equal(0);
+      expect(trackCount).to.equal(0);
     });
   });
 });

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
-var TestServerTask    = require('../../../lib/tasks/test-server');
-var MockProject = require('../../helpers/mock-project');
-var MockUI      = require('../../helpers/mock-ui');
-var MockWatcher = require('../../helpers/mock-watcher');
+var expect         = require('chai').expect;
+var TestServerTask = require('../../../lib/tasks/test-server');
+var MockProject    = require('../../helpers/mock-project');
+var MockUI         = require('../../helpers/mock-ui');
+var MockWatcher    = require('../../helpers/mock-watcher');
 
 describe('test server', function() {
   var subject;
@@ -21,10 +21,10 @@ describe('test server', function() {
       },
       testem: {
         startDev: function(options) {
-          assert.equal(options.file, 'blahzorz.conf');
-          assert.equal(options.port, 123324);
-          assert.equal(options.cwd, 'blerpy-derpy');
-          assert.deepEqual(options.middleware, ['middleware1', 'middleware2']);
+          expect(options.file).to.equal('blahzorz.conf');
+          expect(options.port).to.equal(123324);
+          expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           done();
         }
       }

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
+var expect      = require('chai').expect;
 var TestTask    = require('../../../lib/tasks/test');
 var MockProject = require('../../helpers/mock-project');
 
@@ -15,10 +15,10 @@ describe('test', function() {
       },
       testem: {
         startCI: function(options, cb) {
-          assert.equal(options.file, 'blahzorz.conf');
-          assert.equal(options.port, 123324);
-          assert.equal(options.cwd, 'blerpy-derpy');
-          assert.deepEqual(options.middleware, ['middleware1', 'middleware2']);
+          expect(options.file).to.equal('blahzorz.conf');
+          expect(options.port).to.equal(123324);
+          expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           cb(0);
         },
         app: { reporter: { total: 1 } }

--- a/tests/unit/tasks/update-test.js
+++ b/tests/unit/tasks/update-test.js
@@ -2,7 +2,7 @@
 
 var fs         = require('fs');
 var path       = require('path');
-var assert     = require('../../helpers/assert');
+var expect     = require('chai').expect;
 var MockUI     = require('../../helpers/mock-ui');
 var Promise    = require('../../../lib/ext/promise');
 var UpdateTask = require('../../../lib/tasks/update');
@@ -60,8 +60,8 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.include(ui.output, 'A new version of ember-cli is available');
-        assert.include(ui.output, 'Are you sure you want to update ember-cli?');
+        expect(ui.output).to.include('A new version of ember-cli is available');
+        expect(ui.output).to.include('Are you sure you want to update ember-cli?');
       });
     });
   });
@@ -120,14 +120,14 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.include(ui.output, 'A new version of ember-cli is available');
-        assert.include(ui.output, 'Are you sure you want to update ember-cli?');
-        assert.deepEqual(installCalledWith, [ 'ember-cli' ], '');
-        assert.deepEqual(loadCalledWith, {
+        expect(ui.output).to.include('A new version of ember-cli is available');
+        expect(ui.output).to.include('Are you sure you want to update ember-cli?');
+        expect(installCalledWith).to.deep.equal([ 'ember-cli' ], '');
+        expect(loadCalledWith).to.deep.equal({
           'global': true,
           'loglevel': 'silent'
         }, '');
-        assert(initCommandWasRun);
+        expect(initCommandWasRun);
       });
     });
 
@@ -137,9 +137,8 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.equal(pkg.devDependencies['ember-cli'], '100.0.0');
+        expect(pkg.devDependencies['ember-cli']).to.equal('100.0.0');
       });
     });
-
   });
 });

--- a/tests/unit/ui/write-error-test.js
+++ b/tests/unit/ui/write-error-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert     = require('assert');
+var expect     = require('chai').expect;
 var writeError = require('../../../lib/ui/write-error');
 var MockUI     = require('../../helpers/mock-ui');
 var BuildError = require('../../helpers/build-error');
@@ -23,7 +23,7 @@ describe('writeError', function() {
       message: 'build error'
     }));
 
-    assert.equal(ui.output, chalk.red('build error') + EOL);
+    expect(ui.output).to.equal(chalk.red('build error') + EOL);
   });
 
   it('error with stack', function() {
@@ -31,7 +31,7 @@ describe('writeError', function() {
       stack: 'the stack'
     }));
 
-    assert.equal(ui.output, chalk.red('Error') + EOL + 'the stack' + EOL);
+    expect(ui.output).to.equal(chalk.red('Error') + EOL + 'the stack' + EOL);
   });
 
   it('error with file', function() {
@@ -39,7 +39,7 @@ describe('writeError', function() {
       file: 'the file'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line', function() {
@@ -48,7 +48,7 @@ describe('writeError', function() {
       line: 'the line'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + col', function() {
@@ -57,7 +57,7 @@ describe('writeError', function() {
       col: 'the col'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line + col', function() {
@@ -67,6 +67,6 @@ describe('writeError', function() {
       col:  'the col'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
   });
 });

--- a/tests/unit/utilities/doc-generator-test.js
+++ b/tests/unit/utilities/doc-generator-test.js
@@ -2,7 +2,7 @@
 
 var DocGenerator = require('../../../lib/utilities/doc-generator.js');
 var calculateVersion = require('../../../lib/utilities/ember-cli-version.js');
-var assert = require('assert');
+var expect = require('chai').expect;
 var path = require('path');
 
 describe('generateDocs', function(){
@@ -16,7 +16,7 @@ describe('generateDocs', function(){
       console.log('Pattern:  ' + pattern);
       console.log('Argument: ' + arguments[0]);
 
-      assert.ok((new RegExp(pattern)).test(arguments[0]));
+      expect((new RegExp(pattern)).test(arguments[0])).to.equal(true);
     };
 
     var generator = new DocGenerator({exec: execFunc});

--- a/tests/unit/utilities/git-repo-test.js
+++ b/tests/unit/utilities/git-repo-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var isGitRepo = require('../../../lib/utilities/git-repo');
-var assert    = require('assert');
+var expect    = require('chai').expect;
 
 describe('cleanBaseURL()', function() {
   it('recognizes git-style urls in various formats', function() {
-    assert.ok(isGitRepo('https://github.com/trek/app-blueprint-test.git'));
-    assert.ok(isGitRepo('git@github.com:trek/app-blueprint-test.git'));
-    assert.ok(isGitRepo('git+ssh://user@server/project.git'));
-    assert.ok(isGitRepo('git+https://user@server/project.git'));
+    expect(isGitRepo('https://github.com/trek/app-blueprint-test.git'));
+    expect(isGitRepo('git@github.com:trek/app-blueprint-test.git'));
+    expect(isGitRepo('git+ssh://user@server/project.git'));
+    expect(isGitRepo('git+https://user@server/project.git'));
   });
 });


### PR DESCRIPTION
- [x] `unit`
  - [x] blueprints
  - [x] broccoli
  - [x] cli
  - [x] commands
  - [x] errors
  - [x] models
    - [x] addon-test.js
    - [x] blueprint-test.js
    - [x] builder-test.js
    - [x] command-test.js
    - [x] file-info-test.js
    - [x] project-test.js
    - [x] server-watcher-test.js
    - [x] update-checker-test.js
    - [x] watcher-test.js
  - [x] package
  - [x] preprocessors
  - [x] settings-file
  - [x] tasks
  - [x] ui
  - [x] utilities
  - [x] analytics-test.js

Related to #2797