### PR TITLE
Fixing incorrect import of module: should import from qunit, not ember-qunit

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -56,7 +56,8 @@ Be sure to use the `module` function to invoke `beforeEach` and `afterEach`.
 
 {% highlight javascript linenos %}
 import Ember from "ember";
-import { module, test } from 'ember-qunit';
+import module from 'qunit';
+import test from 'ember-qunit';
 import startApp from '../helpers/start-app';
 var App;
 


### PR DESCRIPTION
As requested on irc, a pull request to update documentation on testing.

Not sure I'm editing the right files - here.  But best efforts given I'm not familiar with how the documentation pages are generated.