### PR TITLE
Remove forward slash from image path.

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -11,7 +11,7 @@ github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-
 
 To add images, fonts, or other assets, place them in the `public/assets` folder. For
 example, if you place `logo.png` in `public/assets/images`, you can reference it in
-templates with `/assets/images/logo.png` or in stylesheets with
+templates with `assets/images/logo.png` or in stylesheets with
 `url('/assets/images/logo.png')`.
 
 ### Minifying


### PR DESCRIPTION
We found that the slash prevented the image from being displayed in a phonegap application.