### PR TITLE
Update nock dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "mocha": "^2.2.1",
     "mocha-jshint": "1.0.0",
     "multiline": "^1.0.2",
-    "nock": "^0.51.0",
+    "nock": "^1.2.1",
     "node-require-timings": "0.0.2",
     "supertest": "0.15.0",
     "tmp-sync": "^1.0.1",

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -18,6 +18,7 @@ var express           = require('express');
 
 describe('express-server', function() {
   var subject, ui, project, proxy, nockProxy;
+  nock.enableNetConnect();
 
   beforeEach(function() {
     this.timeout(10000);


### PR DESCRIPTION
By default `nock` will disable all HTTP requests throwing `NetConnectNotAllowedError`, except for the ones that you specifically create a nock scope for. See #3670.