### PR TITLE
Update ember-cli-qunit to 0.3.9.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.8",
+    "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2"


### PR DESCRIPTION
* Updates JSHint to 2.6.1 (via `broccoli-jshint@0.5.5`).
* Updates `broccoli-jshint` to 0.5.5 to allow specifying console functions.

---

Before:

```
% ember build --silent

app.js: line 6, col 1, Expected an assignment or function call and instead saw an expression.
app.js: line 6, col 6, Missing semicolon.

2 errors

===== 1 JSHint Error
```

After:

```
% ember build --silent
%
```