### PR TITLE
Update ember-cli-qunit to v0.3.7.

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
 var application;
 
-QUnit.module('Acceptance: <%= classifiedModuleName %>', {
+module('Acceptance: <%= classifiedModuleName %>', {
   beforeEach: function() {
     application = startApp();
   },
@@ -13,7 +14,7 @@ QUnit.module('Acceptance: <%= classifiedModuleName %>', {
   }
 });
 
-QUnit.test('visiting /<%= dasherizedModuleName %>', function(assert) {
+test('visiting /<%= dasherizedModuleName %>', function(assert) {
   visit('/<%= dasherizedModuleName %>');
 
   andThen(function() {

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,9 +8,9 @@
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.4",
+    "ember-qunit": "0.2.6",
     "ember-qunit-notifications": "0.0.5",
     "qunit": "~1.17.1"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.3",
+    "ember-cli-qunit": "0.3.7",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.14.1",
     "ember-export-application-global": "^1.0.0",

--- a/blueprints/app/files/tests/.jshintrc
+++ b/blueprints/app/files/tests/.jshintrc
@@ -6,7 +6,6 @@
     "setTimeout",
     "$",
     "-Promise",
-    "QUnit",
     "define",
     "console",
     "visit",

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -1,11 +1,12 @@
 import {
   <%= camelizedModuleName %>
 } from '../../../helpers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
 
-QUnit.module('<%= classifiedModuleName %>Helper');
+module('<%= classifiedModuleName %>Helper');
 
 // Replace this with your real tests.
-QUnit.test('it works', function(assert) {
+test('it works', function(assert) {
   var result = <%= camelizedModuleName %>(42);
   assert.ok(result);
 });

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import { initialize } from '../../../initializers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
 
 var container, application;
 
-QUnit.module('<%= classifiedModuleName %>Initializer', {
+module('<%= classifiedModuleName %>Initializer', {
   beforeEach: function() {
     Ember.run(function() {
       application = Ember.Application.create();
@@ -14,7 +15,7 @@ QUnit.module('<%= classifiedModuleName %>Initializer', {
 });
 
 // Replace this with your real tests.
-QUnit.test('it works', function(assert) {
+test('it works', function(assert) {
   initialize(container, application);
 
   // you would normally confirm the results of the initializer here

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 import <%= classifiedModuleName %>Mixin from '../../../mixins/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
 
-QUnit.module('<%= classifiedModuleName %>Mixin');
+module('<%= classifiedModuleName %>Mixin');
 
 // Replace this with your real tests.
-QUnit.test('it works', function(assert) {
+test('it works', function(assert) {
   var <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
   var subject = <%= classifiedModuleName %>Object.create();
   assert.ok(subject);

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,9 +1,10 @@
 import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
 
-QUnit.module('<%= camelizedModuleName %>');
+module('<%= camelizedModuleName %>');
 
 // Replace this with your real tests.
-QUnit.test('it works', function(assert) {
+test('it works', function(assert) {
   var result = <%= camelizedModuleName %>();
   assert.ok(result);
 });

--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
 
 var application;
 
-QUnit.module('Acceptance', {
+module('Acceptance', {
   beforeEach: function() {
     application = startApp();
   },
@@ -12,7 +13,7 @@ QUnit.module('Acceptance', {
   }
 });
 
-QUnit.test('renders properly', function(assert) {
+test('renders properly', function(assert) {
   visit('/');
 
   andThen(function() {
@@ -21,7 +22,7 @@ QUnit.test('renders properly', function(assert) {
   });
 });
 
-QUnit.test('renders imported component', function(assert) {
+test('renders imported component', function(assert) {
   visit('/');
 
   andThen(function() {

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -3,10 +3,11 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
 
 var application;
 
-QUnit.module('default-development - Integration', {
+module('default-development - Integration', {
   beforeEach: function() {
     application = startApp();
   },
@@ -16,7 +17,7 @@ QUnit.module('default-development - Integration', {
 });
 
 
-QUnit.test('the application boots properly', function(assert) {
+test('the application boots properly', function(assert) {
   assert.expect(1);
 
   visit('/');

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -3,10 +3,11 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
 
 var application;
 
-QUnit.module('pods based templates', {
+module('pods based templates', {
   beforeEach: function() {
     application = startApp();
   },
@@ -16,7 +17,7 @@ QUnit.module('pods based templates', {
 });
 
 
-QUnit.test('the application boots properly with pods based templates', function(assert) {
+test('the application boots properly with pods based templates', function(assert) {
   assert.expect(1);
 
   visit('/');

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -3,10 +3,11 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
 
 var application;
 
-QUnit.module('pods based templates', {
+module('pods based templates', {
   beforeEach: function() {
     application = startApp();
   },
@@ -16,7 +17,7 @@ QUnit.module('pods based templates', {
 });
 
 
-QUnit.test('the application boots properly with pods based templates with a podModulePrefix set', function(assert) {
+test('the application boots properly with pods based templates with a podModulePrefix set', function(assert) {
   assert.expect(1);
 
   visit('/');

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -3,10 +3,11 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
 
 var application;
 
-QUnit.module('wrapInEval in-app test', {
+module('wrapInEval in-app test', {
   beforeEach: function() {
     application = startApp();
   },
@@ -16,7 +17,7 @@ QUnit.module('wrapInEval in-app test', {
 });
 
 
-QUnit.test('the application boots properly with wrapInEval', function(assert) {
+test('the application boots properly with wrapInEval', function(assert) {
   assert.expect(1);
 
   visit('/');

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
 var application;
 
-QUnit.module('Acceptance: Foo', {
+module('Acceptance: Foo', {
   beforeEach: function() {
     application = startApp();
   },
@@ -13,7 +14,7 @@ QUnit.module('Acceptance: Foo', {
   }
 });
 
-QUnit.test('visiting /foo', function(assert) {
+test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {


### PR DESCRIPTION
* Fixed ember-qunit registration in bower so we can install from `ember-qunit` again.
* Fix issue with errors thrown at test module load preventing all tests from
  running.
* Fix `qunit` shim.
* Update blueprints to `import { module, test } from 'qunit';` where applicable.