### PR TITLE
Use node 0.12 on Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,14 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
 
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
   # Install PhantomJS
-  - cinst PhantomJS -Version 1.9.8
+  - cinst PhantomJS -y -Version 1.9.8
   - set path=%path%;C:\tools\PhantomJS\
   - dir C:\tools\PhantomJS
   # Typical npm stuff.


### PR DESCRIPTION
Use node 0.12 on Windows CI and fix chocolatey install deprecation

According to the README node 0.12 is preferred and finally fixed https://github.com/joyent/node/issues/3584, which hides mocha failures in some cases