### PR TITLE
allow for ./server to export express app

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -79,6 +79,10 @@ module.exports = Task.extend({
       if (typeof server !== 'function') {
         throw new TypeError('ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
       }
+      if (server.length === 3) {
+        // express app is function of form req, res, next
+        return this.app.use(server);
+      }
       return server(this.app, options);
     }
   },


### PR DESCRIPTION
the whole app factory pattern is a bit foreign for express apps as there is a build in mechanism for adding routes from one express app to another, that is the `.use` method.  A common pattern is for the server function to export an app that can then be passed as middleware to somewhere else or get used with http[s].createServer, so this pull adds compatablity for having a server/index that does something like 

```js
var app = module.exports = require('express')();
```

by checking if the function exported by the server module has a length of 3, i.e. is of the form

```js
var app = function(req, res, next) {
  app.handle(req, res, next);
};
```

which is what an express app is