### PR TITLE
Explain Azure Deployment

### DIFF
--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -30,6 +30,16 @@ git push heroku master
 
 Need to make a custom nginx configuration change? No problem. In your Ember CLI application, add a `config/nginx.conf.erb` file. You can copy the [existing configuration](https://github.com/tonycoco/heroku-buildpack-ember-cli/blob/master/config/nginx.conf.erb) file and make your changes to it.
 
+### Azure
+Continuous deployment with [Azure Websites](http://www.azure.com) is enabled through Microsoft's module [ember-cli-azure-deploy](https://github.com/felixrieseberg/ember-cli-azure-deploy). The installation is simple - just run the following commands in your Ember Cli app's root folder:
+
+{% highlight bash %}
+npm install --save-dev -g ember-cli-deploy-azure
+azure-deploy init
+{% endhighlight %}
+
+Next, set up your Azure Website's source control to point to your repo - [either via GitHub, BitBucket, VSO or any of the other available options](http://azure.microsoft.com/en-us/documentation/articles/web-sites-publish-source-control/#Step4). As soon as you push a new commit to your repository, Azure Websites will automatically run `ember build` and deploy the contents of the created `dist` folder to your website's `wwwroot`.
+
 ### History API and Base URL
 
 If you are deploying the app to somewhere other than the root URL (`/`),


### PR DESCRIPTION
This commit adds a short explanation of `ember-cli-azure-deploy`, a small Node module we at Microsoft's open source team wrote to make it dramatically easier for Ember Cli users to deploy their apps to Azure Websites. It essentially enables automated builds in the cloud, allowing Azure to recompile every single
time a commit is pushed to the project’s repo. 

We at Microsoft :heart: Ember & Ember-Cli, using it for a bunch of stuff internally. Thanks for everything!