### PR TITLE
Move preprocessor packages to dependencies in addons

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -13,6 +13,15 @@ module.exports = {
     var packagePath = path.join(this._appBlueprint.path, 'files', 'package.json');
     var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
 
+    // preprocessors should be under dependencies
+    var preprocessors = ['ember-cli-htmlbars'];
+    preprocessors.forEach(function(name) {
+      var version = contents.devDependencies[name];
+      delete contents.devDependencies[name];
+      contents.dependencies = contents.dependencies || {};
+      contents.dependencies[name] = version;
+    });
+
     delete contents.private;
     contents.name = this.project.name();
     contents.description = this.description;

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -53,6 +53,8 @@ describe('Acceptance: addon-smoke-test', function() {
     expect(packageContents.private).to.be.an('undefined');
     expect(packageContents.keywords).to.deep.equal([ 'ember-addon' ]);
     expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
+    expect(packageContents.dependencies).to.be.an('object');
+    expect(packageContents.dependencies['ember-cli-htmlbars']).to.be.a('string');
 
     var bowerContents = JSON.parse(fs.readFileSync('bower.json', { encoding: 'utf8' }));
 


### PR DESCRIPTION
We can later add more addons to the list (such as babel) when they start supporting ember-cli 0.2.