### PR TITLE
Fix for aliases for hyphenated options

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -256,10 +256,10 @@ Command.prototype.parseAlias = function(option, alias) {
   if (isValidAlias(alias, option.type)) {
     if (aliasType === 'string') {
       key = alias;
-      value = ['--' + option.key];
+      value = ['--' + option.name];
     } else if (aliasType === 'object') {
       key = Object.keys(alias)[0];
-      value = ['--' + option.key, alias[key]];
+      value = ['--' + option.name, alias[key]];
     }
   } else {
     if (Array.isArray(alias)) {

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -60,6 +60,14 @@ var OptionsAliasCommand = Command.extend({
     aliases:[
       {'mild' : false}
     ]
+  },
+  {
+    name: 'display-message',
+    type: String,
+    aliases:[
+      'dm',
+      { 'hw': 'Hello world' }
+    ]
   }],
   run: function() {}
 });
@@ -215,6 +223,36 @@ describe('models/command.js', function() {
       options: {
         taco: 'soft-shell',
         spicy: true
+      },
+      args: []
+    });
+  });
+
+  it('availableOptions with aliases should work with hyphenated options', function() {
+    expect(new OptionsAliasCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      settings: {}
+    }).parseArgs(['-dm', 'hi'])).to.deep.equal({
+      options: {
+        taco: 'traditional',
+        spicy: true,
+        displayMessage: 'hi'
+      },
+      args: []
+    });
+
+    expect(new OptionsAliasCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      settings: {}
+    }).parseArgs(['-hw'])).to.deep.equal({
+      options: {
+        taco: 'traditional',
+        spicy: true,
+        displayMessage: 'Hello world'
       },
       args: []
     });
@@ -552,6 +590,16 @@ describe('models/command.js', function() {
           {'soft-shell' : 'soft-shell'}
         ],
         key: 'taco',
+        required: false
+      },
+      {
+        name: 'display-message',
+        type: String,
+        aliases:[
+          'dm',
+          { 'hw': 'Hello world' }
+        ],
+        key: 'displayMessage',
         required: false
       },
       {


### PR DESCRIPTION
For instance when we run `ember build -o dist-foo`, inside of `Command#parseAlias` method `option.key` will return `outputPath`, and pass something like this to `nopt`:

`nopt({ 'output-path': path }, { o: [ '--outputPath' ] }, [ '-o', 'dist-foo' ], 0)`
which returns
`{ outputPath: true,
  argv:
   { remain: [ 'dist-foo' ],
     cooked: [ '--outputPath', 'dist-foo' ],
     original: [ '-o', 'dist-foo' ] } }`

Since `--outputPath` is different of `--output-path`. `nopt` doesn't get what we want and return a boolean instead `{ outputPath: true }`

Using `option.name` will use the original option name with hyphen and satisfy the `nopt` parsing:

`nopt({ 'output-path': path }, { o: [ '--output-path' ] }, [ '-o', 'dist-foo' ], 0)`
which returns
`{ 'output-path': '/path/to/dist-foo',
  argv:
   { remain: [],
     cooked: [ '--output-path', 'dist-foo' ],
     original: [ '-o', 'dist-foo' ] } } `

Fixes #2943