### PR TITLE
Check which addon we are developing

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -21,6 +21,7 @@ var preprocessTemplates = p.preprocessTemplates;
 var AddonDiscovery  = require('../models/addon-discovery');
 var AddonsFactory   = require('../models/addons-factory');
 var CoreObject = require('core-object');
+var Project = require('./project');
 
 /**
   Root class for an Addon. If your addon module exports an Object this
@@ -154,7 +155,10 @@ Addon.prototype._unwatchedTreeGenerator = function unwatchedTree(dir) {
   @return {Boolean}
 */
 Addon.prototype.isDevelopingAddon = function() {
-  return process.env.EMBER_ADDON_ENV === 'development';
+  if (process.env.EMBER_ADDON_ENV === 'development' && (this.parent instanceof Project)) {
+    return this.parent.name() === this.name;
+  }
+  return false;
 };
 
 /**

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -319,9 +319,20 @@ describe('models/addon.js', function() {
     });
 
     describe('isDevelopingAddon', function() {
-      var originalEnvValue;
+      var originalEnvValue, addon, project;
 
       beforeEach(function() {
+        var MyAddon = Addon.extend({
+          name: 'test-project'
+        });
+
+        var projectPath = path.resolve(fixturePath, 'simple');
+        var packageContents = require(path.join(projectPath, 'package.json'));
+
+        project = new Project(projectPath, packageContents);
+
+        addon = new MyAddon(project);
+
         originalEnvValue = process.env.EMBER_ADDON_ENV;
       });
 
@@ -332,19 +343,26 @@ describe('models/addon.js', function() {
       it('returns true when `EMBER_ADDON_ENV` is set to development', function() {
         process.env.EMBER_ADDON_ENV = 'development';
 
-        expect(addon.isDevelopingAddon());
+        expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {
         delete process.env.EMBER_ADDON_ENV;
 
-        expect(!addon.isDevelopingAddon());
+        expect(addon.isDevelopingAddon()).to.eql(false);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is something other than `development`', function() {
         process.env.EMBER_ADDON_ENV = 'production';
 
-        expect(!addon.isDevelopingAddon());
+        expect(addon.isDevelopingAddon()).to.equal(false);
+      });
+
+      it('returns false when the addon is not the one being developed', function() {
+        process.env.EMBER_ADDON_ENV = 'development';
+
+        addon.name = 'my-addon';
+        expect(addon.isDevelopingAddon(), 'addon is not being developed').to.eql(false);
       });
     });
 


### PR DESCRIPTION
`isDevelopingAddon` now only returns `true` if it's the addon we're developing (instead of returning true for all addons). This will fix issues such as linting all addons instead of just the addon itself. 

I think a simpler `if(this.parent.name() === this.name)` would work instead of going through the addon discovery object, but I wasn't sure if we wanted to make this assumption (that the addon and project name will always be the same).