### PR TITLE
[Enhancement] - adds a watcher option to the build command

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -10,7 +10,8 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'output-path', type: path, default: 'dist/', aliases: ['o'] },
-    { name: 'watch', type: Boolean, default: false, aliases: ['w'] }
+    { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
+    { name: 'watcher', type: String }
   ],
 
   run: function(commandOptions) {

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -66,4 +66,15 @@ describe('build command', function() {
       expect(buildWatchTaskInstance.project).to.equal(options.project, 'has correct project instance');
     });
   });
+
+  it('BuildWatch task is provided with a watcher option', function() {
+    return new BuildCommand(options).validateAndRun([ '--watch', '--watcher poller' ]).then(function() {
+      var buildWatchRun = tasks.BuildWatch.prototype.run,
+        calledWith = buildWatchRun.calledWith[0]['0'];
+
+      expect(buildWatchRun.called).to.equal(1, 'expected run to be called once');
+      expect(calledWith.watcherPoller).to.equal(true, 'expected run to be called with a poller option');
+
+    });
+  });
 });


### PR DESCRIPTION
Allows you to specify the watcher type from the
build command, this is useful for running build inside
a vagrant box where file watching doesn't work very
well

Specifically when using ember-cli with ember-cli-rails
which compiles the ember app automatically using build
instead of serve