### PR TITLE
add command uninstall:npm

### DIFF
--- a/lib/commands/uninstall-npm.js
+++ b/lib/commands/uninstall-npm.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var Command = require('../models/command');
+
+module.exports = Command.extend({
+  name: 'uninstall:npm',
+  description: 'Uninstalls npm packages.',
+  works: 'insideProject',
+
+  anonymousOptions: [
+    '<package-names...>'
+  ],
+
+  run: function(commandOptions, rawArgs) {
+    var NpmUninstallTask = this.tasks.NpmUninstall;
+    var npmUninstall     = new NpmUninstallTask({
+      ui:         this.ui,
+      analytics:  this.analytics,
+      project:    this.project
+    });
+
+    return npmUninstall.run({
+      packages: rawArgs,
+      'save-dev': true,
+      'save-exact': true
+    });
+  }
+});

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -24,33 +24,36 @@ module.exports = Task.extend({
     };
     var packages = options.packages || [];
 
-    return new Promise(function(resolve, reject) {
+    // npm otherwise is otherwise noisy, already submitted PR for npm to fix
+    // misplaced console.log
+    this.disableLogger();
 
-      // npm otherwise is otherwise noisy, already submitted PR for npm to fix
-      // misplaced console.log
-      this.disableLogger();
+    var load = Promise.denodeify(this.npm.load);
 
-      this.npm.load(npmOptions, function(err) {
-        if (err) {
-          reject(err);
-        } else {
-          this.npm.commands.install(packages, function(err, data) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(data);
-            }
-          });
-        }
-      }.bind(this));
+    return load(npmOptions)
+      .then(function() {
+        // if install is denodeified outside load.then(),
+        // it throws "Call npm.load(config, cb) before using this command."
+        var install = Promise.denodeify(this.npm.commands.install);
 
-    }.bind(this), 'npm install')
+        return install(packages);
+      }.bind(this))
       .finally(this.finally.bind(this))
       .then(this.announceCompletion.bind(this));
   },
 
-  announceCompletion: function() {
+  announceCompletion: function(data) {
+    this.printPackageNames(data);
     this.ui.writeLine(chalk.green('Installed packages for tooling via npm.'));
+  },
+
+  printPackageNames: function(data) {
+    data.forEach(function(pkg) {
+      var name = pkg[0];
+      var path = pkg[1];
+
+      this.ui.writeLine(chalk.green(name + ' ' + path));
+    }.bind(this));
   },
 
   finally: function() {

--- a/lib/tasks/npm-uninstall.js
+++ b/lib/tasks/npm-uninstall.js
@@ -24,33 +24,33 @@ module.exports = Task.extend({
     };
     var packages = options.packages || [];
 
-    return new Promise(function(resolve, reject) {
+    // npm otherwise is otherwise noisy, already submitted PR for npm to fix
+    // misplaced console.log
+    this.disableLogger();
 
-      // npm otherwise is otherwise noisy, already submitted PR for npm to fix
-      // misplaced console.log
-      this.disableLogger();
+    var load = Promise.denodeify(this.npm.load);
 
-      this.npm.load(npmOptions, function(err) {
-        if (err) {
-          reject(err);
-        } else {
-          this.npm.commands.uninstall(packages, function(err, data) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(data);
-            }
-          });
-        }
-      }.bind(this));
+    return load(npmOptions)
+      .then(function() {
+        // if uninstall is denodeified outside load.then(),
+        // it throws "Call npm.load(config, cb) before using this command."
+        var uninstall = Promise.denodeify(this.npm.commands.uninstall);
 
-    }.bind(this), 'npm uninstall')
+        return uninstall(packages);
+      }.bind(this))
       .finally(this.finally.bind(this))
       .then(this.announceCompletion.bind(this));
   },
 
