### PR TITLE
no longer bundle testem, allow it to drift along semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "readline2",
     "resolve",
     "semver",
-    "testem",
     "through",
     "tiny-lr"
   ],


### PR DESCRIPTION
the problems that caused us to bundle literally everyone have started to improve in npm. We will likely still bundle some things (eventually I would like to bundle nothing...).