### PR TITLE
Passing a git url as the blueprint is supported but not documented

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -16,7 +16,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'blueprint', type: path, aliases: ['b'] },
+    { name: 'blueprint', type: ['gitUrl', path], aliases: ['b'] },
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'name', type: String, default: '', aliases: ['n'] }


### PR DESCRIPTION
In the implementation of init blue print is shoveled off into `installBlueprint`. `installBlueprint` determines if it was passed a git url or a regular string.

This PR just documents that this is possible.