### PR TITLE
Update ember-cli-qunit to v0.3.0.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.5",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.2.0",
+    "ember-cli-qunit": "0.3.0",
     "ember-cli-app-version": "0.3.0",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",

--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -4,9 +4,3 @@ import {
 } from 'ember-qunit';
 
 setResolver(resolver);
-
-document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
-
-QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
-var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-document.getElementById('ember-testing-container').style.visibility = containerVisibility;


### PR DESCRIPTION
Changes between v0.2.0 and v0.3.0:

* Update URL for ember-cli-shims.
* Add ember-cli-test-loader to `bower.json` in blueprint.
* Add QUnit config for notifications.
* Add QUnit config for disabling JSHint.
* Add ember-testing-container elements via `contentFor('test-body')` hook.
* Add ability hiding container via QUnit config (formerly in ember-cli-test-loader).

Replaces https://github.com/ember-cli/ember-cli/pull/3093.