### PR TITLE
[BUGFIX] Update ember-cli-qunit to v0.3.8.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.1",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.7",
+    "ember-cli-qunit": "0.3.8",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.14.1",
     "ember-export-application-global": "^1.0.2",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -256,7 +256,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         fs.writeFileSync(testSupportPath, badContent);
       })
       .then(function() {
-        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--silent');
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--silent', '--filter=jshint');
       });
   });
 


### PR DESCRIPTION
Previously, if a given test failed to load we would `console.error` the failure, which may or may not help folks find them.

This update makes those module load failures actual fail a test, so that you get decent warning/info that a whole module of your tests cannot be run.

![screenshot](http://monosnap.com/image/WJ5CyNsBszjrWSie9Y9TtOj07x8LS3.png)

Closes #3201.