### PR TITLE
Use io.js in CI by default.

### DIFF
--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: node_js
+node_js:
+  - "iojs"
 
 sudo: false
 
@@ -9,7 +11,6 @@ cache:
 
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
 
 install:
   - npm install -g bower


### PR DESCRIPTION
References:

* https://github.com/ember-cli/ember-cli/pull/3134
* http://docs.travis-ci.com/user/build-environment-updates/2015-02-03/#iojs_support