### PR TITLE
[BUGFIX] Replaces instances of dasherizedPackageName with relative paths. 

### DIFF
--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -1,6 +1,6 @@
 import {
   <%= camelizedModuleName %>
-} from '<%= dasherizedPackageName %>/helpers/<%= dasherizedModuleName %>';
+} from '../../../helpers/<%= dasherizedModuleName %>';
 
 module('<%= classifiedModuleName %>Helper');
 

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { initialize } from '<%= dasherizedPackageName %>/initializers/<%= dasherizedModuleName %>';
+import { initialize } from '../../../initializers/<%= dasherizedModuleName %>';
 
 var container, application;
 

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
+import <%= classifiedModuleName %>Mixin from '../../../mixins/<%= dasherizedModuleName %>';
 
 module('<%= classifiedModuleName %>Mixin');
 

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>';
 
 module('<%= camelizedModuleName %>');
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -135,7 +135,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
           "  fooBar" + EOL +
-          "} from 'my-app/helpers/foo-bar';"
+          "} from '../../../helpers/foo-bar';"
       });
     });
   });
@@ -152,7 +152,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +
           "  fooBarBaz" + EOL +
-          "} from 'my-app/helpers/foo/bar-baz';"
+          "} from '../../../helpers/foo/bar-baz';"
       });
     });
   });
@@ -481,7 +481,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/mixins/foo-test.js', {
         contains: [
-          "import FooMixin from 'my-app/mixins/foo';"
+          "import FooMixin from '../../../mixins/foo';"
         ]
       });
     });
@@ -497,7 +497,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/mixins/foo/bar-test.js', {
         contains: [
-          "import FooBarMixin from 'my-app/mixins/foo/bar';"
+          "import FooBarMixin from '../../../mixins/foo/bar';"
         ]
       });
     });
@@ -507,7 +507,7 @@ describe('Acceptance: ember generate', function() {
     return generate(['mixin', 'foo/bar/baz']).then(function() {
       assertFile('tests/unit/mixins/foo/bar/baz-test.js', {
         contains: [
-          "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
+          "import FooBarBazMixin from '../../../mixins/foo/bar/baz';"
         ]
       });
     });
@@ -732,7 +732,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from 'my-app/utils/foo-bar';"
+          "import fooBar from '../../../utils/foo-bar';"
         ]
       });
     });
@@ -747,7 +747,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
+          "import fooBarBaz from '../../../utils/foo/bar-baz';"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -218,7 +218,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
           "  fooBar" + EOL +
-          "} from 'my-app/helpers/foo-bar';"
+          "} from '../../../helpers/foo-bar';"
       });
     });
   });
@@ -235,7 +235,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
           "  fooBar" + EOL +
-          "} from 'my-app/helpers/foo-bar';"
+          "} from '../../../helpers/foo-bar';"
       });
     });
   });
@@ -252,7 +252,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +
           "  fooBarBaz" + EOL +
-          "} from 'my-app/helpers/foo/bar-baz';"
+          "} from '../../../helpers/foo/bar-baz';"
       });
     });
   });
@@ -269,7 +269,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +
           "  fooBarBaz" + EOL +
-          "} from 'my-app/helpers/foo/bar-baz';"
+          "} from '../../../helpers/foo/bar-baz';"
       });
     });
   });
@@ -699,7 +699,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/mixins/foo-test.js', {
         contains: [
-          "import FooMixin from 'my-app/mixins/foo';"
+          "import FooMixin from '../../../mixins/foo';"
         ]
       });
     });
@@ -715,7 +715,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/mixins/foo/bar-test.js', {
         contains: [
-          "import FooBarMixin from 'my-app/mixins/foo/bar';"
+          "import FooBarMixin from '../../../mixins/foo/bar';"
         ]
       });
     });
@@ -725,7 +725,7 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['mixin', 'foo/bar/baz', '--pod']).then(function() {
       assertFile('tests/unit/mixins/foo/bar/baz-test.js', {
         contains: [
-          "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
+          "import FooBarBazMixin from '../../../mixins/foo/bar/baz';"
         ]
       });
     });
@@ -1076,7 +1076,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from 'my-app/utils/foo-bar';"
+          "import fooBar from '../../../utils/foo-bar';"
         ]
       });
     });
@@ -1091,7 +1091,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
+          "import fooBarBaz from '../../../utils/foo/bar-baz';"
         ]
       });
     });


### PR DESCRIPTION
Replaces instances of dasherizedPackageName with relative paths for the following generators:

- helper-test
- initializer-test
- mixin-test
- util-test

This closes #3143.