### PR TITLE
[Bugfix] files named app/styles... or app/templates... should also be

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -384,8 +384,10 @@ EmberApp.prototype._filterAppTree = function() {
 
   var podPatterns = this._podTemplatePatterns();
   var excludePatterns = podPatterns.concat([
-    /^styles/,
-    /^templates/
+    // note: do not use path.sep here Funnel uses
+    // walk-sync which always joins with `/` (not path.sep)
+    new RegExp('^styles/'),
+    new RegExp('^templates/'),
   ]);
 
   return this._cachedFilterAppTree = new Funnel(this.trees.app, {

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -86,7 +86,24 @@ describe('Acceptance: brocfile-smoke-test', function() {
         // remove ./app/templates
         return remove(path.join(process.cwd(), 'app/templates'));
       }).then(function() {
-        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--silent');
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+      });
+  });
+
+  it('strips app/styles or app/templates from JS', function() {
+    this.timeout(450000);
+
+    return copyFixtureFiles('brocfile-tests/styles-and-templates-stripped')
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .then(function() {
+        var appFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', appName + '.js'), {
+          encoding: 'utf8'
+        });
+
+        expect(appFileContents).to.include('//app/templates-stuff.js');
+        expect(appFileContents).to.include('//app/styles-manager.js');
       });
   });
 

--- a/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/styles-manager.js
+++ b/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/styles-manager.js
@@ -1,0 +1,1 @@
+//app/styles-manager.js

--- a/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/styles/foo.js
+++ b/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/styles/foo.js
@@ -1,0 +1,1 @@
+//app/styles/foo.js

--- a/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/templates-stuff.js
+++ b/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/templates-stuff.js
@@ -1,0 +1,1 @@
+//app/templates-stuff.js

--- a/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/templates/bar.js
+++ b/tests/fixtures/brocfile-tests/styles-and-templates-stripped/app/templates/bar.js
@@ -1,0 +1,1 @@
+//app/templates/bar.js


### PR DESCRIPTION
included

- [x] tests
- [x] ~~confirm the use of `path.sep` is what windows wants~~ (it is not).