### PR TITLE
- WIP, using 'expect' instead of 'assert' in tests.

### DIFF
--- a/tests/unit/preprocessors/javascript-test.js
+++ b/tests/unit/preprocessors/javascript-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var preprocessJs   = require('../../../lib/preprocessors').preprocessJs;
 
 var registry, plugins;
@@ -36,7 +36,7 @@ describe('preprocessJs', function() {
       registry: registry
     });
 
-    assert.deepEqual(pluginsCalled, ['foo', 'bar']);
+    expect(pluginsCalled).to.deep.equal(['foo', 'bar']);
   });
 
   it('passes the previously returned value into the next plugin', function() {
@@ -56,7 +56,8 @@ describe('preprocessJs', function() {
       registry: registry
     });
 
-    assert.deepEqual(treeValues, ['app', 'foo']);
-    assert.equal(output, 'bar');
+    expect(treeValues).to.deep.equal(['app', 'foo']);
+    expect(output).to.equal('bar');
+
   });
 });

--- a/tests/unit/preprocessors/registry-test.js
+++ b/tests/unit/preprocessors/registry-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assign         = require('lodash-node/modern/objects/assign');
-var assert         = require('../../helpers/assert');
+var expect         = require('chai').expect;
 var PluginRegistry = require('../../../lib/preprocessors/registry');
 
 var pkg, registry, app;
