### PR TITLE
WIP Fixes behavior for apps with multiple style preprocessors

### DIFF
--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -3,6 +3,8 @@
 var path         = require('path');
 var Registry     = require('./preprocessors/registry');
 var requireLocal = require('./utilities/require-local');
+var Funnel       = require('broccoli-funnel');
+var mergeTrees   = require('broccoli-merge-trees');
 
 module.exports.setupRegistry = function(app) {
   var registry = new Registry(app.dependencies(), app);
@@ -50,7 +52,6 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
   var plugins = options.registry.load('css');
 
   if (plugins.length === 0) {
-    var Funnel = require('broccoli-funnel');
 
     return new Funnel(tree, {
       srcDir: inputPath,
@@ -72,7 +73,11 @@ module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {
     });
   }
 
-  return processPlugins(plugins, arguments);
+  var trees = plugins.map(function(plugin) {
+    return plugin.toTree(tree, inputPath, outputPath, options);
+  });
+
+  return mergeTrees(trees);
 };
 
 module.exports.preprocessTemplates = function(/* tree */) {
@@ -101,7 +106,7 @@ function processPlugins(plugins, args) {
   var tree = args.shift();
 
   plugins.forEach(function(plugin) {
-    tree = plugin.toTree.apply(plugin, [tree].concat(args));
+    tree = plugin.toTree.apply(plugin, [tree].concat(args)); 
   });
 
   return tree;

--- a/lib/preprocessors/plugin.js
+++ b/lib/preprocessors/plugin.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var fs   = require('fs');
+var detect = require('lodash-node/modern/collections/find');
 
 function Plugin(name, ext, options) {
   this.name = name;
@@ -20,15 +21,12 @@ Plugin.prototype.toTree = function() {
 };
 
 Plugin.prototype.getExt = function(inputTreeRoot, inputPath, filename) {
-  if(Array.isArray(this.ext)) {
-    var detect = require('lodash-node/modern/collections/find');
-    return detect(this.ext, function(ext) {
-      var filenameAndExt = filename + '.' + ext;
-      return fs.existsSync(path.join(inputTreeRoot, inputPath, filenameAndExt));
-    });
-  } else {
-    return this.ext;
-  }
+  var ext = (Array.isArray(this.ext)) ? this.ext : [this.ext];
+
+  return detect(ext, function(ext) {
+    var filenameAndExt = filename + '.' + ext;
+    return fs.existsSync(path.join(inputTreeRoot, inputPath, filenameAndExt));
+  });  
 };
 
 module.exports = Plugin;

--- a/lib/preprocessors/style-plugin.js
+++ b/lib/preprocessors/style-plugin.js
@@ -4,7 +4,6 @@ var path         = require('path');
 var Plugin       = require('./plugin');
 var requireLocal = require('../utilities/require-local');
 var merge        = require('lodash-node/modern/objects/merge');
-var SilentError  = require('../errors/silent');
 var mergeTrees   = require('broccoli-merge-trees');
 
 function StylePlugin () {
@@ -26,23 +25,16 @@ StylePlugin.prototype.toTree = function(inputTree, inputPath, outputPath, option
 
         var trees = Object.keys(paths).map(function (file) {
           var ext = self.getExt(inputTreeRoot, inputPath, file);
-         
-          // Throw an error if no valid file was found
-          if (!ext) {
-            var attemptedExtensions;
-            if (Array.isArray(self.ext)) {
-              attemptedExtensions = '.[' + self.ext.join('|') + ']';
-            } else {
-              attemptedExtensions = '.' + self.ext;
-            }
-            throw new SilentError(path.join(inputTreeRoot, inputPath, file) + attemptedExtensions + ' does not exist');
+
+          if (ext) { 
+            var input = path.join(inputPath, file + '.' + ext);
+            var output = paths[file];
+
+            return requireLocal(self.name).call(null, [inputTree], input, output, options);
           }
-
-          var input = path.join(inputPath, file + '.' + ext);
-          var output = paths[file];
-
-          return requireLocal(self.name).call(null, [inputTree], input, output, options);
         });
+
+        trees = trees.filter(function(n){ return n !== undefined; });
 
         return readTree(mergeTrees(trees));
       });

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -95,4 +95,33 @@ describe('Acceptance: preprocessor-smoke-test', function() {
         expect(vendorCSS).to.contain('addon styles included');
       });
   });
+
+  
+  it('App with multiple preprocessors compile correctly', function() {
+    this.timeout(100000);
+
+    return copyFixtureFiles('preprocessor-tests/app-with-multiple-preprocessors')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJson = require(packageJsonPath);
+        packageJson.devDependencies['broccoli-sass'] = 'latest';
+        packageJson.devDependencies['broccoli-stylus-single'] = 'latest';
+
+        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--silent');
+      })
+      .then(function() {
+        var mainCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'some-cool-app.css'), {
+          encoding: 'utf8'
+        });
+        var themeCSS = fs.readFileSync(path.join('.', 'dist', 'assets', 'theme.css'), {
+          encoding: 'utf8'
+        });
+
+        expect(mainCSS).to.contain('stylus styles included');
+        expect(themeCSS).to.contain('sass styles included');
+      });
+  });
 });

