### PR TITLE
Remove Hardcoded test-loader

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -781,9 +781,9 @@ EmberApp.prototype.styles = function() {
 EmberApp.prototype.testFiles = function() {
   var testSupportPath = this.options.outputPaths.testSupport.js;
   var testLoaderPath = this.options.outputPaths.testSupport.js.testLoader;
-  
+
   testSupportPath = testSupportPath.testSupport || testSupportPath;
-  
+
   var external = this._processedExternalTree();
 
   var emberCLITree = this._processedEmberCLITree();
@@ -822,7 +822,7 @@ EmberApp.prototype.testFiles = function() {
   var testLoader = pickFiles(external, {
     files: ['test-loader.js'],
     srcDir: '/' + this.bowerDirectory + '/ember-cli-test-loader',
-    destDir: testLoaderPath
+    destDir: path.dirname(testLoaderPath)
   });
 
   var sourceTrees = [

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -114,7 +114,10 @@ function EmberApp(options) {
     },
     testSupport: {
       css: '/assets/test-support.css',
-      js: '/assets/test-support.js'
+      js: {
+        testSupport: '/assets/test-support.js',
+        testLoader: '/assets/test-loader.js'
+      }
     }
   }, defaults);
 
@@ -777,6 +780,10 @@ EmberApp.prototype.styles = function() {
 */
 EmberApp.prototype.testFiles = function() {
   var testSupportPath = this.options.outputPaths.testSupport.js;
+  var testLoaderPath = this.options.outputPaths.testSupport.js.testLoader;
+  
+  testSupportPath = testSupportPath.testSupport || testSupportPath;
+  
   var external = this._processedExternalTree();
 
   var emberCLITree = this._processedEmberCLITree();
@@ -815,7 +822,7 @@ EmberApp.prototype.testFiles = function() {
   var testLoader = pickFiles(external, {
     files: ['test-loader.js'],
     srcDir: '/' + this.bowerDirectory + '/ember-cli-test-loader',
-    destDir: '/assets/'
+    destDir: testLoaderPath
   });
 
   var sourceTrees = [


### PR DESCRIPTION
This is a backwards compatible change and removes the hardcoded `destDir` for the test-loader.