### PR TITLE
Print deprecation warning for Node 0.10.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -7,6 +7,8 @@ var UpdateChecker   = require('../models/update-checker');
 var getOptionArgs   = require('../utilities/get-option-args');
 var debug           = require('debug')('ember-cli:cli');
 
+var validPlatformVersion = require('../utilities/valid-platform-version');
+
 function CLI(options) {
   this.ui   = options.ui;
   this.analytics = options.analytics;
@@ -29,6 +31,12 @@ CLI.prototype.run = function(environment) {
 
     if (commandArgs.indexOf('--silent') !== -1) {
       this.ui.setWriteLevel('ERROR');
+    }
+
+    if (!validPlatformVersion(process.version) && !this.testing) {
+      var chalk = require('chalk');
+
+      this.ui.writeLine(chalk.red('Future versions of Ember CLI will not support ' + process.version + '. Please update to Node 0.12 or io.js.'));
     }
 
     this.ui.writeLine('version: ' + emberCLIVersion());

--- a/lib/utilities/valid-platform-version.js
+++ b/lib/utilities/valid-platform-version.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var semver = require('semver');
+
+module.exports = function(version) {
+
+  return semver.satisfies(version, '^1.0.0') || // io.js
+         semver.satisfies(version, '^0.12.0'); // node 0.12.x
+};

--- a/tests/unit/utilities/valid-platform-version-test.js
+++ b/tests/unit/utilities/valid-platform-version-test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var expect = require('chai').expect;
+var checkValidPlatform = require('../../../lib/utilities/valid-platform-version');
+
+describe('platform-version-check', function() {
+
+  it('should return true if running on iojs', function() {
+    expect(checkValidPlatform('v1.0.0')).to.be.equal(true);
+    expect(checkValidPlatform('v1.0.1')).to.be.equal(true);
+    expect(checkValidPlatform('v1.0.2')).to.be.equal(true);
+    expect(checkValidPlatform('v1.0.3')).to.be.equal(true);
+    expect(checkValidPlatform('v1.0.4')).to.be.equal(true);
+    expect(checkValidPlatform('v1.1.0')).to.be.equal(true);
+    expect(checkValidPlatform('v1.2.0')).to.be.equal(true);
+  });
+
+  it('should return false if running on node v0.10', function() {
+    expect(checkValidPlatform('v0.10.1')).to.be.equal(false);
+    expect(checkValidPlatform('v0.10.15')).to.be.equal(false);
+    expect(checkValidPlatform('v0.10.30')).to.be.equal(false);
+  });
+
+  it('should return true if running on node v0.12', function() {
+    expect(checkValidPlatform('v0.12.0')).to.be.equal(true);
+    expect(checkValidPlatform('v0.12.15')).to.be.equal(true);
+    expect(checkValidPlatform('v0.12.30')).to.be.equal(true);
+  });
+});


### PR DESCRIPTION
Adds warning when running on older Node versions as mentioned in https://github.com/ember-cli/ember-cli/issues/3319#issuecomment-75230978.