### PR TITLE
BUGFIX Related to #3129 - upgrade ember-cli-app-version

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.0",
-    "ember-cli-app-version": "0.3.0",
+    "ember-cli-app-version": "0.3.1",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",


### PR DESCRIPTION
This PR updates the app blueprint to use a version of ember-cli-app-version that includes a fix for #3129.