### PR TITLE
Document add ember install and it's variants

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -104,7 +104,7 @@ And, adding to `resolutions`:
     }
 
 
-Wipe your vendor directory clean then run `bower install`.
+Wipe your vendor directory clean then run `ember install`.
 
 
 ### Removing default ember-cli libraries
@@ -119,7 +119,7 @@ Wipe your vendor directory clean then run `bower install`.
 
 * To reinstall latest Ember Data version
 
-`npm install ember-data --save-dev`
+`ember install:npm ember-data`
 
 ### Solving performance issues on windows
 
@@ -194,7 +194,7 @@ The way Vagrant syncs folders between your desktop and the VM will break the def
 
 #### VM Setup
 
-When setting up your VM, install ember-cli dependencies as you normally would. If you've already run `npm install` in your project's folder from your host machine, you'll have to delete the `node_modules` folder and re-install those dependencies from the VM. This is particularly necessary if you have node dependencies that use native libraries (e.g., [broccoli-sass](#sass), which uses the libsass C library).
+When setting up your VM, install ember-cli dependencies as you normally would. If you've already run `ember install` in your project's folder from your host machine, you'll have to delete the `node_modules` folder and re-install those dependencies from the VM. This is particularly necessary if you have node dependencies that use native libraries (e.g., [broccoli-sass](#sass), which uses the libsass C library).
 
 #### Provider 
 

--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -51,19 +51,13 @@ project directory.
   ember-cli, replacing X.X.X with the version of ember-cli you want to install
 
     {% highlight bash %}
-    npm install --save-dev ember-cli@X.X.X
+    ember install:npm ember-cli@X.X.X
     {% endhighlight %}
 
-* Reinstall NPM dependencies
+* Reinstall NPM and Bower dependencies
 
     {% highlight bash %}
-    npm install
-    {% endhighlight %}
-
-* Reinstall Bower dependencies
-
-    {% highlight bash %}
-    bower install
+    ember install
     {% endhighlight %}
 
 * Run the new project blueprint on your projects directory. Please follow the

--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -11,13 +11,13 @@ This guide will walk through the development cycle of a fictional
 addon `ember-cli-x-button`.
 
 ### Installation
-An addon can be installed like any other npm package:
+An addon can be installed with the `install:addon` command:
 
-`npm install --save-dev <package name>`
+`ember install:addon <package name>`
 
 To install the (fictional) x-button addon package:
 
-`npm install --save-dev ember-cli-x-button`
+`ember install:addon ember-cli-x-button`
 
 ### Discovery
 
@@ -172,11 +172,14 @@ By default, the `"ember-addon"` hash in the `package.json` file has the `"config
 
 Optionally, you may specify whether your `ember-addon` must run `"before"` or `"after"` any other Ember CLI addons.  Both of these properties can take either a string or an array of strings, where the string is the name of the another Ember CLI addon, as defined in the `package.json` of the other addon.
 
+Optionally, you may specify a different name for the `"defaultBlueprint"`. It defaults to the name in the `package.json`. This blueprint will be run automatically when your addon is installed with the `ember install:addon` command.
+
 {% highlight javascript %}
 "ember-addon": {
   // addon configuration properties
   "configPath": "tests/dummy/config",
   "before": "single-addon",
+  "defaultBlueprint": "blueprint-that-isnt-package-name",
   "after": [
     "after-addon-1",
     "after-addon-2"
@@ -189,7 +192,7 @@ Install your client side dependencies via Bower.
 Here we install a fictional bower dependency `x-button`:
 
 {% highlight bash %}
-bower install --save-dev x-button
+ember install:bower x-button
 {% endhighlight %}
 
 Adds bower components to development dependencies
@@ -483,17 +486,17 @@ npm publish
 {% endhighlight %}
 
 ### Using a private repository
-You can upload your addon code to a private git repository and call `npm install`
+You can upload your addon code to a private git repository and call `ember install:addon`
 with a valid [git URL](https://www.npmjs.org/doc/files/package.json.html#git-urls-as-dependencies)
 as the version.
 
 If you are using [bitbucket.org](https://bitbucket.org) the [URL formats can be found here](https://confluence.atlassian.com/display/BITBUCKET/Use+the+SSH+protocol+with+Bitbucket#UsetheSSHprotocolwithBitbucket-RepositoryURLformatsbyconnectionprotocol).
 
-When using the `git+ssh` format, the `npm install` command will require there to
-be an available ssh key with read access to the reposirtory. This can be tested
+When using the `git+ssh` format, the `ember install:addon` command will require there to
+be an available ssh key with read access to the repository. This can be tested
 by running `git clone ssh://git@github.com:user/project.git`.
 
