### PR TITLE
Enforcing newlines in template files results in unwanted Nodes

### DIFF
--- a/blueprints/app/files/.editorconfig
+++ b/blueprints/app/files/.editorconfig
@@ -18,6 +18,7 @@ indent_style = space
 indent_size = 2
 
 [*.hbs]
+insert_final_newline = false
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
The default `.editorconfig` of Ember CLI tells an editor to append new lines to the end of files on write. This can cause surprising behavior when I do not see a new line at the end of my template file, but my rendered component has an extra `Text` node containing a new line at the end of it.

Appending a newline seems fine for any file that's not a template file, but it can be problematic when applied to templates.