### PR TITLE
[DOCS] change broccoli-emblem-compiler to ember-cli-emblem-hbs-printer

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -161,8 +161,10 @@ Note that the ES6 module transpiler is not directly supported with Emberscript, 
 For [Emblem](http://emblemjs.com/), run the following commands:
 
 {% highlight bash %}
-ember install:npm broccoli-emblem-compiler
+ember install:npm ember-cli-emblem-hbs-printer
 {% endhighlight %}
+
+If you're using the older broccoli-emblem-compiler addon, you need to switch over the above ember-cli-emblem-hbs-printer. The older broccoli-emblem-compiler compiles directly to JS instead of Handlebars and therefore is broken on all newer version of HTMLBars.
 
 ### Fingerprinting and CDN URLs
 


### PR DESCRIPTION
In the asset compilation section on the ember-cli website. This is because the broccoli one doesn't actually work while the ember-cli one does work.