### PR TITLE
Enhancement: Move app preview window to be at the bottom of the page so ...

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/test-support.css">
     <style>
       #ember-testing-container {
-        position: absolute;
+        position: relative;
         background: white;
         bottom: 0;
         right: 0;
@@ -24,6 +24,7 @@
         overflow: auto;
         z-index: 9999;
         border: 1px solid #ccc;
+        margin: 0 auto;
       }
       #ember-testing {
         zoom: 50%;


### PR DESCRIPTION
...that it won't cover the tests when run in the browser.

After a certain number of tests, the preview window will cover half of the test description, this would fix that by keeping the preview window below all of the descriptions.