### PR TITLE
BUGFIX serve command host alias was conflicting with help alias

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -13,7 +13,7 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'port', type: Number, default: 4200, aliases: ['p'] },
-    { name: 'host', type: String, default: '0.0.0.0', aliases: ['h'] },
+    { name: 'host', type: String, default: '0.0.0.0', aliases: ['H'] },
     { name: 'proxy',  type: String, aliases: ['pr','pxy'] },
     { name: 'insecure-proxy', type: Boolean, default: false, description: 'Set false to proxy self-signed SSL certificates', aliases: ['inspr'] },
     { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -126,4 +126,16 @@ describe('server command', function() {
       expect(ops.baseURL).to.equal('test', 'Uses the correct environment.');
     });
   });
+
+  it('host alias does not conflict with help alias', function() {
+    return new ServeCommand(options).validateAndRun([
+      '-H', 'hostname'
+    ]).then(function() {
+      var serveRun = tasks.Serve.prototype.run;
+      var ops = serveRun.calledWith[0][0];
+
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
+      expect(ops.host).to.equal('hostname', 'has correct hostname');
+    });
+  });
 });


### PR DESCRIPTION
any variant of -ho, -hos, and -host seem to work as well.  This is more of a documentation fix than anything.