### PR TITLE
`usePodsByDefault` in app config deprecated in favor of `usePods` in .ember-cli

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -42,7 +42,8 @@ module.exports = Command.extend({
     var task = new Task({
       ui: this.ui,
       analytics: this.analytics,
-      project: this.project
+      project: this.project,
+      settings: this.settings
     });
 
     var taskArgs = {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -49,13 +49,13 @@ module.exports = Command.extend({
                                             'blueprint name to be specified. ' +
                                             'For more details, use `ember help`.'));
     }
-
     var Task = this.tasks.GenerateFromBlueprint;
     var task = new Task({
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
-      testing: this.testing
+      testing: this.testing,
+      settings: this.settings
     });
 
     var taskArgs = {

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -28,6 +28,7 @@ var removeFile  = Promise.denodeify(fs.remove);
 var SilentError = require('../errors/silent');
 var CoreObject  = require('core-object');
 var EOL         = require('os').EOL;
+var deprecate   = require('../utilities/deprecate');
 
 module.exports = Blueprint;
 
@@ -336,9 +337,9 @@ Blueprint.prototype.install = function(options) {
   var verbose  = options.verbose;
   this.project = options.project;
   this.testing = options.testing;
-  this.pod     = this.project.config().usePodsByDefault ? !options.pod : options.pod;
+  this.pod     = (options.settings && options.settings.usePods) ? !options.pod : options.pod;
   this.hasPath = hasPathToken(this.files());
-
+  deprecate('`usePodsByDefault` is no longer supported in \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.', this.project.config().usePodsByDefault);
   var actions = {
     write: function(info) {
       ui.writeLine('  ' + chalk.green('create') + ' ' + info.displayPath);
@@ -412,9 +413,12 @@ Blueprint.prototype.uninstall = function(options) {
   var dryRun      = options.dryRun;
   var verbose     = options.verbose;
   this.project    = options.project;
-  this.pod        = this.project.config().usePodsByDefault ? !options.pod : options.pod;
+  this.pod        = (options.settings && options.settings.usePods)? !options.pod : options.pod;
   this.hasPath    = hasPathToken(this.files());
 
+  if (this.project.config().usePodsByDefault) {
+    deprecate('`usePodsByDefault` is no longer supported in \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.', this.project.config().usePodsByDefault);
+  }
   var actions = {
     remove: function(info) {
       ui.writeLine('  ' + chalk.red('remove') + ' ' + info.displayPath);

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -33,6 +33,7 @@ module.exports = Task.extend({
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
+      settings: this.settings,
       testing: this.testing,
       taskOptions: options
     };

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -95,6 +95,41 @@ describe('Acceptance: ember destroy pod', function() {
       });
   }
 
+  function assertDestroyAfterGenerateWithUsePods(args, files) {
+    return initApp()
+      .then(function() {
+        replaceFile('.ember-cli', '"disableAnalytics": false', '"disableAnalytics": false,' + EOL + '"usePods" : true' + EOL);
+        return generate(args);
+      })
+      .then(function() {
+        assertFilesExist(files);
+      })
+      .then(function() {
+        return destroy(args);
+      })
+      .then(function() {
+        assertFilesNotExist(files);
+      });
+  }
+
+  it('.ember-cli usePods setting destroys in pod structure without --pod flag', function() {
+    var commandArgs = ['controller', 'foo'];
+    var files       = [
+      'app/pods/foo/controller.js',
+      'tests/unit/pods/foo/controller-test.js'
+    ];
+    assertDestroyAfterGenerateWithUsePods(commandArgs, files);
+  });
+
+  it('.ember-cli usePods setting destroys in basic structure with --pod flag', function() {
+    var commandArgs = ['controller', 'foo', '--pod'];
+    var files       = [
+      'app/controllers/foo.js',
+      'tests/unit/controllers/foo-test.js'
+    ];
+    assertDestroyAfterGenerateWithUsePods(commandArgs, files);
+  });
+
   it('controller foo --pod', function() {
     var commandArgs = ['controller', 'foo', '--pod'];
     var files       = [

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -80,6 +80,55 @@ describe('Acceptance: ember generate pod', function() {
     });
   }
 
+  function generateWithUsePods(args) {
+    var generateArgs = ['generate'].concat(args);
+
+    return initApp().then(function() {
+      replaceFile('.ember-cli', '"disableAnalytics": false', '"disableAnalytics": false,' + EOL + '"usePods" : true' + EOL);
+      return ember(generateArgs);
+    });
+  }
+
+  it('.ember-cli usePods setting generates in pod structure without --pod flag', function() {
+    return generateWithUsePods(['controller', 'foo']).then(function() {
+      assertFile('app/foo/controller.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Controller.extend({" + EOL + "});"
+        ]
+      });
+      assertFile('tests/unit/foo/controller-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleFor," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleFor('controller:foo'"
+        ]
+      });
+    });
+  });
+
+  it('.ember-cli usePods setting generates in basic structure with --pod flag', function() {
+    return generateWithUsePods(['controller', 'foo', '--pod']).then(function() {
+      assertFile('app/controllers/foo.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Controller.extend({" + EOL + "});"
+        ]
+      });
+      assertFile('tests/unit/controllers/foo-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleFor," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleFor('controller:foo'"
+        ]
+      });
+    });
+  });
+
   it('controller foo --pod', function() {
     return generate(['controller', 'foo', '--pod']).then(function() {
       assertFile('app/foo/controller.js', {


### PR DESCRIPTION
As per #2652
`usePodsByDefault` in the `config/environment.js` file is now deprecated in favor of `usePods` in `.ember-cli`
Added environment settings to generate and destroy commands and tasks to make the `usePods` property available.

- [x] update documentation
- [x] add tests