### PR TITLE
Fixes validation of shorthand commandOptions

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -18,7 +18,6 @@ var reject        = require('lodash-node/modern/collections/reject');
 var EOL           = require('os').EOL;
 var CoreObject    = require('core-object');
 var debug         = require('debug')('ember-cli:command');
-var findKey       = require('lodash-node/modern/objects/findKey');
 var Watcher       = require('../models/watcher');
 var SilentError   = require('../errors/silent');
 
@@ -343,13 +342,12 @@ Command.prototype.parseArgs = function(commandArgs) {
   };
 
   var validateParsed = function(key) {
+    if (!commandOptions.hasOwnProperty(key) && key !== 'argv') {
+      this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not registered with the ' + this.name + ' command. ' +
+                        'Run `ember ' + this.name + ' --help` for a list of supported options.'));
+    }
     if (typeof parsedOptions[key] !== 'object') {
       commandOptions[camelize(key)] = parsedOptions[key];
-    }
-
-    if (findKey(commandOptions, key) === undefined && key !== 'argv') {
-      this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not supported by the ' + this.name + ' command. ' +
-                        'Run `ember ' + this.name + ' --help` for a list of supported options.'));
     }
   };
 

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -14,7 +14,7 @@ var ServeCommand = Command.extend({
     { name: 'port', type: Number, default: 4200 },
     { name: 'host', type: String, default: '0.0.0.0' },
     { name: 'proxy',  type: String },
-    { name: 'live-reload',  type: Boolean, default: true },
+    { name: 'live-reload',  type: Boolean, default: true, aliases: ['lr']},
     { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)'},
     { name: 'environment', type: String, default: 'development' }
   ],
@@ -152,7 +152,7 @@ describe('models/command.js', function() {
       project: project,
       settings: config.getAll()
     }).parseArgs(['foo', '--envirmont', 'production']);
-    expect(ui.output).to.match(/The option '--envirmont' is not supported by the serve command. Run `ember serve --help` for a list of supported options./);
+    expect(ui.output).to.match(/The option '--envirmont' is not registered with the serve command. Run `ember serve --help` for a list of supported options./);
   });
 
   it('parseArgs() should parse shorthand options.', function() {
@@ -162,6 +162,15 @@ describe('models/command.js', function() {
       project: project,
       settings: {}
     }).parseArgs(['-e', 'tacotown'])).to.have.deep.property('options.environment', 'tacotown');
+  });
+
+  it('parseArgs() should parse shorthand dasherized options.', function() {
+    expect(new ServeCommand({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      settings: {}
+    }).parseArgs(['-lr', 'false'])).to.have.deep.property('options.liveReload', false);
   });
 
   it('validateAndRun() should print a message if a required option is missing.', function() {


### PR DESCRIPTION
The command options validation is incorrectly warning on dasherized options when the shorthand form is used (as reported in #2943).

`ember init -d`
results  in a warning:
`The option '--dryRun' is not supported by the init command. Run `ember init --help` for a list of supported options.`

The `--dry-run` option is still picked up, however:
```
installing
You specified the dry-run flag, so no changes will be written.
```

The command option validation now uses `hasOwnProperty` instead of `_.findKey`, and unknown (or misspelled) options are added to command options after a warning. Also reworded the warning:
`The option '--mispelledoption' is not registered with the serve command. Run `ember serve --help` for a list of supported options.`