### PR TITLE
[ENHANCEMENT]: set filter param toLowerCase

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -68,7 +68,7 @@ module.exports = Command.extend({
     }
 
     if (options.filter) {
-      params.push('filter=' + options.filter);
+      params.push('filter=' + options.filter.toLowerCase());
     }
 
     return params.join('&');

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -166,6 +166,14 @@ describe('test command', function() {
       expect(contents['test_page']).to.be.equal('tests/index.html?module=fooModule&filter=bar');
     });
 
+    it('when provided filter is all lowercase to match the test name', function() {
+      runOptions.filter = 'BAR';
+      var newPath = command._generateCustomConfigFile(runOptions);
+      var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
+
+      expect(contents['test_page']).to.be.equal('tests/index.html?filter=bar');
+    });
+
     it('when module and filter option is present uses buildTestPageQueryString for test_page queryString', function() {
       runOptions.filter = 'bar';
       command.buildTestPageQueryString = function(options) {


### PR DESCRIPTION
When I use a filter, I have to make it all lower case as I'm assuming testem will lower case my test name from "Bar foo" to "bar foo". When I am attempting to filter and copy the test name "Bar foo", it will not find the test.

Please let me know if there is a better place or a different way to handle this scenario.

Thanks!