### PR TITLE
Added babel to addons package.json dependencies by default

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -19,13 +19,17 @@ module.exports = {
     contents.name = this.project.name();
     contents.description = this.description;
     contents.keywords = contents.keywords || [];
+    contents.dependencies = contents.dependencies || {}
+    // npm doesn't like it when we have something in both deps and devDeps
+    // and dummy app still uses it when in deps
+    contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];
+    delete contents.devDependencies['ember-cli-babel'];
 
     if (contents.keywords.indexOf('ember-addon') === -1) {
       contents.keywords.push('ember-addon');
     }
 
     contents['ember-addon'] = contents['ember-addon'] || {};
-
     contents['ember-addon'].configPath = 'tests/dummy/config';
 
     fs.writeFileSync(path.join(this.path, 'files', 'package.json'), JSON.stringify(contents, null, 2));


### PR DESCRIPTION
From discussions over at #3556, I don't see any real harm in giving this to addons by default since they don't *have* to use babel syntax and if they truly care, they can simply remove it from them package.json, just like many do for content-security-policy, among others. Good defaults--that's the "ember way"

I think creating options/flags is overcomplicating things. At least as a first pass. If someone wants to add a flag to exclude it, that's cool sugar.

*I would love to write a test for this, but would require some decent refactoring and/or using [mock-fs](https://www.npmjs.com/package/mock-fs) or something. The current addon package.json isn't being tested, I vote get this out then I have cycles to pair with Robert or Stef to refactor so we can test these sort of things, if they'd like.