### PR TITLE
Remove ember-data from package.json

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,6 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.2",
-    "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
Noticed ember-data was in both the `package.json` and the `bower.json`. Verified that my app uses the version included by bower.

Please close if it's there for a reason I'm not aware of.