### PR TITLE
Add .npmignore for ember-cli addons

### DIFF
--- a/blueprints/addon/files/.npmignore
+++ b/blueprints/addon/files/.npmignore
@@ -1,0 +1,12 @@
+tests/
+bower_components/
+
+.travis.yml
+.npmignore
+Brocfile.js
+.editorconfig
+testem.json
+.ember-cli
+bower.json
+.bowerrc
+**/.gitkeep


### PR DESCRIPTION
When packaging the node module it likely does not need all of these
files. We can disucss if anything here should be included.

This was originally submitted to ember-cli-i18n by @pogopaule and we
requested that he submit PR to ember-cli but to my knowledge that has
not happened so I'm taking the initiative.