### PR TITLE
Check if blueprint exists before printing help

### DIFF
--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -83,13 +83,19 @@ module.exports = Command.extend({
   },
 
   printSingleBlueprint: function(options) {
+    var blueprintName = options[0];
     var lookupPaths   = this.project.blueprintLookupPaths();
     var blueprintList = Blueprint.list({ paths: lookupPaths });
     var blueprints = flatten(pluck(blueprintList, 'blueprints'));
     var blueprint = find(blueprints, function(model) {
-      return model.name === options[0];
+      return model.name === blueprintName;
     });
-    this.printBlueprintInfo(blueprint, true);
+    if (blueprint) {
+      this.printBlueprintInfo(blueprint, true);
+    } else {
+      this.ui.writeLine(chalk.yellow('The \'' + blueprintName +
+        '\' blueprint does not exist in this project.'));
+    }
   },
 
   printAllBlueprints: function(options) {

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -20,6 +20,9 @@ describe('generate command', function() {
 
         isEmberCLIProject: function isEmberCLIProject() {
           return true;
+        },
+        blueprintLookupPaths: function() {
+          return [];
         }
       },
 
@@ -53,6 +56,14 @@ describe('generate command', function() {
             'The `ember generate` command requires a ' +
             'blueprint name to be specified. ' +
             'For more details, use `ember help`.');
+      });
+  });
+
+  it('complains if --help is called for non-existent blueprint.', function() {
+    return Promise.resolve(command.printDetailedHelp({rawArgs:['foo','-h']}))
+      .then(function() {
+        expect(command.ui.output).to.include(
+            'The \'foo\' blueprint does not exist in this project.');
       });
   });
 });


### PR DESCRIPTION
Running `ember g foo -h` for a non-existent blueprint throws an error:
```
Cannot read property 'overridden' of undefined
TypeError: Cannot read property 'overridden' of undefined
    at Class.module.exports.Command.extend.printBlueprintInfo (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/generate.js:129:18)
    at Class.module.exports.Command.extend.printSingleBlueprint (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/generate.js:92:10)
    at Class.module.exports.Command.extend.printDetailedHelp (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/generate.js:79:12)
    at Class.module.exports.Command.extend._printHelpForCommand (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/help.js:106:15)
    at Class.module.exports.Command.extend._printDetailedHelpForCommand (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/help.js:97:10)
    at Class.module.exports.Command.extend.run (/Users/trabus/Development/github/ember-cli/ember-cli/lib/commands/help.js:79:14)
    at Class.<anonymous> (/Users/trabus/Development/github/ember-cli/ember-cli/lib/models/command.js:136:17)
    at lib$rsvp$$internal$$tryCatch (/Users/trabus/Development/github/ember-cli/ember-cli/node_modules/rsvp/dist/rsvp.js:489:16)
    at lib$rsvp$$internal$$invokeCallback (/Users/trabus/Development/github/ember-cli/ember-cli/node_modules/rsvp/dist/rsvp.js:501:17)
    at lib$rsvp$$internal$$publish (/Users/trabus/Development/github/ember-cli/ember-cli/node_modules/rsvp/dist/rsvp.js:472:11)
```
This PR puts in a check to ensure the blueprint exists before trying to print the blueprint help, and will throw a warning if the blueprint doesn't exist.
```
The 'foo' blueprint does not exist in this project.
```