### PR TITLE
Updated the relative vs absolute path statement to be a little less opinionated about which is preferred

### DIFF
--- a/_posts/2014-04-02-using-modules-and-the-resolver.md
+++ b/_posts/2014-04-02-using-modules-and-the-resolver.md
@@ -61,10 +61,9 @@ You can also require modules directly with the following syntax:
 import FooMixin from "./mixins/foo";
 {% endhighlight %}
 
-If you like you can reference a module by an absolute path, but keep in
-mind that using relative paths is considered best practice for accessing modules
-within the same package. To reference a module using an absolute path begin
-the path with the name defined in `package.json`:
+You can reference a module by using either a relative or absolute path.
+If you would like to reference a module using absolute begin
+the path with the app name defined in `package.json`:
 
 {% highlight javascript linenos %}
 import FooMixin from "appname/mixins/foo";


### PR DESCRIPTION
This updates the documentation about whether relative or absolute pathing makes sense when you're importing modules. 

Addresses #3482