-  announceCompletion: function() {
+  announceCompletion: function(data) {
+    this.printPackageNames(data);
     this.ui.writeLine(chalk.green('Uninstalled packages for tooling via npm.'));
+  },
+
+  printPackageNames: function(data) {
+    data.forEach(function(pkg) {
+      this.ui.writeLine(chalk.green('unbuild ' + pkg));
+    }.bind(this));
   },
 
   finally: function() {

--- a/lib/tasks/npm-uninstall.js
+++ b/lib/tasks/npm-uninstall.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// Runs `npm uninstall` in cwd
+
+var Promise = require('../ext/promise');
+var chalk   = require('chalk');
+var Task    = require('../models/task');
+
+module.exports = Task.extend({
+
+  init: function() {
+    this.npm = this.npm || require('npm');
+  },
+  // Options: Boolean verbose
+  run: function(options) {
+    this.ui.startProgress(chalk.green('Uninstalling packages for tooling via npm'), chalk.green('.'));
+
+    var npmOptions = {
+      loglevel: options.verbose ? 'verbose' : 'error',
+      logstream: this.ui.outputStream,
+      color: 'always',
+      'save-dev': !!options['save-dev'],
+      'save-exact': !!options['save-exact']
+    };
+    var packages = options.packages || [];
+
+    return new Promise(function(resolve, reject) {
+
+      // npm otherwise is otherwise noisy, already submitted PR for npm to fix
+      // misplaced console.log
+      this.disableLogger();
+
+      this.npm.load(npmOptions, function(err) {
+        if (err) {
+          reject(err);
+        } else {
+          this.npm.commands.uninstall(packages, function(err, data) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(data);
+            }
+          });
+        }
+      }.bind(this));
+
+    }.bind(this), 'npm uninstall')
+      .finally(this.finally.bind(this))
+      .then(this.announceCompletion.bind(this));
+  },
+
+  announceCompletion: function() {
+    this.ui.writeLine(chalk.green('Uninstalled packages for tooling via npm.'));
+  },
+
+  finally: function() {
+    this.ui.stopProgress();
+    this.restoreLogger();
+  },
+
+  disableLogger: function() {
+    this.oldLog = console.log;
+    console.log = function() {};
+  },
+
+  restoreLogger: function() {
+    console.log = this.oldLog; // Hack, see above
+  }
+});

--- a/tests/unit/commands/uninstall-npm-test.js
+++ b/tests/unit/commands/uninstall-npm-test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var expect           = require('chai').expect;
+var stub             = require('../../helpers/stub').stub;
+var commandOptions   = require('../../factories/command-options');
+var UninstallCommand = require('../../../lib/commands/uninstall-npm');
+var Task             = require('../../../lib/models/task');
+
+describe('uninstall:npm command', function() {
+  var command, options, tasks, npmInstance;
+
+  beforeEach(function() {
+    tasks = {
+      NpmUninstall: Task.extend({
+        init: function() {
+          npmInstance = this;
+        }
+      })
+    };
+
+    options = commandOptions({
+      settings: {},
+
+      project: {
+        name: function() {
+          return 'some-random-name';
+        },
+
+        isEmberCLIProject: function() {
+          return true;
+        }
+      },
+
+      tasks: tasks
+    });
+
+    stub(tasks.NpmUninstall.prototype, 'run');
+
+    command = new UninstallCommand(options);
+  });
+
+  afterEach(function() {
+    tasks.NpmUninstall.prototype.run.restore();
+  });
+
+  it('initializes npm task with ui, project and analytics', function() {
+    return command.validateAndRun([]).then(function() {
+      expect(npmInstance.ui, 'ui was set');
+      expect(npmInstance.project, 'project was set');
+      expect(npmInstance.analytics, 'analytics was set');
+    });
+  });
+
+  describe('with no args', function() {
+    it('runs the npm uninstall task with no packages, save-dev true and save-exact true', function() {
+      return command.validateAndRun([]).then(function() {
+        var npmRun = tasks.NpmUninstall.prototype.run;
+        expect(npmRun.called).to.equal(1, 'expected npm uninstall run was called once');
+        expect(npmRun.calledWith[0][0]).to.deep.equal({
+          packages: [],
+          'save-dev': true,
+          'save-exact': true
+        }, 'expected npm uninstall called with no packages, save-dev true, and save-exact true');
+      });
+    });
+  });
+
+  describe('with args', function() {
+    it('runs the npm uninstall task with given packages', function() {
+      return command.validateAndRun(['moment', 'lodash']).then(function() {
+        var npmRun = tasks.NpmUninstall.prototype.run;
+        expect(npmRun.called).to.equal(1, 'expected npm uninstall run was called once');
+        expect(npmRun.calledWith[0][0]).to.deep.equal({
+          packages: ['moment', 'lodash'],
+          'save-dev': true,
+          'save-exact': true
+        }, 'expected npm uninstall called with given packages, save-dev true, and save-exact true');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implementation of #3582. Left out bower because of the deprecation. Basically a port of `ember install:npm`.