### PR TITLE
Provide a helpful error when an addon does not have a template compiler.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -418,6 +418,15 @@ Addon.prototype.compileTemplates = function(tree) {
   this._requireBuildPackages();
 
   if (tree) {
+    var plugins = this.registry.load('template');
+    if (plugins.length === 0) {
+      throw new SilentError('An `addon/templates` tree was detected, but there ' +
+                            'are no template compilers registered for `' + this.name + '`. ' +
+                            'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
+                            'is listed in `dependencies` (NOT `devDependencies`) in ' +
+                            '`' + this.name + '`\'s `package.json`.');
+    }
+
     var standardTemplates = this.pickFiles(tree, {
       srcDir: '/',
       destDir: 'modules/' + this.name + '/templates'

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -413,4 +413,30 @@ describe('models/addon.js', function() {
       }).to.throw(/The `dummy-addon` addon could not be found at `foo\/bar-baz\/blah\/doesnt-exist`\./);
     });
   });
+
+  describe('compileTemplates', function() {
+    beforeEach(function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+      project.initializeAddons();
+
+      addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+    });
+
+    it('should throw a useful error if a template compiler is not present', function() {
+        var tree = path.join(fixturePath, 'simple');
+
+        expect(function() {
+          addon.compileTemplates(tree);
+        }).to.throw(
+          'An `addon/templates` tree was detected, but there ' +
+          'are no template compilers registered for `' + addon.name + '`. ' +
+          'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
+          'is listed in `dependencies` (NOT `devDependencies`) in ' +
+          '`' + addon.name + '`\'s `package.json`.'
+        );
+    });
+  });
 });


### PR DESCRIPTION
> An `addon/templates` tree was detected, but there are no template compilers
> registered for `my-addon-name`. Please make sure your template precompiler
> (commonly `ember-cli-htmlbars`) is listed in `dependencies` (NOT `devDependencies`) in
> `my-addon-name`'s `package.json`.'