@@ -28,37 +28,37 @@ describe('Plugin Loader', function() {
   it('returns array of one plugin when only one', function() {
     var plugins = registry.load('css');
 
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-sass');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-sass');
   });
 
   it('returns the correct list of plugins when there are more than one', function() {
     registry.availablePlugins['broccoli-ruby-sass'] = 'latest';
     var plugins = registry.load('css');
 
-    assert.equal(plugins.length, 2);
-    assert.equal(plugins[0].name, 'broccoli-sass');
-    assert.equal(plugins[1].name, 'broccoli-ruby-sass');
+    expect(plugins.length).to.equal(2);
+    expect(plugins[0].name).to.equal('broccoli-sass');
+    expect(plugins[1].name).to.equal('broccoli-ruby-sass');
   });
 
   it('returns plugin of the correct type', function() {
     registry.add('js', 'broccoli-coffee');
     var plugins = registry.load('js');
 
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-coffee');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-coffee');
   });
 
   it('returns plugin that was in dependencies', function() {
     registry.add('template', 'broccoli-emblem');
     var plugins = registry.load('template');
-    assert.equal(plugins[0].name, 'broccoli-emblem');
+    expect(plugins[0].name).to.equal('broccoli-emblem');
   });
 
   it('returns null when no plugin available for type', function() {
     registry.add('blah', 'not-available');
     var plugins = registry.load('blah');
-    assert.equal(plugins.length, 0);
+    expect(plugins.length).to.equal(0);
   });
 
   it('returns the configured extension for the plugin', function() {
@@ -66,7 +66,7 @@ describe('Plugin Loader', function() {
     registry.availablePlugins = { 'broccoli-less-single': 'latest' };
     var plugins = registry.load('css');
 
-    assert.equal(plugins[0].ext, 'less');
+    expect(plugins[0].ext).to.equal('less');
   });
 
   it('can specify fallback extensions', function() {
@@ -74,15 +74,15 @@ describe('Plugin Loader', function() {
     var plugins = registry.load('css');
     var plugin  = plugins[0];
 
-    assert.equal(plugin.ext[0], 'scss');
-    assert.equal(plugin.ext[1], 'sass');
+    expect(plugin.ext[0]).to.equal('scss');
+    expect(plugin.ext[1]).to.equal('sass');
   });
 
   it('provides the application name to each plugin', function() {
     registry.add('js', 'broccoli-coffee');
     var plugins = registry.load('js');
 
-    assert.equal(plugins[0].applicationName, 'some-application-name');
+    expect(plugins[0].applicationName).to.equal('some-application-name');
   });
 
   it('adds a plugin directly if it is provided', function() {
@@ -91,7 +91,7 @@ describe('Plugin Loader', function() {
     registry.add('js', randomPlugin);
     var registered = registry.registry['js'];
 
-    assert.equal(registered[0], randomPlugin);
+    expect(registered[0]).to.equal(randomPlugin);
   });
 
   it('returns plugins added manually even if not present in package deps', function() {
@@ -100,7 +100,7 @@ describe('Plugin Loader', function() {
     registry.add('foo', randomPlugin);
     var plugins = registry.load('foo');
 
-    assert.equal(plugins[0], randomPlugin);
+    expect(plugins[0]).to.equal(randomPlugin);
   });
 
   describe('extensionsForType', function() {
@@ -108,20 +108,20 @@ describe('Plugin Loader', function() {
 
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['css', 'scss', 'sass']);
+      expect(extensions).to.deep.equal(['css', 'scss', 'sass']);
     });
 
     it('can handle mixed array and non-array extensions', function() {
       registry.add('css', 'broccoli-foo', 'foo');
       var extensions = registry.extensionsForType('css');
 
-      assert.deepEqual(extensions, ['css', 'scss', 'sass', 'foo']);
+      expect(extensions).to.deep.equal(['css', 'scss', 'sass', 'foo']);
     });
   });
 
   describe('adds a plugin directly if it is provided', function() {
     it('returns an empty array if called on an unknown type', function() {
-      assert.deepEqual(registry.registeredForType('foo'), []);
+      expect(registry.registeredForType('foo')).to.deep.equal([]);
     });
 
     it('returns the current array if type is found', function() {
@@ -129,7 +129,7 @@ describe('Plugin Loader', function() {
 
       registry.registry['foo'] = fooArray;
 
-      assert.equal(registry.registeredForType('foo'), fooArray);
+      expect(registry.registeredForType('foo')).to.equal(fooArray);
     });
   });
 
@@ -138,8 +138,8 @@ describe('Plugin Loader', function() {
     registry.remove('css', 'broccoli-sass');
 
     var plugins = registry.load('css');
-    assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, 'broccoli-ruby-sass');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0].name).to.equal('broccoli-ruby-sass');
   });
 
   it('allows removal of plugin added as instantiated objects', function() {
@@ -149,11 +149,11 @@ describe('Plugin Loader', function() {
     registry.add('foo', randomPlugin);
 
     plugins = registry.load('foo');
-    assert.equal(plugins[0], randomPlugin); // precondition
+    expect(plugins[0]).to.equal(randomPlugin); // precondition
 
     registry.remove('foo', randomPlugin);
 
     plugins = registry.load('foo');
-    assert.equal(plugins.length, 0);
+    expect(plugins.length).to.equal(0);
   });
 });

--- a/tests/unit/preprocessors/style-plugin-test.js
+++ b/tests/unit/preprocessors/style-plugin-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
+var expect      = require('chai').expect;
 var StylePlugin = require('../../../lib/preprocessors/style-plugin');
 
 describe('Style Plugin', function(){
@@ -16,22 +16,22 @@ describe('Style Plugin', function(){
       plugin = new StylePlugin('california-stylesheets', 'cass', options);
     });
     it('sets type', function(){
-      assert.equal(plugin.type, 'css');
+      expect(plugin.type).to.equal('css');
     });
     it('sets name', function(){
-      assert.equal(plugin.name, 'california-stylesheets');
+      expect(plugin.name).to.equal('california-stylesheets');
     });
     it('sets ext', function(){
-      assert.equal(plugin.ext, 'cass');
+      expect(plugin.ext).to.equal('cass');
     });
     it('sets options', function(){
-      assert.equal(plugin.options, options);
+      expect(plugin.options).to.equal(options);
     });
     it('sets registry', function(){
-      assert.equal(plugin.registry, 'some/registry');
+      expect(plugin.registry).to.equal('some/registry');
     });
     it('sets applicationName', function(){
-      assert.equal(plugin.applicationName, 'some/application');
+      expect(plugin.applicationName).to.equal('some/application');
     });
   });
 });

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert            = require('../../../helpers/assert');
+var expect            = require('chai').expect;
 var ExpressServer     = require('../../../../lib/tasks/server/express-server');
 var Promise           = require('../../../../lib/ext/promise');
 var MockUI            = require('../../../helpers/mock-ui');
@@ -53,9 +53,9 @@ describe('express-server', function() {
         require: function() { return {};   }
       };
 
-      assert.throws(function() {
+      expect(function() {
         subject.processAppMiddlewares();
-      }, TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
+      }).to.throw(TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
     });
   });
 
@@ -68,9 +68,12 @@ describe('express-server', function() {
         baseURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[1], 'Serving on http://0.0.0.0:1337/');
-        assert.deepEqual(output[0], 'Proxying to http://localhost:3001/');
-        assert.deepEqual(output.length, 2, 'expected only two lines of output');
+        // assert.deepEqual(output[1], 'Serving on http://0.0.0.0:1337/');
+        // assert.deepEqual(output[0], 'Proxying to http://localhost:3001/');
+        // assert.deepEqual(output.length, 2, 'expected only two lines of output');
+        expect(output[1]).to.equal('Serving on http://0.0.0.0:1337/');
+        expect(output[0]).to.equal('Proxying to http://localhost:3001/');
+        expect(output.length).to.equal(2);
       });
     });
 
