### PR TITLE
Check if style file with project name exists

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -904,6 +904,10 @@ EmberApp.prototype.javascript = function() {
   @return {Tree} Merged tree for styles
 */
 EmberApp.prototype.styles = function() {
+  if (fs.existsSync('app/styles/' + this.name + '.css')) {
+    throw new Error('Style file cannot have the name of the application - ' + this.name);
+  }
+
   var addonTrees = this.addonTreesFor('styles');
   var external = this._processedExternalTree();
   var styles = pickFiles(this.trees.styles, {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -13,6 +13,7 @@ var EOL   = require('os').EOL;
 var Project      = require('../models/project');
 var cleanBaseURL = require('../utilities/clean-base-url');
 var escapeRegExp = require('../utilities/escape-regexp');
+var SilentError  = require('../errors/silent');
 
 var preprocessJs  = p.preprocessJs;
 var preprocessCss = p.preprocessCss;
@@ -905,7 +906,7 @@ EmberApp.prototype.javascript = function() {
 */
 EmberApp.prototype.styles = function() {
   if (fs.existsSync('app/styles/' + this.name + '.css')) {
-    throw new Error('Style file cannot have the name of the application - ' + this.name);
+    throw new SilentError('Style file cannot have the name of the application - ' + this.name);
   }
 
   var addonTrees = this.addonTreesFor('styles');


### PR DESCRIPTION
Currently if a style sheet file named the same as the project exists will cause an exception when building. The error is not very obvious. This check prevents the build and displays an error.