### PR TITLE
Uses Ember.keys instead of Object.keys in reexport

### DIFF
--- a/lib/utilities/reexport-template.js
+++ b/lib/utilities/reexport-template.js
@@ -1,7 +1,7 @@
 /* global define */
-define("{{DEST}}", ["{{SRC}}","exports"], function(__index__, __exports__) {
+define("{{DEST}}", ["{{SRC}}", "ember", "exports"], function(__index__, __Ember__, __exports__) {
   "use strict";
-  Object.keys(__index__).forEach(function(key){
+  __Ember__["default"].keys(__index__).forEach(function(key){
     __exports__[key] = __index__[key];
   });
 });


### PR DESCRIPTION
`Object.keys` does not exist in IE8, so we use `Ember.keys` in `reexport`
instead of `Object.keys` to prevent explosions :fire: :boom: 