@@ -81,8 +84,10 @@ describe('express-server', function() {
         baseURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/');
-        assert.deepEqual(output.length, 1, 'expected only one line of output');
+        // assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/');
+        // assert.deepEqual(output.length, 1, 'expected only one line of output');
+        expect(output[0]).to.equal('Serving on http://0.0.0.0:1337/');
+        expect(output.length).to.equal(1);
       });
     });
 
@@ -93,8 +98,10 @@ describe('express-server', function() {
         baseURL: '/foo'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
-        assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/foo/');
-        assert.deepEqual(output.length, 1, 'expected only one line of output');
+        // assert.deepEqual(output[0], 'Serving on http://0.0.0.0:1337/foo/');
+        // assert.deepEqual(output.length, 1, 'expected only one line of output');
+        expect(output[0]).to.equal('Serving on http://0.0.0.0:1337/foo/');
+        expect(output.length).to.equal(1);
       });
     });
 
@@ -107,10 +114,10 @@ describe('express-server', function() {
         port: '1337'
       })
         .then(function() {
-          assert(false, 'should have rejected');
+          expect(true, 'should have rejected').to.equal(false);
         })
         .catch(function(reason) {
-          assert.equal(reason, 'Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
+          expect(reason).to.equal('Could not serve on http://0.0.0.0:1337. It is either in use or you do not have permission.');
         })
           .finally(function() {
             preexistingServer.close(done);
@@ -141,13 +148,13 @@ describe('express-server', function() {
             .get('/foo')
             .set('accept', 'application/json, */*')
             .expect(function(res) {
-              assert.equal(res.text, expected);
+              expect(res.text).to.equal(expected);
             })
             .end(function(err) {
               if (err) {
                 return done(err);
               }
-              assert(!proxy.called);
+              expect(proxy.called).to.equal(false);
               done();
             });
         });
@@ -171,7 +178,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(!proxy.called);
+            expect(proxy.called).to.equal(false);
             if (responseCallback) { responseCallback(response); }
             done();
           });
@@ -183,7 +190,7 @@ describe('express-server', function() {
 
       it('bypasses proxy for files that exist', function(done) {
         bypassTest(subject.app, '/test-file.txt', done, function(response) {
-          assert.equal(response.text.trim(), 'some contents');
+          expect(response.text.trim()).to.equal('some contents');
         });
       });
 
@@ -196,9 +203,9 @@ describe('express-server', function() {
               return done(err);
             }
 
-            assert(proxy.called, 'proxy receives the request');
-            assert.equal(proxy.lastReq.method, method.toUpperCase());
-            assert.equal(proxy.lastReq.url, url);
+            expect(proxy.called).to.equal(true);
+            expect(proxy.lastReq.method).to.equal(method.toUpperCase());
+            expect(proxy.lastReq.url).to.equal(url);
             done();
           });
       }
@@ -223,7 +230,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(proxy.called, 'proxy receives the request');
+            expect(proxy.called).to.equal(true);
             done();
           });
       });
