### PR TITLE
[ENHANCEMENT] Prevent addon generation in existing ember-cli project

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -1,10 +1,12 @@
-var fs         = require('fs');
-var path       = require('path');
-var walkSync   = require('walk-sync');
-var stringUtil = require('../../lib/utilities/string');
-var assign     = require('lodash-node/modern/objects/assign');
-var uniq       = require('lodash-node/underscore/arrays/uniq');
-var date       = new Date();
+var fs          = require('fs');
+var path        = require('path');
+var walkSync    = require('walk-sync');
+var stringUtil  = require('../../lib/utilities/string');
+var assign      = require('lodash-node/modern/objects/assign');
+var uniq        = require('lodash-node/underscore/arrays/uniq');
+var Blueprint   = require('../../lib/models/blueprint');
+var SilentError = require('../../lib/errors/silent');
+var date        = new Date();
 
 module.exports = {
   description: 'The default blueprint for ember-cli addons.',
@@ -119,5 +121,15 @@ module.exports = {
     } else {
       return path.resolve(this._appBlueprint.path, 'files', file);
     }
+  },
+
+  normalizeEntityName: function(entityName) {
+    entityName = Blueprint.prototype.normalizeEntityName.apply(this, arguments);
+
+    if(this.project.isEmberCLIProject()) {
+      throw new SilentError('Generating an addon in an existing ember-cli project is not supported.');
+    }
+
+    return entityName;
   }
 };

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var Blueprint   = require('../../../lib/models/blueprint');
+var MockProject = require('../../helpers/mock-project');
+var expect      = require('chai').expect;
+
+describe('blueprint - addon', function(){
+  describe('entityName', function(){
+    var mockProject;
+
+    beforeEach(function() {
+      mockProject = new MockProject();
+      mockProject.isEmberCLIProject = function() { return true; };
+    });
+
+    afterEach(function() {
+      mockProject = null;
+    });
+
+    it('throws error when current project is an existing ember-cli project', function(){
+      var blueprint = Blueprint.lookup('addon');
+
+      blueprint.project = mockProject;
+
+      expect(function() {
+        blueprint.normalizeEntityName('foo');
+      }).to.throw('Generating an addon in an existing ember-cli project is not supported.');
+    });
+
+    it('keeps existing behavior by calling Blueprint.normalizeEntityName', function(){
+      var blueprint = Blueprint.lookup('addon');
+
+      blueprint.project = mockProject;
+
+      expect(function() {
+        var nonConformantComponentName = 'foo/';
+        blueprint.normalizeEntityName(nonConformantComponentName);
+      }).to.throw(/trailing slash/);
+    });
+  });
+});


### PR DESCRIPTION
This fixes #3411.

This commit prevents addon generation if the current project is an existing ember-cli project.

Any thoughts or feedback are welcome.