### PR TITLE
[ENHANCEMENT] Adds the ability to run generate on multiple addons at once

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -381,11 +381,11 @@ Blueprint.prototype.install = function(options) {
   }
 
   podDeprecations(this.project.config(), this.ui);
-  
+
   ui.writeLine('installing');
 
   if (dryRun) {
-    ui.writeLine(chalk.yellow('You specified the dry-run flag, so no changes will' + 
+    ui.writeLine(chalk.yellow('You specified the dry-run flag, so no changes will' +
       ' be written.'));
   }
 
@@ -397,7 +397,7 @@ Blueprint.prototype.install = function(options) {
     ui.writeLine(chalk.yellow('You specified the pod flag, but this blueprint does' +
       ' not support pod structure. It will be generated with the default structure.'));
   }
-  
+
   if (options.inRepoAddon) {
     if (!inRepoAddonExists(options.inRepoAddon, this.project.root)) {
       throw new SilentError('You specified the in-repo-addon flag, but the' +
@@ -448,7 +448,7 @@ Blueprint.prototype.uninstall = function(options) {
   }
 
   podDeprecations(this.project.config(), this.ui);
-  
+
   ui.writeLine('uninstalling');
 
   if (dryRun) {
@@ -1069,6 +1069,25 @@ Blueprint.prototype.lookupBlueprint = function(dasherizedName) {
 
   return Blueprint.lookup(dasherizedName, {
     paths: projectPaths
+  });
+};
+
+/**
+  Returns true if the given blueprint is built into ember-cli.
+  @static
+  @method isBuiltIn
+  @param {string} name
+  @return {bool}
+*/
+Blueprint.isBuiltIn = function(name) {
+  var paths = generateLookupPaths();
+
+  return paths.some(function(lookupPath) {
+    var blueprintPath = path.resolve(lookupPath, name);
+
+    if (fs.existsSync(blueprintPath)) {
+      return true;
+    }
   });
 };
 

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1077,7 +1077,7 @@ Blueprint.prototype.lookupBlueprint = function(dasherizedName) {
   @static
   @method isLocalBlueprint
   @param {string} name
-  @param {Array} name
+  @param {Array} paths
   @return {bool}
 */
 Blueprint.isFoundInPaths = function(name, paths) {

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1073,15 +1073,14 @@ Blueprint.prototype.lookupBlueprint = function(dasherizedName) {
 };
 
 /**
-  Returns true if the given blueprint is built into ember-cli.
+  Returns true if the given blueprint is found in any of the given paths.
   @static
-  @method isBuiltIn
+  @method isLocalBlueprint
   @param {string} name
+  @param {Array} name
   @return {bool}
 */
-Blueprint.isBuiltIn = function(name) {
-  var paths = generateLookupPaths();
-
+Blueprint.isFoundInPaths = function(name, paths) {
   return paths.some(function(lookupPath) {
     var blueprintPath = path.resolve(lookupPath, name);
 

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -18,12 +18,14 @@ module.exports = Task.extend({
     if (isBuiltInBlueprint) {
       blueprints.push({
         name: options.args[0],
-        options: options.args
+        args: options.args,
+        options: options
       });
     } else {
       options.args.forEach(function(arg) {
         blueprints.push({
-          name: arg
+          name: arg,
+          options: options
         });
       }, this);
     }
@@ -49,7 +51,8 @@ module.exports = Task.extend({
 
   runBlueprint: function(blueprint) {
     var name = blueprint.name;
-    var options = blueprint.options || [];
+    var args = blueprint.args || [];
+    var options = blueprint.options || {};
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);
@@ -64,9 +67,9 @@ module.exports = Task.extend({
       options: {}
     };
 
-    if (options.length > 1) {
-      entity.name = options[1];
-      entity.options = parseOptions(options.slice(2));
+    if (args.length > 1) {
+      entity.name = args[1];
+      entity.options = parseOptions(args.slice(2));
     }
 
     var blueprintOptions = {

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -12,8 +12,44 @@ module.exports = Task.extend({
   blueprintFunction: 'install',
 
   run: function(options) {
-    var self = this;
-    var name = options.args[0];
+    var blueprints = [];
+    var isBuiltInBlueprint = Blueprint.isBuiltIn(options.args[0]);
+
+    if (isBuiltInBlueprint) {
+      blueprints.push({
+        name: options.args[0],
+        options: options.args
+      });
+    } else {
+      options.args.forEach(function(arg) {
+        blueprints.push({
+          name: arg
+        });
+      }, this);
+    }
+
+    return this.runBlueprints(blueprints);
+  },
+
+  lookupBlueprint: function(name, ignoreMissing) {
+    return Blueprint.lookup(name, {
+      paths: this.project.blueprintLookupPaths(),
+      ignoreMissing: ignoreMissing
+    });
+  },
+
+  runBlueprints: function(blueprints) {
+    return this.runBlueprint(blueprints.shift())
+      .then(function() {
+        if (blueprints.length > 0) {
+          this.runBlueprints(blueprints);
+        }
+      }.bind(this));
+  },
+
+  runBlueprint: function(blueprint) {
+    var name = blueprint.name;
+    var options = blueprint.options || [];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);
@@ -24,9 +60,14 @@ module.exports = Task.extend({
     }
 
     var entity = {
-      name: options.args[1],
-      options: parseOptions(options.args.slice(2))
+      name: null,
+      options: {}
     };
+
+    if (options.length > 1) {
+      entity.name = options[1];
+      entity.options = parseOptions(options.slice(2));
+    }
 
     var blueprintOptions = {
       target: this.project.root,
@@ -39,7 +80,7 @@ module.exports = Task.extend({
       taskOptions: options
     };
 
-    blueprintOptions = merge(blueprintOptions, options || {});
+    blueprintOptions = merge(blueprintOptions, options);
 
     return mainBlueprint[this.blueprintFunction](blueprintOptions)
       .then(function() {
@@ -53,8 +94,8 @@ module.exports = Task.extend({
 
         var testBlueprintOptions = merge({} , blueprintOptions, { installingTest: true });
 
-        return testBlueprint[self.blueprintFunction](testBlueprintOptions);
-      })
+        return testBlueprint[this.blueprintFunction](testBlueprintOptions);
+      }.bind(this))
       .then(function() {
         if (!addonBlueprint) { return; }
         if (!this.project.isEmberCLIAddon() && blueprintOptions.inRepoAddon === null) { return; }
@@ -67,14 +108,7 @@ module.exports = Task.extend({
 
         var addonBlueprintOptions = merge({}, blueprintOptions, { installingAddon: true });
 
-        return addonBlueprint[self.blueprintFunction](addonBlueprintOptions);
+        return addonBlueprint[this.blueprintFunction](addonBlueprintOptions);
       }.bind(this));
-  },
-
-  lookupBlueprint: function(name, ignoreMissing) {
-    return Blueprint.lookup(name, {
-      paths: this.project.blueprintLookupPaths(),
-      ignoreMissing: ignoreMissing
-    });
   }
 });

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -13,11 +13,16 @@ module.exports = Task.extend({
 
   run: function(options) {
     var blueprints = [];
-    var isBuiltInBlueprint = Blueprint.isBuiltIn(options.args[0]);
+    var firstArg = options.args[0];
 
-    if (isBuiltInBlueprint) {
+    var paths = Blueprint.defaultLookupPaths();
+    paths = paths.concat(this.project.localBlueprintLookupPath());
+
+    var isInPaths = Blueprint.isFoundInPaths(firstArg, paths);
+
+    if (isInPaths) {
       blueprints.push({
-        name: options.args[0],
+        name: firstArg,
         args: options.args,
         options: options
       });


### PR DESCRIPTION
This is my initial stab at #3650. This isn't quite ready for merge yet (needs tests at least), but I wanted some feedback on this as there are a couple of areas that don't sit well with me.

Firstly I am making the assumption that when running ```ember g addon1``` you cannot specify any options for that command (like you can in ```ember g model foo name:string```).

Secondly I am not to sure on the way that I am detecting if the blueprint is an addon or not. Currently looking in ```Blueprint#defaultLookupPaths()``` and ```Project#localBlueprintLookupPath()``` to work this out.

Overall though, this is working and doesn't break existing tests, so it can't be all that bad :) 