### PR TITLE
Update broccoli-funnel to v0.2.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "broccoli-es3-safe-recast": "1.0.0",
     "broccoli-es6modules": "^0.5.0",
     "broccoli-filter": "0.1.7",
-    "broccoli-funnel": "0.2.1",
+    "broccoli-funnel": "0.2.2",
     "broccoli-kitchen-sink-helpers": "0.2.5",
     "broccoli-merge-trees": "0.2.1",
     "broccoli-sane-watcher": "^0.1.1",


### PR DESCRIPTION
* `fs.existsSync(somePath)` returns false if `somePath` is a broken symlink (because it is using `fs.stat` and following symlinks).
* The prior cleanup code attempted to avoid unneeded cleanup when the output dir didn't already exist, but this checking actually
  hit the issue mentioned above when the input tree's output path has changed (causing the prior symlink to be pointing to an invalid
  location).
* Added a test for this issue, and a number of tests confirming that rebuilds work in general (it was previously untested).

Closes #3270.