### PR TITLE
ENHANCEMENT: Added `--test-port`/`testPort` option to configure test port

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,6 +7,8 @@ var Builder   = require('../models/builder');
 var fs = require('fs');
 var path = require('path');
 
+var defaultPortNumber = 7357;
+
 module.exports = Command.extend({
   name: 'test',
   aliases: ['test', 't'],
@@ -17,7 +19,7 @@ module.exports = Command.extend({
     { name: 'config-file', type: String,  default: './testem.json', aliases: ['c', 'cf'] },
     { name: 'server',      type: Boolean, default: false, aliases: ['s'] },
     { name: 'host',        type: String,  aliases: ['H'] },
-    { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.', aliases: ['p'] },
+    { name: 'test-port',   type: Number,  default: defaultPortNumber, description: 'The test port to use when running with --server.', aliases: ['tp'] },
     { name: 'filter',      type: String,  description: 'A string to filter tests to run', aliases: ['f'] },
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
@@ -69,6 +71,11 @@ module.exports = Command.extend({
     return customPath;
   },
 
+  _generateTestPortNumber: function(options) {
+    if (options.port && options.testPort !== defaultPortNumber || options.testPort && !options.port) { return options.testPort; }
+    if (options.port) { return parseInt(options.port, 10) + 1; }
+  },
+
   buildTestPageQueryString: function(options) {
     var params = [];
 
@@ -89,7 +96,8 @@ module.exports = Command.extend({
     var testOptions = this.assign({}, commandOptions, {
       outputPath: outputPath,
       project: this.project,
-      configFile: this._generateCustomConfigFile(commandOptions)
+      configFile: this._generateCustomConfigFile(commandOptions),
+      port: this._generateTestPortNumber(commandOptions)
     });
 
     var options = {

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -68,19 +68,43 @@ describe('test command', function() {
     });
   });
 
+  it('does not pass any port options', function() {
+    return new TestCommand(options).validateAndRun([]).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.port).to.equal(7357);
+    });
+  });
+
+  it('passes through a custom test port option', function() {
+    return new TestCommand(options).validateAndRun(['--test-port=5679']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.port).to.equal(5679);
+    });
+  });
+
+  it('only passes through the port option', function() {
+    return new TestCommand(options).validateAndRun(['--port=5678']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.port).to.equal(5679);
+    });
+  });
+
+  it('passes both the port and the test port options', function() {
+    return new TestCommand(options).validateAndRun(['--port=5678', '--test-port=5900']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.port).to.equal(5900);
+    });
+  });
+
   it('passes through custom host option', function() {
     return new TestCommand(options).validateAndRun(['--host=greatwebsite.com']).then(function() {
       var testOptions  = testRun.calledWith[0][0];
 
       expect(testOptions.host).to.equal('greatwebsite.com');
-    });
-  });
-
-  it('passes through custom port option', function() {
-    return new TestCommand(options).validateAndRun(['--port=5678']).then(function() {
-      var testOptions  = testRun.calledWith[0][0];
-
-      expect(testOptions.port).to.equal(5678);
     });
   });
 


### PR DESCRIPTION
Fixes #3022 

/cc @stefanpenner 

~~I hope I've gone about this the right way. It kind of seems weird to me that you can pass `--port` (will output `port+1`) and `--test-port` through the CLI but I needed to do that for my tests to pass. Any pointers/feedback appreciated.~~

Removes `--port` and adds `--test-port` to the `test` command. This is to stop clashes with the port in the app v test server when customizing it in `.ember-cli`

* [x] No port passed defaults to 7357
* [x] Only `port` passed becomes `port` + 1
* [x] `testPort` or `--test-port` becomes the test port
* [x] tests
* [ ] Update docs?