### PR TITLE
Allow beforeInstall hook in the blueprint model to access and modify locals.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -393,7 +393,7 @@ Blueprint.prototype.install = function(options) {
   var locals = this._locals(options);
 
   return Promise.resolve()
-    .then(this.beforeInstall.bind(this, options))
+    .then(this.beforeInstall.bind(this, options, locals))
     .then(this.processFiles.bind(this, intoDir, locals)).map(commit)
     .then(this.afterInstall.bind(this, options));
 };


### PR DESCRIPTION
  This is the only hook that can update locals asynchronously.  If you need to generate `locals` or `fileMapTokens` asynchronously right now, you can't.  Those hooks are called synchronously.