### PR TITLE
Update ember-export-application-global to v1.0.2.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -31,7 +31,7 @@
     "ember-cli-qunit": "0.3.7",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.14.1",
-    "ember-export-application-global": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   }


### PR DESCRIPTION
Ensures that the global export cannot overwrite an existing global.