### PR TITLE
Fixes style preprocessor behavior in addons

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -919,6 +919,15 @@ EmberApp.prototype.otherAssets = function() {
 };
 
 /**
+  @public
+  @method dependencies
+  @return {Object} Alias to the project's dependencies function
+*/
+EmberApp.prototype.dependencies = function(pkg) {
+  return this.project.dependencies(pkg);
+};
+
+/**
   Imports an asset into the application.
 
   Options:

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -332,6 +332,7 @@ Addon.prototype.compileStyles = function(tree) {
   if (tree) {
     var self = this;
     var processedStyles = preprocessCss(tree, '/', '/', {
+      stylesPath: path.join(this.root, '/addon/styles'),
       registry: this.registry
     });
 
@@ -530,6 +531,16 @@ Addon.prototype.config = function (env, baseConfig) {
 
     return configGenerator(env, baseConfig);
   }
+};
+
+/**
+  @public
+  @method dependencies
+  @return {Object} The addon's dependencies based on the addon's package.json
+*/
+Addon.prototype.dependencies = function() {
+  var pkg = this.pkg || {};
+  return assign({}, pkg['devDependencies'], pkg['dependencies']);
 };
 
 /**

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -5,7 +5,7 @@ var Registry     = require('./preprocessors/registry');
 var requireLocal = require('./utilities/require-local');
 
 module.exports.setupRegistry = function(app) {
-  var registry = new Registry(app.project.dependencies(), app);
+  var registry = new Registry(app.dependencies(), app);
 
   registry.add('css', 'broccoli-sass', ['scss', 'sass']);
   registry.add('css', 'broccoli-ruby-sass', ['scss', 'sass']);

--- a/lib/preprocessors/plugin.js
+++ b/lib/preprocessors/plugin.js
@@ -24,7 +24,7 @@ Plugin.prototype.getExt = function(inputPath, filename) {
     var detect = require('lodash-node/modern/collections/find');
     return detect(this.ext, function(ext) {
       var filenameAndExt = filename + '.' + ext;
-      return fs.existsSync(path.join('.', inputPath, filenameAndExt));
+      return fs.existsSync(path.join(inputPath, filenameAndExt));
     });
   } else {
     return this.ext;

--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -18,22 +18,33 @@ StylePlugin.prototype._superConstructor = Plugin;
 
 StylePlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
   options = merge({}, this.options, options);
-  var _this = this,
-      paths = options.outputPaths;
+  
+  var paths = options.outputPaths;
 
-  var trees = Object.keys(paths).map(function (file) {
-    var ext = _this.getExt(inputPath, file);
-    if (!ext) {
-      var attemptedExtensions = Array.isArray(_this.ext) ? _this.ext : [_this.ext];
-      throw new SilentError('app/styles/' + file + '.[' + attemptedExtensions.join('/') + '] does not exist');
-    }
-    var input = path.join(inputPath, file + '.' + ext);
-    var output = paths[file];
+  // outputPaths are not available in Addons
+  if (paths) {
+    var self = this;
+    var trees = Object.keys(paths).map(function (file) {
+      return self._processFile(tree, file, inputPath, paths[file], options);
+    });
 
-    return requireLocal(_this.name).call(null, [tree], input, output, options);
-  });
+    return mergeTrees(trees);
+  } else {
+    var file = options.fileName || 'app';
+    outputPath = path.join(outputPath, file + '.css');
+    return this._processFile(tree, file, inputPath, outputPath, options);
+  }
+};
 
-  return mergeTrees(trees);
+StylePlugin.prototype._processFile = function(tree, file, inputPath, outputPath, options) { 
+  var filePath = options.stylesPath || path.join('.', inputPath);
+  var ext = this.getExt(filePath, file);
+  if (!ext) {
+    var attemptedExtensions = Array.isArray(this.ext) ? this.ext.join('/') : this.ext;
+    throw new SilentError(path.join(filePath, file) + '.[' + attemptedExtensions + '] does not exist');
+  }
+  var input = path.join(inputPath, file + '.' + ext);
+  return requireLocal(this.name).call(null, [tree], input, outputPath, options);
 };
 
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var path       = require('path');
+var fs         = require('fs');
+var expect     = require('chai').expect;
+
+var runCommand          = require('../helpers/run-command');
+var acceptance          = require('../helpers/acceptance');
+var copyFixtureFiles    = require('../helpers/copy-fixture-files');
+var assertDirEmpty      = require('../helpers/assert-dir-empty');
+var createTestTargets   = acceptance.createTestTargets;
+var teardownTestTargets = acceptance.teardownTestTargets;
+var linkDependencies    = acceptance.linkDependencies;
+var cleanupRun          = acceptance.cleanupRun;
+
+var appName  = 'some-cool-app';
+
+describe('Acceptance: preprocessor-smoke-test', function() {
+  before(function() {
+    this.timeout(360000);
+    return createTestTargets(appName);
+  });
+
+  after(function() {
+    this.timeout(15000);
+    return teardownTestTargets();
+  });
+
+  beforeEach(function() {
+    this.timeout(360000);
+    return linkDependencies(appName);
+  });
+
+  afterEach(function() {
+    this.timeout(15000);
+    return cleanupRun().then(function() {
+      assertDirEmpty('tmp');
+    });
+  });
+
+  it('addons with preprocessors compile correctly', function() {
+    this.timeout(100000);
+
+    return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = require(packageJsonPath);
+        packageJson.devDependencies['broccoli-sass'] = 'latest';
+        packageJson.devDependencies['ember-cool-addon'] = 'latest';
+
+        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--silent');
+      })
+      .then(function() {
+        var mainCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'some-cool-app.css'), {
+          encoding: 'utf8'
+        });
+
+        var vendorCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'vendor.css'), {
+          encoding: 'utf8'
+        });
+
+        expect(mainCSS).to.contain('app styles included');
+        expect(vendorCSS).to.contain('addon styles included');
+      });
+  });
+
+  it('addons without preprocessors compile correctly', function() {
+    this.timeout(100000);
+
+    return copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = require(packageJsonPath);
+        packageJson.devDependencies['broccoli-sass'] = 'latest';
+
+        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--silent');
+      })
+      .then(function() {
+        var mainCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'some-cool-app.css'), {
+          encoding: 'utf8'
+        });
+
+        var vendorCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'vendor.css'), {
+          encoding: 'utf8'
+        });
+
+        expect(mainCSS).to.contain('app styles included');
+        expect(vendorCSS).to.contain('addon styles included');
+      });
+  });
+});

--- a/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'Ember Addon With Dependencies'
+}

--- a/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ember-addon-with-dependencies",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli": "latest",
+    "something-else": "latest"
+  }
+}
+

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -16,7 +16,8 @@
     "non-ember-thingy": "latest",
     "ember-before-blueprint-addon": "latest",
     "ember-after-blueprint-addon": "latest",
-    "ember-devDeps-addon": "latest"
+    "ember-devDeps-addon": "latest",
+    "ember-addon-with-dependencies": "latest"
   }
 }
 

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/app/styles/app.scss
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/app/styles/app.scss
@@ -1,0 +1,1 @@
+/* app styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/broccoli-sass/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/broccoli-sass/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Writer = require('broccoli-writer');
+
+function copyPreserveSync (src, dest) {
+  var srcStats = fs.statSync(src);
+  if (srcStats.isFile()) {
+    var destDir = path.dirname(dest);
+    var dirs = [];
+    while (destDir && !fs.existsSync(destDir)) {
+      dirs.unshift(destDir);
+      destDir = path.dirname(destDir);
+    }
+    dirs.forEach(function (dir) {
+      fs.mkdirSync(dir);
+    });
+    var content = fs.readFileSync(src);
+    fs.writeFileSync(dest, content, { flag: 'wx' });
+    fs.utimesSync(dest, srcStats.atime, srcStats.mtime);
+  } else {
+    throw new Error('Unexpected file type for ' + src);
+  }
+}
+
+module.exports = SassCompiler;
+SassCompiler.prototype = Object.create(Writer.prototype);
+SassCompiler.prototype.constructor = SassCompiler;
+function SassCompiler (sourceTrees, inputFile, outputFile, options) {
+  if (!(this instanceof SassCompiler)) return new SassCompiler(sourceTrees, inputFile, outputFile, options);
+  if (!Array.isArray(sourceTrees)) throw new Error('Expected array for first argument - did you mean [tree] instead of tree?');
+  this.sourceTrees = sourceTrees;
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+}
+
+SassCompiler.prototype.write = function (readTree, destDir) {
+  var self = this;
+
+  return readTree(this.sourceTrees[0]).then(function (srcDir) {
+    copyPreserveSync(
+      path.join(srcDir, self.inputFile),
+      path.join(destDir, self.outputFile));
+  });
+};

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/broccoli-sass/package.json
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/broccoli-sass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broccoli-sass",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/addon/styles/app.scss
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/addon/styles/app.scss
@@ -1,0 +1,1 @@
+/* addon styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/package.json
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ember-cool-addon",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "broccoli-sass": "latest"
+  }
+}
+

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/app/styles/app.scss
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/app/styles/app.scss
@@ -1,0 +1,1 @@
+/* app styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/broccoli-sass/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/broccoli-sass/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Writer = require('broccoli-writer');
+
+function copyPreserveSync (src, dest) {
+  var srcStats = fs.statSync(src);
+  if (srcStats.isFile()) {
+    var destDir = path.dirname(dest);
+    var dirs = [];
+    while (destDir && !fs.existsSync(destDir)) {
+      dirs.unshift(destDir);
+      destDir = path.dirname(destDir);
+    }
+    dirs.forEach(function (dir) {
+      fs.mkdirSync(dir);
+    });
+    var content = fs.readFileSync(src);
+    fs.writeFileSync(dest, content, { flag: 'wx' });
+    fs.utimesSync(dest, srcStats.atime, srcStats.mtime);
+  } else {
+    throw new Error('Unexpected file type for ' + src);
+  }
+}
+
+module.exports = SassCompiler;
+SassCompiler.prototype = Object.create(Writer.prototype);
+SassCompiler.prototype.constructor = SassCompiler;
+function SassCompiler (sourceTrees, inputFile, outputFile, options) {
+  if (!(this instanceof SassCompiler)) return new SassCompiler(sourceTrees, inputFile, outputFile, options);
+  if (!Array.isArray(sourceTrees)) throw new Error('Expected array for first argument - did you mean [tree] instead of tree?');
+  this.sourceTrees = sourceTrees;
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+}
+
+SassCompiler.prototype.write = function (readTree, destDir) {
+  var self = this;
+
+  return readTree(this.sourceTrees[0]).then(function (srcDir) {
+    copyPreserveSync(
+      path.join(srcDir, self.inputFile),
+      path.join(destDir, self.outputFile));
+  });
+};

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/broccoli-sass/package.json
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/broccoli-sass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broccoli-sass",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/addon/styles/app.css
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/addon/styles/app.css
@@ -1,0 +1,1 @@
+/* addon styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/package.json
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-cool-addon",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -9,6 +9,7 @@ var expect  = require('chai').expect;
 var rimraf  = Promise.denodeify(require('rimraf'));
 var tmp     = require('tmp-sync');
 var path    = require('path');
+var findWhere = require('lodash-node/modern/collections/find');
 
 var root    = process.cwd();
 var tmproot = path.join(root, 'tmp');
@@ -130,7 +131,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon no-export', function() {
       before(function() {
-        addon = project.addons[7];
+        addon = findWhere(project.addons, { name: '(generated ember-generated-no-export-addon addon)' });
       });
 
       it('sets it\'s project', function() {
@@ -233,7 +234,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon with-export', function() {
       beforeEach(function() {
-        addon = project.addons[4];
+        addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
 
         // Clear the caches
         delete addon._includedModules;
@@ -314,6 +315,21 @@ describe('models/addon.js', function() {
           var tree = addon.treeFor('addon');
           expect(typeof tree.read).to.equal('function');
         });
+      });
+    });
+
+    describe('addon with dependencies', function() {
+      beforeEach(function() {
+        addon = findWhere(project.addons, { name: 'Ember Addon With Dependencies' });
+      });
+
+      it('returns a listing of all dependencies in the addon\'s package.json', function() {
+        var expected = {
+          'ember-cli': 'latest',
+          'something-else': 'latest'
+        };
+
+        expect(addon.dependencies()).to.deep.equal(expected);
       });
     });
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -157,7 +157,8 @@ describe('models/project.js', function() {
         'ember-before-blueprint-addon': 'latest',
         'ember-after-blueprint-addon': 'latest',
         'something-else': 'latest',
-        'ember-devDeps-addon': 'latest'
+        'ember-devDeps-addon': 'latest',
+        'ember-addon-with-dependencies': 'latest'
       };
 
       expect(project.dependencies()).to.deep.equal(expected);
@@ -189,7 +190,8 @@ describe('models/project.js', function() {
         'proxy-server-middleware', 'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon', 'ember-generated-no-export-addon',
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
-        'ember-devDeps-addon', 'ember-yagni', 'ember-ng', 'ember-super-button'
+        'ember-devDeps-addon', 'ember-addon-with-dependencies', 'ember-yagni', 
+        'ember-ng', 'ember-super-button'
       ];
 
       project.buildAddonPackages();


### PR DESCRIPTION
Currently when a style preprocessor is used in an Ember-CLI app, it will attempt to preprocess styles in any addons which include a `/addon/styles` folder. The style preprocessor assumes that `outputPaths` will be passed along with the options, and fails since addons do not.

It also fails in the `getExt` function because addons do not pass the full directory to the preprocessor. Unfortunately, because the tree passed by the addons resolves to the styles directory, there isn't a simple way to get the full path of the styles directory, so the current solution I've implemented is to pass it in as an additional option. 

Finally, the preprocessor will get called on any addon, regardless of whether or not the addon actually uses a preprocessor. To solve this each addon's registry is passed the dependencies of the addon rather than the dependencies of the parent project. This way the addon will only invoke the preprocessor if it is also required by the addon (i.e. the addon uses the preprocessor, and we can expect an app.[sass/scss/less/styl] there).

TODO: 
* This will not support addons which use a preprocessor that is not included in the parent app. In order to support that, the dynamics of nested addons need to be established and the behavior of  `require-local` will have to be changed.
* Find a more elegant solution to the `getExt` problem.