### PR TITLE
[ENHANCEMENT] Update ember-cli-qunit to 0.2.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.2",
+    "ember-cli-qunit": "0.2.0",
     "ember-cli-app-version": "0.3.0",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -13,22 +13,6 @@
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= name %>.css">
     <link rel="stylesheet" href="assets/test-support.css">
-    <style>
-      #ember-testing-container {
-        position: absolute;
-        background: white;
-        bottom: 0;
-        right: 0;
-        width: 640px;
-        height: 384px;
-        overflow: auto;
-        z-index: 9999;
-        border: 1px solid #ccc;
-      }
-      #ember-testing {
-        zoom: 50%;
-      }
-    </style>
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -114,7 +114,10 @@ function EmberApp(options) {
     sourcemaps: {},
     trees: {},
     jshintrc: {},
-    vendorFiles: {}
+    vendorFiles: {},
+    'ember-cli-qunit': {
+      disableContainerStyles: false
+    }
   }, defaults);
 
   // needs a deeper merge than is provided above


### PR DESCRIPTION
* Adds `lintTree` hook (for use in making linting more pluggable).
* Removes need for inline styles in tests/index.html (making tests CSP compliant).
* The inline container can be removed via the following `Brocfile.js`:

```javascript
var app = new EmberApp({
  'ember-cli-qunit': {
    disableContainerStyles: true
  }
});
```