### PR TITLE
[DOCS] Generalize Sublime Text issues to both versions 2 and 3

### DIFF
--- a/_posts/2013-04-02-editors.md
+++ b/_posts/2013-04-02-editors.md
@@ -15,11 +15,11 @@ Search for [ember-cli-helper](https://atom.io/packages/ember-cli-helper)
 
 `Install`
 
-### SublimeText 3
+### Sublime Text
 
-If you are using [SublimeText 3](http://www.sublimetext.com) with `ember-cli`, by default it will try to index all files in your `tmp` directory for its GoToAnything functionality.  This will cause your computer to come to a screeching halt @ 90%+ CPU usage.  Simply remove these directories from the folders ST3 watches:
+If you are using [Sublime Text](http://www.sublimetext.com) with `ember-cli`, by default it will try to index all files in your `tmp` directory for its GoToAnything functionality.  This will cause your computer to come to a screeching halt @ 90%+ CPU usage, and can significantly increase build times.  Simply remove these directories from the folders Sublime Text watches:
 
-`Sublime Text -> Preferences -> Settings -User`
+`Sublime Text -> Preferences -> Settings - User`
 
 {% highlight javascript %}
 // folder_exclude_patterns and file_exclude_patterns control which files


### PR DESCRIPTION
Using Sublime Text 2, I experienced significantly slower build times before realizing that the same issue (already described specifically for Sublime Text 3) was the cause. The same solution - excluding the tmp directory - also resolved my issue.

I think it would be helpful to point out that both Sublime Text 2 and Sublime Text 3 can potentially cause issues.

*Note that these changes had been previously merged with https://github.com/ember-cli/ember-cli/pull/2385, but look to have since been overwritten with https://github.com/ember-cli/ember-cli/pull/3042*