### PR TITLE
Update Broccoli to 0.13.6 to provide errors on new API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "abbrev": "^1.0.5",
     "bower": "^1.3.5",
     "bower-config": "0.5.2",
-    "broccoli": "0.13.3",
+    "broccoli": "0.13.6",
     "broccoli-caching-writer": "0.5.1",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "1.0.0",


### PR DESCRIPTION
We are preparing to update to the next major revision of Broccoli, and 0.13.6 provides an error if we discover a `rebuild` method.

Shortly after releasing 0.2.0 of ember-cli, we need to update to use Broccoli 0.15.0, which enables the new API.