### PR TITLE
Enhancement: Allow `ember-cli` to be included in `dependencies` in

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -66,7 +66,12 @@ Project.prototype.name = function() {
 };
 
 Project.prototype.isEmberCLIProject = function() {
-  return this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies;
+  if (this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies) {
+      return true;
+    }
+  if (this.pkg.dependencies && 'ember-cli' in this.pkg.dependencies) {
+      return true;
+    }
 };
 
 Project.prototype.isEmberCLIAddon = function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -137,6 +137,30 @@ describe('models/project.js', function() {
     });
   });
 
+  describe('isEmberCLIProject', function() {
+    beforeEach(function() {
+      projectPath = process.cwd() + '/tmp/test-app';
+
+      project = new Project(projectPath, {});
+    });
+
+    it('should return true if `ember-cli` is included in devDependencies', function(){
+      project.pkg.devDependencies = { 'ember-cli': '^1.0.0' };
+      expect(project.isEmberCLIProject()).to.equal(true);
+    });
+
+    it('should return true if `ember-cli` is included in dependencies', function(){
+      project.pkg.dependencies = { 'ember-cli': '^1.0.0' };
+      expect(project.isEmberCLIProject()).to.equal(true);
+    });
+
+    it('should return false if `ember-cli` is not included in dependencies or devDependencies', function(){
+      project.pkg.devDependencies = {};
+      project.pkg.dependencies = {};
+      expect(project.isEmberCLIProject()).to.equal(false);
+    });
+  });
+
   describe('addons', function() {
     beforeEach(function() {
       projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');


### PR DESCRIPTION
package.json rather than only being allowed in `devDependencies`.

Addresses issue #2207