### PR TITLE
disable visual progress effect in dumb terminals

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -66,7 +66,7 @@ function cli(options) {
   var ui = new UI({
     inputStream:  options.inputStream,
     outputStream: options.outputStream,
-    ci:           process.env.CI,
+    ci:           process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
     writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
   });
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -542,7 +542,7 @@ function ensureUI(_ui) {
     ui = new UI({
       inputStream:  process.stdin,
       outputStream: process.stdout,
-      ci:           process.env.CI,
+      ci:           process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
       writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
     });
   }


### PR DESCRIPTION
Disables visual progress indicators in dumb terminals such as editor buffers which don't support terminal cursor movement. They configure the environment with `TERM=dumb` and in the case of emacs it configures the environment with `TERM=emacs` in compilation mode.