### PR TITLE
[BUGFIX] temporarily disable podModulePrefix deprecation

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,7 +4,7 @@
     "jquery": "^1.11.1",
     "ember": "1.10.0",
     "ember-data": "1.0.0-beta.16",
-    "ember-resolver": "~0.1.14",
+    "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1287,10 +1287,13 @@ function hasPathToken(files) {
 }
 
 function podDeprecations(config, ui){
+  /*
   var podModulePrefix = config.podModulePrefix || '';
   var podPath = podModulePrefix.substr(podModulePrefix.lastIndexOf('/') + 1);
-  deprecateUI(ui)('`usePodsByDefault` is no longer supported in \'config/environment.js\','+
-    ' use `usePods` in \'.ember-cli\' instead.', config.usePodsByDefault);
+  // Disabled until we are ready to deprecate podModulePrefix
   deprecateUI(ui)('`podModulePrefix` is deprecated and will be removed from future versions of ember-cli.'+
     ' Please move existing pods from \'app/' + podPath + '/\' to \'app/\'.', config.podModulePrefix);
+  */
+  deprecateUI(ui)('`usePodsByDefault` is no longer supported in \'config/environment.js\','+
+    ' use `usePods` in \'.ember-cli\' instead.', config.usePodsByDefault);
 }

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -635,7 +635,8 @@ describe('Acceptance: ember destroy pod', function() {
       });
   });
   
-  it('podModulePrefix deprecation warning', function() {
+  // Skip until podModulePrefix is deprecated
+  it.skip('podModulePrefix deprecation warning', function() {
     return destroyAfterGenerate(['controller', 'foo', '--pod']).then(function(result) {
       expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
       " removed from future versions of ember-cli. Please move existing pods from"+

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1546,7 +1546,8 @@ describe('Acceptance: ember generate pod', function() {
       });
   });
   
-  it('podModulePrefix deprecation warning', function() {
+  // Skip until podModulePrefix is deprecated
+  it.skip('podModulePrefix deprecation warning', function() {
     return generateWithPrefix(['controller', 'foo', '--pod']).then(function(result) {
       expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
       " removed from future versions of ember-cli. Please move existing pods from"+


### PR DESCRIPTION
Temporarily disabling the `podModulePrefix` deprecation warning (#3424) until we have an agreed upon solution for pods in ember-cli.

- [x] bump the ember-resolver version to include the disabled deprecation warnings there.