### PR TITLE
Update Broccoli to 0.15.3

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -18,7 +18,7 @@ module.exports = Task.extend({
     this.environment = this.environment || 'development';
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
-    var broccoli = require('ember-cli-broccoli');
+    var broccoli = require('broccoli');
     this.tree    = broccoli.loadBrocfile();
     this.builder = new broccoli.Builder(this.tree);
   },

--- a/lib/tasks/server/middleware/serve-files/index.js
+++ b/lib/tasks/server/middleware/serve-files/index.js
@@ -13,7 +13,7 @@ ServeFilesAddon.prototype.serverMiddleware = function(options) {
   options = options.options;
   debug('serverMiddleware: %s',options.outputPath);
 
-  var broccoliMiddleware = options.middleware || require('ember-cli-broccoli/lib/middleware');
+  var broccoliMiddleware = options.middleware || require('broccoli/lib/middleware');
   var middleware = broccoliMiddleware(options.watcher);
 
   var baseURL = cleanBaseURL(options.baseURL);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "bundledDependencies": [
     "bower",
     "bower-config",
-    "ember-cli-broccoli",
+    "broccoli",
     "broccoli-clean-css",
     "broccoli-filter",
     "broccoli-funnel",
@@ -82,7 +82,7 @@
     "abbrev": "^1.0.5",
     "bower": "^1.3.12",
     "bower-config": "0.5.2",
-    "ember-cli-broccoli": "0.13.6",
+    "broccoli": "0.13.6",
     "broccoli-caching-writer": "0.5.5",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "abbrev": "^1.0.5",
     "bower": "^1.3.12",
     "bower-config": "0.5.2",
-    "broccoli": "0.13.6",
+    "broccoli": "0.15.3",
     "broccoli-caching-writer": "0.5.5",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "^2.0.0",

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -216,22 +216,22 @@ describe('models/addon.js', function() {
       describe('trees for it\'s treePaths', function() {
         it('app', function() {
           var tree = addon.treeFor('app');
-          expect(typeof tree.read).to.equal('function');
+          expect(typeof (tree.read || tree.rebuild)).to.equal('function');
         });
 
         it('styles', function() {
           var tree = addon.treeFor('styles');
-          expect(typeof tree.read).to.equal('function');
+          expect(typeof (tree.read || tree.rebuild)).to.equal('function');
         });
 
         it('templates', function() {
           var tree = addon.treeFor('templates');
-          expect(typeof tree.read).to.equal('function');
+          expect(typeof (tree.read || tree.rebuild)).to.equal('function');
         });
 
         it('vendor', function() {
           var tree = addon.treeFor('vendor');
-          expect(typeof tree.read).to.equal('function');
+          expect(typeof (tree.read || tree.rebuild)).to.equal('function');
         });
 
         it('addon', function() {
@@ -255,7 +255,7 @@ describe('models/addon.js', function() {
           };
           addon.app = app;
           var tree = addon.treeFor('addon');
-          expect(typeof tree.read).to.equal('function');
+          expect(typeof (tree.read || tree.rebuild)).to.equal('function');
         });
       });
 

--- a/tests/unit/utilities/reexport-test.js
+++ b/tests/unit/utilities/reexport-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var broccoli = require('ember-cli-broccoli');
+var broccoli = require('broccoli');
 var walkSync = require('walk-sync');
 var expect   = require('chai').expect;
 var Reexporter = require('../../../lib/utilities/reexport');


### PR DESCRIPTION
OK, new plan of attack:

I thought we could update everything in one go and avoid having Broccoli's ugly compatibility code deployed widely. Turns out it's too many changes, and we'll have to do piecemeal plugin updates.

This updates to Broccoli 0.15.1, which supports new-style `.rebuild` trees but does not print noisy deprecation warnings unless you pass BROCCOLI_WARN_READ_API=y in the process environment.

Stef, was there something you had in the ember-cli-broccoli fork that you wanted me to merge? I can probably merge it and push it out in 0.15.2.

(Let's be sure to wait for Travis.)