### PR TITLE
Remove extra Addon build steps.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -588,10 +588,10 @@ EmberApp.prototype._processedVendorTree = function() {
     return this._cachedVendorTree;
   }
 
-  var addonTrees   = mergeTrees(this.addonTreesFor('addon'));
+  var addonTrees   = mergeTrees(this.addonTreesFor('addon'), { overwrite: true });
   addonTrees = mergeTrees([
-    this.concatFiles(addonTrees, { inputFiles: ['*.css'], outputFile: '/addons.css', allowNone: true, description: 'Concat: Addon CSS' }),
-    this.concatFiles(addonTrees, { inputFiles: ['*.js'],  outputFile: '/addons.js',  allowNone: true, description: 'Concat: Addon JS' })
+    this.concatFiles(addonTrees, { inputFiles: ['**/*.css'], outputFile: '/addons.css', allowNone: true, description: 'Concat: Addon CSS' }),
+    this.concatFiles(addonTrees, { inputFiles: ['**/*.js'],  outputFile: '/addons.js',  allowNone: true, description: 'Concat: Addon JS' })
   ].concat(this.addonTreesFor('vendor')), {
     overwrite: true
   });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -11,7 +11,6 @@ var assign       = require('lodash-node/modern/objects/assign');
 var glob         = require('glob');
 var SilentError  = require('../errors/silent');
 var reexport     = require('../utilities/reexport');
-var escapeRegExp = require('../utilities/escape-regexp');
 
 var p                   = require('../preprocessors');
 var preprocessJs        = p.preprocessJs;
@@ -304,17 +303,8 @@ Addon.prototype.treeForAddon = function(tree) {
 
   var addonTree = this.compileAddon(tree);
   var stylesTree = this.compileStyles(this._treeFor('addon-styles'));
-  var jsTree;
 
-  if (addonTree) {
-    jsTree = this.concatFiles(addonTree, {
-      inputFiles: ['**/*.js'],
-      outputFile: '/' + this.name + '.js',
-      allowNone: true
-    });
-  }
-
-  return this.mergeTrees([jsTree, stylesTree].filter(Boolean));
+  return this.mergeTrees([addonTree, stylesTree].filter(Boolean));
 };
 
 /**
@@ -386,30 +376,17 @@ Addon.prototype.compileAddon = function(tree) {
 
   var addonJs = this.addonJsFiles(tree);
   var templatesTree = this.compileTemplates(this._treeFor('addon-templates'));
-  var reexported = reexport(this.name, '__reexport.js');
+  var reexported = reexport(this.name, this.name + '.js');
   var trees = [addonJs, templatesTree].filter(Boolean);
 
-  var es6Tree = new this.transpileModules(
-    new this.Funnel(this.mergeTrees(trees), {
-      include: [new RegExp(escapeRegExp(this.name+'/') + '.*\\.js$')],
-      description: 'Funnel: Addon Tree'
-    }),
-
-    {
-      description: 'ES6: ' + this.name,
-      esperantoOptions: {
-        _evilES3SafeReExports: this.app.options.es3Safe
-      }
+  var es6Tree = new this.transpileModules(this.mergeTrees(trees), {
+    description: 'ES6: ' + this.name,
+    esperantoOptions: {
+      _evilES3SafeReExports: this.app.options.es3Safe
     }
-  );
+  });
 
   es6Tree = this.mergeTrees([es6Tree, reexported]);
-
-  es6Tree = this.concatFiles(es6Tree, {
-    inputFiles: [this.name + '/**/*.js'],
-    outputFile: '/' + this.name + '.js',
-    footerFiles: ['__reexport.js']
-  });
 
   return es6Tree;
 };


### PR DESCRIPTION
This is in support of https://github.com/ember-cli/ember-cli/pull/3166.  When that lands we will need to ensure that we:

1) Keep output as individual files as long as possible.
2) Preserve the concept that the last instance of a given addon is used.