### PR TITLE
Update documentation to support integration tests

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -56,7 +56,7 @@ Be sure to use the `module` function to invoke `beforeEach` and `afterEach`.
 
 {% highlight javascript linenos %}
 import Ember from "ember";
-import { module, test } from 'ember-qunit';
+import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 var App;
 


### PR DESCRIPTION
The documentation describes using `import { module, test } from 'ember-qunit'`, but this won't work, as `ember-qunit` doesn't have a `module` function. The syntax has been updated to use plain `qunit` instead.