-When using the `git+https` format, the `npm install` command will ask you for
+When using the `git+https` format, the `ember install:addon` command will ask you for
 the account password.
 
 ### Install and use addon
@@ -501,15 +504,22 @@ In order to use the addon from you hosting application:
 
 To install your addon from the [npm.org](https://www.npmjs.org/) repository:
 
-`npm install ember-cli-<your-addon-name-here> --save-dev`.
+`ember install:addon <your-addon-name-here>`.
 
 For our *x-button* sample addon:
 
-`npm install ember-cli-x-button --save-dev`.
+`ember install:addon x-button my-button`.
 
-Run the *x-button* blueprint generator via:
+This will first install the x-button addon from npm. Then, because we have
+a blueprint with the same name as our addon, it will run the blueprint
+automatically with the passed in arguments.
 
-`ember generate x-button`
+This is equivalent of running:
+
+{% highlight bash %}
+ember install:npm x-button
+ember generate x-button my-button
+{% endhighlight %}
 
 ### Updating addons
 You can update an addon the same way you update an Ember app by

--- a/_posts/2013-04-08-managing-dependencies.md
+++ b/_posts/2013-04-08-managing-dependencies.md
@@ -14,16 +14,16 @@ CLI project, and lists the dependencies for your project. Changes to your
 dependencies should be managed through this file, rather than manually
 installing packages individually.
 
-Executing `bower install` will install all of the dependencies listed in
+Executing `ember install:bower` will install all of the dependencies listed in
 `bower.json` in one step.
 
 Ember CLI is configured to have git ignore your `bower_components` directory by
 default. Using the Bower configuration file allows collaborators to fork your
-repo and get their dependencies installed locally by executing `bower install`
-themselves.
+repo and get their dependencies installed locally by executing 
+`ember install:bower` themselves.
 
 Ember CLI watches `bower.json` for changes. Thus it reloads your app if you
-install new dependencies via `bower install --save <dependencies>`.
+install new dependencies via `ember install:bower <dependencies>`.
 
 Further documentation about Bower is available at their
 [official documentation page](http://bower.io/).
@@ -207,7 +207,7 @@ With the [broccoli-static-compiler](https://github.com/joliss/broccoli-static-co
 package needed to build are installed:
 
 {% highlight bash %}
-npm install --save-dev broccoli-static-compiler
+ember install:npm broccoli-static-compiler
 {% endhighlight %}
 
 Add this import to the top of `Brocfile.js`, just below the `EmberApp` require:

--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -34,7 +34,7 @@ Ember CLI supports plain CSS out of the box. You can add your css styles to
 
 For example, to add bootstrap in your project you need to do the following:
 {% highlight bash %}
-bower install --save-dev bootstrap
+ember install:bower bootstrap
 {% endhighlight %}
 
 In `Brocfile.js` add the following:
@@ -69,7 +69,7 @@ To enable [LESS](http://lesscss.org/), you'll need to add
 your NPM modules.
 
 {% highlight bash %}
-npm install --save-dev ember-cli-less
+ember install:addon ember-cli-less
 {% endhighlight %}
 
 #### Sass
@@ -79,7 +79,7 @@ add [broccoli-sass](https://github.com/joliss/broccoli-sass) to your NPM
 modules *(both .scss/.sass are allowed as of broccoli-sass > 0.2.0)*.
 
 {% highlight bash %}
-npm install --save-dev broccoli-sass
+ember install:npm broccoli-sass
 {% endhighlight %}
 
 #### Compass
@@ -88,7 +88,7 @@ To use [Compass](http://compass-style.org/) with your ember-cli app, install
 [ember-cli-compass-compiler](https://github.com/quaertym/ember-cli-compass-compiler) addon using NPM.
 
 {% highlight bash %}
-npm install --save-dev ember-cli-compass-compiler
+ember install:addon ember-cli-compass-compiler
 {% endhighlight %}
 
 #### Stylus
@@ -98,7 +98,7 @@ To enable [Stylus](http://learnboost.github.io/stylus/), you must first add
 modules:
 
 {% highlight bash %}
-npm install --save-dev ember-cli-stylus
+ember install:addon ember-cli-stylus
 {% endhighlight %}
 
 ### CoffeeScript
@@ -108,7 +108,7 @@ first add [ember-cli-coffeescript](https://github.com/kimroen/ember-cli-coffeesc
 NPM modules:
 
 {% highlight bash %}
-npm install --save-dev ember-cli-coffeescript
+ember install:addon ember-cli-coffeescript
 {% endhighlight %}
 
 The modified `package.json` should be checked into source control. CoffeeScript
@@ -141,7 +141,7 @@ first add [broccoli-ember-script](https://github.com/aradabaugh/broccoli-ember-s
 NPM modules:
 
 {% highlight bash %}
-npm install --save-dev broccoli-ember-script
+ember install:npm broccoli-ember-script
 {% endhighlight %}
 
 Note that the ES6 module transpiler is not directly supported with Emberscript, to allow use of ES6 modules use the `` ` `` character to escape raw Javascript similar to the CoffeeScript example above.
@@ -151,7 +151,7 @@ Note that the ES6 module transpiler is not directly supported with Emberscript, 
 For [Emblem](http://emblemjs.com/), run the following commands:
 
 {% highlight bash %}
-npm install --save-dev broccoli-emblem-compiler
+ember install:npm broccoli-emblem-compiler
 {% endhighlight %}
 
 ### Fingerprinting and CDN URLs

--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -81,7 +81,7 @@ you will need to install dependencies yourself before running the server:
 
 {% highlight bash %}
 git clone git@github.com:me/my-app.git
-cd my-app && npm install && bower install
+cd my-app && ember install
 ember server
 {% endhighlight %}
 
@@ -96,6 +96,10 @@ ember server
  `ember server`                              | Starts up the server. Default port is `4200`. Use `--proxy` flag to proxy all ajax requests to the given address. For example `ember server --proxy http://127.0.0.1:8080` will proxy all your apps XHR to your server running at port 8080.
  <span style="white-space:nowrap">`ember generate <generator-name> <options>`</span> | Runs a specific generator. To see available generators, run `ember help generate`.
  `ember test`                                | Run tests with Testem on CI mode. You can pass any options to Testem through `testem.json`, by default we'll search for it under your project's root or you can specify `config-file`.
+ `ember install`                             | Installs npm and bower dependencies
+ `ember install:npm <packages>`              | Installs the given npm dependencies to your project and saves them to the `package.json`
+ `ember install:bower <packages>`            | Installs the given bower dependencies to your project and saves them to the `bower.json`
+ `ember install:addon <addon-name>`          | Installs the given addon to your project and saves it to the `package.json`. It will run the addon's `defaultBlueprint` if it provides one.
 
 ### Folder Layout
 


### PR DESCRIPTION
- Updated addon install references and npm / bower references to use the correct
  ember install command
- Updated the developing addons tutorial to use this and add info about the
  `defaultBlueprint`

closes #2802 

These are already in v0.1.5 so if y'all think it's good it's ready to merge
