### PR TITLE
[BUGFIX] Bump ember-qunit to v0.2.1 for ES3 safety.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -10,7 +10,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.0",
+    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.1",
     "ember-qunit-notifications": "0.0.5",
     "qunit": "~1.17.1"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.2",
+    "ember-cli-qunit": "0.3.3",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",


### PR DESCRIPTION
Updates ember-qunit to v0.2.1 which fixes issues with ES3 safe build output.