@@ -253,9 +260,9 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(nockProxy.called, 'proxy receives the request');
-            assert.equal(nockProxy.method, method.toUpperCase());
-            assert.equal(nockProxy.url, url);
+            expect(nockProxy.called).to.equal(true);
+            expect(nockProxy.method).to.equal(method.toUpperCase());
+            expect(nockProxy.url).to.equal(url);
             done();
           });
       }
@@ -343,7 +350,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            assert(nockProxy.called, 'proxy receives the request');
+            expect(nockProxy.called).to.equal(true);
             done();
           });
       });
@@ -453,7 +460,7 @@ describe('express-server', function() {
             request(subject.app)
             .get('/test-file.txt')
             .end(function(err, response) {
-              assert.equal(response.text.trim(), 'some contents');
+              expect(response.text.trim()).to.equal('some contents');
               done();
             });
           });
@@ -470,7 +477,7 @@ describe('express-server', function() {
                   return done(err);
                 }
 
-                assert.equal(response.text.trim(), 'some other content');
+                expect(response.text.trim()).to.equal('some other content');
 
                 done();
               });
@@ -488,7 +495,7 @@ describe('express-server', function() {
                   return done(err);
                 }
 
-                assert.equal(response.text.trim(), 'some other content');
+                expect(response.text.trim()).to.equal('some other content');
 
                 done();
               });
@@ -511,7 +518,7 @@ describe('express-server', function() {
           host:  '0.0.0.0',
           port: '1337'
         }).then(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
     });
@@ -543,8 +550,8 @@ describe('express-server', function() {
           host:  '0.0.0.0',
           port: '1337'
         }).then(function() {
-          assert.equal(firstCalls, 1);
-          assert.equal(secondCalls, 1);
+          expect(firstCalls).to.equal(1);
+          expect(secondCalls).to.equal(1);
         });
       });
 
@@ -556,8 +563,8 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(firstCalls, 2);
-          assert.equal(secondCalls, 2);
+          expect(firstCalls).to.equal(2);
+          expect(secondCalls).to.equal(2);
         });
       });
     });
@@ -583,8 +590,8 @@ describe('express-server', function() {
         };
 
         return subject.start(realOptions).then(function() {
-          assert(passedOptions === realOptions);
-          assert.equal(calls, 1);
+          expect(passedOptions).to.equal(realOptions);
+          expect(calls).to.equal(1);
         });
       });
 
@@ -603,10 +610,10 @@ describe('express-server', function() {
             return subject.restartHttpServer();
           })
           .then(function() {
-            assert(subject.app);
-            assert.notEqual(originalApp, subject.app);
-            assert(passedOptions === realOptions);
-            assert.equal(calls, 2);
+            expect(!subject.app).to.equal(false);
+            expect(originalApp).not.to.equal(subject.app);
+            expect(passedOptions).to.equal(realOptions);
+            expect(calls).to.equal(2);
           });
       });
 
@@ -623,7 +630,7 @@ describe('express-server', function() {
         };
 
         return subject.start(realOptions).then(function() {
-          assert(!!passedOptions.httpServer.listen);
+          expect(!passedOptions.httpServer.listen).to.equal(false);
         });
       });
     });
