### PR TITLE
Moved reverse() to after filter() so we can keep consistent order

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -464,13 +464,13 @@ Project.prototype.blueprintLookupPaths = function() {
   @return {Array} List of paths
  */
 Project.prototype.addonBlueprintLookupPaths = function() {
-  var addonPaths = this.addons.reverse().map(function(addon) {
+  var addonPaths = this.addons.map(function(addon) {
     if (addon.blueprintsPath) {
       return addon.blueprintsPath();
     }
   }, this);
 
-  return addonPaths.filter(Boolean);
+  return addonPaths.filter(Boolean).reverse();
 };
 
 /**

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -222,7 +222,7 @@ describe('models/project.js', function() {
       expect(project.localBlueprintLookupPath()).to.equal(expected);
     });
 
-    it('returns a listing of all addon blueprints paths ordered by last loaded', function() {
+    it('returns a listing of all addon blueprints paths ordered by last loaded when called once', function() {
       var loadedBlueprintPaths = [
         project.root + path.normalize('/node_modules/ember-before-blueprint-addon/blueprints'),
         project.root + path.normalize('/node_modules/ember-random-addon/blueprints'),
@@ -231,8 +231,24 @@ describe('models/project.js', function() {
 
       // the first found addon blueprint should be the last one defined
       var expected = loadedBlueprintPaths.reverse();
+      var first = project.addonBlueprintLookupPaths();
 
-      expect(project.addonBlueprintLookupPaths()).to.deep.equal(expected);
+      expect(first).to.deep.equal(expected);
+    });
+
+    it('returns a listing of all addon blueprints paths ordered by last loaded when called twice', function() {
+      var loadedBlueprintPaths = [
+        project.root + path.normalize('/node_modules/ember-before-blueprint-addon/blueprints'),
+        project.root + path.normalize('/node_modules/ember-random-addon/blueprints'),
+        project.root + path.normalize('/node_modules/ember-after-blueprint-addon/blueprints')
+      ];
+
+      // the first found addon blueprint should be the last one defined
+      var expected = loadedBlueprintPaths.reverse();
+      /*var first = */project.addonBlueprintLookupPaths();
+      var second = project.addonBlueprintLookupPaths();
+
+      expect(second).to.deep.equal(expected);
     });
 
     it('returns a listing of all blueprints paths', function() {
@@ -283,8 +299,6 @@ describe('models/project.js', function() {
 
       expect(added);
     });
-
-
   });
 
   describe('reloadAddon', function() {


### PR DESCRIPTION
I have a project that has multiple "overrides" for blueprints. However the paths for the main blueprint and the test blueprint were coming up in an inconsistent order. That means I would get the main blueprint for one project and the test blueprint for another.

To help illustrate the problem I have this

1. ember-cli
2. ember-coffeescript
3. in-repo addon

When I run this command

```
ember g adapter users --dry-run
```

It chooses the adapter blueprint from `in-repo addon` and the adapter-test blueprint from `ember-coffeescript`. Even-though both blueprints exist in the `in-repo addon`. When I traced it down it seemed to work everytime as long as we reverse after the filter.