### PR TITLE
Switch to test-framework-agnostic test loader

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.5",

--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -1,3 +1,4 @@
+/* global require */
 import resolver from './helpers/resolver';
 import {
   setResolver
@@ -10,3 +11,22 @@ document.write('<div id="ember-testing-container"><div id="ember-testing"></div>
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
 var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
 document.getElementById('ember-testing-container').style.visibility = containerVisibility;
+
+QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
+
+if (QUnit.notifications) {
+  QUnit.notifications({
+    icons: {
+      passed: '/assets/passed.png',
+      failed: '/assets/failed.png'
+    }
+  });
+}
+
+$(document).ready(function(){
+  var TestLoader = require('ember-cli/test-loader')['default'];
+  TestLoader.prototype.shouldLoadModule = function(moduleName) {
+    return moduleName.match(/[-_]test$/) || (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/));
+  };
+  TestLoader.load();
+});


### PR DESCRIPTION
This moves qunit-specific code out of the test-loader and into the test-helper blueprint where it can be easily replaced by other testing libs. 

cc @dgeb