### PR TITLE
[BUGFIX] only include dependencies(not devDependencies) of included addons

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -130,9 +130,15 @@ Project.prototype.require = function(file) {
 
 Project.prototype.emberCLIVersion = emberCLIVersion;
 
-Project.prototype.dependencies = function(pkg) {
+Project.prototype.dependencies = function(pkg, excludeDevDeps) {
   pkg = pkg || this.pkg || {};
-  return assign({}, pkg['devDependencies'], pkg['dependencies']);
+
+  var devDependencies = pkg['devDependencies'];
+  if (excludeDevDeps) {
+    devDependencies = {};
+  }
+
+  return assign({}, devDependencies, pkg['dependencies']);
 };
 
 Project.prototype.bowerDependencies = function(bower) {
@@ -157,11 +163,11 @@ Project.prototype.buildAddonPackages = function() {
     this.addIfAddon(this.root);
   }
 
-  this.discoverAddons(this.root, this.pkg);
+  this.discoverAddons(this.root, this.pkg, false);
 };
 
-Project.prototype.discoverAddons = function(root, pkg) {
-  Object.keys(this.dependencies(pkg)).forEach(function(name) {
+Project.prototype.discoverAddons = function(root, pkg, excludeDevDeps) {
+  Object.keys(this.dependencies(pkg, excludeDevDeps)).forEach(function(name) {
     if (name !== 'ember-cli') {
       var addonPath = path.join(root, 'node_modules', name);
       this.addIfAddon(addonPath);
@@ -186,7 +192,7 @@ Project.prototype.addIfAddon = function(addonPath) {
     addonPkg['ember-addon'] = addonPkg['ember-addon'] || {};
 
     if (keywords.indexOf('ember-addon') > -1) {
-      this.discoverAddons(addonPath, addonPkg);
+      this.discoverAddons(addonPath, addonPkg, true);
       this.addonPackages[addonPkg.name] = {
         path: addonPath,
         pkg: addonPkg

--- a/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/node_modules/ember-cli-nested/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/node_modules/ember-cli-nested/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-cli-nested",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ]
+}
+

--- a/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/package.json
+++ b/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ember-devDeps-addon",
+  "private": true,
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon"
+  ],
+  "devDependencies": {
+    "ember-cli-nested": "*"
+  }
+}
+

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -15,7 +15,8 @@
     "ember-generated-no-export-addon": "latest",
     "non-ember-thingy": "latest",
     "ember-before-blueprint-addon": "latest",
-    "ember-after-blueprint-addon": "latest"
+    "ember-after-blueprint-addon": "latest",
+    "ember-devDeps-addon": "latest"
   }
 }
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -156,7 +156,8 @@ describe('models/project.js', function() {
         'non-ember-thingy': 'latest',
         'ember-before-blueprint-addon': 'latest',
         'ember-after-blueprint-addon': 'latest',
-        'something-else': 'latest'
+        'something-else': 'latest',
+        'ember-devDeps-addon': 'latest'
       };
 
       expect(project.dependencies()).to.deep.equal(expected);
@@ -188,7 +189,7 @@ describe('models/project.js', function() {
         'proxy-server-middleware', 'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon', 'ember-generated-no-export-addon',
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
-        'ember-yagni', 'ember-ng', 'ember-super-button'
+        'ember-devDeps-addon', 'ember-yagni', 'ember-ng', 'ember-super-button'
       ];
 
       project.buildAddonPackages();


### PR DESCRIPTION
It used to include devDependencies which causes issues when developing locally.
It can also lead to a hard to debug error where something works locally because
you addon is linked and works but when installing from npm it doesn't.

closes #2935