### PR TITLE
[bugfix] Use ember-cli-babel instead of ember-cli-6to5

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-6to5": "^3.0.0",
+    "ember-cli-babel": "^4.0.0",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",


### PR DESCRIPTION
The 6to5 project has been renamed to Babel. This commit *depends on*
https://github.com/babel/ember-cli-6to5/pull/14 being merged and
a 4.0.0 version package being released. This should also be called out
in the release notes so that people won't be confused when 6to5
disappears when running `ember init`.