### PR TITLE
[BREAKING ENHANCEMENT] Update ember-cli-content-security-policy to v0.4.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-babel": "^4.0.0",
-    "ember-cli-content-security-policy": "0.3.0",
+    "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",


### PR DESCRIPTION
This PR updates the version of [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy) that vanilla Ember apps are generated with.

The benefit of this is to avoid https://github.com/rwjblue/ember-cli-content-security-policy/issues/27, which was creating unnecessary console errors for Ember users.