### PR TITLE
Move static file check earlier so it only affects the default value

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -126,6 +126,13 @@ function EmberApp(options) {
     extensions: ['js']
   }, defaults);
 
+  // in Ember 1.10 and higher `ember.js` is deprecated in favor of
+  // the more aptly named `ember.debug.js`.
+  var defaultDevelopmentEmber = this.bowerDirectory + '/ember/ember.debug.js';
+  if (!fs.existsSync(path.join(this.project.root, defaultDevelopmentEmber))) {
+    defaultDevelopmentEmber = this.bowerDirectory + '/ember/ember.js';
+  }
+
   this.vendorFiles = omit(merge({
     'loader.js': this.options.loader,
     'jquery.js': this.bowerDirectory + '/jquery/dist/jquery.js',
@@ -134,7 +141,7 @@ function EmberApp(options) {
       production:  this.bowerDirectory + '/handlebars/handlebars.runtime.js'
     },
     'ember.js': {
-      development: this.bowerDirectory + '/ember/ember.debug.js',
+      development: defaultDevelopmentEmber,
       production:  this.bowerDirectory + '/ember/ember.prod.js'
     },
     'ember-testing.js': [
@@ -170,13 +177,6 @@ function EmberApp(options) {
   // 1.8.0 (when ember-testing.js was added to the deployment)
   if (!fs.existsSync(this.vendorFiles['ember-testing.js'][0])) {
     delete this.vendorFiles['ember-testing.js'];
-  }
-
-  // in Ember 1.10 and higher `ember.js` is deprecated in favor of
-  // the more aptly named `ember.debug.js`.
-  var emberFiles = this.vendorFiles['ember.js'];
-  if (typeof emberFiles === 'object' && !fs.existsSync(emberFiles.development)) {
-    emberFiles.development = this.bowerDirectory + '/ember/ember.js';
   }
 
   this.options.trees = merge(this.options.trees, {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1,5 +1,4 @@
 /* global escape */
-
 'use strict';
 
 var fs       = require('fs');
@@ -441,9 +440,38 @@ describe('broccoli/ember-app', function() {
           'handlebars.js': null
         }
       });
-      var vendorFiles = Object.keys(EmberApp);
+      var vendorFiles = Object.keys(emberApp.vendorFiles);
       expect(vendorFiles.indexOf('ember.js')).to.equal(-1);
       expect(vendorFiles.indexOf('handlebars.js')).to.equal(-1);
+    });
+
+    it('defaults to ember.debug.js if exists in bower_components', function () {
+      var root = path.resolve(__dirname, '../../fixtures/app/with-default-ember-debug');
+
+      emberApp = new EmberApp({
+        project: new Project(root, {})
+      });
+
+      var emberFiles = emberApp.vendorFiles['ember.js'];
+      expect(emberFiles.development).to.equal('bower_components/ember/ember.debug.js');
+    });
+
+    it('switches the default ember.debug.js to ember.js if it does not exist', function () {
+      emberApp = new EmberApp();
+      var emberFiles = emberApp.vendorFiles['ember.js'];
+      expect(emberFiles.development).to.equal('bower_components/ember/ember.js');
+    });
+
+    it('does not clobber an explicitly configured ember development file', function () {
+      emberApp = new EmberApp({
+        vendorFiles: {
+          'ember.js': {
+            development: 'vendor/ember.debug.js'
+          }
+        }
+      });
+      var emberFiles = emberApp.vendorFiles['ember.js'];
+      expect(emberFiles.development).to.equal('vendor/ember.debug.js');
     });
   });
 });


### PR DESCRIPTION
This is determining the best default value, by moving it earlier, it allows vendorFiles to refer to an import from the vendor broccoli tree, not just statically available in the root.