### PR TITLE
Specified which files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "bugs": {
     "url": "https://github.com/ember-cli/ember-cli/issues"
   },
+  "files": ["bin/ember", "blueprints", "lib"],
   "bundledDependencies": [
     "bower",
     "bower-config",


### PR DESCRIPTION
We're currently publishing pretty much everything (except stuff from `.gitignore`, which npm auto-ignores).

I figured we can shed a little weight, especially since `tests/` is large and growing...I know every little bit counts on a project this size.

###### tarball sizes:

```
  25,595,044 bytes (before)
- 25,364,564 bytes (after)
===========================
≈ 230.48 KB savings
```
###### before
![image](https://cloud.githubusercontent.com/assets/762949/6764452/369e7768-cf6d-11e4-9fc6-81081628bcc7.png)
###### after
![image](https://cloud.githubusercontent.com/assets/762949/6764444/1a22dfd4-cf6d-11e4-9b76-8ea25bb50edc.png)