### PR TITLE
Use 'ember server' consistently to minimize hiccups for newbies like me

### DIFF
--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -52,7 +52,7 @@ and thus also the Router, to function correctly.
 ### Content security policy
 To enable the Content Security Policy on your production stack, you'll need to copy the
 `Content-Security-Policy` and `X-Content-Security-Policy` (for IE) from the headers generated
-by `ember serve`. If you'd like to enable it in report-only mode, use `Content-Security-Policy-Report-Only`
+by `ember server`. If you'd like to enable it in report-only mode, use `Content-Security-Policy-Report-Only`
 and `X-Content-Security-Policy-Report-Only`. Make sure you've set a `report-uri` if you enable
 the CSP in report-only mode.
 

--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -30,7 +30,7 @@ Additionally, Ember-CLI contains a number of environment-dependent helpers for a
  
 It is now also possible to override command line options by creating a file in your app's root directory called `.ember-cli` and placing desired overrides in it.
 
-For example, a common desire is to [change the port](http://stackoverflow.com/questions/24003944/save-port-number-for-ember-cli-in-a-config-file) that ember-cli serves the app from. It's possible to pass the port number directly to ember server in the command line, e.g. `ember serve --port 8080`. If you wish to make this change a permanent configuration change, make the `.ember-cli` file and add the options you wish to pass to the server in a hash.
+For example, a common desire is to [change the port](http://stackoverflow.com/questions/24003944/save-port-number-for-ember-cli-in-a-config-file) that ember-cli serves the app from. It's possible to pass the port number directly to ember server in the command line, e.g. `ember server --port 8080`. If you wish to make this change a permanent configuration change, make the `.ember-cli` file and add the options you wish to pass to the server in a hash.
 
 {% highlight javascript %}
 {

--- a/_posts/2013-04-12-ember-data.md
+++ b/_posts/2013-04-12-ember-data.md
@@ -96,7 +96,7 @@ ember g http-mock posts
 A basic [ExpressJS](http://expressjs.com/) server will be scaffolded for
 your endpoint under `/your-app/server/mocks/posts.js`. Once you add the 
 appropriate JSON response, you're ready to go. The next time you run
-`ember serve`, your new mock server will be listening for any API requests
+`ember server`, your new mock server will be listening for any API requests
 from your Ember app.
 
 > Note: Mocks are just for development and testing. The entire `/server` 


### PR DESCRIPTION
Preserved `ember serve ...` usage in changelogs, only updated from `ember serve` to `ember server` in the main docs that weren't already using `ember server`.