### PR TITLE
[NO MERGE - VERY WIP] Pre-built addons

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -8,6 +8,8 @@ var merge    = require('lodash-node/modern/objects/merge');
 var Funnel   = require('broccoli-funnel');
 var defaults = require('lodash-node/modern/objects/defaults');
 var EmberApp = require('./ember-app');
+var Funnel   = require('broccoli-funnel');
+var escapeRegExp = require('../utilities/escape-regexp');
 
 module.exports = EmberAddon;
 
@@ -45,3 +47,41 @@ function EmberAddon(options) {
 EmberAddon.prototype = Object.create(EmberApp.prototype);
 EmberAddon.prototype.constructor = EmberAddon;
 EmberAddon.prototype.appConstructor = EmberApp.prototype.constructor;
+
+EmberAddon.prototype.addonTreesFor = function(type) {
+  var project = this.project;
+  return project.addons.map(function(addon) {
+    if (addon.name == project.name()) {
+      this.currentAddon = addon;
+      return;
+    }
+    if (addon.treeFor && addon.name != project.name()) {
+      return addon.treeFor(type);
+    }
+  }, this).filter(Boolean);
+};
+
+EmberAddon.prototype.currentAddonTree = function() {
+  var addonTree = this.currentAddon.treeFor('addon');
+  return new Funnel(addonTree, {
+    destDir: this.project.name() + '/',
+    description: 'Funnel: Current addon'
+  });
+};
+
+EmberAddon.prototype.toArray = function() {
+  var sourceTrees = [
+    this.index(),
+    this.javascript(),
+    this.styles(),
+    this.otherAssets(),
+    this.publicTree(),
+    this.currentAddonTree()
+  ];
+
+  if (this.tests) {
+    sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles());
+  }
+
+  return sourceTrees;
+};


### PR DESCRIPTION
This is just a POC, can probably done in a nicer way (probably after @lukemelia's work is merged).

Isolates files related to the current addon during the build and puts them in a separate directory (`/addon-name`). This is nice for a couple of reasons:
- Addons can be used with Globals-based Ember projects
- Addons can be used in fiddles
- Addons can be shipped in pre-built state, reducing the built overhead for every addon.

Work to be done (at least):
- [ ] Make sure template compiler version matches app
- [ ] Include public
- [ ] Document/implement how addon vendor files should be handled.