### PR TITLE
[BUGFIX] Fixes nested component generation in addons with correct relative path for template import

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -47,9 +47,14 @@ module.exports = {
     var contents       = '';
     // if we're in an addon, build import statement
     if (options.project.isEmberCLIAddon()) {
-      templatePath = options.pod ? './template' : '../templates/components/' + stringUtil.dasherize(options.entity.name);
-      importTemplate = 'import layout from \'' + templatePath + '\';\n';
-      contents = '\n  layout: layout';
+      if(options.pod) {
+        templatePath   = './template'
+      } else {
+        templatePath   = getPathLevel(options.entity.name) +
+          'templates/components/' + stringUtil.dasherize(options.entity.name);
+      }
+      importTemplate   = 'import layout from \'' + templatePath + '\';\n';
+      contents         = '\n  layout: layout';
     }
 
     return {
@@ -58,3 +63,7 @@ module.exports = {
     };
   }
 };
+
+function getPathLevel(name) {
+  return new Array(name.split('/').length + 1).join('../');
+}

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1211,6 +1211,38 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('in-addon component nested/x-foo', function() {
+    return generateInAddon(['component', 'nested/x-foo']).then(function() {
+      assertFile('addon/components/nested/x-foo.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "import layout from '../../templates/components/nested/x-foo';",
+          "export default Ember.Component.extend({",
+          "layout: layout",
+          "});"
+        ]
+      });
+      assertFile('addon/templates/components/nested/x-foo.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('app/components/nested/x-foo.js', {
+        contains: [
+          "import nestedXFoo from 'my-addon/components/nested/x-foo';",
+          "export default nestedXFoo;"
+        ]
+      });
+      assertFile('tests/unit/components/nested/x-foo-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('nested/x-foo'"
+        ]
+      });
+    });
+  });
+
   it('availableOptions work with aliases.', function() {
     return generate(['route', 'foo', '-resource']).then(function() {
       assertFile('app/router.js', {


### PR DESCRIPTION
This PR fixes #3514

Generating nested components inside of an addon was not taking into account the path depth when generating the template import path.