### PR TITLE
[fixes #2851] CI=true puts the UI into `silent` writeLevel

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -46,10 +46,6 @@ CLI.prototype.run = function(environment) {
       process.env['EMBER_VERBOSE_' + arg.toUpperCase()] = 'true';
     });
 
-    if (commandArgs.indexOf('--silent') !== -1) {
-      this.ui.setWriteLevel('ERROR');
-    }
-
     if (!validPlatformVersion(process.version) && !this.testing) {
       var chalk = require('chalk');
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -58,9 +58,12 @@ function cli(options) {
     leekOptions = defaultLeekOptions;
   }
 
+  // TODO: one UI (lib/models/project.js also has one for now...)
   var ui = new UI({
     inputStream:  options.inputStream,
-    outputStream: options.outputStream
+    outputStream: options.outputStream,
+    ci:           process.env.CI,
+    writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
   });
 
   debug('leek: %o', leekOptions);

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -538,9 +538,12 @@ function ensureUI(_ui) {
   var ui = _ui;
 
   if (!ui) {
+    // TODO: one UI (lib/cli/index.js also has one for now...)
     ui = new UI({
-      inputStream: process.stdin,
-      outputStream: process.stdout
+      inputStream:  process.stdin,
+      outputStream: process.stdout,
+      ci:           process.env.CI,
+      writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
     });
   }
 

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -12,7 +12,23 @@ var writeError       = require('./write-error');
 
 module.exports = UI;
 
-function UI(options) { // options === { inputStream, outputStream }
+/*
+  @constructor
+
+  The UI provides the CLI with a unified mechanism for providing output and
+  requesting input from the user. This becomes useful when wanting to adjust
+  logLevels, or mock input/output for tests.
+
+  new UI{
+    inputStream: process.stdin,
+    outputStream: process.stdout,
+    writeLevel: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR'
+    ci: true | false
+  });
+
+**/
+
+function UI(options) {
   var pleasantProgress = this.pleasantProgress = new PleasantProgress();
 
   this.through  = require('through');
@@ -32,20 +48,46 @@ function UI(options) { // options === { inputStream, outputStream }
   this.inputStream = options.inputStream;
 
   this.writeLevel = options.writeLevel || 'INFO';
+  this.ci = !!options.ci;
 }
 
+/**
+  Unified mechanism to write a string to the console.
+  Optionally include a writeLevel, this is used to decide if the specific
+  logging mechanism should or should not be printed.
+
+  @method write
+  @param {String} data
+  @param {Number} writeLevel
+*/
 UI.prototype.write = function(data, writeLevel) {
   if (this.writeLevelVisible(writeLevel)) {
     this.outputStream.write(data);
   }
 };
 
+/**
+  Unified mechanism to write a string and new line to the console.
+  Optionally include a writeLevel, this is used to decide if the specific
+
+  logging mechanism should or should not be printed.
+  @method writeLine
+  @param {String} data
+  @param {Number} writeLevel
+*/
 UI.prototype.writeLine = function(data, writeLevel) {
   if (this.writeLevelVisible(writeLevel)) {
     this.write(data + EOL);
   }
 };
 
+/**
+  Unified mechanism to an Error to the console.
+  This will occure at a writeLevel of ERROR
+
+  @method writeError
+  @param {Error} error
+*/
 UI.prototype.writeError = function(error) {
   writeError(this, error);
 };
@@ -67,12 +109,18 @@ UI.prototype.setWriteLevel = function(level) {
 
 UI.prototype.startProgress = function(message, stepString) {
   if (this.writeLevelVisible('INFO')) {
-    this.pleasantProgress.start(message, stepString);
+    if (this.ci) {
+      this.writeLine(message);
+    } else {
+      this.pleasantProgress.start(message, stepString);
+    }
   }
 };
 
 UI.prototype.stopProgress = function(printWithFullStepString) {
-  this.pleasantProgress.stop(printWithFullStepString);
+  if (this.writeLevelVisible('INFO') && !this.ci) {
+    this.pleasantProgress.stop(printWithFullStepString);
+  }
 };
 
 UI.prototype.prompt = function(questions, callback) {
@@ -109,10 +157,10 @@ UI.prototype.prompt = function(questions, callback) {
   @type Object
 */
 UI.prototype.WRITE_LEVELS = {
-    'DEBUG': 1,
-    'INFO': 2,
-    'WARNING': 3,
-    'ERROR': 4
+  'DEBUG': 1,
+  'INFO': 2,
+  'WARNING': 3,
+  'ERROR': 4
 };
 
 /**

--- a/lib/ui/write-error.js
+++ b/lib/ui/write-error.js
@@ -9,16 +9,16 @@ module.exports = function writeError(ui, error){
     if (error.line) {
       file += error.col ? ' (' + error.line + ':' + error.col + ')' : ' (' + error.line + ')';
     }
-    ui.writeLine(chalk.red('File: ' + file));
+    ui.writeLine(chalk.red('File: ' + file), 'ERROR');
   }
 
   if (error.message) {
-    ui.writeLine(chalk.red(error.message));
+    ui.writeLine(chalk.red(error.message), 'ERROR');
   } else {
-    ui.writeLine(chalk.red(error));
+    ui.writeLine(chalk.red(error), 'ERROR');
   }
 
   if (error.stack) {
-    ui.writeLine(error.stack);
+    ui.writeLine(error.stack, 'ERROR');
   }
 };


### PR DESCRIPTION
- [x] recent UI usage to display invalid packages doesn't use the correct UI https://github.com/ember-cli/ember-cli/commit/49b99728bf54dd6bf5acd96669a982dc5a8c7251#diff-3677132bf6240059b3a3637716019c84R537

[fixes #2423]