### PR TITLE
Use symlink-or-copy so acceptance slow tests don't fail on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "nock": "^0.51.0",
     "node-require-timings": "0.0.2",
     "supertest": "0.14.0",
+    "symlink-or-copy": "^1.0.1",
     "tmp-sync": "^1.0.1",
     "yuidocjs": "0.3.50"
   }

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var path       = require('path');
-var fs         = require('fs-extra');
-var runCommand = require('./run-command');
-var RSVP       = require('rsvp');
-var tmp        = require('./tmp');
-var conf       = require('./conf');
-var copy       = RSVP.denodeify(fs.copy);
-var root       = process.cwd();
+var symlinkOrCopySync = require('symlink-or-copy').sync;
+var path              = require('path');
+var fs                = require('fs-extra');
+var runCommand        = require('./run-command');
+var RSVP              = require('rsvp');
+var tmp               = require('./tmp');
+var conf              = require('./conf');
+var copy              = RSVP.denodeify(fs.copy);
+var root              = process.cwd();
 
 var onOutput = {
   onOutput: function() {
@@ -47,11 +48,7 @@ function mvRm(from, to) {
 }
 
 function symLinkDir(projectPath, from, to) {
-  var isWin = /^win/.test(process.platform);
-
-  // Need to junction on windows since we likely don't have persmission to symlink
-  var type = isWin ? 'junction' : 'dir';
-  fs.symlinkSync(path.resolve(root, from), path.resolve(projectPath, to), type);
+  symlinkOrCopySync(path.resolve(root, from), path.resolve(projectPath, to));
 }
 
 function applyCommand(command, name /*, ...flags*/) {


### PR DESCRIPTION
Hopefully this fixes the Appveyor failures.