### PR TITLE
Update docs according to QUnit 2.0 changes

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -52,11 +52,11 @@ All Ember Apps come with built-in [ember test helpers](http://emberjs.com/guides
 which are useful for writing integration tests.
 In order to use them, you will need to import `tests/helpers/start-app.js`, which injects the required helpers.
 
-Be sure to use the injected `module` function to invoke `beforeEach` and `afterEach`.
+Be sure to use the `module` function to invoke `beforeEach` and `afterEach`.
 
 {% highlight javascript linenos %}
 import Ember from "ember";
-import { test } from 'ember-qunit';
+import { module, test } from 'ember-qunit';
 import startApp from '../helpers/start-app';
 var App;
 
@@ -242,10 +242,12 @@ Depending on your approach, you may want to define one helper per file or a grou
 
 {% highlight javascript linenos %}
 // helpers/routes-to.js
-export default Ember.Test.registerAsyncHelper('routesTo', function (app, url, route_name) {
+import Ember from "ember";
+
+export default Ember.Test.registerAsyncHelper('routesTo', function (app, assert, url, route_name) {
   visit(url);
   andThen(function () {
-    equal(currentRouteName(), route_name, 'Expected ' + route_name + ', got: ' + currentRouteName());
+    assert.equal(currentRouteName(), route_name, 'Expected ' + route_name + ', got: ' + currentRouteName());
   });
 });
 {% endhighlight %}


### PR DESCRIPTION
Updated testing documentation to use new hook names `beforeEach`/`afterEach` and replace global assertions with `assert` argument. This change should match the recent changes to the blueprints (see #3197) 

I was not sure how to apply the `assert` argument with the [test helper example](http://www.ember-cli.com/#single-helper-per-file). Pointers how to update this part are appreciated.