### PR TITLE
Fix Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
   # Install PhantomJS
-  - cinst PhantomJS
+  - cinst PhantomJS -Version 1.9.8
   - set path=%path%;C:\tools\PhantomJS\
   - dir C:\tools\PhantomJS
   # Typical npm stuff.


### PR DESCRIPTION
Chocolate installs now PhantomJS 2.0 [by default](https://chocolatey.org/packages/PhantomJS). Testem has issues with PhantomJS 2.0 on windows. https://github.com/airportyh/testem/pull/505

This PR locks PhantomJS to 1.9.8