### PR TITLE
[FEATURE] NPM should use save-exact flags

### DIFF
--- a/lib/commands/install-addon.js
+++ b/lib/commands/install-addon.js
@@ -31,7 +31,8 @@ module.exports = Command.extend({
 
     return npmInstall.run({
       packages: rawArgs,
-      'save-dev': true
+      'save-dev': true,
+      'save-exact': true
     }).then(function() {
       return this.project.reloadAddons();
     }.bind(this)).then(function() {

--- a/lib/commands/install-npm.js
+++ b/lib/commands/install-npm.js
@@ -21,7 +21,8 @@ module.exports = Command.extend({
 
     return npmInstall.run({
       packages: rawArgs,
-      'save-dev': true
+      'save-dev': true,
+      'save-exact': true
     });
   }
 });

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -19,7 +19,8 @@ module.exports = Task.extend({
       loglevel: options.verbose ? 'verbose' : 'error',
       logstream: this.ui.outputStream,
       color: 'always',
-      'save-dev': !!options['save-dev']
+      'save-dev': !!options['save-dev'],
+      'save-exact': !!options['save-exact']
     };
     var packages = options.packages || [];
 

--- a/tests/unit/commands/install-addon-test.js
+++ b/tests/unit/commands/install-addon-test.js
@@ -99,7 +99,8 @@ describe('install:addon command', function() {
 
         expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: ['ember-data'],
-          'save-dev': true
+          'save-dev': true,
+          'save-exact': true
         }, 'expected npm install called with given name and save-dev true');
       });
     });

--- a/tests/unit/commands/install-npm-test.js
+++ b/tests/unit/commands/install-npm-test.js
@@ -52,14 +52,15 @@ describe('install:npm command', function() {
   });
 
   describe('with no args', function() {
-    it('runs the npm install task with no packages and save-dev true', function() {
+    it('runs the npm install task with no packages, save-dev true and save-exact true', function() {
       return command.validateAndRun([]).then(function() {
         var npmRun = tasks.NpmInstall.prototype.run;
         expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
         expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: [],
-          'save-dev': true
-        }, 'expected npm install called with no packages and save-dev true');
+          'save-dev': true,
+          'save-exact': true
+        }, 'expected npm install called with no packages, save-dev true, and save-exact true');
       });
     });
   });
@@ -71,8 +72,9 @@ describe('install:npm command', function() {
         expect(npmRun.called).to.equal(1, 'expected npm install run was called once');
         expect(npmRun.calledWith[0][0]).to.deep.equal({
           packages: ['moment', 'lodash'],
-          'save-dev': true
-        }, 'expected npm install called with given packages and save-dev true');
+          'save-dev': true,
+          'save-exact': true
+        }, 'expected npm install called with given packages, save-dev true, and save-exact true');
       });
     });
   });


### PR DESCRIPTION
NPM chooses not to do this by default. I think is a mistake because of issues with fuzzy matching dependencies.  We have an opportunity to lock dependencies down to real versions in Ember CLI by default.