### PR TITLE
Use Ember.HTMLBars by default in new helpers.

### DIFF
--- a/blueprints/helper/files/app/helpers/__name__.js
+++ b/blueprints/helper/files/app/helpers/__name__.js
@@ -4,4 +4,4 @@ export function <%= camelizedModuleName %>(input) {
   return input;
 }
 
-export default Ember.Handlebars.makeBoundHelper(<%= camelizedModuleName %>);
+export default Ember.HTMLBars.makeBoundHelper(<%= camelizedModuleName %>);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -150,7 +150,7 @@ describe('Acceptance: ember generate', function() {
                   "export function fooBar(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBar);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
@@ -167,7 +167,7 @@ describe('Acceptance: ember generate', function() {
                   "export function fooBarBaz(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -285,7 +285,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBar(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBar);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
@@ -302,7 +302,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBar(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBar);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import {" + EOL +
@@ -319,7 +319,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBarBaz(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +
@@ -336,7 +336,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBarBaz(input) {" + EOL +
                   "  return input;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.Handlebars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import {" + EOL +


### PR DESCRIPTION
I assume this is the preferred way to go since Ember.Handlebars.makeBoundHelper is deprecated.

http://emberjs.com/api/classes/Ember.Handlebars.html#method_makeBoundHelper
http://emberjs.com/api/classes/Ember.HTMLBars.html#method_makeBoundHelper