@@ -640,7 +647,7 @@ describe('express-server', function() {
           port: '1337'
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
 
@@ -656,7 +663,7 @@ describe('express-server', function() {
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
           subject.serverWatcher.emit('change', 'bar.txt');
-          assert.equal(calls, 2);
+          expect(calls).to.equal(2);
         });
       });
     });
@@ -669,13 +676,13 @@ describe('express-server', function() {
         };
 
         subject.scheduleServerRestart();
-        assert.equal(calls, 0);
+        expect(calls).to.equal(0);
         setTimeout(function() {
-          assert.equal(calls, 0);
+          expect(calls).to.equal(0);
           subject.scheduleServerRestart();
         }, 50);
         setTimeout(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
           done();
         }, 175);
       });
@@ -695,11 +702,11 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(ui.output, EOL + chalk.green('Server restarted.') + EOL + EOL);
-          assert(subject.httpServer, 'HTTP server exists');
-          assert.notEqual(subject.httpServer, originalHttpServer, 'HTTP server has changed');
-          assert(subject.app, 'App exists');
-          assert.notEqual(subject.app, originalApp, 'App has changed');
+          expect(ui.output).to.equal(EOL + chalk.green('Server restarted.') + EOL + EOL);
+          expect(!subject.httpServer).to.equal(false);
+          expect(subject.httpServer).not.to.equal(originalHttpServer, 'HTTP server has changed');
+          expect(!subject.app).to.equal(false);
+          expect(subject.app).not.to.equal(originalApp);
         });
       });
 
@@ -721,10 +728,10 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert(subject.httpServer, 'HTTP server exists');
-          assert.notEqual(subject.httpServer, originalHttpServer, 'HTTP server has changed');
-          assert(subject.app, 'App exists');
-          assert.notEqual(subject.app, originalApp, 'App has changed');
+          expect(!subject.httpServer).to.equal(false);
+          expect(subject.httpServer).not.to.equal(originalHttpServer, 'HTTP server has changed');
+          expect(!subject.app).to.equal(false);
+          expect(subject.app).not.to.equal(originalApp);
         });
       });
 
@@ -740,7 +747,7 @@ describe('express-server', function() {
           subject.changedFiles = ['bar.js'];
           return subject.restartHttpServer();
         }).then(function() {
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
       });
     });

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert            = require('../../../helpers/assert');
+var expect            = require('chai').expect;
 var LiveReloadServer  = require('../../../../lib/tasks/server/livereload-server');
 var MockUI            = require('../../../helpers/mock-ui');
 var MockExpressServer = require('../../../helpers/mock-express-server');
@@ -46,8 +46,11 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: false
       }).then(function(output) {
-        assert.equal(output, 'Livereload server manually disabled.');
-        assert(!subject._liveReloadServer);
+        expect(output).to.equal('Livereload server manually disabled.');
+        // assert(!subject._liveReloadServer);
+        // expect(subject._liveReloadServer).to.equal(false);
+        // Help, is the following expect correct ? the one above did not work!
+        expect(subject._liveReloadServer).to.be.an('undefined');
       });
     });
 
@@ -56,7 +59,7 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: true
       }).then(function() {
-        assert.equal(ui.output, 'Livereload server on port 1337' + EOL);
+        expect(ui.output).to.equal('Livereload server on port 1337' + EOL);
       });
     });
 
@@ -69,7 +72,7 @@ describe('livereload-server', function() {
           liveReload: true
         })
         .catch(function(reason) {
-          assert.equal(reason, 'Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
+          expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
         })
         .finally(function() {
           preexistingServer.close(done);
@@ -89,7 +92,7 @@ describe('livereload-server', function() {
           liveReload: true
         }).then(function () {
           expressServer.emit('restart');
-          assert.equal(calls, 1);
+          expect(calls).to.equal(1);
         });
     });
   });
