### PR TITLE
Removes initializer mention from service generator help text

### DIFF
--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: 'Generates a service and initializer for injections.'
+  description: 'Generates a service.'
 };


### PR DESCRIPTION
As of 2ea101c, an initializer is no longer automatically created when running the `service` generator.