### PR TITLE
Fixed highlights in webstorm instructions

### DIFF
--- a/_posts/2013-04-02-editors.md
+++ b/_posts/2013-04-02-editors.md
@@ -32,10 +32,10 @@ If you are using [Sublime Text](http://www.sublimetext.com) with `ember-cli`, by
 If you are using [WebStorm](https://www.jetbrains.com/webstorm/) with `ember-cli`, you will need to modify your `.gitignore` file, enable `ECMAScript6` settings, and mark certain directories.
 
 First, add the following line to `.gitignore`:
-{% highlight %}
+{% highlight bash %}
 .idea
 {% endhighlight %}
- 
+
 Next, from the WebStorm menu:
 
 `File > Settings -> Languages & Frameworks -> JavaScript -> ECMAScript6`
@@ -43,20 +43,20 @@ Next, from the WebStorm menu:
 Right-click on each of the following directories and mark as indicated:
 
 Mark as `excluded`:
-{% highlight %}
+{% highlight bash %}
 /tmp
 /dist
 {% endhighlight %}
 
 Mark as `resource route`:
-{% highlight %}
+{% highlight bash %}
 /
 /bower_components
 /bower_components/ember-qunit/lib
 /public
 {% endhighlight %}
- 
+
 Mark as `test sources root`:
-{% highlight %}
+{% highlight bash %}
 /tests
 {% endhighlight %}


### PR DESCRIPTION
Fixes highlights that were breaking the jekyll build. Was missing language, so I added bash for all of them.