### PR TITLE
Update app blueprint to use ember-cli-app-version 0.3.2

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-app-version": "0.3.1",
+    "ember-cli-app-version": "0.3.2",
     "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",


### PR DESCRIPTION
ember-cli-app-version@0.3.2 includes git-repo-version@0.2.0

Here is diff of changes: https://github.com/embersherpa/ember-cli-app-version/compare/717c295386062607792b8b0b8ce5c1b252871096...master