### PR TITLE
Fix not setting of base tag when locationType is 'hash'.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1258,8 +1258,7 @@ EmberApp.prototype.contentFor = function(config, match, type) {
   @return {String}        Base tag or empty string
  */
 function calculateBaseTag(config){
-  var baseURL      = cleanBaseURL(config.baseURL);
-  var locationType = config.locationType;
+  var baseURL = cleanBaseURL(config.baseURL);
 
   if (baseURL) {
     return '<base href="' + baseURL + '" />';

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1261,10 +1261,6 @@ function calculateBaseTag(config){
   var baseURL      = cleanBaseURL(config.baseURL);
   var locationType = config.locationType;
 
-  if (locationType === 'hash') {
-    return '';
-  }
-
   if (baseURL) {
     return '<base href="' + baseURL + '" />';
   } else {


### PR DESCRIPTION
Should resolve this issue: https://github.com/ember-cli/ember-cli/issues/2957

This is a issue surfaces when you have a Rails backend that serves up multiple Ember apps at different subdirectories. The Ember app needs to be aware of it's `baseURL` so that it can grab the correct set of assets and it needs `locationType = 'hash'` because the Rails router will grab all of the URL changes before Ember's router.