### PR TITLE
Tweak error message for executing `ember unknownCommand`

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -10,8 +10,8 @@ var UnknownCommand = Command.extend({
 
   validateAndRun: function() {
     throw new SilentError('The specified command ' + this.commandName +
-                          ' is invalid, for available options see ' +
-                          'ember help' + '.');
+                          ' is invalid. For available options, see' +
+                          ' ember help.');
   }
 });
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -495,7 +495,8 @@ describe('Unit: CLI', function() {
 
     return ember(['unknownCommand']).then(function() {
       var output = ui.output.trim().split(EOL);
-      expect(true, /The specified command .*unknownCommand.* is invalid/.test(output[1]), 'expected an invalid command message');
+      var helpfulMessage = /The specified command .*unknownCommand.* is invalid\. For available options/;
+      expect(true, helpfulMessage.test(output[1]), 'expected an invalid command message');
       expect(help.called).to.equal(0, 'expected the help command to be run');
     });
   });


### PR DESCRIPTION
The English syntax is more correct, and the JavaScript
was updated a bit.