### PR TITLE
[ENHANCEMENT] Update ember-qunit to 0.2.0.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -10,7 +10,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.1.8",
+    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.0",
     "ember-qunit-notifications": "0.0.5",
     "qunit": "~1.17.1"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.1",
+    "ember-cli-qunit": "0.3.2",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -15,7 +15,7 @@ test('it renders', function() {
   var component = this.subject();
   equal(component._state, 'preRender');
 
-  // appends the component to the page
-  this.append();
+  // renders the component to the page
+  this.render();
   equal(component._state, 'inDOM');
 });

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForComponent('<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Component', {
+moduleForComponent('<%= dasherizedModuleName %>', {
   // specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
 });

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('controller:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Controller', {
+moduleFor('controller:<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('<%= dasherizedModuleName %>', '<%= classifiedModuleName %>', {
+moduleForModel('<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
 <%= typeof needs !== 'undefined' ? needs : '' %>
 });

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('route:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Route', {
+moduleFor('route:<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('serializer:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Serializer', {
+moduleFor('serializer:<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/blueprints/service-test/files/tests/unit/services/__name__-test.js
+++ b/blueprints/service-test/files/tests/unit/services/__name__-test.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('service:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Service', {
+moduleFor('service:<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
 });

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('transform:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Transform', {
+moduleFor('transform:<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('view:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>View');
+moduleFor('view:<%= dasherizedModuleName %>');
 
 // Replace this with your real tests.
 test('it exists', function() {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -74,7 +74,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo', 'FooController'"
+          "moduleFor('controller:foo'"
         ]
       });
     });
@@ -94,7 +94,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo/bar', 'FooBarController'"
+          "moduleFor('controller:foo/bar'"
         ]
       });
     });
@@ -117,7 +117,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleForComponent," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForComponent('x-foo', 'XFooComponent'"
+          "moduleForComponent('x-foo'"
         ]
       });
     });
@@ -171,7 +171,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo', 'Foo'"
+          "moduleForModel('foo'"
         ]
       });
     });
@@ -249,7 +249,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo/bar', 'FooBar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });
@@ -263,7 +263,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo', 'Foo'"
+          "moduleForModel('foo'"
         ],
         doesNotContain: 'needs'
       });
@@ -290,7 +290,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('route:foo', 'FooRoute'"
+          "moduleFor('route:foo'"
         ]
       });
     });
@@ -376,7 +376,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo', 'FooView'"
+          "moduleFor('view:foo'"
         ]
       });
     });
@@ -396,7 +396,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo/bar', 'FooBarView'"
+          "moduleFor('view:foo/bar'"
         ]
       });
     });
@@ -417,10 +417,10 @@ describe('Acceptance: ember generate', function() {
         contains: '{{outlet}}'
       });
       assertFile('tests/unit/models/foo-test.js', {
-        contains: "moduleForModel('foo', 'Foo'"
+        contains: "moduleForModel('foo'"
       });
       assertFile('tests/unit/routes/foos-test.js', {
-        contains: "moduleFor('route:foos', 'FoosRoute'"
+        contains: "moduleFor('route:foos'"
       });
     });
   });
@@ -527,7 +527,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('adapter:application', 'ApplicationAdapter'"
+          "moduleFor('adapter:application'"
         ]
       });
     });
@@ -547,7 +547,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('adapter:foo', 'FooAdapter'"
+          "moduleFor('adapter:foo'"
         ]
       });
     });
@@ -661,7 +661,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar', 'FooBarSerializer'"
+          "moduleFor('serializer:foo/bar'"
         ]
       });
     });
@@ -689,7 +689,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo', 'FooTransform'"
+          "moduleFor('transform:foo'"
         ]
       });
     });
@@ -717,7 +717,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo/bar', 'FooBarTransform'"
+          "moduleFor('transform:foo/bar'"
         ]
       });
     });
@@ -776,7 +776,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('service:foo', 'FooService'"
+          "moduleFor('service:foo'"
         ]
       });
     });
@@ -805,7 +805,7 @@ describe('Acceptance: ember generate', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('service:foo/bar', 'FooBarService'"
+          "moduleFor('service:foo/bar'"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -94,7 +94,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo', 'FooController'"
+          "moduleFor('controller:foo'"
         ]
       });
     });
@@ -114,7 +114,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo', 'FooController'"
+          "moduleFor('controller:foo'"
         ]
       });
     });
@@ -134,7 +134,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo/bar', 'FooBarController'"
+          "moduleFor('controller:foo/bar'"
         ]
       });
     });
@@ -154,7 +154,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('controller:foo/bar', 'FooBarController'"
+          "moduleFor('controller:foo/bar'"
         ]
       });
     });
