### PR TITLE
Guard against rawArgs being undefined

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -595,7 +595,7 @@ Blueprint.prototype.processFiles = function(intoDir, templateVariables) {
 
   var fileInfos = files.map(this.buildFileInfo.bind(this, destPath, templateVariables));
 
-  if (fileInfos.filter(isFilePath).length < 1) {
+  if (fileInfos.filter(isFilePath).length < 1 && templateVariables.rawArgs) {
     this.ui.writeLine(chalk.yellow('The globPattern \"' + templateVariables.rawArgs +
       '\" did not match any files, so no file updates will be made.'));
   }
@@ -690,6 +690,7 @@ Blueprint.prototype._locals = function(options) {
   var podPath = podModulePrefix.substr(podModulePrefix.lastIndexOf('/') + 1);
   var sanitizedModuleName = moduleName.replace(/\//g, '-');
   var customLocals = this.locals(options);
+
   var fileMapVariables = {
     pod: this.pod,
     podPath: podPath,

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -16,7 +16,7 @@ module.exports = Task.extend({
     var packageName      = options['package'];
     var extraArgs        = options.extraArgs || [];
     var blueprintOptions = options.blueprintOptions || {};
-
+    
     var npmInstall = new this.NpmInstallTask({
       ui:         this.ui,
       analytics:  this.analytics,


### PR DESCRIPTION
I'm not sure if this is the right fix for #3142. I'm not even sure `rawArgs` is used for since I ran a bunch of generators to see what it what it's value was. It seemed to always be `undefined`. @rwjblue, @stefanpenner, or @bcardarella can you drop some knowledge bombs on this?

This makes the message go away but I'm not sure what is the root cause. Traced it all the way back to `_locals`.  It only effects bower.