### PR TITLE
Add a hook for postprocessing tests tree

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -640,7 +640,7 @@ EmberApp.prototype.appAndDependencies = function() {
       registry: this.registry
     });
 
-    sourceTrees.push(preprocessedTests);
+    sourceTrees.push(this.addonPostprocessTree('test', preprocessedTests));
 
     if (this.hinting) {
       var jshintedApp = jshintTrees(this._filterAppTree(), {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -346,6 +346,18 @@ describe('broccoli/ember-app', function() {
 
         expect(emberApp.toTree()).to.equal('blap');
       });
+
+      it('calls each addon postprocessTree hook', function() {
+        stub(emberApp, '_processedTemplatesTree', 'x');
+        stub(addon, 'postprocessTree', 'blap');
+        expect(emberApp.toTree()).to.equal('blap');
+        expect(
+          addon.postprocessTree.calledWith.map(function(args){
+            return args[0];
+          }).sort()
+        ).to.deep.equal(['all', 'js', 'test']);
+      });
+
     });
 
     describe('isEnabled is called properly', function() {


### PR DESCRIPTION
This adds a postprocessTree hook for the tests tree, analogous to the one we already have for app js.

With this, ember-browserify will support importing npm dependencies within the tests tree.