### PR TITLE
Remove module transpilation from Addon model.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -579,6 +579,56 @@ EmberApp.prototype._processedBowerTree = function() {
 };
 
 /**
+
+*/
+EmberApp.prototype._addonTree = function _addonTree() {
+  if (this._cachedAddonTree) {
+    return this._cachedAddonTree;
+  }
+
+  var addonTrees   = mergeTrees(this.addonTreesFor('addon'), { overwrite: true });
+  var addonES6     = new Funnel(addonTrees, {
+    srcDir: 'modules',
+    allowEmpty: true,
+    description: 'Funnel: Addon JS'
+  });
+
+  // it is not currently possible to make Esperanto processing
+  // pre-existing AMD a no-op, so we have to remove the reexports
+  // to then merge them later :(
+  var addonReexports = new Funnel(addonTrees, {
+    srcDir: 'reexports',
+    allowEmpty: true,
+    description: 'Funnel: Addon Re-exports'
+  });
+
+  var transpiledAddonTree = new transpileES6(addonES6, {
+    description: 'ES6: Addon Trees',
+    esperantoOptions: {
+      _evilES3SafeReExports: this.options.es3Safe
+    }
+  });
+
+  var reexportsAndTranspiledAddonTree = mergeTrees([transpiledAddonTree, addonReexports]);
+
+  return this._cachedAddonTree = [
+    this.concatFiles(addonTrees, {
+      inputFiles: ['**/*.css'],
+      outputFile: '/addons.css',
+      allowNone: true,
+      description: 'Concat: Addon CSS'
+    }),
+
+    this.concatFiles(reexportsAndTranspiledAddonTree, {
+      inputFiles: ['**/*.js'],
+      outputFile: '/addons.js',
+      allowNone: true,
+      description: 'Concat: Addon JS'
+    })
+  ];
+};
+
+/**
   @private
   @method _processedVendorTree
   @return
@@ -588,15 +638,10 @@ EmberApp.prototype._processedVendorTree = function() {
     return this._cachedVendorTree;
   }
 
-  var addonTrees   = mergeTrees(this.addonTreesFor('addon'), { overwrite: true });
-  addonTrees = mergeTrees([
-    this.concatFiles(addonTrees, { inputFiles: ['**/*.css'], outputFile: '/addons.css', allowNone: true, description: 'Concat: Addon CSS' }),
-    this.concatFiles(addonTrees, { inputFiles: ['**/*.js'],  outputFile: '/addons.js',  allowNone: true, description: 'Concat: Addon JS' })
-  ].concat(this.addonTreesFor('vendor')), {
-    overwrite: true
-  });
+  var trees = this._importTrees.slice();
+  trees = trees.concat(this._addonTree());
+  trees = trees.concat(this.addonTreesFor('vendor'));
 
-  var trees = this._importTrees.concat(addonTrees);
   if (this.trees.vendor) {
     trees.push(this.trees.vendor);
   }
@@ -610,6 +655,7 @@ EmberApp.prototype._processedVendorTree = function() {
     srcDir: '/',
     destDir: 'vendor/'
   });
+
   return this._cachedVendorTree;
 };
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -340,7 +340,7 @@ Addon.prototype.compileTemplates = function(tree) {
   if (tree) {
     var standardTemplates = this.pickFiles(tree, {
       srcDir: '/',
-      destDir: this.name + '/templates'
+      destDir: 'modules/' + this.name + '/templates'
     });
 
     var includePatterns = this.registry.extensionsForType('template').map(function(extension) {
@@ -349,7 +349,7 @@ Addon.prototype.compileTemplates = function(tree) {
 
     var podTemplates = new this.Funnel(tree, {
       include: includePatterns,
-      destDir: this.name + '/',
+      destDir: 'modules/' + this.name + '/',
       description: 'Funnel: Addon Pod Templates'
     });
 
@@ -377,18 +377,9 @@ Addon.prototype.compileAddon = function(tree) {
   var addonJs = this.addonJsFiles(tree);
   var templatesTree = this.compileTemplates(this._treeFor('addon-templates'));
   var reexported = reexport(this.name, this.name + '.js');
-  var trees = [addonJs, templatesTree].filter(Boolean);
+  var trees = [addonJs, templatesTree, reexported].filter(Boolean);
 
-  var es6Tree = new this.transpileModules(this.mergeTrees(trees), {
-    description: 'ES6: ' + this.name,
-    esperantoOptions: {
-      _evilES3SafeReExports: this.app.options.es3Safe
-    }
-  });
-
-  es6Tree = this.mergeTrees([es6Tree, reexported]);
-
-  return es6Tree;
+  return this.mergeTrees(trees);
 };
 
 /**
@@ -432,7 +423,7 @@ Addon.prototype.addonJsFiles = function(tree) {
 
   var files = new this.Funnel(tree, {
     include: includePatterns,
-    destDir: this.moduleName(),
+    destDir: 'modules/' + this.moduleName(),
     description: 'Funnel: Addon JS'
   });
 

--- a/lib/utilities/reexport.js
+++ b/lib/utilities/reexport.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
+var Promise = require('../ext/promise');
+var rimraf = Promise.denodeify(fs.remove);
 var template = fs.readFileSync(path.join(__dirname, 'reexport-template.js'), 'utf-8');
 var quickTemp = require('quick-temp');
 
@@ -19,12 +21,14 @@ Reexporter.prototype.content = function() {
 
 Reexporter.prototype.read = function() {
   var dir = quickTemp.makeOrReuse(this, 'tmpCacheDir');
-  fs.writeFileSync(path.join(dir, this.outputFile), this.content());
+  fs.mkdirSync(path.join(dir, 'reexports'));
+  fs.writeFileSync(path.join(dir, 'reexports', this.outputFile), this.content());
+
   return dir;
 };
 
 Reexporter.prototype.cleanup = function() {
-  quickTemp.remove(this, 'tmpCacheDir');
+  return rimraf(this['tmpCacheDir']);
 };
 
 module.exports = function(name, outputFile) {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "broccoli-es3-safe-recast": "1.0.0",
     "broccoli-es6modules": "^0.4.3",
     "broccoli-filter": "0.1.7",
-    "broccoli-funnel": "0.1.5",
+    "broccoli-funnel": "0.2.1",
     "broccoli-kitchen-sink-helpers": "0.2.5",
     "broccoli-merge-trees": "0.2.1",
     "broccoli-sane-watcher": "^0.1.1",


### PR DESCRIPTION
The long term goal is to keep ES6 as the lingua franca for JS modules and to extract a "Packager" role to handle the final bundling.