### PR TITLE
Update ember-cli-qunit to v0.3.1.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.0",
+    "ember-cli-qunit": "0.3.1",
     "ember-cli-app-version": "0.3.0",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.12",


### PR DESCRIPTION
We moved to using ember-cli-qunit to handle the JSHint'ing in ember-cli 0.1.10 and ember-cli-qunit 0.3.0, but unfortunately ember-cli-qunit was always using the `tests/.jshintrc` (even for the app tree).

ember-cli-qunit 0.3.1 fixes that.