### PR TITLE
Ensure `ember test --environment=production` runs JSHint.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -86,15 +86,12 @@ function EmberApp(options) {
   this.registry = options.registry || p.setupRegistry(this);
 
   var isProduction = this.env === 'production';
+  var testsEnabledDefault = process.env.EMBER_CLI_TEST_COMMAND || !isProduction;
 
-  this.tests   = options.hasOwnProperty('tests')   ? options.tests   : !isProduction;
-  this.hinting = options.hasOwnProperty('hinting') ? options.hinting : !isProduction;
+  this.tests   = options.hasOwnProperty('tests')   ? options.tests   : testsEnabledDefault;
+  this.hinting = options.hasOwnProperty('hinting') ? options.hinting : testsEnabledDefault;
 
   this.bowerDirectory = this.project.bowerDirectory;
-
-  if (process.env.EMBER_CLI_TEST_COMMAND) {
-    this.tests = true;
-  }
 
   this.options = merge(options, {
     es3Safe: true,

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -115,21 +115,18 @@ describe('Acceptance: smoke-test', function() {
     this.timeout(450000);
 
     return copyFixtureFiles('smoke-tests/passing-test')
-        .then(function() {
-          return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--environment=production', '--silent')
-              .then(function(result) {
-                var exitCode = result.code;
-                var output = result.output.join(EOL);
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--environment=production', '--silent');
+      })
+      .then(function(result) {
+        var exitCode = result.code;
+        var output = result.output.join(EOL);
 
-                expect(exitCode).to.equal(0, 'exit code should be 0 for passing tests');
-                expect(output).to.not.match(/JSHint/, 'JSHint should not be run on production assets');
-                expect(output).to.match(/fail\s+0/, 'no failures');
-                expect(output).to.match(/pass\s+1/, '1 passing');
-              })
-              .catch(function(result) {
-                expect(false, 'failed `ember test --environment=production`.  The following output was received:' + EOL + result.output.join(EOL));
-              });
-        });
+        expect(exitCode).to.equal(0, 'exit code should be 0 for passing tests');
+        expect(output).to.match(/JSHint/, 'JSHint should be run on production assets');
+        expect(output).to.match(/fail\s+0/, 'no failures');
+        expect(output).to.match(/pass\s+7/, '1 passing');
+      });
   });
 
   it('ember new foo, build development, and verify generated files', function() {


### PR DESCRIPTION
Prior to this change `ember test --environment=production` would run tests, but not perform any hinting.  Now hinting and tests are both done in production when running `ember test`, but are disabled when running other commands (like `ember serve` and `ember build`) in production.

It should be highly encouraged (maybe it should be the default), to run tests against the `production` environment. This PR ensures that hinting is handled properly.