### PR TITLE
Improve blueprint help output method (markdown support)

### DIFF
--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -1,6 +1,4 @@
-      model <name> <attr:type>
-        ^gr^Generates an ember-data model.^gr^
-        ^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
+         ^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
           <attr-name>
           <attr-name>:array
           <attr-name>:boolean

--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -1,15 +1,15 @@
-^grey^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^grey^
-  <attr-name>
-  <attr-name>:array
-  <attr-name>:boolean
-  <attr-name>:date
-  <attr-name>:object
-  <attr-name>:number
-  <attr-name>:string
-  <attr-name>:belongs-to:<model-name>
-  <attr-name>:has-many:<model-name>
+<grey>You may generate models with as many attrs as you would like to pass. The following attribute types are supported:</grey>
+  <yellow><attr-name></yellow>
+  <yellow><attr-name></yellow>:array
+  <yellow><attr-name></yellow>:boolean
+  <yellow><attr-name></yellow>:date
+  <yellow><attr-name></yellow>:object
+  <yellow><attr-name></yellow>:number
+  <yellow><attr-name></yellow>:string
+  <yellow><attr-name></yellow>:belongs-to:<yellow><model-name></yellow>
+  <yellow><attr-name></yellow>:has-many:<yellow><model-name></yellow>
 
-For instance: ^green^\`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc\`^green^
+For instance: <green>\`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc\`</green>
 would result in the following model:
 
 ```js

--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -1,4 +1,4 @@
-^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
+^grey^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^grey^
   <attr-name>
   <attr-name>:array
   <attr-name>:boolean
@@ -9,16 +9,16 @@
   <attr-name>:belongs-to:<model-name>
   <attr-name>:has-many:<model-name>
 
-For instance: ^g^\`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc\`^g^
+For instance: ^green^\`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc\`^green^
 would result in the following model:
 
 ```js
 import DS from 'ember-data';
 export default DS.Model.extend({
   filling: DS.belongsTo('protein'),
-  toppings: DS.hasMany('topping')
+  toppings: DS.hasMany('topping'),
   name: DS.attr('string'),
-  price: DS.attr('number')
+  price: DS.attr('number'),
   misc: DS.attr()
 });
 ```

--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -1,0 +1,25 @@
+      model <name> <attr:type>
+        ^gr^Generates an ember-data model.^gr^
+        ^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
+          <attr-name>
+          <attr-name>:array
+          <attr-name>:boolean
+          <attr-name>:date
+          <attr-name>:object
+          <attr-name>:number
+          <attr-name>:string
+          <attr-name>:belongs-to:<model-name>
+          <attr-name>:has-many:<model-name>
+
+        For instance: ^g^`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc`^g^
+        would result in the following model:
+```js
+        import DS from 'ember-data';
+        export default DS.Model.extend({
+          filling: DS.belongsTo('protein'),
+          toppings: DS.hasMany('topping')
+          name: DS.attr('string'),
+          price: DS.attr('number')
+          misc: DS.attr()
+        });
+```

--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -1,23 +1,24 @@
-         ^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
-          <attr-name>
-          <attr-name>:array
-          <attr-name>:boolean
-          <attr-name>:date
-          <attr-name>:object
-          <attr-name>:number
-          <attr-name>:string
-          <attr-name>:belongs-to:<model-name>
-          <attr-name>:has-many:<model-name>
+^gr^You may generate models with as many attrs as you would like to pass. The following attribute types are supported:^gr^
+  <attr-name>
+  <attr-name>:array
+  <attr-name>:boolean
+  <attr-name>:date
+  <attr-name>:object
+  <attr-name>:number
+  <attr-name>:string
+  <attr-name>:belongs-to:<model-name>
+  <attr-name>:has-many:<model-name>
 
-        For instance: ^g^`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc`^g^
-        would result in the following model:
+For instance: ^g^\`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc\`^g^
+would result in the following model:
+
 ```js
