### PR TITLE
Enable ember generate <blueprint> --help for individual blueprint docs

### DIFF
--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,6 +1,7 @@
 var inflection  = require('inflection');
 var stringUtils = require('../../lib/utilities/string');
 var EOL         = require('os').EOL;
+var chalk       = require('chalk');
 
 module.exports = {
   description: 'Generates an ember-data model.',
@@ -41,6 +42,35 @@ module.exports = {
       attrs: attrs,
       needs: needs
     };
+  },
+
+  printDetailedHelp: function() {
+    // TODO: update this with a proper help for the model blueprint
+    var output = '';
+    var indent = '        ';
+    output += indent + chalk.grey('You may generate models with as many attrs as you would like to pass.');
+    output += chalk.grey(' The following attribute types are supported:') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:array') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:boolean') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:date') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:object') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:number') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:string') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:belongs-to:<model-name>') + EOL;
+    output += indent + '  ' + chalk.yellow('<attr-name>:has-many:<model-name>') + EOL + EOL;
+    output += indent + chalk.grey('For instance: ');
+    output += chalk.green('`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc`') + EOL;
+    output += indent + chalk.grey('would result in the following model:') + EOL + EOL;
+    output += indent + 'import DS from \'ember-data\';' + EOL;
+    output += indent + 'export default DS.Model.extend({' + EOL;
+    output += indent + '  filling: DS.belongsTo(\'protein\'),' + EOL;
+    output += indent + '  toppings: DS.hasMany(\'topping\')' + EOL;
+    output += indent + '  name: DS.attr(\'string\'),' + EOL;
+    output += indent + '  price: DS.attr(\'number\')' + EOL;
+    output += indent + '  misc: DS.attr()' + EOL;
+    output += indent + '});' + EOL;
+    return output;
   }
 };
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -8,7 +8,7 @@ var getOptionArgs   = require('../utilities/get-option-args');
 var debug           = require('debug')('ember-cli:cli');
 
 function CLI(options) {
-  this.ui   = options.ui;
+  this.ui = options.ui;
   this.analytics = options.analytics;
   this.testing = options.testing;
 
@@ -22,16 +22,8 @@ CLI.prototype.run = function(environment) {
     var args = environment.cliArgs.slice();
     var commandName = args.shift();
     var commandArgs = args;
-
-    getOptionArgs('--verbose', commandArgs).forEach(function(arg){
-      process.env['EMBER_VERBOSE_' + arg.toUpperCase()] = 'true';
-    });
-
-    if (commandArgs.indexOf('--silent') !== -1) {
-      this.ui.setWriteLevel('ERROR');
-    }
-
-    this.ui.writeLine('version: ' + emberCLIVersion());
+    var helpOptions;
+    var update;
 
     var CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
       project: environment.project,
@@ -48,8 +40,15 @@ CLI.prototype.run = function(environment) {
       testing:   this.testing
     });
 
-    var update;
+    getOptionArgs('--verbose', commandArgs).forEach(function(arg){
+      process.env['EMBER_VERBOSE_' + arg.toUpperCase()] = 'true';
+    });
 
+    if (commandArgs.indexOf('--silent') !== -1) {
+      this.ui.setWriteLevel('ERROR');
+    }
+
+    this.ui.writeLine('version: ' + emberCLIVersion());
     debug('command: %s', commandName);
 
     if (commandName !== 'update' && !this.testing) {
@@ -65,7 +64,20 @@ CLI.prototype.run = function(environment) {
 
     return Promise.resolve(update).then(function() {
       return command.validateAndRun(commandArgs);
-    }).then(function(exitCode) {
+    }).then(function(result) {
+      // if the help option was passed, call the help command
+      if (result === 'callHelp') {
+        helpOptions = {
+          environment: environment,
+          commandName: commandName,
+          commandArgs: commandArgs
+        };
+
+        return this.callHelp(helpOptions);
+      }
+
+      return result;
+    }.bind(this)).then(function(exitCode) {
       // TODO: fix this
       // Possibly this issue: https://github.com/joyent/node/issues/8329
       // Wait to resolve promise when running on windows.
@@ -80,6 +92,41 @@ CLI.prototype.run = function(environment) {
     });
 
   }.bind(this)).catch(this.logError.bind(this));
+};
+
+CLI.prototype.callHelp = function(options) {
+  var environment = options.environment;
+  var commandName = options.commandName;
+  var commandArgs = options.commandArgs;
+  var helpIndex = commandArgs.indexOf('--help');
+  var hIndex = commandArgs.indexOf('-h');
+
+  var HelpCommand = lookupCommand(environment.commands, 'help', commandArgs, {
+    project: environment.project,
+    ui: this.ui
+  });
+
+  var help = new HelpCommand({
+    ui:        this.ui,
+    analytics: this.analytics,
+    commands:  environment.commands,
+    tasks:     environment.tasks,
+    project:   environment.project,
+    settings:  environment.settings,
+    testing:   this.testing
+  });
+
+  if (helpIndex > -1) {
+    commandArgs.splice(helpIndex,1);
+  }
+
+  if (hIndex > -1) {
+    commandArgs.splice(hIndex,1);
+  }
+
+  commandArgs.unshift(commandName);
+
+  return help.validateAndRun(commandArgs);
 };
 
 CLI.prototype.logError = function(error) {

--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -20,13 +20,6 @@ module.exports = function(commands, commandName, commandArgs, optionHash) {
   var project = options.project;
   var ui      = options.ui;
 
-  // special case help
-  if (commandArgs && (commandArgs.indexOf('--help') > -1 || commandArgs.indexOf('-h') > -1)) {
-    commandArgs.splice(0);
-    commandArgs.push(commandName);
-    commandName = 'help';
-  }
-
   function aliasMatches(alias) {
     return alias === commandName;
   }

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -6,6 +6,9 @@ var Command   = require('../models/command');
 var Promise   = require('../ext/promise');
 var Blueprint = require('../models/blueprint');
 var merge     = require('lodash-node/modern/objects/merge');
+var find      = require('lodash-node/modern/collections/find');
+var pluck     = require('lodash-node/modern/collections/pluck');
+var flatten     = require('lodash-node/modern/arrays/flatten');
 var EOL       = require('os').EOL;
 
 var SilentError = require('../errors/silent');
@@ -72,7 +75,21 @@ module.exports = Command.extend({
   },
 
   printDetailedHelp: function(options) {
-    this.printAllBlueprints(options);
+    if (options.rawArgs) {
+      this.printSingleBlueprint(options.rawArgs);
+    } else {
+      this.printAllBlueprints(options);
+    }
+  },
+
+  printSingleBlueprint: function(options) {
+    var lookupPaths   = this.project.blueprintLookupPaths();
+    var blueprintList = Blueprint.list({ paths: lookupPaths });
+    var blueprints = flatten(pluck(blueprintList, 'blueprints'));
+    var blueprint = find(blueprints, function(model) {
+      return model.name === options[0];
+    });
+    this.printBlueprintInfo(blueprint, true);
   },
 
   printAllBlueprints: function(options) {
@@ -102,14 +119,13 @@ module.exports = Command.extend({
     this.ui.writeLine('    ' + collection.source + ':');
 
     blueprints.forEach(function(blueprint) {
-      this.printBlueprintInfo(blueprint);
+      this.printBlueprintInfo(blueprint, verbose);
     }, this);
   },
 
-  printBlueprintInfo: function(blueprint) {
+  printBlueprintInfo: function(blueprint, verbose) {
     var options;
     var output = '      ';
-
     if (blueprint.overridden) {
       output += chalk.grey('(overridden) ');
       output += chalk.grey(blueprint.name);
@@ -163,6 +179,11 @@ module.exports = Command.extend({
           }
         });
       }
+
+      if (verbose && blueprint.printDetailedHelp) {
+        output += EOL + blueprint.printDetailedHelp(options);
+      }
+
     }
 
     this.ui.writeLine(output);

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -31,6 +31,8 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions, rawArgs) {
+    var multipleCommands = ['g','generate'];
+    var command;
     if (rawArgs.length === 0) {
       var rootCommand = new RootCommand({
         ui: this.ui,
@@ -69,11 +71,21 @@ module.exports = Command.extend({
         }.bind(this));
       }
 
-      // Iterate through each arg beyond the initial 'help' command,
-      // and try to display usage instructions.
-      rawArgs.forEach(function(commandName) {
-        this._printDetailedHelpForCommand(commandName, commandOptions);
-      }.bind(this));
+      if(multipleCommands.indexOf(rawArgs[0]) > -1) {
+        command = rawArgs.shift();
+        if (rawArgs.length > 0) {
+          commandOptions.rawArgs = rawArgs;
+        }
+        this._printDetailedHelpForCommand(command, commandOptions);
+
+      } else {
+
+        // Iterate through each arg beyond the initial 'help' command,
+        // and try to display usage instructions.
+        rawArgs.forEach(function(commandName) {
+          this._printDetailedHelpForCommand(commandName, commandOptions);
+        }.bind(this));
+      }
     }
   },
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -234,11 +234,11 @@ module.exports = Blueprint;
   ### beforeInstall & beforeUninstall
 
   Called before any of the template files are processed and receives
-  the the `options` and `locals` hashes as parameters. Typically used for 
-  validating any additional command line options or for any asynchronous 
-  setup that is needed.   As an example, the `controller` blueprint validates 
-  its `--type` option in this hook.  If you need to run any asynchronous code, 
-  wrap it in a promise and return that promise from these hooks.  This will 
+  the the `options` and `locals` hashes as parameters. Typically used for
+  validating any additional command line options or for any asynchronous
+  setup that is needed.   As an example, the `controller` blueprint validates
+  its `--type` option in this hook.  If you need to run any asynchronous code,
+  wrap it in a promise and return that promise from these hooks.  This will
   ensure that your code is executed correctly.
 
   ### afterInstall & afterUninstall

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -105,6 +105,11 @@ Command.prototype.beforeRun = function() {};
 */
 Command.prototype.validateAndRun = function(args) {
   var commandOptions = this.parseArgs(args);
+  // if the help option was passed, resolve with 'callHelp' to call help command
+  if (commandOptions && (commandOptions.options.help || commandOptions.options.h)) {
+    debug(this.name + ' called with help option');
+    return Promise.resolve('callHelp');
+  }
 
   this.analytics.track({
     name:    'ember ',
@@ -159,7 +164,10 @@ Command.prototype.mergeDuplicateOption = function(key) {
 
     // replace aliases with unique aliases
     mergedOption.aliases = uniq(mergedAliases, function(alias) {
-      return alias[Object.keys(alias)[0]];
+      if(typeof alias === 'object') {
+        return alias[Object.keys(alias)[0]];
+      }
+      return alias;
     });
 
     // remove duplicates from options
@@ -342,7 +350,8 @@ Command.prototype.parseArgs = function(commandArgs) {
   };
 
   var validateParsed = function(key) {
-    if (!commandOptions.hasOwnProperty(key) && key !== 'argv') {
+    // ignore 'argv', 'h', and 'help'
+    if (!commandOptions.hasOwnProperty(key) && key !== 'argv' && key !== 'h' && key !== 'help') {
       this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not registered with the ' + this.name + ' command. ' +
                         'Run `ember ' + this.name + ' --help` for a list of supported options.'));
     }
@@ -520,4 +529,3 @@ function isValidAlias(alias, expectedType) {
 
   return false;
 }
-

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -64,4 +64,100 @@ describe('Acceptance: ember help', function() {
         expect(output).to.include('  view');
       });
   });
+
+  it('generate single blueprint', function() {
+    this.timeout(10000);
+    var output = '';
+
+    return runCommand(ember, 'init',
+                      '--name=my-app',
+                      '--silent',
+                      '--skip-npm',
+                      '--skip-bower')
+      .then(function() {
+        return runCommand(ember, 'help', 'generate', 'model', {
+          onOutput: function(string) {
+            output += string;
+          }
+        });
+      })
+      .then(function() {
+        expect(output).to.include('Generates new code from blueprints.');
+        expect(output).to.include('You may generate models with as many attrs as ' +
+        'you would like to pass. The following attribute types are supported:');
+        expect(output).to.include('<attr-name>');
+        expect(output).to.include('<attr-name>:array');
+        expect(output).to.include('<attr-name>:boolean');
+        expect(output).to.include('<attr-name>:date');
+        expect(output).to.include('<attr-name>:object');
+        expect(output).to.include('<attr-name>:number');
+        expect(output).to.include('<attr-name>:string');
+        expect(output).to.include('<attr-name>:belongs-to:<model-name>');
+        expect(output).to.include('<attr-name>:has-many:<model-name>');
+      });
+  });
+
+  it('generate single blueprint --help', function() {
+    this.timeout(10000);
+    var output = '';
+
+    return runCommand(ember, 'init',
+                      '--name=my-app',
+                      '--silent',
+                      '--skip-npm',
+                      '--skip-bower')
+      .then(function() {
+        return runCommand(ember, 'generate', 'model', '--help', {
+          onOutput: function(string) {
+            output += string;
+          }
+        });
+      })
+      .then(function() {
+        expect(output).to.include('Generates new code from blueprints.');
+        expect(output).to.include('You may generate models with as many attrs as ' +
+        'you would like to pass. The following attribute types are supported:');
+        expect(output).to.include('<attr-name>');
+        expect(output).to.include('<attr-name>:array');
+        expect(output).to.include('<attr-name>:boolean');
+        expect(output).to.include('<attr-name>:date');
+        expect(output).to.include('<attr-name>:object');
+        expect(output).to.include('<attr-name>:number');
+        expect(output).to.include('<attr-name>:string');
+        expect(output).to.include('<attr-name>:belongs-to:<model-name>');
+        expect(output).to.include('<attr-name>:has-many:<model-name>');
+      });
+  });
+
+  it('generate single blueprint -h', function() {
+    this.timeout(10000);
+    var output = '';
+
+    return runCommand(ember, 'init',
+                      '--name=my-app',
+                      '--silent',
+                      '--skip-npm',
+                      '--skip-bower')
+      .then(function() {
+        return runCommand(ember, 'generate', 'model', '-h', {
+          onOutput: function(string) {
+            output += string;
+          }
+        });
+      })
+      .then(function() {
+        expect(output).to.include('Generates new code from blueprints.');
+        expect(output).to.include('You may generate models with as many attrs as ' +
+        'you would like to pass. The following attribute types are supported:');
+        expect(output).to.include('<attr-name>');
+        expect(output).to.include('<attr-name>:array');
+        expect(output).to.include('<attr-name>:boolean');
+        expect(output).to.include('<attr-name>:date');
+        expect(output).to.include('<attr-name>:object');
+        expect(output).to.include('<attr-name>:number');
+        expect(output).to.include('<attr-name>:string');
+        expect(output).to.include('<attr-name>:belongs-to:<model-name>');
+        expect(output).to.include('<attr-name>:has-many:<model-name>');
+      });
+  });
 });

--- a/tests/helpers/stub.js
+++ b/tests/helpers/stub.js
@@ -16,7 +16,6 @@ module.exports = {
 
     obj[name].called = 0;
     obj[name].calledWith = [];
-
     return obj[name];
   },
   stubPath: function stubPath(path) {

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -32,6 +32,15 @@ function ember(args) {
   });
 }
 
+function stubCallHelp() {
+  return stub(CLI.prototype, 'callHelp');
+}
+
+function stubValidateAndRunHelp(name) {
+  commands[name] = require('../../../lib/commands/' + name);
+  return stub(commands[name].prototype, 'validateAndRun', 'callHelp');
+}
+
 function stubValidateAndRun(name) {
   commands[name] = require('../../../lib/commands/' + name);
   return stub(commands[name].prototype, 'validateAndRun');
@@ -100,8 +109,8 @@ describe('Unit: CLI', function() {
       });
 
       it('ember new ' + command, function() {
-        var help = stubValidateAndRun('help');
-        var newCommand = stubValidateAndRun('new');
+        var help = stubCallHelp();
+        var newCommand = stubValidateAndRunHelp('new');
 
         return ember(['new', command]).then(function() {
           expect(help.called).to.equal(1, 'expected help to be called once');
@@ -109,7 +118,7 @@ describe('Unit: CLI', function() {
           assertVersion(output[0]);
           expect(output.length).to.equal(1, 'expected no extra output');
 
-          expect(newCommand.called).to.equal(0, 'expected the new command to never be called');
+          expect(newCommand.called).to.equal(1, 'expected the new command to be called once');
         });
       });
     });


### PR DESCRIPTION
This PR fixes #2553, adding the ability to add `printDetailedHelp` to blueprints.

I've extracted the help logic from `lookup-command.js` and added a then in the command processing promise chain in `cli.js` which allows a command to exit before running if the `-h` or `--help` option is present. From there the help command is run with the original options passed in (in addition to the command name).

I've added the help option to `availableOptions` for all commands, which as a side effect lists the `--help` option as an availableOption for every command. For example:
```
// with --help added to availableOptions
ember version <options...>
  outputs ember-cli version
  aliases: v, version, -v, --version
  --verbose (Boolean) (Default: false)
  --help (Boolean) (Default: false)
    aliases: -h

// without
ember version <options...>
  outputs ember-cli version
  aliases: v, version, -v, --version
  --verbose (Boolean) (Default: false)
```

I can remove this if desired, which would go back to the current setup where the `--help` option is assumed present.

I still need to write tests for this, and I would like to follow this PR up with adding `printDetailedHelp` to all of the built-in blueprints that could use it. I've mainly put this up for review as I progress on it.