### PR TITLE
Update to app blueprint to use QUnit 1.17.1.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -12,6 +12,6 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.5",
-    "qunit": "~1.16.0"
+    "qunit": "~1.17.1"
   }
 }


### PR DESCRIPTION
QUnit 1.16 had some show stopper bugs that are resolved in 1.17.x.