-        import DS from 'ember-data';
-        export default DS.Model.extend({
-          filling: DS.belongsTo('protein'),
-          toppings: DS.hasMany('topping')
-          name: DS.attr('string'),
-          price: DS.attr('number')
-          misc: DS.attr()
-        });
+import DS from 'ember-data';
+export default DS.Model.extend({
+  filling: DS.belongsTo('protein'),
+  toppings: DS.hasMany('topping')
+  name: DS.attr('string'),
+  price: DS.attr('number')
+  misc: DS.attr()
+});
 ```

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,6 +1,5 @@
 var inflection  = require('inflection');
 var stringUtils = require('../../lib/utilities/string');
-var MarkdownColor = require('../../lib/utilities/markdown-color');
 var EOL         = require('os').EOL;
 var chalk       = require('chalk');
 
@@ -43,11 +42,6 @@ module.exports = {
       attrs: attrs,
       needs: needs
     };
-  },
-
-  printDetailedHelp: function() {
-    var markdownColor = new MarkdownColor();
-    return markdownColor.renderFile(this.srcPath('../HELP.md'));
   }
 };
 

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,5 +1,6 @@
 var inflection  = require('inflection');
 var stringUtils = require('../../lib/utilities/string');
+var MarkdownColor = require('../../lib/utilities/markdown-color');
 var EOL         = require('os').EOL;
 var chalk       = require('chalk');
 
@@ -45,32 +46,8 @@ module.exports = {
   },
 
   printDetailedHelp: function() {
-    // TODO: update this with a proper help for the model blueprint
-    var output = '';
-    var indent = '        ';
-    output += indent + chalk.grey('You may generate models with as many attrs as you would like to pass.');
-    output += chalk.grey(' The following attribute types are supported:') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:array') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:boolean') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:date') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:object') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:number') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:string') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:belongs-to:<model-name>') + EOL;
-    output += indent + '  ' + chalk.yellow('<attr-name>:has-many:<model-name>') + EOL + EOL;
-    output += indent + chalk.grey('For instance: ');
-    output += chalk.green('`ember generate model taco filling:belongs-to:protein toppings:has-many:toppings name:string price:number misc`') + EOL;
-    output += indent + chalk.grey('would result in the following model:') + EOL + EOL;
-    output += indent + 'import DS from \'ember-data\';' + EOL;
-    output += indent + 'export default DS.Model.extend({' + EOL;
-    output += indent + '  filling: DS.belongsTo(\'protein\'),' + EOL;
-    output += indent + '  toppings: DS.hasMany(\'topping\')' + EOL;
-    output += indent + '  name: DS.attr(\'string\'),' + EOL;
-    output += indent + '  price: DS.attr(\'number\')' + EOL;
-    output += indent + '  misc: DS.attr()' + EOL;
-    output += indent + '});' + EOL;
-    return output;
+    var markdownColor = new MarkdownColor();
+    return markdownColor.renderFile(this.srcPath('../HELP.md'));
   }
 };
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -3,32 +3,33 @@
 /**
 @module ember-cli
 */
-var FileInfo    = require('./file-info');
-var Promise     = require('../ext/promise');
-var any         = require('lodash-node/compat/collections/some');
-var chalk       = require('chalk');
-var contains    = require('lodash-node/compat/collections/contains');
-var fs          = require('fs-extra');
-var glob        = require('glob');
-var inflector   = require('inflection');
-var keys        = require('lodash-node/compat/objects/keys');
-var merge       = require('lodash-node/compat/objects/merge');
-var minimatch   = require('minimatch');
-var path        = require('path');
-var sequence    = require('../utilities/sequence');
-var stat        = Promise.denodeify(fs.stat);
-var stringUtils = require('../utilities/string');
-var uniq        = require('lodash-node/compat/arrays/uniq');
-var intersect   = require('lodash-node/compat/arrays/intersection');
-var values      = require('lodash-node/compat/objects/values');
-var walkSync    = require('walk-sync');
-var zipObject   = require('lodash-node/compat/arrays/zipObject');
-var writeFile   = Promise.denodeify(fs.outputFile);
-var removeFile  = Promise.denodeify(fs.remove);
-var SilentError = require('../errors/silent');
-var CoreObject  = require('core-object');
-var EOL         = require('os').EOL;
-var deprecate   = require('../utilities/deprecate');
+var FileInfo      = require('./file-info');
+var Promise       = require('../ext/promise');
+var any           = require('lodash-node/compat/collections/some');
+var chalk         = require('chalk');
+var MarkdownColor = require('../../lib/utilities/markdown-color');
+var contains      = require('lodash-node/compat/collections/contains');
+var fs            = require('fs-extra');
+var glob          = require('glob');
+var inflector     = require('inflection');
+var keys          = require('lodash-node/compat/objects/keys');
+var merge         = require('lodash-node/compat/objects/merge');
+var minimatch     = require('minimatch');
+var path          = require('path');
+var sequence      = require('../utilities/sequence');
+var stat          = Promise.denodeify(fs.stat);
+var stringUtils   = require('../utilities/string');
+var uniq          = require('lodash-node/compat/arrays/uniq');
+var intersect     = require('lodash-node/compat/arrays/intersection');
+var values        = require('lodash-node/compat/objects/values');
+var walkSync      = require('walk-sync');
+var zipObject     = require('lodash-node/compat/arrays/zipObject');
+var writeFile     = Promise.denodeify(fs.outputFile);
+var removeFile    = Promise.denodeify(fs.remove);
+var SilentError   = require('../errors/silent');
+var CoreObject    = require('core-object');
+var EOL           = require('os').EOL;
+var deprecate     = require('../utilities/deprecate');
 
 module.exports = Blueprint;
 
@@ -1026,6 +1027,15 @@ Blueprint.prototype._exec = function(command) {
   } else {
     return exec(command);
   }
+};
+
+Blueprint.prototype.printDetailedHelp = function() {
+  var markdownColor = new MarkdownColor();
+  var filePath = this.srcPath('../HELP.md');
+  if (fs.existsSync(filePath)) {
+    return markdownColor.renderFile(filePath);
+  }
+  return '';
 };
 
 /**

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1038,7 +1038,7 @@ Blueprint.prototype.printDetailedHelp = function() {
   }
 
   if (fs.existsSync(filePath)) {
-    return markdownColor.renderFile(filePath);
+    return markdownColor.renderFile(filePath, {indent:'        '});
   }
   return '';
 };

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1031,7 +1031,12 @@ Blueprint.prototype._exec = function(command) {
 
 Blueprint.prototype.printDetailedHelp = function() {
   var markdownColor = new MarkdownColor();
-  var filePath = this.srcPath('../HELP.md');
+  var filePath = null;
+
+  if (this.path) {
+    filePath = path.join(this.path, './HELP.md');
+  }
+
   if (fs.existsSync(filePath)) {
     return markdownColor.renderFile(filePath);
   }

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -10,51 +10,48 @@ var isArray           = require('lodash-node/modern/objects/isArray');
 
 var colors = ['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black', 'white', 'grey', 'gray'];
 var backgroundColors = ['bgRed', 'bgGreen', 'bgBlue', 'bgCyan', 'bgMagenta', 'bgYellow', 'bgWhite', 'bgBlack'];
-var defaultTokens = {
-  // ember-cli styles
-  option: {
-    name: 'option',
-    token: '--option',
-    pattern: /((--\w*\b)|(<options>))/g,
-    render: renderStylesFactory('cyan')
-  },
-  default: {
-    name: 'default',
-    token: '(Default: default)',
-    pattern: /(\(Default:\s.*\))/g,
-    render: renderStylesFactory('cyan')
-  },
-  required: {
-    name: 'required',
-    token: '(Required)',
-    pattern: /(\(Required\))/g,
-    render: renderStylesFactory('cyan')
-  },
-  args:{
-    name: 'args',
-    token: '<args>',
-    pattern: /(<[^>]+>)/g,
-    render: renderStylesFactory('yellow')
-  }
-};
-
-var colorTokens = unshiftValue(colors.concat(backgroundColors).map(getToken), {}).reduce(setToken);
-var tokens = merge(colorTokens, defaultTokens);
 
 module.exports = MarkdownColor;
 
 /*
+  Parses markdown and applies coloring to output by matching defined tokens and 
+  applying styling. Default outputs chalk.js coloring for terminal output.
+  Options:
+    tokens: pass additional tokens in the following format:
+    {
+      name:{
+        token: '(Reserved)', // example of token
+        pattern: /(Reserved)/g, // regexp pattern
+        render: function(string) { return string + '!'} // function that takes and returns a string
+      }
+    }
+    
+    markdownRenderer: pass a renderer object that will render your markdown
+      See https://github.com/mikaelbr/marked-terminal for an example
+    
+    renderStyles: pass an object to render color styles, default is chalk.js
 
+  @class MarkdownColor
+  @constructor
+  @param {Object} [options]
 */
 function MarkdownColor(options) {
   var optionTokens = options && options.tokens || {};
+  var renderStyles = options && options.renderStyles || chalk;
+  var tokens = this.generateTokens(renderStyles);
+  
   this.options = options || {};
   this.marked = marked;
   this.tokens = merge(tokens, optionTokens);
-  var defaultOptions = {
-    renderer: new TerminalRenderer({
+  this.markdownRenderer = options && options.markdownRenderer || new TerminalRenderer(
+    {
       code: chalk.green
-    }),
+    }
+  );
+
+  var defaultOptions;
+  defaultOptions = {
+    renderer: this.markdownRenderer,
   };
 
   var markedOptions = merge(defaultOptions, this.options);
@@ -62,6 +59,12 @@ function MarkdownColor(options) {
   return this;
 }
 
+/*
+  Lookup markdown file and render contents
+  @method renderFile
+  @param {String} [filePath]
+  @param {Object} [options]
+*/
 MarkdownColor.prototype.renderFile = function (filePath, options) {
   var file;
   if (fs.existsSync(filePath)) {
@@ -74,72 +77,133 @@ MarkdownColor.prototype.renderFile = function (filePath, options) {
   return this.render(file, options);
 };
 
+/*
+  Parse markdown and output as string
+  @method render
+  @param {String} [string]
+  @param {Object} [options]
+  @return {String}
+*/
 MarkdownColor.prototype.render = function (string, options) {
   var indent = options && options.indent || '';
   var input  = this.marked(string);
-  var styles = Object.keys(tokens);
+  var styles = Object.keys(this.tokens);
   input = input.replace(/^/mg, indent);
   styles.reverse().map(function(style) {
-    input = input.replace(tokens[style].pattern, tokens[style].render);
-  });
+    input = input.replace(this.tokens[style].pattern, this.tokens[style].render);
+  }.bind(this));
   input = input.replace(/\~\^(.*)\~\^/g, escapeToken);
   return input;
 };
 
 /*
+  Generate default style tokens
+  @method generateTokens
+  @return {Object}
+*/
+MarkdownColor.prototype.generateTokens = function (renderer) {
+  var defaultTokens = {
+    // ember-cli styles
+    option: {
+      name: 'option',
+      token: '--option',
+      pattern: /((--\w*\b)|(<options>))/g,
+      render: renderStylesFactory(renderer, 'cyan')
+    },
+    default: {
+      name: 'default',
+      token: '(Default: default)',
+      pattern: /(\(Default:\s.*\))/g,
+      render: renderStylesFactory(renderer, 'cyan')
+    },
+    required: {
+      name: 'required',
+      token: '(Required)',
+      pattern: /(\(Required\))/g,
+      render: renderStylesFactory(renderer, 'cyan')
+    }
+  };
 
+  var colorTokens = unshiftValue(colors.concat(backgroundColors).map(getToken), {}).reduce(setToken);
+  return merge(colorTokens, defaultTokens);
+};
+
+
+/*
+  Looks up multiple styles to apply to the rendered output
+  @method renderStylesFactory
+  @param {Object} [renderer] should match chalk.js format
+  @param {String, Array} [styleNames]
+  @return {Function} Function that will wrap the input string with styling
 */
 MarkdownColor.prototype.renderStylesFactory = renderStylesFactory;
-
-function renderStylesFactory(styleNames){
+function renderStylesFactory(renderer, styleNames){
   var styles;
   if (isArray(styleNames)) {
-    styles = styleNames.map(getChalkStyle);
+    styles = styleNames.map(checkStyleName.bind(null, renderer));
   } else {
-    styles = [getChalkStyle(styleNames)];
+    styles = [checkStyleName(renderer, styleNames)];
   }
   return function(match, pattern) {
     return styles.reverse().reduce(function (previous, current) {
-      return chalk[current](previous);
+      return renderer[current](previous);
     }, pattern);
   };
 }
 
-function getChalkStyle(style) {
-  if (Object.keys(chalk.styles).indexOf(style) > -1) {
-    return style;
+/*
+  Check to see if style exists on the renderer
+  @param {Object} [renderer] should match chalk.js format
+  @param {String} [name]
+*/
+function checkStyleName(renderer, name) {
+  if (Object.keys(renderer.styles).indexOf(name) > -1) {
+    return name;
   } else {
-    throw new SilentError('The style \'' + style + '\' is not supported by chalk.');
+    throw new SilentError('The style \'' + name + '\' is not supported by the markdown renderer.');
   }
 }
 
+/*
+  @param {String} [name]
+  @param {Object} [options]
+  @return {RegExp} Returns lookup pattern
+*/
 function getColorTokenRegex(name, options) {
   options = options || {};
-  var start = options.start || '(?:\\^';
-  var end = options.end || '\\^)';
+  var start = options.start || '(?:<';
+  var end = options.end || '>)';
+  var close = options.close || '(?:<\/';
   var middle = options.middle || '(.*?)';
   var tag = start + name + end;
-  var pattern = tag + middle + tag;
+  var closeTag = close + name + end;
+  var pattern = tag + middle + closeTag;
   return new RegExp(pattern, 'g');
 }
 
-function getToken(name) {
+/*
+  @param {String} [name]
+  @param {Object} [options]
+  @return {Object} Returns token object
+*/
+function getToken(name, options) {
+  var renderer = options && options.renderer || chalk;
   return {
     name: name,
-    token: '^' + name + '^',
+    token: '<' + name + '></' + name + '>',
     pattern: getColorTokenRegex(name),
-    render: renderStylesFactory(name)
+    render: renderStylesFactory(renderer, name)
   };
 }
 
-function setToken(result,color) {
+function setToken(result, color) {
   result[color.name] = color;
   return result;
 }
 
 function escapeToken(match, pattern){
   var output = pattern.replace(/\~/g,'');
-  return '^' + output + '^';
+  return '<' + output + '>';
 }
 
 function unshiftValue(array, value) {

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -114,7 +114,7 @@ var tokens = {
   },
   args:{
     token: '<args>',
-    pattern: /(<.*>)/g,
+    pattern: /(<[^>]+>)/g,
     render: renderStylesFactory('yellow')
   }
 };
@@ -140,7 +140,7 @@ function MarkdownColor(options) {
   return this;
 }
 
-MarkdownColor.prototype.renderFile = function (filePath) {
+MarkdownColor.prototype.renderFile = function (filePath, options) {
   var file;
   if (fs.existsSync(filePath)) {
     file = fs.readFileSync(filePath, 'utf-8');
@@ -149,12 +149,14 @@ MarkdownColor.prototype.renderFile = function (filePath) {
       ' Please check your filePath');
   }
 
-  return this.render(file);
+  return this.render(file, options);
 };
 
-MarkdownColor.prototype.render = function (string) {
-  var input = this.marked(string);
+MarkdownColor.prototype.render = function (string, options) {
+  var indent = options && options.indent || '';
+  var input  = this.marked(string);
   var styles = Object.keys(tokens);
+  input = input.replace(/^/mg, indent);
   styles.reverse().map(function(style) {
     input = input.replace(tokens[style].pattern, tokens[style].render);
   });

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -81,16 +81,16 @@ module.exports = MarkdownColor;
 
 */
 function MarkdownColor(options) {
+  var optionTokens = options && options.tokens || {};
   this.options = options || {};
   this.marked = marked;
-  this.tokens = tokens;
+  this.tokens = merge(tokens, optionTokens);
 
   var defaultOptions = {
     renderer: new TerminalRenderer(),
   };
 
   var markedOptions = merge(defaultOptions, this.options);
-  console.log(markedOptions);
   this.marked.setOptions(markedOptions);
   return this;
 }

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -8,117 +8,38 @@ var SilentError       = require('../errors/silent');
 var merge             = require('lodash-node/modern/objects/merge');
 var isArray           = require('lodash-node/modern/objects/isArray');
 
-var tokens = {
-  // colors
-  red: {
-    token: '^r^',
-    pattern: /(?:\^r\^)(.*?)(?:\^r\^)/g,
-    render: renderStylesFactory('red')
-  },
-  green: {
-    token: '^g^',
-    pattern: /(?:\^g\^)(.*?)(?:\^g\^)/g,
-    render: renderStylesFactory('green')
-  },
-  blue: {
-    token: '^b^',
-    pattern: /(?:\^b\^)(.*?)(?:\^b\^)/g,
-    render: renderStylesFactory('blue')
-  },
-  cyan: {
-    token: '^c^',
-    pattern:/(?:\^c\^)(.*?)(?:\^c\^)/g,
-    render: renderStylesFactory('cyan')
-  },
-  magenta: {
-    token: '^m^',
-    pattern: /(?:\^m\^)(.*?)(?:\^m\^)/g,
-    render: renderStylesFactory('magenta')
-  },
-  yellow: {
-    token: '^y^',
-    pattern: /(?:\^y\^)(.*?)(?:\^y\^)/g,
-    render: renderStylesFactory('yellow')
-  },
-  black: {
-    token: '^k^',
-    pattern: /(?:\^k\^)(.*?)(?:\^k\^)/g,
-    render: renderStylesFactory('black')
-  },
-  grey: {
-    token: '^gr^',
-    pattern: /(?:\^gr\^)(.*?)(?:\^gr\^)/g,
-    render: renderStylesFactory('grey')
-  },
-  white: {
-    token: '^w^',
-    pattern: /(?:\^w\^)(.*?)(?:\^w\^)/g,
-    render: renderStylesFactory('white')
-  },
-  bgRed: {
-    token: '^br^',
-    pattern: /(?:\^br\^)(.*?)(?:\^br\^)/g,
-    render: renderStylesFactory('bgRed')
-  },
-  bgGreen: {
-    token: '^bg^',
-    pattern: /(?:\^bg\^)(.*?)(?:\^bg\^)/g,
-    render: renderStylesFactory('bgGreen')
-  },
-  bgBlue: {
-    token: '^bb^',
-    pattern: /(?:\^bb\^)(.*?)(?:\^bb\^)/g,
-    render: renderStylesFactory('bgBlue')
-  },
-  bgCyan: {
-    token: '^bc^',
-    pattern:/(?:\^bc\^)(.*?)(?:\^bc\^)/g,
-    render: renderStylesFactory('bgCyan')
-  },
-  bgMagenta: {
-    token: '^bm^',
-    pattern: /(?:\^bm\^)(.*?)(?:\^bm\^)/g,
-    render: renderStylesFactory('bgMagenta')
-  },
-  bgYellow: {
-    token: '^by^',
-    pattern: /(?:\^by\^)(.*?)(?:\^by\^)/g,
-    render: renderStylesFactory('bgYellow')
-  },
-  bgBlack: {
-    token: '^bk^',
-    pattern: /(?:\^bk\^)(.*?)(?:\^bk\^)/g,
-    render: renderStylesFactory('bgBlack')
-  },
-  bgWhite: {
-    token: '^bw^',
-    pattern: /(?:\^bw\^)(.*?)(?:\^bw\^)/g,
-    render: renderStylesFactory('bgWhite')
-  },
-
+var colors = ['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black', 'white', 'grey', 'gray'];
+var backgroundColors = ['bgRed', 'bgGreen', 'bgBlue', 'bgCyan', 'bgMagenta', 'bgYellow', 'bgWhite', 'bgBlack'];
+var defaultTokens = {
   // ember-cli styles
   option: {
+    name: 'option',
     token: '--option',
     pattern: /((--\w*\b)|(<options>))/g,
     render: renderStylesFactory('cyan')
   },
   default: {
+    name: 'default',
     token: '(Default: default)',
     pattern: /(\(Default:\s.*\))/g,
     render: renderStylesFactory('cyan')
   },
   required: {
+    name: 'required',
     token: '(Required)',
     pattern: /(\(Required\))/g,
     render: renderStylesFactory('cyan')
   },
   args:{
+    name: 'args',
     token: '<args>',
     pattern: /(<[^>]+>)/g,
     render: renderStylesFactory('yellow')
   }
 };
 
+var colorTokens = unshiftValue(colors.concat(backgroundColors).map(getToken), {}).reduce(setToken);
+var tokens = merge(colorTokens, defaultTokens);
 
 module.exports = MarkdownColor;
 
@@ -130,9 +51,10 @@ function MarkdownColor(options) {
   this.options = options || {};
   this.marked = marked;
   this.tokens = merge(tokens, optionTokens);
-
   var defaultOptions = {
-    renderer: new TerminalRenderer(),
+    renderer: new TerminalRenderer({
+      code: chalk.green
+    }),
   };
 
   var markedOptions = merge(defaultOptions, this.options);
@@ -191,10 +113,40 @@ function getChalkStyle(style) {
   }
 }
 
+function getColorTokenRegex(name, options) {
+  options = options || {};
+  var start = options.start || '(?:\\^';
+  var end = options.end || '\\^)';
+  var middle = options.middle || '(.*?)';
+  var tag = start + name + end;
+  var pattern = tag + middle + tag;
+  return new RegExp(pattern, 'g');
+}
+
+function getToken(name) {
+  return {
+    name: name,
+    token: '^' + name + '^',
+    pattern: getColorTokenRegex(name),
+    render: renderStylesFactory(name)
+  };
+}
+
+function setToken(result,color) {
+  result[color.name] = color;
+  return result;
+}
+
 function escapeToken(match, pattern){
   var output = pattern.replace(/\~/g,'');
   return '^' + output + '^';
 }
+
+function unshiftValue(array, value) {
+  array.unshift(value);
+  return array;
+}
+
 /*
 Formatting colors for ember-cli help
 

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -50,6 +50,51 @@ var tokens = {
     pattern: /(?:\^gr\^)(.*?)(?:\^gr\^)/g,
     render: renderStylesFactory('grey')
   },
+  white: {
+    token: '^w^',
+    pattern: /(?:\^w\^)(.*?)(?:\^w\^)/g,
+    render: renderStylesFactory('white')
+  },
+  bgRed: {
+    token: '^br^',
+    pattern: /(?:\^br\^)(.*?)(?:\^br\^)/g,
+    render: renderStylesFactory('bgRed')
+  },
+  bgGreen: {
+    token: '^bg^',
+    pattern: /(?:\^bg\^)(.*?)(?:\^bg\^)/g,
+    render: renderStylesFactory('bgGreen')
+  },
+  bgBlue: {
+    token: '^bb^',
+    pattern: /(?:\^bb\^)(.*?)(?:\^bb\^)/g,
+    render: renderStylesFactory('bgBlue')
+  },
+  bgCyan: {
+    token: '^bc^',
+    pattern:/(?:\^bc\^)(.*?)(?:\^bc\^)/g,
+    render: renderStylesFactory('bgCyan')
+  },
+  bgMagenta: {
+    token: '^bm^',
+    pattern: /(?:\^bm\^)(.*?)(?:\^bm\^)/g,
+    render: renderStylesFactory('bgMagenta')
+  },
+  bgYellow: {
+    token: '^by^',
+    pattern: /(?:\^by\^)(.*?)(?:\^by\^)/g,
+    render: renderStylesFactory('bgYellow')
+  },
+  bgBlack: {
+    token: '^bk^',
+    pattern: /(?:\^bk\^)(.*?)(?:\^bk\^)/g,
+    render: renderStylesFactory('bgBlack')
+  },
+  bgWhite: {
+    token: '^bw^',
+    pattern: /(?:\^bw\^)(.*?)(?:\^bw\^)/g,
+    render: renderStylesFactory('bgWhite')
+  },
 
   // ember-cli styles
   option: {
@@ -110,7 +155,7 @@ MarkdownColor.prototype.renderFile = function (filePath) {
 MarkdownColor.prototype.render = function (string) {
   var input = this.marked(string);
   var styles = Object.keys(tokens);
-  styles.map(function(style) {
+  styles.reverse().map(function(style) {
     input = input.replace(tokens[style].pattern, tokens[style].render);
   });
   input = input.replace(/\~\^(.*)\~\^/g, escapeToken);
@@ -120,6 +165,8 @@ MarkdownColor.prototype.render = function (string) {
 /*
 
 */
+MarkdownColor.prototype.renderStylesFactory = renderStylesFactory;
+
 function renderStylesFactory(styleNames){
   var styles;
   if (isArray(styleNames)) {

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -1,0 +1,188 @@
+'use strict';
+
+var fs                = require('fs');
+var marked            = require('marked');
+var chalk             = require('chalk');
+var TerminalRenderer  = require('marked-terminal');
+var SilentError       = require('../errors/silent');
+var merge             = require('lodash-node/modern/objects/merge');
+var isArray           = require('lodash-node/modern/objects/isArray');
+
+var tokens = {
+  // colors
+  red: {
+    token: '^r^',
+    pattern: /(?:\^r\^)(.*?)(?:\^r\^)/g,
+    render: renderStylesFactory('red')
+  },
+  green: {
+    token: '^g^',
+    pattern: /(?:\^g\^)(.*?)(?:\^g\^)/g,
+    render: renderStylesFactory('green')
+  },
+  blue: {
+    token: '^b^',
+    pattern: /(?:\^b\^)(.*?)(?:\^b\^)/g,
+    render: renderStylesFactory('blue')
+  },
+  cyan: {
+    token: '^c^',
+    pattern:/(?:\^c\^)(.*?)(?:\^c\^)/g,
+    render: renderStylesFactory('cyan')
+  },
+  magenta: {
+    token: '^m^',
+    pattern: /(?:\^m\^)(.*?)(?:\^m\^)/g,
+    render: renderStylesFactory('magenta')
+  },
+  yellow: {
+    token: '^y^',
+    pattern: /(?:\^y\^)(.*?)(?:\^y\^)/g,
+    render: renderStylesFactory('yellow')
+  },
+  black: {
+    token: '^k^',
+    pattern: /(?:\^k\^)(.*?)(?:\^k\^)/g,
+    render: renderStylesFactory('black')
+  },
+  grey: {
+    token: '^gr^',
+    pattern: /(?:\^gr\^)(.*?)(?:\^gr\^)/g,
+    render: renderStylesFactory('grey')
+  },
+
+  // ember-cli styles
+  option: {
+    token: '--option',
+    pattern: /((--\w*\b)|(<options>))/g,
+    render: renderStylesFactory('cyan')
+  },
+  default: {
+    token: '(Default: default)',
+    pattern: /(\(Default:\s.*\))/g,
+    render: renderStylesFactory('cyan')
+  },
+  required: {
+    token: '(Required)',
+    pattern: /(\(Required\))/g,
+    render: renderStylesFactory('cyan')
+  },
+  args:{
+    token: '<args>',
+    pattern: /(<.*>)/g,
+    render: renderStylesFactory('yellow')
+  }
+};
+
+
+module.exports = MarkdownColor;
+
+/*
+
+*/
+function MarkdownColor(options) {
+  this.options = options || {};
+  this.marked = marked;
+  this.tokens = tokens;
+
+  var defaultOptions = {
+    renderer: new TerminalRenderer(),
+  };
+
+  var markedOptions = merge(defaultOptions, this.options);
+  console.log(markedOptions);
+  this.marked.setOptions(markedOptions);
+  return this;
+}
+
+MarkdownColor.prototype.renderFile = function (filePath) {
+  var file;
+  if (fs.existsSync(filePath)) {
+    file = fs.readFileSync(filePath, 'utf-8');
+  } else {
+    throw new SilentError('The file \'' + filePath + '\' doesn\'t exist.' +
+      ' Please check your filePath');
+  }
+
+  return this.render(file);
+};
+
+MarkdownColor.prototype.render = function (string) {
+  var input = this.marked(string);
+  var styles = Object.keys(tokens);
+  styles.map(function(style) {
+    input = input.replace(tokens[style].pattern, tokens[style].render);
+  });
+  input = input.replace(/\~\^(.*)\~\^/g, escapeToken);
+  return input;
+};
+
+/*
+
+*/
+function renderStylesFactory(styleNames){
+  var styles;
+  if (isArray(styleNames)) {
+    styles = styleNames.map(getChalkStyle);
+  } else {
+    styles = [getChalkStyle(styleNames)];
+  }
+  return function(match, pattern) {
+    return styles.reverse().reduce(function (previous, current) {
+      return chalk[current](previous);
+    }, pattern);
+  };
+}
+
+function getChalkStyle(style) {
+  if (Object.keys(chalk.styles).indexOf(style) > -1) {
+    return style;
+  } else {
+    throw new SilentError('The style \'' + style + '\' is not supported by chalk.');
+  }
+}
+
+function escapeToken(match, pattern){
+  var output = pattern.replace(/\~/g,'');
+  return '^' + output + '^';
+}
+/*
+Formatting colors for ember-cli help
+
+white: ember serve
+yellow: <arg-option, >
+cyan: --port, --important-option
+cyan: (Default: something), (Default: 4200)
+white: Description 1, Description 2
+cyan: (Required)
+*/
+
+/* Chalk supported styles -
+styles:
+   { reset: { open: '\u001b[0m', close: '\u001b[0m', closeRe: /[0m/g },
+     bold: { open: '\u001b[1m', close: '\u001b[22m', closeRe: /[22m/g },
+     dim: { open: '\u001b[2m', close: '\u001b[22m', closeRe: /[22m/g },
+     italic: { open: '\u001b[3m', close: '\u001b[23m', closeRe: /[23m/g },
+     underline: { open: '\u001b[4m', close: '\u001b[24m', closeRe: /[24m/g },
+     inverse: { open: '\u001b[7m', close: '\u001b[27m', closeRe: /[27m/g },
+     hidden: { open: '\u001b[8m', close: '\u001b[28m', closeRe: /[28m/g },
+     strikethrough: { open: '\u001b[9m', close: '\u001b[29m', closeRe: /[29m/g },
+     black: { open: '\u001b[30m', close: '\u001b[39m', closeRe: /[39m/g },
+     red: { open: '\u001b[31m', close: '\u001b[39m', closeRe: /[39m/g },
+     green: { open: '\u001b[32m', close: '\u001b[39m', closeRe: /[39m/g },
+     yellow: { open: '\u001b[33m', close: '\u001b[39m', closeRe: /[39m/g },
+     blue: { open: '\u001b[34m', close: '\u001b[39m', closeRe: /[39m/g },
+     magenta: { open: '\u001b[35m', close: '\u001b[39m', closeRe: /[39m/g },
+     cyan: { open: '\u001b[36m', close: '\u001b[39m', closeRe: /[39m/g },
+     white: { open: '\u001b[37m', close: '\u001b[39m', closeRe: /[39m/g },
+     gray: { open: '\u001b[90m', close: '\u001b[39m', closeRe: /[39m/g },
+     bgBlack: { open: '\u001b[40m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgRed: { open: '\u001b[41m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgGreen: { open: '\u001b[42m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgYellow: { open: '\u001b[43m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgBlue: { open: '\u001b[44m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgMagenta: { open: '\u001b[45m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgCyan: { open: '\u001b[46m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgWhite: { open: '\u001b[47m', close: '\u001b[49m', closeRe: /[49m/g },
+     grey: { open: '\u001b[90m', close: '\u001b[39m', closeRe: /[39m/g } },
+*/

--- a/package.json
+++ b/package.json
@@ -119,6 +119,8 @@
     "js-string-escape": "^1.0.0",
     "leek": "0.0.17",
     "lodash-node": "^2.4.1",
+    "marked": "^0.3.3",
+    "marked-terminal": "^1.1.3",
     "minimatch": "^1.0.0",
     "morgan": "^1.2.2",
     "node-uuid": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "leek": "0.0.17",
     "lodash-node": "^2.4.1",
     "marked": "^0.3.3",
-    "marked-terminal": "^1.1.3",
+    "marked-terminal": "^1.2.0",
     "minimatch": "^1.0.0",
     "morgan": "^1.2.2",
     "node-uuid": "^1.4.1",

--- a/tests/fixtures/markdown/foo.md
+++ b/tests/fixtures/markdown/foo.md
@@ -1,0 +1,1 @@
+  ^c^tacos are ^y^delicious^y^ ^b^and I^b^ enjoy eating them ^c^

--- a/tests/fixtures/markdown/foo.md
+++ b/tests/fixtures/markdown/foo.md
@@ -1,1 +1,1 @@
-  ^c^tacos are ^y^delicious^y^ ^b^and I^b^ enjoy eating them ^c^
+  ^cyan^tacos are ^yellow^delicious^yellow^ ^blue^and I^blue^ enjoy eating them ^cyan^

--- a/tests/fixtures/markdown/foo.md
+++ b/tests/fixtures/markdown/foo.md
@@ -1,1 +1,1 @@
-  ^cyan^tacos are ^yellow^delicious^yellow^ ^blue^and I^blue^ enjoy eating them ^cyan^
+<cyan>tacos are <yellow>delicious</yellow> <blue>and I</blue> enjoy eating them</cyan>

--- a/tests/unit/utilities/markdown-color-test.js
+++ b/tests/unit/utilities/markdown-color-test.js
@@ -32,30 +32,29 @@ function isAnsiSupported() {
   });
 
   it('parses color tokens', function() {
-    expect(mc.render('^red^red^red^')).to.equal('\u001b[0m\u001b[31mred\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^green^green^green^')).to.equal('\u001b[0m\u001b[32mgreen\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^blue^blue^blue^')).to.equal('\u001b[0m\u001b[34mblue\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^cyan^cyan^cyan^')).to.equal('\u001b[0m\u001b[36mcyan\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^magenta^magenta^magenta^')).to.equal('\u001b[0m\u001b[35mmagenta\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^yellow^yellow^yellow^')).to.equal('\u001b[0m\u001b[33myellow\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^black^black^black^')).to.equal('\u001b[0m\u001b[30mblack\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^gray^gray^gray^')).to.equal('\u001b[0m\u001b[90mgray\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^grey^grey^grey^')).to.equal('\u001b[0m\u001b[90mgrey\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('<red>red</red>')).to.equal('\u001b[90m\u001b[31mred\u001b[39m\u001b[39m');
+    expect(mc.render('<green>green</green>')).to.equal('\u001b[90m\u001b[32mgreen\u001b[39m\u001b[39m');
+    expect(mc.render('<blue>blue</blue>')).to.equal('\u001b[90m\u001b[34mblue\u001b[39m\u001b[39m');
+    expect(mc.render('<cyan>cyan</cyan>')).to.equal('\u001b[90m\u001b[36mcyan\u001b[39m\u001b[39m');
+    expect(mc.render('<magenta>magenta</magenta>')).to.equal('\u001b[90m\u001b[35mmagenta\u001b[39m\u001b[39m');
+    expect(mc.render('<yellow>yellow</yellow>')).to.equal('\u001b[90m\u001b[33myellow\u001b[39m\u001b[39m');
+    expect(mc.render('<black>black</black>')).to.equal('\u001b[90m\u001b[30mblack\u001b[39m\u001b[39m');
+    expect(mc.render('<gray>gray</gray>')).to.equal('\u001b[90m\u001b[90mgray\u001b[39m\u001b[39m');
+    expect(mc.render('<grey>grey</grey>')).to.equal('\u001b[90m\u001b[90mgrey\u001b[39m\u001b[39m');
 
-    expect(mc.render('^bgRed^bgRed^bgRed^')).to.equal('\u001b[0m\u001b[41mbgRed\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgGreen^bgGreen^bgGreen^')).to.equal('\u001b[0m\u001b[42mbgGreen\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgBlue^bgBlue^bgBlue^')).to.equal('\u001b[0m\u001b[44mbgBlue\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgCyan^bgCyan^bgCyan^')).to.equal('\u001b[0m\u001b[46mbgCyan\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgMagenta^bgMagenta^bgMagenta^')).to.equal('\u001b[0m\u001b[45mbgMagenta\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgYellow^bgYellow^bgYellow^')).to.equal('\u001b[0m\u001b[43mbgYellow\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bgBlack^bgBlack^bgBlack^')).to.equal('\u001b[0m\u001b[40mbgBlack\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('<bgRed>bgRed</bgRed>')).to.equal('\u001b[90m\u001b[41mbgRed\u001b[49m\u001b[39m');
+    expect(mc.render('<bgGreen>bgGreen</bgGreen>')).to.equal('\u001b[90m\u001b[42mbgGreen\u001b[49m\u001b[39m');
+    expect(mc.render('<bgBlue>bgBlue</bgBlue>')).to.equal('\u001b[90m\u001b[44mbgBlue\u001b[49m\u001b[39m');
+    expect(mc.render('<bgCyan>bgCyan</bgCyan>')).to.equal('\u001b[90m\u001b[46mbgCyan\u001b[49m\u001b[39m');
+    expect(mc.render('<bgMagenta>bgMagenta</bgMagenta>')).to.equal('\u001b[90m\u001b[45mbgMagenta\u001b[49m\u001b[39m');
+    expect(mc.render('<bgYellow>bgYellow</bgYellow>')).to.equal('\u001b[90m\u001b[43mbgYellow\u001b[49m\u001b[39m');
+    expect(mc.render('<bgBlack>bgBlack</bgBlack>')).to.equal('\u001b[90m\u001b[40mbgBlack\u001b[49m\u001b[39m');
   });
 
   it('parses custom tokens', function() {
     expect(mc.render('--option')).to.equal('\u001b[0m\u001b[36m--option\u001b[39m\u001b[0m\n\n');
     expect(mc.render('(Default: value)')).to.equal('\u001b[0m\u001b[36m(Default: value)\u001b[39m\u001b[0m\n\n');
     expect(mc.render('(Required)')).to.equal('\u001b[0m\u001b[36m(Required)\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('<args>')).to.equal('\u001b[90m\u001b[33m<args>\u001b[39m\u001b[39m');
   });
 
   it('accepts tokens on instantiation', function() {
@@ -64,7 +63,7 @@ function isAnsiSupported() {
         foo: {
           token: '^foo^',
           pattern: /(?:\^foo\^)(.*?)(?:\^foo\^)/g,
-          render: MarkdownColor.prototype.renderStylesFactory(['blue','bgWhite'])
+          render: MarkdownColor.prototype.renderStylesFactory(chalk, ['blue','bgWhite'])
         }
       }
     });
@@ -72,13 +71,13 @@ function isAnsiSupported() {
   });
 
   it('parses markdown files', function() {
-    // console.log('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
+    // console.log(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md')))
     expect(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md'))).to
-      .equal('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
+      .equal('\u001b[90m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them\u001b[39m\n\u001b[39m');
   });
 
   it('allows tokens inside other token bounds', function() {
-    expect(mc.render('^cyan^tacos are ^yellow^delicious^yellow^ and I enjoy eating them ^cyan^')).to.equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m and I enjoy eating them \u001b[39m\u001b[0m\n\n');
+    expect(mc.render('<cyan>tacos are <yellow>delicious</yellow> and I enjoy eating them</cyan>')).to.equal('\u001b[90m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m and I enjoy eating them\u001b[39m\u001b[39m');
   });
 });
 /* Chalk supported styles -

--- a/tests/unit/utilities/markdown-color-test.js
+++ b/tests/unit/utilities/markdown-color-test.js
@@ -6,7 +6,7 @@ var path          = require('path');
 var chalk         = require('chalk');
 
 function isAnsiSupported() {
-  // when ansi is supported this should be
+  // when ansi is supported this should be '\u001b[0m\u001b[31ma\u001b[39m\u001b[0m\n\n'
   return chalk.red('a') !== 'a';
 }
 
@@ -32,22 +32,23 @@ function isAnsiSupported() {
   });
 
   it('parses color tokens', function() {
-    expect(mc.render('^r^red^r^')).to.equal('\u001b[0m\u001b[31mred\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^g^green^g^')).to.equal('\u001b[0m\u001b[32mgreen\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^b^blue^b^')).to.equal('\u001b[0m\u001b[34mblue\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^c^cyan^c^')).to.equal('\u001b[0m\u001b[36mcyan\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^m^magenta^m^')).to.equal('\u001b[0m\u001b[35mmagenta\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^y^yellow^y^')).to.equal('\u001b[0m\u001b[33myellow\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^k^black^k^')).to.equal('\u001b[0m\u001b[30mblack\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('^gr^grey^gr^')).to.equal('\u001b[0m\u001b[90mgrey\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^red^red^red^')).to.equal('\u001b[0m\u001b[31mred\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^green^green^green^')).to.equal('\u001b[0m\u001b[32mgreen\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^blue^blue^blue^')).to.equal('\u001b[0m\u001b[34mblue\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^cyan^cyan^cyan^')).to.equal('\u001b[0m\u001b[36mcyan\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^magenta^magenta^magenta^')).to.equal('\u001b[0m\u001b[35mmagenta\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^yellow^yellow^yellow^')).to.equal('\u001b[0m\u001b[33myellow\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^black^black^black^')).to.equal('\u001b[0m\u001b[30mblack\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^gray^gray^gray^')).to.equal('\u001b[0m\u001b[90mgray\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^grey^grey^grey^')).to.equal('\u001b[0m\u001b[90mgrey\u001b[39m\u001b[0m\n\n');
 
-    expect(mc.render('^br^bgRed^br^')).to.equal('\u001b[0m\u001b[41mbgRed\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bg^bgGreen^bg^')).to.equal('\u001b[0m\u001b[42mbgGreen\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bb^bgBlue^bb^')).to.equal('\u001b[0m\u001b[44mbgBlue\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bc^bgCyan^bc^')).to.equal('\u001b[0m\u001b[46mbgCyan\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bm^bgMagenta^bm^')).to.equal('\u001b[0m\u001b[45mbgMagenta\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^by^bgYellow^by^')).to.equal('\u001b[0m\u001b[43mbgYellow\u001b[49m\u001b[0m\n\n');
-    expect(mc.render('^bk^bgBlack^bk^')).to.equal('\u001b[0m\u001b[40mbgBlack\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgRed^bgRed^bgRed^')).to.equal('\u001b[0m\u001b[41mbgRed\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgGreen^bgGreen^bgGreen^')).to.equal('\u001b[0m\u001b[42mbgGreen\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgBlue^bgBlue^bgBlue^')).to.equal('\u001b[0m\u001b[44mbgBlue\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgCyan^bgCyan^bgCyan^')).to.equal('\u001b[0m\u001b[46mbgCyan\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgMagenta^bgMagenta^bgMagenta^')).to.equal('\u001b[0m\u001b[45mbgMagenta\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgYellow^bgYellow^bgYellow^')).to.equal('\u001b[0m\u001b[43mbgYellow\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bgBlack^bgBlack^bgBlack^')).to.equal('\u001b[0m\u001b[40mbgBlack\u001b[49m\u001b[0m\n\n');
   });
 
   it('parses custom tokens', function() {
@@ -77,7 +78,7 @@ function isAnsiSupported() {
   });
 
   it('allows tokens inside other token bounds', function() {
-    expect(mc.render('^c^tacos are ^y^delicious^y^ and I enjoy eating them ^c^')).to.equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m and I enjoy eating them \u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^cyan^tacos are ^yellow^delicious^yellow^ and I enjoy eating them ^cyan^')).to.equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m and I enjoy eating them \u001b[39m\u001b[0m\n\n');
   });
 });
 /* Chalk supported styles -
@@ -108,4 +109,6 @@ styles:
      bgCyan: { open: '\u001b[46m', close: '\u001b[49m', closeRe: /[49m/g },
      bgWhite: { open: '\u001b[47m', close: '\u001b[49m', closeRe: /[49m/g },
      grey: { open: '\u001b[90m', close: '\u001b[39m', closeRe: /[39m/g } },
+
+Use strip-ansi to check content in environments that don't support it?
 */

--- a/tests/unit/utilities/markdown-color-test.js
+++ b/tests/unit/utilities/markdown-color-test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var MarkdownColor = require('../../../lib/utilities/markdown-color');
+var expect        = require('chai').expect;
+var path          = require('path');
+
+describe('MarkdownColor', function() {
+  var mc;
+
+  beforeEach(function() {
+    mc = new MarkdownColor();
+  });
+
+  it('parses default markdown', function() {
+
+  });
+
+  it('parses color tokens', function() {
+    expect(mc.render('^r^red^r^')).to.equal('\u001b[0m\u001b[31mred\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^g^green^g^')).to.equal('\u001b[0m\u001b[32mgreen\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^b^blue^b^')).to.equal('\u001b[0m\u001b[34mblue\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^c^cyan^c^')).to.equal('\u001b[0m\u001b[36mcyan\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^m^magenta^m^')).to.equal('\u001b[0m\u001b[35mmagenta\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^y^yellow^y^')).to.equal('\u001b[0m\u001b[33myellow\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^k^black^k^')).to.equal('\u001b[0m\u001b[30mblack\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('^gr^grey^gr^')).to.equal('\u001b[0m\u001b[90mgrey\u001b[39m\u001b[0m\n\n');
+
+    expect(mc.render('^br^bgRed^br^')).to.equal('\u001b[0m\u001b[41mbgRed\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bg^bgGreen^bg^')).to.equal('\u001b[0m\u001b[42mbgGreen\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bb^bgBlue^bb^')).to.equal('\u001b[0m\u001b[44mbgBlue\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bc^bgCyan^bc^')).to.equal('\u001b[0m\u001b[46mbgCyan\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bm^bgMagenta^bm^')).to.equal('\u001b[0m\u001b[45mbgMagenta\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^by^bgYellow^by^')).to.equal('\u001b[0m\u001b[43mbgYellow\u001b[49m\u001b[0m\n\n');
+    expect(mc.render('^bk^bgBlack^bk^')).to.equal('\u001b[0m\u001b[40mbgBlack\u001b[49m\u001b[0m\n\n');
+  });
+
+  it('parses custom tokens', function() {
+    expect(mc.render('--option')).to.equal('\u001b[0m\u001b[36m--option\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('(Default: value)')).to.equal('\u001b[0m\u001b[36m(Default: value)\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('(Required)')).to.equal('\u001b[0m\u001b[36m(Required)\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('<args>')).to.equal('\u001b[90m\u001b[33m<args>\u001b[39m\u001b[39m');
+  });
+
+  it('accepts tokens on instantiation', function() {
+    var mctemp = new MarkdownColor({
+      tokens: {
+        foo: {
+          token: '^foo^',
+          pattern: /(?:\^foo\^)(.*?)(?:\^foo\^)/g,
+          render: MarkdownColor.prototype.renderStylesFactory(['blue','bgWhite'])
+        }
+      }
+    });
+    expect(mctemp.render('^foo^foo^foo^')).to.equal('\u001b[0m\u001b[34m\u001b[47mfoo\u001b[49m\u001b[39m\u001b[0m\n\n');
+  });
+
+  it('parses markdown files', function() {
+    console.log('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
+    expect(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md'))).to
+      .equal('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
+  });
+
+  it('allows tokens inside other token bounds', function() {
+    expect(mc.render('^c^tacos are ^y^delicious^y^ and I enjoy eating them ^c^')).to.equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m and I enjoy eating them \u001b[39m\u001b[0m\n\n');
+  });
+});
+/* Chalk supported styles -
+styles:
+   { reset: { open: '\u001b[0m', close: '\u001b[0m', closeRe: /[0m/g },
+     bold: { open: '\u001b[1m', close: '\u001b[22m', closeRe: /[22m/g },
+     dim: { open: '\u001b[2m', close: '\u001b[22m', closeRe: /[22m/g },
+     italic: { open: '\u001b[3m', close: '\u001b[23m', closeRe: /[23m/g },
+     underline: { open: '\u001b[4m', close: '\u001b[24m', closeRe: /[24m/g },
+     inverse: { open: '\u001b[7m', close: '\u001b[27m', closeRe: /[27m/g },
+     hidden: { open: '\u001b[8m', close: '\u001b[28m', closeRe: /[28m/g },
+     strikethrough: { open: '\u001b[9m', close: '\u001b[29m', closeRe: /[29m/g },
+     black: { open: '\u001b[30m', close: '\u001b[39m', closeRe: /[39m/g },
+     red: { open: '\u001b[31m', close: '\u001b[39m', closeRe: /[39m/g },
+     green: { open: '\u001b[32m', close: '\u001b[39m', closeRe: /[39m/g },
+     yellow: { open: '\u001b[33m', close: '\u001b[39m', closeRe: /[39m/g },
+     blue: { open: '\u001b[34m', close: '\u001b[39m', closeRe: /[39m/g },
+     magenta: { open: '\u001b[35m', close: '\u001b[39m', closeRe: /[39m/g },
+     cyan: { open: '\u001b[36m', close: '\u001b[39m', closeRe: /[39m/g },
+     white: { open: '\u001b[37m', close: '\u001b[39m', closeRe: /[39m/g },
+     gray: { open: '\u001b[90m', close: '\u001b[39m', closeRe: /[39m/g },
+     bgBlack: { open: '\u001b[40m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgRed: { open: '\u001b[41m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgGreen: { open: '\u001b[42m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgYellow: { open: '\u001b[43m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgBlue: { open: '\u001b[44m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgMagenta: { open: '\u001b[45m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgCyan: { open: '\u001b[46m', close: '\u001b[49m', closeRe: /[49m/g },
+     bgWhite: { open: '\u001b[47m', close: '\u001b[49m', closeRe: /[49m/g },
+     grey: { open: '\u001b[90m', close: '\u001b[39m', closeRe: /[39m/g } },
+*/

--- a/tests/unit/utilities/markdown-color-test.js
+++ b/tests/unit/utilities/markdown-color-test.js
@@ -3,16 +3,32 @@
 var MarkdownColor = require('../../../lib/utilities/markdown-color');
 var expect        = require('chai').expect;
 var path          = require('path');
+var chalk         = require('chalk');
 
-describe('MarkdownColor', function() {
+function isAnsiSupported() {
+  // when ansi is supported this should be
+  return chalk.red('a') !== 'a';
+}
+
+(isAnsiSupported() ? describe : describe.skip)('MarkdownColor', function() {
   var mc;
 
   beforeEach(function() {
+    /*
+    // check to make sure ansi is supported
+    // can use this.skip() after Mocha 2.1.1
+    // see https://github.com/mochajs/mocha/pull/946
+    if (isAnsiSupported()) {
+      this.skip();
+    }
+    */
     mc = new MarkdownColor();
   });
 
   it('parses default markdown', function() {
-
+    expect(mc.render('# foo\n__bold__ words\n* un\n* ordered\n* list')).to.equal(
+      '\u001b[1m\u001b[4m\u001b[35m# foo\u001b[39m\u001b[24m\u001b[22m\n\u001b[0m\u001b[1m' +
+      'bold\u001b[22m words\u001b[0m\n\n   \u001b[0m* un\u001b[0m\n   \u001b[0m* ordered\u001b[0m\n   \u001b[0m* list\u001b[0m\n\n');
   });
 
   it('parses color tokens', function() {
@@ -55,7 +71,7 @@ describe('MarkdownColor', function() {
   });
 
   it('parses markdown files', function() {
-    console.log('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
+    // console.log('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
     expect(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md'))).to
       .equal('\u001b[0m  \u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them \u001b[39m\u001b[0m\n\n');
   });


### PR DESCRIPTION
This PR fulfills #3331 by adding a new utility for parsing markdown into color terminal output. Additional tokens have been added, as well as recognized patterns such as `--option` (should be cyan) and `<argument>` (should be yellow) as laid out [here](https://github.com/ember-cli/ember-cli/blob/master/ARCHITECTURE.md#formatting-colors).
The current implementation is as simple as:
```
var markdownColor = new MarkdownColor();
markdownColor.renderFile('./HELP.md');
```
Example output:
(the first block is output after being parsed with marked, the second is after parsing with markdown-color)
![screen shot 2015-02-22 at 1 36 28 pm](https://cloud.githubusercontent.com/assets/324797/6320639/04e4c680-ba98-11e4-8d98-ce028656ba06.png)

`MarkdownColor` also exposes a `render(string)` method to allow manipulation to the input before rendering.

Internally, tokens are defined as a regex pattern and the chalk style[s] to apply to the matched text. For instance:
```
var tokens = {
  cyan: {
    token: '<cyan>', // example of what the token looks like
    pattern:/(?:<cyan>)(.*?)(?:<\/cyan>)/g, // pattern to match token
    render: renderStylesFactory('cyan') // chalk style to render matched text with
  },
  option: {
    token: '--option',
    pattern: /((--\w*\b)|(<options>))/g,
    render: renderStylesFactory(['cyan', 'underline]) //renders both cyan and underlined
  }
};
```
The currently available color tokens are as follows:
* red:` <red></red>`
* green:` <green></green>`
* blue:` <blue></green>`
* cyan:` <cyan></green>`
* magenta:` <magenta></magenta>`
* yellow:` <yellow></yellow>`
* black:` <black></black>`
* grey:` <grey></grey>`
* gray:` <gray></gray>`
* bgRed:` <bgRed></bgRed>`
* bgGreen:` <bgGreen></bgGreen>`
* bgBlue:` <bgBlue></bgGreen>`
* bgCyan:` <bgCyan></bgCyan>`
* bgMagenta:` <bgMagenta></bgMagenta>`
* bgYellow:` <bgYellow></bgYellow>`
* bgBlack:` <bgBlack></bgBlack>`

The tokens can then be used in your markdown like so:
```
// file.md
<cyan>This text is cyan <red>but this is red</red> this back to cyan though</cyan>
```

Some additional work needs to be done:
- [x] fix code highlighting (more involved than this PR, will have to be resolved later)
- [x] clean up some of the ember-cli patterns
- [x] add tokens and renderers for the other styles and background colors
- [x] determine if any additional preset styles should be added
- [x] add optional indent value
- [x] unit tests for `markdown-color.js`
- [x] ~~acceptance tests for `markdown-color.js`~~ (stdout eats ansi, so this would just be a duplicate of the unit test)