### PR TITLE
ember-cli is a invalid project name

### DIFF
--- a/lib/utilities/valid-project-name.js
+++ b/lib/utilities/valid-project-name.js
@@ -3,7 +3,7 @@
 module.exports = function(name) {
   name = name.toLowerCase();
 
-  if (['test', 'ember', 'vendor'].indexOf(name) > -1) { return false; }
+  if (['test', 'ember', 'ember-cli', 'vendor'].indexOf(name) > -1) { return false; }
   if (name.indexOf('.') > -1) { return false; }
   if (!isNaN(parseInt(name.charAt(0), 10))) { return false; }
 

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -48,6 +48,15 @@ describe('new command', function() {
     });
   });
 
+  it('doesn\'t allow to create an application named `ember-cli`', function() {
+    return command.validateAndRun(['ember-cli']).then(function() {
+      expect(false, 'should have rejected with an application name of ember-cli');
+    })
+    .catch(function(error) {
+      expect(error.message).to.equal('We currently do not support a name of `ember-cli`.');
+    });
+  });
+
   it('doesn\'t allow to create an application named `vendor`', function() {
     return command.validateAndRun(['vendor']).then(function() {
       expect(false, 'should have rejected with an application name of `vendor`');


### PR DESCRIPTION
I tried to build an example project which is named `ember-cli`. It seems there is a problem with the project name:

```
~ % cd /tmp
/tmp % ember new ember-cli
version: 0.1.12
installing
[...]
Installed packages for tooling via npm.
Installed browser packages via Bower.
Successfully initialized git.
ember new ember-cli  18.09s user 2.20s system 92% cpu 21.951 total
/tmp % cd ember-cli 
/tmp/ember-cli % ember build
version: 0.1.12
You have to be inside an ember-cli project in order to use the build command.
```

Also I see this for names like `ember`, so I would extend the tests with names like `ember-cli`. I simply add the exception to `lib/utilities/valid-project-name.js` but if I run `npm test` it doesn't work. It seems the tests use my cloned directory `ember-cli` as project name for other tests? But I have no idea how to fix it.

Can you help me? What's the reason for the name exceptions? Is there is a problem with projects named `ember` etc. in resolving of ES6 modules? Is there any idea how to resolve this?