### PR TITLE
[ENHANCEMENT] Add podModulePrefix deprecation for generate and destroy commands

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -28,6 +28,7 @@ resolve('ember-cli', {
     inputStream: process.stdin,
     outputStream: process.stdout
   }).then(function(result) {
-    exit(result && result.exitCode || result);
+    var exitCode = typeof result === 'object' ? result.exitCode : result;
+    exit(exitCode);
   });
 });

--- a/bin/ember
+++ b/bin/ember
@@ -27,5 +27,7 @@ resolve('ember-cli', {
     cliArgs: process.argv.slice(2),
     inputStream: process.stdin,
     outputStream: process.stdout
-  }).then(exit);
+  }).then(function(result) {
+    exit(result && result.exitCode || result);
+  });
 });

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,7 +4,7 @@
     "jquery": "^1.11.1",
     "ember": "1.10.0",
     "ember-data": "1.0.0-beta.15",
-    "ember-resolver": "~0.1.13",
+    "ember-resolver": "~0.1.14",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,7 +4,7 @@
     "jquery": "^1.11.1",
     "ember": "1.10.0",
     "ember-data": "1.0.0-beta.15",
-    "ember-resolver": "~0.1.12",
+    "ember-resolver": "~0.1.13",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -86,13 +86,10 @@ CLI.prototype.run = function(environment) {
       // Possibly this issue: https://github.com/joyent/node/issues/8329
       // Wait to resolve promise when running on windows.
       // This ensures that stdout is flushed so acceptance tests get full output
-      var result = exitCode;
-      if (this.testing) {
-        result = {
-          exitCode: exitCode,
-          ui: this.ui
-        };
-      }
+      var result = {
+        exitCode: exitCode,
+        ui: this.ui
+      };
       return new Promise(function(resolve) {
         if (process.platform === 'win32') {
           setTimeout(resolve, 250, result);

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -86,14 +86,21 @@ CLI.prototype.run = function(environment) {
       // Possibly this issue: https://github.com/joyent/node/issues/8329
       // Wait to resolve promise when running on windows.
       // This ensures that stdout is flushed so acceptance tests get full output
+      var result = exitCode;
+      if (this.testing) {
+        result = {
+          exitCode: exitCode,
+          ui: this.ui
+        };
+      }
       return new Promise(function(resolve) {
         if (process.platform === 'win32') {
-          setTimeout(resolve, 250, exitCode);
+          setTimeout(resolve, 250, result);
         } else {
-          resolve(exitCode);
+          resolve(result);
         }
       });
-    });
+    }.bind(this));
 
   }.bind(this)).catch(this.logError.bind(this));
 };

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -29,7 +29,7 @@ var removeFile    = Promise.denodeify(fs.remove);
 var SilentError   = require('../errors/silent');
 var CoreObject    = require('core-object');
 var EOL           = require('os').EOL;
-var deprecate     = require('../utilities/deprecate');
+var deprecateUI   = require('../utilities/deprecate').deprecateUI;
 
 module.exports = Blueprint;
 
