### PR TITLE
allow generated acceptance tests to be in directories

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
+import startApp from '<%= dasherizedPackageName %>/tests/helpers/start-app';
 
 var application;
 

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
+import startApp from 'my-app/tests/helpers/start-app';
 
 var application;
 


### PR DESCRIPTION
An example of what currently doesn't work:

    ember g acceptance-test projects/create


Opening this to start a discussion. Probably you guys know a better solution.