### PR TITLE
[fixes #3732] configure YAM with the Project.root.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -37,7 +37,21 @@ function cli(options) {
   var UI = options.UI || require('../ui');
   var Leek = options.Leek || require('leek');
   var Yam = options.Yam || require('yam');
-  var config = new Yam('ember-cli');
+
+  // TODO: one UI (lib/models/project.js also has one for now...)
+  var ui = new UI({
+    inputStream:  options.inputStream,
+    outputStream: options.outputStream,
+    ci:           process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
+    writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
+  });
+
+  var project = Project.projectOrNullProject(ui);
+
+  var config = new Yam('ember-cli', {
+    primary: project.root
+  });
+
   var leekOptions;
 
   var disableAnalytics = options.cliArgs &&
@@ -62,26 +76,9 @@ function cli(options) {
     leekOptions = defaultLeekOptions;
   }
 
-  // TODO: one UI (lib/models/project.js also has one for now...)
-  var ui = new UI({
-    inputStream:  options.inputStream,
-    outputStream: options.outputStream,
-    ci:           process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
-    writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
-  });
-
   debug('leek: %o', leekOptions);
+
   var leek = new Leek(leekOptions);
-
-  var project = Project.closest(process.cwd(), ui)
-    .catch(function(reason) {
-      if (reason instanceof Project.NotFoundError) {
-        return Project.NULL_PROJECT;
-      } else {
-        throw reason;
-      }
-    });
-
   var environment = {
     tasks:    tasks,
     cliArgs:  options.cliArgs,

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -524,6 +524,31 @@ Project.closestSync = function(pathName, _ui) {
   }
 };
 
+/**
+  Returns a new project based on the first package.json that is found
+  in `pathName`, or the nullProject.
+
+  The nullProject signifies no-project, but abides by the null object pattern
+
+  @private
+  @static
+  @method projectOrNullProject
+  @param  {String} pathName Path to your project
+  @param  {UI} ui The UI instance to provide to the created Project.
+  @return {Project}         Project instance
+ */
+Project.projectOrNullProject = function(_ui) {
+  try {
+    return Project.closestSync(process.cwd(), _ui);
+  } catch(reason) {
+    if (reason instanceof Project.NotFoundError) {
+      return Project.NULL_PROJECT;
+    } else {
+      throw reason;
+    }
+  }
+};
+
 function NotFoundError(message) {
   this.name = 'NotFoundError';
   this.message = message;


### PR DESCRIPTION
This should enable .ember-cli to be looked-up correctly
regardless of where in the app tree `ember` is invoked.
- [x] make work
- [ ] tests:
  - [ ] `ember g` in some nested dir
  - [ ] Project.projectOrNullProject

cc @ebryn @twokul 