### PR TITLE
dist can be watched, it really is just tmp that matters. This prevents p...

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -73,8 +73,6 @@ module.exports = Task.extend({
         fs.mkdirsSync(outputPath);
       }
 
-      attemptNeverIndex(outputPath);
-
       resolve(cpd.sync(inputPath, outputPath));
     });
   },


### PR DESCRIPTION
...eople from deploying this strange file by mistake.