### PR TITLE
[BUGFIX] fixes 'Error: EEXIST, file already exists' error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "findup": "0.1.5",
     "fs-extra": "0.12.0",
     "git-repo-info": "^1.0.2",
-    "glob": "4.0.5",
+    "glob": "^4.4.2",
     "http-proxy": "^1.6.2",
     "inflection": "^1.4.0",
     "inquirer": "0.5.1",


### PR DESCRIPTION
Fixes this issue 
[Error: EEXIST, file already exists  #3413](https://github.com/ember-cli/ember-cli/issues/3413)
by updating an invalid version of 'glob'.

Source:
`npm ls glob`  ->  `glob@4.0.5  invalid`

I am new to Github: Does this kind of change need a test? How would you test it?