### PR TITLE
Update ember-router-generator (single quote all the things)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "core-object": "0.0.2",
     "debug": "^2.1.0",
     "diff": "^1.0.8",
-    "ember-router-generator": "^0.2.0",
+    "ember-router-generator": "^0.3.0",
     "exit": "^0.1.2",
     "express": "^4.8.5",
     "findup": "0.1.5",

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -273,7 +273,7 @@ describe('Acceptance: ember generate', function() {
   it('route foo', function() {
     return generate(['route', 'foo']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.route(\"foo\")"
+        contains: 'this.route(\'foo\')'
       });
       assertFile('app/routes/foo.js', {
         contains: [
@@ -300,8 +300,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['route', 'foo', '--path=:foo_id/show']).then(function() {
       assertFile('app/router.js', {
         contains: [
-          'this.route("foo", {',
-          'path: ":foo_id/show"',
+          'this.route(\'foo\', {',
+          'path: \':foo_id/show\'',
           '});'
         ]
       });
@@ -311,7 +311,7 @@ describe('Acceptance: ember generate', function() {
   it('route foos --type=resource', function() {
     return generate(['route', 'foos', '--type=resource']).then(function() {
       assertFile('app/router.js', {
-        contains: 'this.resource("foos", function() {});'
+        contains: 'this.resource(\'foos\', function() {});'
       });
     });
   });
@@ -405,7 +405,7 @@ describe('Acceptance: ember generate', function() {
   it('resource foos', function() {
     return generate(['resource', 'foos']).then(function() {
       assertFile('app/router.js', {
-        contains: 'this.resource("foos", function() {});'
+        contains: 'this.resource(\'foos\', function() {});'
       });
       assertFile('app/models/foo.js', {
         contains: 'export default DS.Model.extend'
@@ -429,8 +429,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['resource', 'foos', '--path=app/foos']).then(function() {
       assertFile('app/router.js', {
         contains: [
-          'this.resource("foos", {',
-          'path: "app/foos"',
+          'this.resource(\'foos\', {',
+          'path: \'app/foos\'',
           '}, function() {});'
         ]
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -391,7 +391,7 @@ describe('Acceptance: ember generate pod', function() {
   it('route foo --pod', function() {
     return generate(['route', 'foo', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.route(\"foo\")"
+        contains: 'this.route(\'foo\')'
       });
       assertFile('app/foo/route.js', {
         contains: [
@@ -419,8 +419,8 @@ describe('Acceptance: ember generate pod', function() {
       .then(function() {
         assertFile('app/router.js', {
           contains: [
-            'this.route("foo", {',
-            'path: ":foo_id/show"',
+            'this.route(\'foo\', {',
+            'path: \':foo_id/show\'',
             '});'
           ]
         });
@@ -431,7 +431,7 @@ describe('Acceptance: ember generate pod', function() {
   it('route foo --pod podModulePrefix', function() {
     return generateWithPrefix(['route', 'foo', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.route(\"foo\")"
+        contains: 'this.route(\'foo\')'
       });
       assertFile('app/pods/foo/route.js', {
         contains: [
@@ -457,7 +457,7 @@ describe('Acceptance: ember generate pod', function() {
   it('route foos --type=resource --pod', function() {
     return generate(['route', 'foos', '--type=resource', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.resource(\"foos\", function() {});"
+        contains: 'this.resource(\'foos\', function() {});'
       });
     });
   });
@@ -603,7 +603,7 @@ describe('Acceptance: ember generate pod', function() {
   it('resource foos --pod', function() {
     return generate(['resource', 'foos', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.resource(\"foos\", function() {});"
+        contains: 'this.resource(\'foos\', function() {});'
       });
       assertFile('app/foo/model.js', {
         contains: 'export default DS.Model.extend'
@@ -628,8 +628,8 @@ describe('Acceptance: ember generate pod', function() {
       .then(function() {
         assertFile('app/router.js', {
           contains: [
-            'this.resource("foos", {',
-            'path: "app/foos"',
+            'this.resource(\'foos\', {',
+            'path: \'app/foos\'',
             '}, function() {});'
           ]
         });
@@ -639,7 +639,7 @@ describe('Acceptance: ember generate pod', function() {
   it('resource foos --pod podModulePrefix', function() {
     return generateWithPrefix(['resource', 'foos', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: "this.resource(\"foos\", function() {});"
+        contains: 'this.resource(\'foos\', function() {});'
       });
       assertFile('app/pods/foo/model.js', {
         contains: 'export default DS.Model.extend'


### PR DESCRIPTION
Now we can specify quote or single quote for strings, default back to
single quotes.