### PR TITLE
ENHANCEMENT: update-checker.js should use environment http_proxy if detected

### DIFF
--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -66,7 +66,7 @@ UpdateChecker.prototype.doCheck = function() {
 UpdateChecker.prototype.checkNPM = function() {
   // use npm to determine the currently availabe ember-cli version
   var loadNPM = Promise.denodeify(require('npm').load);
-  var getEmberCliVersion = function(npm){
+  var fetchEmberCliVersion = function(npm){
     return Promise.denodeify(npm.commands.view)(['ember-cli', 'version']);
   };
   var extractVersion = function(data) { return Object.keys(data)[0]; };
@@ -77,9 +77,14 @@ UpdateChecker.prototype.checkNPM = function() {
       'cache-min': 1,
       'cache-max': 0
     })
-    .then(getEmberCliVersion)
+    .then(fetchEmberCliVersion)
     .then(extractVersion)
-    .then(this.saveVersionInformation.bind(this));
+    .then(this.saveVersionInformation.bind(this))
+    .catch(function(){
+      this.ui.writeLine(chalk.red('An error occurred while checking for Ember CLI updates. ' +
+        'Please verify your internet connectivity and npm configurations.'));
+      return false;
+    }.bind(this));
 };
 
 UpdateChecker.prototype.saveVersionInformation = function(version) {

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -64,25 +64,32 @@ UpdateChecker.prototype.doCheck = function() {
 };
 
 UpdateChecker.prototype.checkNPM = function() {
-  // make an http call to npm to get the latest version
-  var http = require('http');
-  var concat = require('concat-stream');
+  // use npm to determine the currently availabe ember-cli version
+  var npm = require('npm'),
+      npmViewConfig = {
+        'loglevel': 'silent',
+        'fetch-retries': 1,
+        'cache-min': 1,
+        'cache-max': 0
+      };
 
   return new Promise(function(resolve, reject) {
-    http.get('http://registry.npmjs.org/ember-cli/latest', function(res) {
-      res.setEncoding('utf8');
-
-      res.pipe(concat(function (data) {
-        try {
-          resolve(JSON.parse(data).version);
-        } catch(error) {
-          reject(error);
-        }
-      }));
-
-      res.on('error', reject);
+    npm.load(npmViewConfig, function(err) {
+      if (!err) {
+        npm.commands.view(['ember-cli', 'version'], function(err, data) {
+          if (!err) {
+            resolve(Object.keys(data)[0]);
+          }
+          else {
+            reject(err);
+          }
+        });
+      }
+      else {
+        reject(err);
+      }
     });
-  }).then(function(version) {
+  }.then(function(version) {
     // we only want to save the version information when we check NPM
     return this.saveVersionInformation(version);
   }.bind(this)).catch(function(error) {

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -65,37 +65,28 @@ UpdateChecker.prototype.doCheck = function() {
 
 UpdateChecker.prototype.checkNPM = function() {
   // use npm to determine the currently availabe ember-cli version
-  var npm = require('npm'),
-      npmViewConfig = {
-        'loglevel': 'silent',
-        'fetch-retries': 1,
-        'cache-min': 1,
-        'cache-max': 0
-      };
+  var loadNPM = Promise.denodeify(require('npm').load);
+  var getEmberCliVersion = function(npm){
+    return Promise.denodeify(npm.commands.view)(['ember-cli', 'version']);
+  };
+  var extractVersion = function(data) { return Object.keys(data)[0]; };
 
-  return new Promise(function(resolve, reject) {
-    npm.load(npmViewConfig, function(err) {
-      if (!err) {
-        npm.commands.view(['ember-cli', 'version'], function(err, data) {
-          if (!err) {
-            resolve(Object.keys(data)[0]);
-          }
-          else {
-            reject(err);
-          }
-        });
-      }
-      else {
-        reject(err);
-      }
-    });
-  }.then(function(version) {
-    // we only want to save the version information when we check NPM
-    return this.saveVersionInformation(version);
-  }.bind(this)).catch(function(error) {
-    this.ui.writeLine('There was an error checking NPM for an update: ' + error);
-    throw error;
-  }.bind(this));
+  return loadNPM({
+      'loglevel': 'silent',
+      'fetch-retries': 1,
+      'cache-min': 1,
+      'cache-max': 0
+    })
+    .then(getEmberCliVersion)
+    .then(extractVersion)
+    .then(function(version) {
+      // we only want to save the version information when we check NPM
+      return this.saveVersionInformation(version);
+    }.bind(this))
+    .catch(function(error) {
+      this.ui.writeLine('There was an error checking NPM for an update: ' + error);
+      throw error;
+    }.bind(this));
 };
 
 UpdateChecker.prototype.saveVersionInformation = function(version) {

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -79,14 +79,7 @@ UpdateChecker.prototype.checkNPM = function() {
     })
     .then(getEmberCliVersion)
     .then(extractVersion)
-    .then(function(version) {
-      // we only want to save the version information when we check NPM
-      return this.saveVersionInformation(version);
-    }.bind(this))
-    .catch(function(error) {
-      this.ui.writeLine('There was an error checking NPM for an update: ' + error);
-      throw error;
-    }.bind(this));
+    .then(this.saveVersionInformation.bind(this));
 };
 
 UpdateChecker.prototype.saveVersionInformation = function(version) {


### PR DESCRIPTION
I am working behind corporate proxy and every command I provide to ember-cli (except test & update) result in an error without ability to proceed/recover.