### PR TITLE
Pass baseUrl to the router's rootUrl, resolves redirect issues

### DIFF
--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 var Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.baseURL
 });
 
 Router.map(function() {


### PR DESCRIPTION
Fixes issues with plugins like ember-simple-auth when they want to reload the page.

:warning: Needs tests still.