@@ -340,7 +340,7 @@ Blueprint.prototype.install = function(options) {
   this.testing = options.testing;
   this.pod     = options.pod;
   this.hasPath = hasPathToken(this.files());
-  deprecate('`usePodsByDefault` is no longer supported in \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.', this.project.config().usePodsByDefault);
+  
   var actions = {
     write: function(info) {
       ui.writeLine('  ' + chalk.green('create') + ' ' + info.displayPath);
@@ -381,6 +381,8 @@ Blueprint.prototype.install = function(options) {
     }
   }
 
+  podDeprecations(this.project.config(), this.ui);
+  
   ui.writeLine('installing');
 
   if (dryRun) {
@@ -417,9 +419,6 @@ Blueprint.prototype.uninstall = function(options) {
   this.pod        = options.pod;
   this.hasPath    = hasPathToken(this.files());
 
-  if (this.project.config().usePodsByDefault) {
-    deprecate('`usePodsByDefault` is no longer supported in \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.', this.project.config().usePodsByDefault);
-  }
   var actions = {
     remove: function(info) {
       ui.writeLine('  ' + chalk.red('remove') + ' ' + info.displayPath);
@@ -439,6 +438,8 @@ Blueprint.prototype.uninstall = function(options) {
     }
   }
 
+  podDeprecations(this.project.config(), this.ui);
+  
   ui.writeLine('uninstalling');
 
   if (dryRun) {
@@ -1283,4 +1284,13 @@ function generateLookupPaths(lookupPaths) {
 */
 function hasPathToken(files) {
   return files.join().match(/__path__/);
+}
+
+function podDeprecations(config, ui){
+  var podModulePrefix = config.podModulePrefix || '';
+  var podPath = podModulePrefix.substr(podModulePrefix.lastIndexOf('/') + 1);
+  deprecateUI(ui)('`usePodsByDefault` is no longer supported in \'config/environment.js\','+
+    ' use `usePods` in \'.ember-cli\' instead.', config.usePodsByDefault);
+  deprecateUI(ui)('`podModulePrefix` is deprecated and will be removed from future versions of ember-cli.'+
+    ' Please move existing pods from \'app/' + podPath + '/\' to \'app/\'.', config.podModulePrefix);
 }

--- a/lib/utilities/deprecate.js
+++ b/lib/utilities/deprecate.js
@@ -4,6 +4,14 @@ var chalk = require('chalk');
 
 module.exports = function(message, test) {
   if(!test) { return; }
-
+  
   console.log(chalk.yellow('DEPRECATION: ' + message));
+};
+
+module.exports.deprecateUI = function(ui){
+  return function(message, test) {
+    if(!test) { return; }
+
+    ui.writeLine(chalk.yellow('DEPRECATION: ' + message));
+  };
 };

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -128,7 +128,7 @@ describe('Acceptance: ember destroy pod', function() {
         assertFilesNotExist(files);
       });
   }
-
+  
   function assertDestroyAfterGenerateInAddon(args, files) {
     return initAddon()
       .then(function() {
@@ -142,6 +142,28 @@ describe('Acceptance: ember destroy pod', function() {
       })
       .then(function() {
         assertFilesNotExist(files);
+      });
+  }
+  
+  function destroyAfterGenerateWithPodsByDefault(args) {
+    return initApp()
+      .then(function() {
+        replaceFile('config/environment.js', "var ENV = {", "var ENV = {" + EOL + "usePodsByDefault: true, " + EOL);
+        return generate(args);
+      })
+      .then(function() {
+        return destroy(args);
+      });
+  }
+  
+  function destroyAfterGenerate(args) {
+    return initApp()
+      .then(function() {
+        replaceFile('config/environment.js', "var ENV = {", "var ENV = {" + EOL + "podModulePrefix: 'app/pods', " + EOL);
+        return generate(args);
+      })
+      .then(function() {
+        return destroy(args);
       });
   }
 
@@ -611,6 +633,21 @@ describe('Acceptance: ember destroy pod', function() {
       .then(function() {
         assertFilesNotExist(files);
       });
+  });
+  
+  it('podModulePrefix deprecation warning', function() {
+    return destroyAfterGenerate(['controller', 'foo', '--pod']).then(function(result) {
+      expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
+      " removed from future versions of ember-cli. Please move existing pods from"+
+      " 'app/pods/' to 'app/'.");
+    });
+  });
+  
+  it('usePodsByDefault deprecation warning', function() {
+    return destroyAfterGenerateWithPodsByDefault(['controller', 'foo', '--pod']).then(function(result) {
+      expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+
+        ' \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.');
+    });
   });
 
 });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -88,7 +88,16 @@ describe('Acceptance: ember generate pod', function() {
       return ember(generateArgs);
     });
   }
+  
+  function generateWithUsePodsDeprecated(args) {
+    var generateArgs = ['generate'].concat(args);
 
+    return initApp().then(function() {
+      replaceFile('config/environment.js', "var ENV = {", "var ENV = {" + EOL + "usePodsByDefault: true, " + EOL);
+      return ember(generateArgs);
+    });
+  }
+  
   function initAddon() {
     return ember([
       'addon',
@@ -1535,6 +1544,21 @@ describe('Acceptance: ember generate pod', function() {
           contains: 'custom: true'
         });
       });
+  });
+  
+  it('podModulePrefix deprecation warning', function() {
+    return generateWithPrefix(['controller', 'foo', '--pod']).then(function(result) {
+      expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
+      " removed from future versions of ember-cli. Please move existing pods from"+
+      " 'app/pods/' to 'app/'.");
+    });
+  });
+  
+  it('usePodsByDefault deprecation warning', function() {
+    return generateWithUsePodsDeprecated(['controller', 'foo', '--pod']).then(function(result) {
+      expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+
+        ' \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.');
+    });
   });
 
   it('route foo --dry-run --pod does not change router.js', function() {


### PR DESCRIPTION
This PR fulfills #3424 by adding deprecation warnings for generate and destroy commands, as well as bumping the ember-resolver version to 0.1.14.

The deprecation warnings were not using the ui, so I added an additional version of deprecate that allows you to pass the ui in. I also changed `cli.run()` so it returns an object containing the ui so we can now check the ui inside of acceptance tests. So now inside any ember-cli acceptance test you need to check the ui output by doing the following:
```js
it('outputs ui text', function() {
  ember(['new','my-app']).then(function(result){
    expect(result.ui.output).to.include('new');
  });
});
```