### PR TITLE
removing the npm package printing

### DIFF
--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -42,18 +42,8 @@ module.exports = Task.extend({
       .then(this.announceCompletion.bind(this));
   },
 
-  announceCompletion: function(data) {
-    this.printPackageNames(data);
+  announceCompletion: function() {
     this.ui.writeLine(chalk.green('Installed packages for tooling via npm.'));
-  },
-
-  printPackageNames: function(data) {
-    data.forEach(function(pkg) {
-      var name = pkg[0];
-      var path = pkg[1];
-
-      this.ui.writeLine(chalk.green(name + ' ' + path));
-    }.bind(this));
   },
 
   finally: function() {

--- a/lib/tasks/npm-uninstall.js
+++ b/lib/tasks/npm-uninstall.js
@@ -42,15 +42,8 @@ module.exports = Task.extend({
       .then(this.announceCompletion.bind(this));
   },
 
-  announceCompletion: function(data) {
-    this.printPackageNames(data);
+  announceCompletion: function() {
     this.ui.writeLine(chalk.green('Uninstalled packages for tooling via npm.'));
-  },
-
-  printPackageNames: function(data) {
-    data.forEach(function(pkg) {
-      this.ui.writeLine(chalk.green('unbuild ' + pkg));
-    }.bind(this));
   },
 
   finally: function() {


### PR DESCRIPTION
Fixing regression #3616. Removing the package printing for both `ember install:npm` and `ember uninstall:npm`.