### PR TITLE
Override default port with `PORT` env var

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -12,7 +12,7 @@ module.exports = Command.extend({
   aliases: ['server', 's'],
 
   availableOptions: [
-    { name: 'port', type: Number, default: 4200, aliases: ['p'] },
+    { name: 'port', type: Number, default: process.env.PORT || 4200, aliases: ['p'] },
     { name: 'host', type: String, default: '0.0.0.0', aliases: ['H'] },
     { name: 'proxy',  type: String, aliases: ['pr','pxy'] },
     { name: 'insecure-proxy', type: Boolean, default: false, description: 'Set false to proxy self-signed SSL certificates', aliases: ['inspr'] },


### PR DESCRIPTION
`PORT=3000 npm start` will run the server on port 3000.

Where `npm start` is `ember serve`.

If this sounds good, I can add a test. Also, might be nice to add the override for when the port is set. Maybe it needs to be done at a different level..