### PR TITLE
Blueprint templates with undefined variables should fallback to raw text

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -87,7 +87,7 @@ FileInfo.prototype.render = function() {
       try {
         return processTemplate(content.toString(), context);
       } catch (error) {
-        return content;
+        return content.toString();
       }
     });
   }

--- a/tests/fixtures/blueprints/with-templating/files/with-undefined-variable.txt
+++ b/tests/fixtures/blueprints/with-templating/files/with-undefined-variable.txt
@@ -1,0 +1,1 @@
+Howdy <%= enemy %>

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -11,6 +11,7 @@ var writeFile = Promise.denodeify(fs.writeFile);
 var root       = process.cwd();
 var tmproot    = path.join(root, 'tmp');
 var tmp        = require('tmp-sync');
+var assign     = require('lodash-node/modern/objects/assign');
 var tmpdir;
 var testOutputPath;
 
@@ -49,6 +50,19 @@ describe('Unit - FileInfo', function(){
     return fileInfo.render().then(function(output){
       expect(output.trim()).to.equal('Howdy Billy',
         'expects the template to have been run');
+    });
+  });
+
+  it('falls back to raw text if template throws', function(){
+    var templateWithUndefinedVariable = path.resolve(__dirname,
+      '../../fixtures/blueprints/with-templating/files/with-undefined-variable.txt');
+    var options = {};
+    assign(options, validOptions, { inputPath: templateWithUndefinedVariable });
+    var fileInfo = new FileInfo(options);
+
+    return fileInfo.render().then(function(output){
+      expect(output.trim()).to.equal('Howdy <%= enemy %>',
+        'expects to fall back to raw text');
     });
   });
 


### PR DESCRIPTION
Right now, if you have a blueprint template that references an undefined variable, the `generate` command blows up with an obscure stack trace:

```
$ ember g my-blueprint
version: 0.1.12
installing
[?] Overwrite foobar.js? Diff
Object This is my template
Here is line two <%= undefinedVariable %>
Foobar
Line four has no method 'split'
TypeError: Object This is my template
Here is line two  <%= undefinedVariable %>
Foobar
Line four has no method 'split'
  at Object.LineDiff.tokenize (/Users/fizz/foobar/node_modules/ember-cli/node_modules/diff/diff.js:261:25)
  at Object.Diff.diff (/Users/fizz/foobar/node_modules/ember-cli/node_modules/diff/diff.js:117:28)
  at Object.JsDiff.createPatch (/Users/fizz/foobar/node_modules/ember-cli/node_modules/diff/diff.js:366:29)
  at /Users/fizz/foobar/node_modules/ember-cli/lib/models/file-info.js:61:23
  at $$$internal$$tryCatch (/Users/fizz/foobar/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:490:16)
  at $$$internal$$invokeCallback (/Users/fizz/foobar/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:502:17)
  at $$$internal$$publish (/Users/fizz/foobar/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:473:11)
  at Object.$$rsvp$asap$$flush [as _onImmediate] (/Users/fizz/foobar/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1581:9)
  at processImmediate [as _immediateCallback] (timers.js:330:15)
```

Which leads us to the [models/file-info.js](https://github.com/ember-cli/ember-cli/blob/master/lib/models/file-info.js#L90):

```js
    this.rendered = readFile(path).then(function(content){
      try {
        return processTemplate(content.toString(), context);
      } catch (error) {
        return content;
      }
    });
```

`readFile` resolves to a buffer, and if the template doesn't throw during rendering, it is converted into a string. But if your template throws (say, because you referenced an undefined error), then it returns a Buffer, hence the cryptic stack trace above.

Added a unit test to check for this, and added the `toString()` in the catch block. This effectively means that templates that throw will be treated as raw strings (not templates). That could end up being a bit surprising, but I went with what looked like the original intent here.
