### PR TITLE
closes #3195 enable editing diffs on windows

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -47,7 +47,7 @@ FileInfo.prototype.confirmOverwrite = function(path) {
 };
 
 function canEdit() {
-  return ! /^win/.test(process.platform) && process.env.EDITOR !== undefined;
+  return process.env.EDITOR !== undefined;
 }
 
 FileInfo.prototype.displayDiff = function() {


### PR DESCRIPTION
After successfully editing diffs with this on windows I don't see any reason for excluding windows from editing diffs. It doesn't appear to require any special support for windows.