@@ -177,7 +177,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForComponent," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForComponent('x-foo', 'XFooComponent'"
+          "moduleForComponent('x-foo'"
         ]
       });
     });
@@ -200,7 +200,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForComponent," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForComponent('x-foo', 'XFooComponent'"
+          "moduleForComponent('x-foo'"
         ]
       });
     });
@@ -288,7 +288,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo', 'Foo'"
+          "moduleForModel('foo'"
         ]
       });
     });
@@ -308,7 +308,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo', 'Foo'"
+          "moduleForModel('foo'"
         ]
       });
     });
@@ -362,7 +362,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo/bar', 'FooBar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });
@@ -382,7 +382,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo/bar', 'FooBar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });
@@ -408,7 +408,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('route:foo', 'FooRoute'"
+          "moduleFor('route:foo'"
         ]
       });
     });
@@ -448,7 +448,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('route:foo', 'FooRoute'"
+          "moduleFor('route:foo'"
         ]
       });
     });
@@ -534,7 +534,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo', 'FooView'"
+          "moduleFor('view:foo'"
         ]
       });
     });
@@ -554,7 +554,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo', 'FooView'"
+          "moduleFor('view:foo'"
         ]
       });
     });
@@ -574,7 +574,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo/bar', 'FooBarView'"
+          "moduleFor('view:foo/bar'"
         ]
       });
     });
@@ -594,7 +594,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('view:foo/bar', 'FooBarView'"
+          "moduleFor('view:foo/bar'"
         ]
       });
     });
@@ -615,10 +615,10 @@ describe('Acceptance: ember generate pod', function() {
         contains: '{{outlet}}'
       });
       assertFile('tests/unit/foo/model-test.js', {
-        contains: "moduleForModel('foo', 'Foo'"
+        contains: "moduleForModel('foo'"
       });
       assertFile('tests/unit/foos/route-test.js', {
-        contains: "moduleFor('route:foos', 'FoosRoute'"
+        contains: "moduleFor('route:foos'"
       });
     });
   });
@@ -651,10 +651,10 @@ describe('Acceptance: ember generate pod', function() {
         contains: '{{outlet}}'
       });
       assertFile('tests/unit/pods/foo/model-test.js', {
-        contains: "moduleForModel('foo', 'Foo'"
+        contains: "moduleForModel('foo'"
       });
       assertFile('tests/unit/pods/foos/route-test.js', {
-        contains: "moduleFor('route:foos', 'FoosRoute'"
+        contains: "moduleFor('route:foos'"
       });
     });
   });
@@ -745,7 +745,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('adapter:application', 'ApplicationAdapter'"
+          "moduleFor('adapter:application'"
         ]
       });
     });
@@ -765,7 +765,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('adapter:foo', 'FooAdapter'"
+          "moduleFor('adapter:foo'"
         ]
       });
     });
@@ -785,7 +785,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('adapter:foo', 'FooAdapter'"
+          "moduleFor('adapter:foo'"
         ]
       });
     });
@@ -929,7 +929,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar', 'FooBarSerializer'"
+          "moduleFor('serializer:foo/bar'"
         ]
       });
     });
@@ -949,7 +949,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar', 'FooBarSerializer'"
+          "moduleFor('serializer:foo/bar'"
         ]
       });
     });
@@ -977,7 +977,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo', 'FooTransform'"
+          "moduleFor('transform:foo'"
         ]
       });
     });
@@ -1005,7 +1005,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo', 'FooTransform'"
+          "moduleFor('transform:foo'"
         ]
       });
     });
@@ -1033,7 +1033,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo/bar', 'FooBarTransform'"
+          "moduleFor('transform:foo/bar'"
         ]
       });
     });
@@ -1061,7 +1061,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('transform:foo/bar', 'FooBarTransform'"
+          "moduleFor('transform:foo/bar'"
         ]
       });
     });
@@ -1120,7 +1120,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('service:foo', 'FooService'"
+          "moduleFor('service:foo'"
         ]
       });
     });
@@ -1149,7 +1149,7 @@ describe('Acceptance: ember generate pod', function() {
           "  moduleFor," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('service:foo/bar', 'FooBarService'"
+          "moduleFor('service:foo/bar'"
         ]
       });
     });


### PR DESCRIPTION
The update to ember-qunit 0.2.0 has a few caveats but is largely compatible with 0.1.x.  A few of the main changes are:

* Rewritten to be a thin wrapper around ember-test-helpers, which are now shared between ember-qunit and ember-mocha.
* Deprecated `this.append()` in favor of `this.render()` in `moduleForComponent`.
* `setup` callback no longer receives the `container` as its first argument. This requires a largely mechanical refactor to use `this.container` in the callback (instead of using the first argument).

Users that update ember-cli-qunit, but not ember-qunit will see no changes (ember-cli-qunit itself is compatible with both versions).