### PR TITLE
Pave the way for pod styles.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -411,13 +411,16 @@ EmberApp.prototype._filterAppTree = function() {
     return this._cachedFilterAppTree;
   }
 
-  var podPatterns = this._podTemplatePatterns();
-  var excludePatterns = podPatterns.concat([
-    // note: do not use path.sep here Funnel uses
-    // walk-sync which always joins with `/` (not path.sep)
-    new RegExp('^styles/'),
-    new RegExp('^templates/'),
-  ]);
+  var excludePatterns = [].concat(
+    this._podTemplatePatterns(),
+    this._podStylePatterns(),
+    [
+      // note: do not use path.sep here Funnel uses
+      // walk-sync which always joins with `/` (not path.sep)
+      new RegExp('^styles/'),
+      new RegExp('^templates/'),
+    ]
+  );
 
   return this._cachedFilterAppTree = new Funnel(this.trees.app, {
     exclude: excludePatterns,
@@ -543,6 +546,17 @@ EmberApp.prototype._processedTemplatesTree = function() {
 EmberApp.prototype._podTemplatePatterns = function() {
   return this.registry.extensionsForType('template').map(function(extension) {
     return new RegExp('template.' + extension + '$');
+  });
+};
+
+/**
+  @private
+  @method _podStylePatterns
+  @returns Array An array of regexp's for each known style extension.
+*/
+EmberApp.prototype._podStylePatterns = function() {
+  return this.registry.extensionsForType('css').map(function(extension) {
+    return new RegExp(extension + '$');
   });
 };
 
@@ -911,8 +925,14 @@ EmberApp.prototype.styles = function() {
     destDir: '/app/styles'
   });
 
-  var trees = [external].concat(addonTrees);
-  trees.push(styles);
+  var podStyles = new Funnel(this.trees.app, {
+    include: this._podStylePatterns(),
+    exclude: [ /^styles/ ],
+    destDir: '/app',
+    description: 'Funnel: Pod Styles'
+  });
+
+  var trees = [external].concat(addonTrees, podStyles, styles);
 
   var stylesAndVendor = mergeTrees(trees, {
     description: 'TreeMerger (stylesAndVendor)'


### PR DESCRIPTION
Prior to this, adding `foo.css` in `app/pods/my-foo/` would throw an error, this prevents it and allows an addon to make an intelligent decision on how to deal with these files (via a registry preprocessor).