### PR TITLE
bump loader

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -5,7 +5,7 @@
     "ember": "1.10.0",
     "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
-    "loader.js": "ember-cli/loader.js#3.0.0",
+    "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",


### PR DESCRIPTION
now includes `alias`  @rwjblue / @ef4 this should be nicer then the current re-export thing we got going on.