### PR TITLE
Fix acceptance slow test helper by moving assertion

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -41,7 +41,7 @@ describe('Acceptance: addon-smoke-test', function() {
 
   afterEach(function() {
     this.timeout(15000);
-    return cleanupRun(function() {
+    return cleanupRun().then(function() {
       assertDirEmpty('tmp');
     });
   });

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -5,6 +5,7 @@ var fs                  = require('fs');
 var expect              = require('chai').expect;
 var acceptance          = require('../helpers/acceptance');
 var runCommand          = require('../helpers/run-command');
+var assertDirEmpty      = require('../helpers/assert-dir-empty');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
@@ -31,7 +32,9 @@ describe('Acceptance: blueprint smoke tests', function() {
 
   afterEach(function() {
     this.timeout(10000);
-    return cleanupRun();
+    return cleanupRun().then(function() {
+      assertDirEmpty('tmp');
+    });
   });
 
   it('generating an http-proxy installs packages to package.json', function() {

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -10,6 +10,7 @@ var EOL        = require('os').EOL;
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
+var assertDirEmpty      = require('../helpers/assert-dir-empty');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
@@ -35,7 +36,9 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
   afterEach(function() {
     this.timeout(15000);
-    return cleanupRun();
+    return cleanupRun().then(function() {
+      assertDirEmpty('tmp');
+    });
   });
 
   it('a custom EmberENV in config/environment.js is used for window.EmberENV', function() {

--- a/tests/acceptance/express-server-restart-slow.js
+++ b/tests/acceptance/express-server-restart-slow.js
@@ -41,7 +41,7 @@ describe('Acceptance: express server restart', function () {
 
   afterEach(function() {
     this.timeout(15000);
-    return cleanupRun(function() {
+    return cleanupRun().then(function() {
       assertDirEmpty('tmp');
     });
   });

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -37,7 +37,7 @@ describe('Acceptance: smoke-test', function() {
   afterEach(function() {
     this.timeout(20000);
 
-    return cleanupRun(function() {
+    return cleanupRun().then(function() {
       assertDirEmpty('tmp');
     });
   });

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -163,13 +163,9 @@ function linkDependencies(projectName) {
 
 /**
  * Clean a test run and optionally assert.
- * @param  {Function} [assertion] An assertion that gets ran at the end of a run
  * @return {Promise}
  */
-function cleanupRun(assertion) {
-  if (assertion) {
-    assertion();
-  }
+function cleanupRun() {
   return tmp.teardown('./tmp');
 }
 


### PR DESCRIPTION
The new acceptance test pattern typically passes an assertion to the teardown helper asserting that the `tmp/` directory should be empty after each test. Because the assertion is called before the folder is actually torn down, sometimes the test fails. This fixes the issue by calling the assertion after the promise for destroying the `tmp/` directory has resolved.