### PR TITLE
Clarify error message for ensuring hyphen presence in component name

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -33,8 +33,8 @@ module.exports = {
 
     if(! /\-/.test(entityName)) {
       throw new SilentError('You specified "' + entityName + '", but in order to prevent ' +
-                            'clashes with current or future HTML element names you must have ' +
-                            'a hyphen.');
+                            'clashes with current or future HTML element names, you must include ' +
+                            'a hyphen in the component name.');
     }
 
     return entityName;

--- a/tests/unit/blueprints/component-test.js
+++ b/tests/unit/blueprints/component-test.js
@@ -11,7 +11,7 @@ describe('blueprint - component', function(){
       expect(function() {
         var nonConformantComponentName = 'form';
         blueprint.normalizeEntityName(nonConformantComponentName);
-      }).to.throw(/must have a hyphen/);
+      }).to.throw(/must include a hyphen in the component name/);
     });
 
 


### PR DESCRIPTION
The previous error message is slightly ambiguous. I hope this slight wording tweak clarifies how to properly name a component.