### PR TITLE
[ENHANCEMENT] Add testem --launch option to ember test command

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -20,6 +20,7 @@ module.exports = Command.extend({
     { name: 'filter',      type: String,  description: 'A string to filter tests to run', aliases: ['f'] },
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
+    { name: 'launch',      type: String,  default: false, description: 'A comma seperated list of browsers to launch for tests.' },
   ],
 
   init: function() {
@@ -45,7 +46,7 @@ module.exports = Command.extend({
   },
 
   _generateCustomConfigFile: function(options) {
-    if (!options.filter && !options.module) { return options.configFile; }
+    if (!options.filter && !options.module && !options.launch) { return options.configFile; }
 
     var tmpPath = this.quickTemp.makeOrRemake(this, '-customConfigFile');
     var customPath = path.join(tmpPath, 'testem.json');
@@ -55,6 +56,9 @@ module.exports = Command.extend({
     var testPageJoinChar    = containsQueryString ? '&' : '?';
 
     originalContents['test_page'] = originalContents['test_page'] + testPageJoinChar + this.buildTestPageQueryString(options);
+    if (options.launch) {
+      originalContents['launch'] = options.launch;
+    }
     fs.writeFileSync(customPath, JSON.stringify(originalContents));
 
     return customPath;

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -122,17 +122,18 @@ describe('test command', function() {
       expect(fs.existsSync(newPath));
     });
 
-    it('should return the original path if filter or module isn\'t present', function() {
+    it('should return the original path if filter or module or launch isn\'t present', function() {
       var originalPath = runOptions.configFile;
       var newPath = command._generateCustomConfigFile(runOptions);
 
       expect(newPath).to.equal(originalPath);
     });
 
-    it('when module and filter option is present the new file path returned exists', function() {
+    it('when module and filter and launch option is present the new file path returned exists', function() {
       var originalPath = runOptions.configFile;
       runOptions.module = 'fooModule';
       runOptions.filter = 'bar';
+      runOptions.launch = 'fooLauncher';
       var newPath = command._generateCustomConfigFile(runOptions);
 
       expect(newPath).to.not.equal(originalPath);
@@ -157,6 +158,15 @@ describe('test command', function() {
       expect(fs.existsSync(newPath), 'file should exist');
     });
 
+    it('when launch option is present the new file path returned exists', function() {
+      var originalPath = runOptions.configFile;
+      runOptions.launch = 'fooLauncher';
+      var newPath = command._generateCustomConfigFile(runOptions);
+
+      expect(newPath).to.not.equal(originalPath);
+      expect(fs.existsSync(newPath), 'file should exist');
+    });
+
     it('when provided filter and module the new file returned contains the both option values in test_page', function() {
       runOptions.module = 'fooModule';
       runOptions.filter = 'bar';
@@ -164,6 +174,14 @@ describe('test command', function() {
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
       expect(contents['test_page']).to.be.equal('tests/index.html?module=fooModule&filter=bar');
+    });
+
+    it('when provided launch the new file returned contains the value in launch', function() {
+      runOptions.launch = 'fooLauncher';
+      var newPath = command._generateCustomConfigFile(runOptions);
+      var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
+
+      expect(contents['launch']).to.be.equal('fooLauncher');
     });
 
     it('when provided filter is all lowercase to match the test name', function() {


### PR DESCRIPTION
Passing a list of of launchers into testem like this allows for more control over the setup in a CI environment.

Specifically a Saucelabs testem.json setup like this:
```yml
"launchers": {
    "SauceLabs_Chrome": {
      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --no-ct -u <url>",
      "protocol": "tap"
    },
    "SauceLabs_Firefox": {
      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --browserNameSL='firefox' --no-ct -u <url>",
      "protocol": "tap"
    },
}
```
And a travis setup like this:
```yml
matrix:
  fast_finish: true
  allow_failures:
    - env: "LAUNCHER='SauceLabs_Firefox'
  include:
    - env: "LAUNCHER='SauceLabs_Chrome'
script:
  - ember test --launch=${LAUNCHER}
```

Would make it possible to:
1. Run each browser tests in paralel
2. Allow some browsers to fail without the build failing

