### PR TITLE
Add `chai` as dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,13 +143,13 @@
     "yam": "0.0.18"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
+    "chai": "^2.1.2",
     "chai-as-promised": "^4.1.1",
+    "ember-cli-ncp": "1.0.2",
     "github": "^0.2.3",
     "mocha": "^1.18.0",
     "mocha-jshint": "0.0.9",
     "multiline": "^1.0.1",
-    "ember-cli-ncp": "1.0.2",
     "nock": "^0.51.0",
     "node-require-timings": "0.0.2",
     "supertest": "0.14.0",


### PR DESCRIPTION
Fixes Travis builds:

```
npm WARN peerDependencies The peer dependency chai@>= 2.1.2 < 3 included from chai-as-promised will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```