### PR TITLE
[fixes #3520, #3174] disable ES3SafeFilter if babel is present, as babel...

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -773,7 +773,7 @@ EmberApp.prototype.appAndDependencies = function() {
   var templates = this._processedTemplatesTree();
   var config    = this._configTree();
 
-  if (this.options.es3Safe) {
+  if (!this.registry.availablePlugins['ember-cli-babel'] && this.options.es3Safe) {
     app = new ES3SafeFilter(app);
   }
 


### PR DESCRIPTION
... does it for us.

* should be faster initial builds
* more sensible experience.