### PR TITLE
Added Ember + DS to predef to align with guides

### DIFF
--- a/blueprints/app/files/.jshintrc
+++ b/blueprints/app/files/.jshintrc
@@ -2,6 +2,8 @@
   "predef": [
     "document",
     "window",
+    "DS",
+    "Ember",
     "-Promise"
   ],
   "browser": true,

--- a/blueprints/app/files/tests/.jshintrc
+++ b/blueprints/app/files/tests/.jshintrc
@@ -18,6 +18,7 @@
     "findWithAssert",
     "wait",
     "DS",
+    "Ember",
     "andThen",
     "currentURL",
     "currentPath",


### PR DESCRIPTION
DO NOT MERGE

In the [guides rewrite](https://github.com/emberjs/guides/issues/9#issuecomment-82526641) it was decided to leave out importing `Ember` and `DS`. In the current implementation that will confront users with jshint errors if they copy code examples from the guides.

If the guides rewrite is going to push a lot of people to try Ember CLI, we should [avoid people running into this](https://www.google.nl/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=%22ember%20is%20not%20defined%22).

Alternate solutions:
- Clearly document the need to import in the guides (for example the "Concepts" section), like on the [ember cli website](https://github.com/ember-cli/ember-cli/pull/1016/files)
- Add imports to the examples/snippets