### PR TITLE
[BUGFIX] Use recent Esperanto update to allow ES3 safe output.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -765,7 +765,12 @@ EmberApp.prototype.javascript = function() {
       description: 'Funnel: App JS Files'
     }),
 
-    { description: 'ES6: App Tree' }
+    {
+      description: 'ES6: App Tree',
+      esperantoOptions: {
+        _evilES3SafeReExports: this.options.es3Safe
+      }
+    }
   );
 
   es6 = mergeTrees([es6, this._processedEmberCLITree()]);

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -393,7 +393,14 @@ Addon.prototype.compileAddon = function(tree) {
     new this.Funnel(this.mergeTrees(trees), {
       include: [new RegExp(escapeRegExp(this.name+'/') + '.*\\.js$')],
       description: 'Funnel: Addon Tree'
-    })
+    }),
+
+    {
+      description: 'ES6: ' + this.name,
+      esperantoOptions: {
+        _evilES3SafeReExports: this.app.options.es3Safe
+      }
+    }
   );
 
   es6Tree = this.mergeTrees([es6Tree, reexported]);

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "broccoli-caching-writer": "0.5.1",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "1.0.0",
-    "broccoli-es6modules": "^0.4.1",
+    "broccoli-es6modules": "^0.4.2",
     "broccoli-filter": "0.1.7",
     "broccoli-funnel": "0.1.5",
     "broccoli-kitchen-sink-helpers": "0.2.5",


### PR DESCRIPTION
* Update broccoli-es6modules to v0.4.2 ([compare view](https://github.com/ember-cli/broccoli-es6modules/compare/v0.4.1...v0.4.2)).
* Use the pre-existing `es3safe` `Brocfile.js` option to determine if we should pass instruct Esperanto to use ES3 safe re-exports.

This fixes an ES3 safety regression introduced in v0.1.8 (the switch to Esperanto). Prior to the move to Esperanto ember-cli supported IE8 out of the box, this restores that compatiblity (while allowing users to opt-out of ES3 safety exactly as before).