@@ -127,8 +130,8 @@ describe('livereload-server', function() {
 
     it('triggers the liverreload server of a change when no pattern matches', function() {
       subject.didChange({filePath: ''});
-      assert.equal(changedCount, 1);
-      assert.equal(trackCount, 1);
+      expect(changedCount).to.equal(1);
+      expect(trackCount).to.equal(1);
     });
 
     it('does not trigger livereoad server of a change when there is a pattern match', function() {
@@ -142,8 +145,8 @@ describe('livereload-server', function() {
       subject.didChange({
         filePath: '/home/user/my-project/test/fixtures/proxy/file-a.js'
       });
-      assert.equal(changedCount, 0);
-      assert.equal(trackCount, 0);
+      expect(changedCount).to.equal(0);
+      expect(trackCount).to.equal(0);
     });
   });
 });

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
+var expect      = require('chai').expect;
 var TestServerTask    = require('../../../lib/tasks/test-server');
 var MockProject = require('../../helpers/mock-project');
 var MockUI      = require('../../helpers/mock-ui');
@@ -21,10 +21,10 @@ describe('test server', function() {
       },
       testem: {
         startDev: function(options) {
-          assert.equal(options.file, 'blahzorz.conf');
-          assert.equal(options.port, 123324);
-          assert.equal(options.cwd, 'blerpy-derpy');
-          assert.deepEqual(options.middleware, ['middleware1', 'middleware2']);
+          expect(options.file).to.equal('blahzorz.conf');
+          expect(options.port).to.equal(123324);
+          expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           done();
         }
       }

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
+var expect     = require('chai').expect;
 var TestTask    = require('../../../lib/tasks/test');
 var MockProject = require('../../helpers/mock-project');
 
@@ -15,10 +15,10 @@ describe('test', function() {
       },
       testem: {
         startCI: function(options, cb) {
-          assert.equal(options.file, 'blahzorz.conf');
-          assert.equal(options.port, 123324);
-          assert.equal(options.cwd, 'blerpy-derpy');
-          assert.deepEqual(options.middleware, ['middleware1', 'middleware2']);
+          expect(options.file).to.equal('blahzorz.conf');
+          expect(options.port).to.equal(123324);
+          expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           cb(0);
         },
         app: { reporter: { total: 1 } }

--- a/tests/unit/tasks/update-test.js
+++ b/tests/unit/tasks/update-test.js
@@ -2,7 +2,7 @@
 
 var fs         = require('fs');
 var path       = require('path');
-var assert     = require('../../helpers/assert');
+var expect     = require('chai').expect;
 var MockUI     = require('../../helpers/mock-ui');
 var Promise    = require('../../../lib/ext/promise');
 var UpdateTask = require('../../../lib/tasks/update');
@@ -60,8 +60,8 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.include(ui.output, 'A new version of ember-cli is available');
-        assert.include(ui.output, 'Are you sure you want to update ember-cli?');
+        expect(ui.output).to.include('A new version of ember-cli is available');
+        expect(ui.output).to.include('Are you sure you want to update ember-cli?');
       });
     });
   });
@@ -120,14 +120,14 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.include(ui.output, 'A new version of ember-cli is available');
-        assert.include(ui.output, 'Are you sure you want to update ember-cli?');
-        assert.deepEqual(installCalledWith, [ 'ember-cli' ], '');
-        assert.deepEqual(loadCalledWith, {
+        expect(ui.output).to.include('A new version of ember-cli is available');
+        expect(ui.output).to.include('Are you sure you want to update ember-cli?');
+        expect(installCalledWith).to.deep.equal([ 'ember-cli' ]);
+        expect(loadCalledWith).to.deep.equal({
           'global': true,
           'loglevel': 'silent'
-        }, '');
-        assert(initCommandWasRun);
+        });
+        expect(initCommandWasRun).to.equal(true);
       });
     });
 
@@ -137,7 +137,7 @@ describe('update task', function() {
       }, {
         newestVersion: '100.0.0'
       }).then(function() {
-        assert.equal(pkg.devDependencies['ember-cli'], '100.0.0');
+        expect(pkg.devDependencies['ember-cli']).to.equal('100.0.0');
       });
     });
 

