### PR TITLE
Ensure that an addons styles tree is in the same path as the apps.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -387,6 +387,23 @@ Addon.prototype.treeForAddon = function(tree) {
 };
 
 /**
+  @method treeForStyles
+  @param {Tree} tree The tree to process, usually `app/styles/` in the addon.
+  @returns {Tree} The return tree has the same contents as the input tree, but is moved so that the `app/styles/` path is preserved.
+*/
+Addon.prototype.treeForStyles = function(tree) {
+  this._requireBuildPackages();
+
+  if (!tree) {
+    return tree;
+  }
+
+  return new this.Funnel(tree, {
+    destDir: 'app/styles'
+  });
+};
+
+/**
   Runs the styles tree through preprocessors.
 
   @private

--- a/tests/fixtures/addon/with-app-styles/app/styles/foo-bar.css
+++ b/tests/fixtures/addon/with-app-styles/app/styles/foo-bar.css
@@ -1,0 +1,1 @@
+/* app/styles/foo-ba.css contents */


### PR DESCRIPTION
This change allows an addon to have a file at `app/styles/foo-bar.scss`, which can be imported in the consuming app with `@import 'foo-bar';`.

Addresses one aspect of #2905.