--- a/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/Brocfile.js
+++ b/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/Brocfile.js
@@ -1,0 +1,11 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var name = require('./package.json').name;
+
+var app = new EmberApp({
+  name: name,
+  outputPaths: { app: { css: { 'app': '/assets/'+name+'.css', 'theme': '/assets/theme.css' } } }
+});
+
+module.exports = app.toTree();

--- a/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/app/styles/app.styl
+++ b/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/app/styles/app.styl
@@ -1,0 +1,1 @@
+/* stylus styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/app/styles/theme.scss
+++ b/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/app/styles/theme.scss
@@ -1,0 +1,1 @@
+/* sass styles included */

--- a/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/node_modules/broccoli-stylus-single/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/node_modules/broccoli-stylus-single/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Writer = require('broccoli-writer');
+
+function copyPreserveSync (src, dest) {
+  var srcStats = fs.statSync(src);
+  if (srcStats.isFile()) {
+    var destDir = path.dirname(dest);
+    var dirs = [];
+    while (destDir && !fs.existsSync(destDir)) {
+      dirs.unshift(destDir);
+      destDir = path.dirname(destDir);
+    }
+    dirs.forEach(function (dir) {
+      fs.mkdirSync(dir);
+    });
+    var content = fs.readFileSync(src);
+    fs.writeFileSync(dest, content, { flag: 'wx' });
+    fs.utimesSync(dest, srcStats.atime, srcStats.mtime);
+  } else {
+    throw new Error('Unexpected file type for ' + src);
+  }
+}
+
+module.exports = StylusCompiler;
+StylusCompiler.prototype = Object.create(Writer.prototype);
+StylusCompiler.prototype.constructor = StylusCompiler;
+function StylusCompiler (sourceTrees, inputFile, outputFile, options) {
+  if (!(this instanceof StylusCompiler)) return new StylusCompiler(sourceTrees, inputFile, outputFile, options);
+  if (!Array.isArray(sourceTrees)) throw new Error('Expected array for first argument - did you mean [tree] instead of tree?');
+  this.sourceTrees = sourceTrees;
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+}
+
+StylusCompiler.prototype.write = function (readTree, destDir) {
+  var self = this;
+
+  return readTree(this.sourceTrees[0]).then(function (srcDir) {
+    copyPreserveSync(
+      path.join(srcDir, self.inputFile),
+      path.join(destDir, self.outputFile));
+  });
+};

--- a/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/node_modules/broccoli-stylus-single/package.json
+++ b/tests/fixtures/preprocessor-tests/app-with-multiple-preprocessors/node_modules/broccoli-stylus-single/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broccoli-stylus-single",
+  "private": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Apps that have multiple preprocessors (such as the one mentioned in #2959). This PR currently allows for multiple preprocessors to output to separate files by customizing an app's outputPaths. This allows users to include the output in their app in whatever order they choose, solving dependency issues.

`mergeTrees()` will throw an error if an app contains two or more files with the same name under different preprocessors (e.g. `app.scss` and `app.styl`). I am thinking that default behavior should be to concatenate same name files in arbitrary order (whatever order they were registered in the registry). This will require a custom version of broccoli-merge-trees, or a broccoli plugin that provides this functionality. Thoughts?