### PR TITLE
Nested addons should be overrideable from parent.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -248,7 +248,7 @@ Addon.prototype.treeFor = function treeFor(name) {
   this._requireBuildPackages();
 
   var tree;
-  var trees = [];
+  var trees = this.eachAddonInvoke('treeFor', [name]);
 
   if (tree = this._treeFor(name)) {
     trees.push(tree);
@@ -258,9 +258,10 @@ Addon.prototype.treeFor = function treeFor(name) {
     trees.push(this.jshintAddonTree());
   }
 
-  trees = trees.concat(this.eachAddonInvoke('treeFor', [name]));
-
-  return this.mergeTrees(trees.filter(Boolean));
+  return this.mergeTrees(trees.filter(Boolean), {
+    overwrite: true,
+    description: 'Addon#treeFor (' + this.name + ' - ' + name + ')'
+  });
 };
 
 /**


### PR DESCRIPTION
The initial logic added to call `treeFor` on all of a given addons
nested children had the following issues:

* The trees returned could not be overridden by the including addon.
* The final merging of those trees did not use the `overwrite: true`
  flag, which meant that any shared addons would throw an error instead
  of simply using the last one (which is the Ember CLI 0.1.x behavior).