### PR TITLE
Added inline docs regarding the removal of body-parser

### DIFF
--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -8,16 +8,29 @@ module.exports = function(app) {
     });
   });
 
-  <%= camelizedModuleName %>Router.post('/', function(req, res) {
-    res.status(201).end();
-  });
-
   <%= camelizedModuleName %>Router.get('/:id', function(req, res) {
     res.send({
       '<%= dasherizedModuleName %>': {
         id: req.params.id
       }
     });
+  });
+
+/**
+  The POST and PUT call will not contain a request body
+  because the body-parser is not included by default.
+  To use req.body, run:
+
+     npm install --save-dev body-parser
+
+  After installing, you need to `use` the body-parser for
+  this mock by appending:
+
+     app.use('/api/<%= decamelizedModuleName %>', require('body-parser'));
+
+*/   
+  <%= camelizedModuleName %>Router.post('/', function(req, res) {
+    res.status(201).end();
   });
 
   <%= camelizedModuleName %>Router.put('/:id', function(req, res) {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -870,16 +870,29 @@ describe('Acceptance: ember generate', function() {
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
-                  "  fooRouter.post('/', function(req, res) {" + EOL +
-                  "    res.status(201).end();" + EOL +
-                  "  });" + EOL +
-                  EOL +
                   "  fooRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
                   "      'foo': {" + EOL +
                   "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "/**" + EOL +
+                  "  The POST and PUT call will not contain a request body" + EOL +
+                  "  because the body-parser is not included by default." + EOL +
+                  "  To use req.body, run:" + EOL +
+                  EOL +                       
+                  "     npm install --save-dev body-parser" + EOL +
+                  EOL +                       
+                  "  After installing, you need to `use` the body-parser for" + EOL +
+                  "  this mock by appending:" + EOL +
+                  EOL +                       
+                  "     app.use('/api/foo', require('body-parser'));" + EOL +
+                  EOL +
+                  "*/   " + EOL +
+                  "  fooRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooRouter.put('/:id', function(req, res) {" + EOL +
@@ -919,16 +932,29 @@ describe('Acceptance: ember generate', function() {
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
-                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
-                  "    res.status(201).end();" + EOL +
-                  "  });" + EOL +
-                  EOL +
                   "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
                   "      'foo-bar': {" + EOL +
                   "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "/**" + EOL +
+                  "  The POST and PUT call will not contain a request body" + EOL +
+                  "  because the body-parser is not included by default." + EOL +
+                  "  To use req.body, run:" + EOL +
+                  EOL +                       
+                  "     npm install --save-dev body-parser" + EOL +
+                  EOL +                       
+                  "  After installing, you need to `use` the body-parser for" + EOL +
+                  "  this mock by appending:" + EOL +
+                  EOL +                       
+                  "     app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                  EOL +
+                  "*/   " + EOL +
+                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooBarRouter.put('/:id', function(req, res) {" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1213,16 +1213,29 @@ describe('Acceptance: ember generate pod', function() {
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
-                  "  fooRouter.post('/', function(req, res) {" + EOL +
-                  "    res.status(201).end();" + EOL +
-                  "  });" + EOL +
-                  EOL +
                   "  fooRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
                   "      'foo': {" + EOL +
                   "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "/**" + EOL +
+                  "  The POST and PUT call will not contain a request body" + EOL +
+                  "  because the body-parser is not included by default." + EOL +
+                  "  To use req.body, run:" + EOL +
+                  EOL +                       
+                  "     npm install --save-dev body-parser" + EOL +
+                  EOL +                       
+                  "  After installing, you need to `use` the body-parser for" + EOL +
+                  "  this mock by appending:" + EOL +
+                  EOL +                       
+                  "     app.use('/api/foo', require('body-parser'));" + EOL +
+                  EOL +
+                  "*/   " + EOL +
+                  "  fooRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooRouter.put('/:id', function(req, res) {" + EOL +
@@ -1262,16 +1275,29 @@ describe('Acceptance: ember generate pod', function() {
                   "    });" + EOL +
                   "  });" + EOL +
                   EOL +
-                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
-                  "    res.status(201).end();" + EOL +
-                  "  });" + EOL +
-                  EOL +
                   "  fooBarRouter.get('/:id', function(req, res) {" + EOL +
                   "    res.send({" + EOL +
                   "      'foo-bar': {" + EOL +
                   "        id: req.params.id" + EOL +
                   "      }" + EOL +
                   "    });" + EOL +
+                  "  });" + EOL +
+                  EOL +
+                  "/**" + EOL +
+                  "  The POST and PUT call will not contain a request body" + EOL +
+                  "  because the body-parser is not included by default." + EOL +
+                  "  To use req.body, run:" + EOL +
+                  EOL +                       
+                  "     npm install --save-dev body-parser" + EOL +
+                  EOL +                       
+                  "  After installing, you need to `use` the body-parser for" + EOL +
+                  "  this mock by appending:" + EOL +
+                  EOL +                       
+                  "     app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                  EOL +
+                  "*/   " + EOL +
+                  "  fooBarRouter.post('/', function(req, res) {" + EOL +
+                  "    res.status(201).end();" + EOL +
                   "  });" + EOL +
                   EOL +
                   "  fooBarRouter.put('/:id', function(req, res) {" + EOL +


### PR DESCRIPTION
refs #3208 

Adds the following docblock to eg. `server/mocks/foo-bar`:

```javascript
/**
  The POST and PUT call will not contain a request body
  because the body-parser is not included by default.
  To use req.body, run:

     npm install --save-dev body-parser

  After installing, you need to `use` the body-parser for
  this mock by appending:

     app.use('/api/foo-bar', require('body-parser'));

*/  
```