### PR TITLE
Ensure that removing a missing entry from the registry works properly.

### DIFF
--- a/lib/models/registry.js
+++ b/lib/models/registry.js
@@ -33,17 +33,25 @@ Registry.prototype.extensionsForType = function(type) {
     return memo.concat(plugin.ext);
   }, [type]);
 
-  return require('lodash-node/underscore/arrays/uniq')(extensions);
+  extensions = require('lodash-node/underscore/arrays/uniq')(extensions);
+
+  debug('extensions for type %s: %s', type, extensions);
+
+  return extensions;
 };
 
 Registry.prototype.load = function(type) {
-  var plugins = this.registeredForType(type).map(function(plugin) {
+  var knownPlugins = this.registeredForType(type);
+  var plugins = knownPlugins.map(function(plugin) {
     if(this.instantiatedPlugins.indexOf(plugin) > -1 || this.availablePlugins.hasOwnProperty(plugin.name)) {
       return plugin;
     }
-  }.bind(this));
+  }.bind(this))
+  .filter(Boolean);
 
-  return plugins.filter(Boolean);
+  debug('loading %s: available plugins %s; found plugins %s;', type, knownPlugins.map(function(p) { return p.name; }), plugins.map(function(p) { return p.name; }));
+
+  return plugins;
 };
 
 Registry.prototype.registeredForType = function(type) {
@@ -51,8 +59,6 @@ Registry.prototype.registeredForType = function(type) {
 };
 
 Registry.prototype.add = function(type, name, extension, options) {
-  debug('add type: %s, name: %s, extension:%s, options:%s', type, name, extension, options);
-
   var registered = this.registeredForType(type);
   var plugin, PluginType;
 
@@ -69,32 +75,37 @@ Registry.prototype.add = function(type, name, extension, options) {
     plugin = new PluginType(name, extension, options);
   }
 
+  debug('add type: %s, name: %s, extension:%s, options:%s', type, plugin.name, plugin.ext, options);
+
   registered.push(plugin);
 };
 
-Registry.prototype.remove = function(type, name) {
+Registry.prototype.remove = function(type /* name */) {
+  var registered = this.registeredForType(type);
+  var registeredIndex, name;
+
+  if (typeof arguments[1] === 'object') {
+    name = arguments[1].name;
+  } else {
+    name = arguments[1];
+  }
+
   debug('remove type: %s, name: %s', type, name);
 
-  var registered = this.registeredForType(type);
-  var registeredIndex, instantiatedPluginIndex;
-
-  // plugin is being added directly do not instantiate it
-  if (typeof name === 'object') {
-    instantiatedPluginIndex = this.instantiatedPlugins.indexOf(name);
-    registeredIndex = registered.indexOf(name);
-
-    if (instantiatedPluginIndex !== -1) {
-      this.instantiatedPlugins.splice(instantiatedPluginIndex, 1);
-    }
-  } else {
-    for (var i = 0, l = registered.length; i < l; i++) {
-      if (registered[i].name === name) {
-        registeredIndex = i;
-      }
+  for (var i = 0, l = registered.length; i < l; i++) {
+    if (registered[i].name === name) {
+      registeredIndex = i;
     }
   }
 
-  if (registeredIndex !== -1) {
+  var plugin = registered[registeredIndex];
+  var instantiatedPluginIndex = this.instantiatedPlugins.indexOf(plugin);
+
+  if (instantiatedPluginIndex > -1) {
+    this.instantiatedPlugins.splice(instantiatedPluginIndex, 1);
+  }
+
+  if (registeredIndex !== undefined && registeredIndex > -1) {
     registered.splice(registeredIndex, 1);
   }
 };

--- a/lib/preprocessors.js
+++ b/lib/preprocessors.js
@@ -3,6 +3,7 @@
 var path         = require('path');
 var Registry     = require('./models/registry');
 var requireLocal = require('./utilities/require-local');
+var debug = require('debug')('ember-cli:preprocessors');
 
 /**
   Invokes the `setupRegistryForEachAddon('parent', registry)` hook for each of the parent objects addons.
@@ -157,6 +158,8 @@ module.exports.preprocessTemplates = function(/* tree */) {
   var options = arguments[arguments.length - 1];
   var plugins = options.registry.load('template');
 
+  debug('plugins found for templates: %s', plugins.map(function(p) { return p.name; }));
+
   if (plugins.length === 0) {
     throw new Error('Missing template processor');
   }
@@ -179,6 +182,7 @@ function processPlugins(plugins, args) {
   var tree = args.shift();
 
   plugins.forEach(function(plugin) {
+    debug('processing %s', plugin.name);
     tree = plugin.toTree.apply(plugin, [tree].concat(args));
   });
 

--- a/tests/unit/models/registry-test.js
+++ b/tests/unit/models/registry-test.js
@@ -156,4 +156,32 @@ describe('Plugin Loader', function() {
     plugins = registry.load('foo');
     expect(plugins.length).to.equal(0);
   });
+
+  it('an unfound item does not affect the registered list', function() {
+    var plugins;
+
+    function pluginNames(plugins) {
+      return plugins.map(function(p) { return p.name; });
+    }
+
+    registry.availablePlugins['blah-zorz'] = 'latest';
+    registry.availablePlugins['blammo'] = 'latest';
+
+    registry.add('foo', 'blah-zorz', 'zorz');
+    registry.add('foo', 'blammo', 'blam');
+
+    plugins = registry.load('foo');
+
+    expect(pluginNames(plugins)).to.eql(['blah-zorz', 'blammo']); // precondition
+
+    registry.remove('foo', 'nothing I know');
+    plugins = registry.load('foo');
+
+    expect(pluginNames(plugins)).to.eql(['blah-zorz', 'blammo']);
+
+    registry.remove('foo', 'blah-zorz');
+    plugins = registry.load('foo');
+
+    expect(pluginNames(plugins)).to.eql(['blammo']);
+  });
 });


### PR DESCRIPTION
Previously, calling `registry.remove` on a non-existing (or unfound) item resulted in the last item for a given type being removed.

Basically because of:

```javascript
['a','b'].splice(undefined, 1)
// => ["a"]
```

Fixes #3396.