### PR TITLE
BUGFIX Close #3095

### DIFF
--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -26,7 +26,7 @@ module.exports = {
         return mainBlueprint[type](options);
       })
       .then(function() {
-        var testBlueprint = Blueprint.lookup(name + '-test', {
+        var testBlueprint = mainBlueprint.lookupBlueprint(name + '-test', {
           ui: this.ui,
           analytics: this.analytics,
           project: this.project,

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1020,6 +1020,42 @@ describe('Acceptance: ember generate', function() {
       });
   });
 
+  it('uses custom model-test blueprint when generating resources', function() {
+    return initApp()
+      .then(function() {
+        return outputFile(
+          'blueprints/model-test/files/tests/unit/models/__test__.js',
+          "// custom model-test" + EOL
+        );
+      })
+      .then(function() {
+        return ember(['generate', 'resource', 'foo']);
+      })
+      .then(function() {
+        assertFile('tests/unit/models/foo-test.js', {
+          contains: '// custom model-test'
+        });
+      });
+  });
+
+  it('uses custom route-test blueprint when generating resources', function() {
+    return initApp()
+      .then(function() {
+        return outputFile(
+          'blueprints/route-test/files/tests/unit/routes/__test__.js',
+          "// custom route-test" + EOL
+        );
+      })
+      .then(function() {
+        return ember(['generate', 'resource', 'foo']);
+      })
+      .then(function() {
+        assertFile('tests/unit/routes/foo-test.js', {
+          contains: '// custom route-test'
+        });
+      });
+  });
+
   it('passes custom cli arguments to blueprint options', function() {
     return initApp()
       .then(function() {


### PR DESCRIPTION
This PR closes #3095. 

When using custom test blueprints, e.g., [ember-cli-mocha](https://github.com/switchfly/ember-cli-mocha), `ember generate resource foo` would not use the custom blueprints for the model-test and route-test. Instead, it used the default ember-cli generators.

Changing the blueprint lookup from the class method to the instance method fixed this issue.