### PR TITLE
Component blueprint only import layout when generated inside addon

### DIFF
--- a/blueprints/component/files/__root__/__path__/__name__.js
+++ b/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,6 +1,4 @@
 import Ember from 'ember';
-import layout from '<%= templatePath %>';
-
-export default Ember.Component.extend({
-  layout: layout
+<%= importTemplate %>
+export default Ember.Component.extend({<%= contents %>
 });

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -42,13 +42,19 @@ module.exports = {
   },
 
   locals: function(options) {
-    var templatePath = '../templates/components/' + stringUtil.dasherize(options.entity.name);
-
-    if (options.pod) {
-      templatePath = './template';
+    var templatePath   = '';
+    var importTemplate = '';
+    var contents       = '';
+    // if we're in an addon, build import statement
+    if (options.project.isEmberCLIAddon()) {
+      templatePath = options.pod ? './template' : '../templates/components/' + stringUtil.dasherize(options.entity.name);
+      importTemplate = 'import layout from \'' + templatePath + '\';\n';
+      contents = '\n  layout: layout';
     }
+
     return {
-      templatePath: templatePath
+      importTemplate: importTemplate,
+      contents: contents
     };
   }
 };

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -122,9 +122,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('app/components/x-foo.js', {
         contains: [
           "import Ember from 'ember';",
-          "import layout from '../templates/components/x-foo';",
           "export default Ember.Component.extend({",
-          "layout: layout",
           "});"
         ]
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -151,9 +151,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/components/x-foo/component.js', {
         contains: [
           "import Ember from 'ember';",
-          "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
           "});"
         ]
       });
@@ -257,9 +255,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/components/x-foo/component.js', {
         contains: [
           "import Ember from 'ember';",
-          "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
           "});"
         ]
       });
@@ -283,9 +279,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/components/x-foo/component.js', {
         contains: [
           "import Ember from 'ember';",
-          "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
           "});"
         ]
       });


### PR DESCRIPTION
This PR removes the layout import statement when generating components in a regular project. Still has import statement when generating inside an addon project.

This issue was found as part of https://github.com/ember-cli/ember-cli/issues/3472

Need to add/update tests still.