### PR TITLE
Bump ember-router-generator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "core-object": "0.0.2",
     "debug": "^2.1.0",
     "diff": "^1.0.8",
-    "ember-router-generator": "^0.1.1",
+    "ember-router-generator": "^0.2.0",
     "exit": "^0.1.2",
     "express": "^4.8.5",
     "findup": "0.1.5",


### PR DESCRIPTION
Fixes #2882.

Also single quotes will be kept but new routes will use double quotes, to fix this we'll need to PR against recast see https://github.com/ember-cli/ember-router-generator/issues/4