--- a/tests/unit/ui/write-error-test.js
+++ b/tests/unit/ui/write-error-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assert     = require('assert');
+var expect     = require('chai').expect;
 var writeError = require('../../../lib/ui/write-error');
 var MockUI     = require('../../helpers/mock-ui');
 var BuildError = require('../../helpers/build-error');
@@ -23,7 +23,7 @@ describe('writeError', function() {
       message: 'build error'
     }));
 
-    assert.equal(ui.output, chalk.red('build error') + EOL);
+    expect(ui.output).to.equal(chalk.red('build error') + EOL);
   });
 
   it('error with stack', function() {
@@ -31,7 +31,7 @@ describe('writeError', function() {
       stack: 'the stack'
     }));
 
-    assert.equal(ui.output, chalk.red('Error') + EOL + 'the stack' + EOL);
+    expect(ui.output).to.equal(chalk.red('Error') + EOL + 'the stack' + EOL);
   });
 
   it('error with file', function() {
@@ -39,7 +39,7 @@ describe('writeError', function() {
       file: 'the file'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line', function() {
@@ -48,7 +48,7 @@ describe('writeError', function() {
       line: 'the line'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + col', function() {
@@ -57,7 +57,7 @@ describe('writeError', function() {
       col: 'the col'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line + col', function() {
@@ -67,6 +67,6 @@ describe('writeError', function() {
       col:  'the col'
     }));
 
-    assert.equal(ui.output, chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal(chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
   });
 });

--- a/tests/unit/utilities/doc-generator-test.js
+++ b/tests/unit/utilities/doc-generator-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var DocGenerator = require('../../../lib/utilities/doc-generator.js');
+var DocGenerator     = require('../../../lib/utilities/doc-generator.js');
 var calculateVersion = require('../../../lib/utilities/ember-cli-version.js');
-var assert = require('assert');
-var path = require('path');
+var expect           = require('chai').expect;
+var path             = require('path');
 
 describe('generateDocs', function(){
   it('calls the the appropriate command', function(){
@@ -16,7 +16,7 @@ describe('generateDocs', function(){
       console.log('Pattern:  ' + pattern);
       console.log('Argument: ' + arguments[0]);
 
-      assert.ok((new RegExp(pattern)).test(arguments[0]));
+      expect((new RegExp(pattern)).test(arguments[0])).to.equal(true);
     };
 
     var generator = new DocGenerator({exec: execFunc});

--- a/tests/unit/utilities/git-repo-test.js
+++ b/tests/unit/utilities/git-repo-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var isGitRepo = require('../../../lib/utilities/git-repo');
-var assert    = require('assert');
+var expect    = require('chai').expect ;
 
 describe('cleanBaseURL()', function() {
   it('recognizes git-style urls in various formats', function() {
-    assert.ok(isGitRepo('https://github.com/trek/app-blueprint-test.git'));
-    assert.ok(isGitRepo('git@github.com:trek/app-blueprint-test.git'));
-    assert.ok(isGitRepo('git+ssh://user@server/project.git'));
-    assert.ok(isGitRepo('git+https://user@server/project.git'));
+    expect(isGitRepo('https://github.com/trek/app-blueprint-test.git')).to.equal(true);
+    expect(isGitRepo('git@github.com:trek/app-blueprint-test.git')).to.equal(true);
+    expect(isGitRepo('git+ssh://user@server/project.git')).to.equal(true);
+    expect(isGitRepo('git+https://user@server/project.git')).to.equal(true);
   });
 });


### PR DESCRIPTION
In this PR, the following tests are done (changing 'assert' to 'expect'):
Currently, this is my WIP,
- [ ] `unit`
  - [ ] package
  - [x] preprocessors
  - [x] tasks
  - [x] ui
  - [x] utilities