### PR TITLE
Clarify the description of --filter option

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -17,7 +17,7 @@ module.exports = Command.extend({
     { name: 'config-file', type: String,  default: './testem.json', aliases: ['c', 'cf'] },
     { name: 'server',      type: Boolean, default: false, aliases: ['s'] },
     { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.', aliases: ['p'] },
-    { name: 'filter',      type: String,  description: 'A regex to filter tests ran', aliases: ['f'] },
+    { name: 'filter',      type: String,  description: 'A string to filter tests to run', aliases: ['f'] },
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
   ],


### PR DESCRIPTION
The given value is not interpreted as an regex, but a case-insensitive
substring search in `module.name + ": " + testName` is used.

You might negate the match using an exclamation mark as the first
letter, e.g. `--filter '!foo'` will run all tests *except* those
containing the word "foo".