### PR TITLE
Only app.import Handlebars if present in bower.json.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
     "ember": "1.10.0",
     "ember-data": "1.0.0-beta.15",

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -149,13 +149,20 @@ function EmberApp(options) {
     defaultDevelopmentEmber = this.bowerDirectory + '/ember/ember.js';
   }
 
+  var handlebarsVendorFiles;
+  if ('handlebars.js' in this.project.bowerDependencies()) {
+    handlebarsVendorFiles = {
+      development: this.bowerDirectory + '/handlebars/handlebars.js',
+      production:  this.bowerDirectory + '/handlebars/handlebars.runtime.js'
+    };
+  } else {
+    handlebarsVendorFiles = null;
+  }
+
   this.vendorFiles = omit(merge({
     'loader.js': this.options.loader,
     'jquery.js': this.bowerDirectory + '/jquery/dist/jquery.js',
-    'handlebars.js': {
-      development: this.bowerDirectory + '/handlebars/handlebars.js',
-      production:  this.bowerDirectory + '/handlebars/handlebars.runtime.js'
-    },
+    'handlebars.js': handlebarsVendorFiles,
     'ember.js': {
       development: defaultDevelopmentEmber,
       production:  this.bowerDirectory + '/ember/ember.prod.js'

--- a/tests/fixtures/addon/simple/bower.json
+++ b/tests/fixtures/addon/simple/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "test-project",
   "dependencies": {
-    "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
     "ember": "1.7.0",
     "ember-data": "1.0.0-beta.10",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -406,9 +406,44 @@ describe('broccoli/ember-app', function() {
 
   describe('vendorFiles', function() {
     var defaultVendorFiles = [
-      'loader.js', 'jquery.js', 'handlebars.js', 'ember.js',
+      'loader.js', 'jquery.js', 'ember.js',
       'app-shims.js', 'ember-resolver.js', 'ember-load-initializers.js'
     ];
+
+    describe('handlebars.js', function() {
+      it('does not app.import handlebars if not present in bower.json', function() {
+        var app = new EmberApp({
+          project: project
+        });
+
+        expect(app.vendorFiles).not.to.include.keys('handlebars.js');
+      });
+
+      it('includes handlebars if present in bower.json', function() {
+        project.bowerDependencies = function() {
+          return {
+            'handlebars.js': '1.3.0'
+          };
+        };
+
+        var app = new EmberApp({
+          project: project
+        });
+
+        expect(app.vendorFiles).to.include.keys('handlebars.js');
+      });
+
+      it('includes handlebars if present in provided `vendorFiles`', function() {
+        var app = new EmberApp({
+          project: project,
+          vendorFiles: {
+            'handlebars.js': 'some/path/whatever.js'
+          }
+        });
+
+        expect(app.vendorFiles).to.include.keys('handlebars.js');
+      });
+    });
 
     it('defines vendorFiles by default', function() {
       emberApp = new EmberApp();

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -166,7 +166,6 @@ describe('models/project.js', function() {
 
     it('returns a listing of all dependencies in the projects bower.json', function() {
       var expected = {
-        'handlebars': '~1.3.0',
         'jquery': '^1.11.1',
         'ember': '1.7.0',
         'ember-data': '1.0.0-beta.10',


### PR DESCRIPTION
This makes removing the `Handlebars` dep as simple as removing from
`bower.json.`.