### PR TITLE
[BUGFIX] Don't override the request's path

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -30,7 +30,7 @@ HistorySupportAddon.prototype.serverMiddleware = function(config) {
         if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
           var assetPath = req.path.slice(baseURL.length);
           if (!fs.existsSync(path.join(results.directory, assetPath))) {
-            req.url = baseURL + 'index.html';
+            req.serveUrl = baseURL + 'index.html';
           }
         }
 

--- a/lib/tasks/server/middleware/serve-files/index.js
+++ b/lib/tasks/server/middleware/serve-files/index.js
@@ -22,13 +22,14 @@ ServeFilesAddon.prototype.serverMiddleware = function(options) {
 
   app.use(function(req, res, next) {
     var oldURL = req.url;
-    debug('serving: %s', req.url);
+    var url = req.serveUrl || req.url;
+    debug('serving: %s', url);
 
     var actualPrefix   = req.url.slice(0, baseURL.length - 1); // Don't care
     var expectedPrefix = baseURL.slice(0, baseURL.length - 1); // about last slash
 
     if (actualPrefix === expectedPrefix) {
-      req.url = req.url.slice(actualPrefix.length); // Remove baseURL prefix
+      req.url = url.slice(actualPrefix.length); // Remove baseURL prefix
       debug('serving: (prefix stripped) %s', req.url);
 
       // Serve file, if no file has been found, reset url for proxy stuff


### PR DESCRIPTION
I am writing an add-on which needs to get access to some URLs server-side (to perform OAuth authentication).
The thing is, the request's path is being rewritten to display the default file content.

Displaying the default file when nothing else can be rendered makes sense. But overriding the path and preventing middlewares from reading doesn't.