### PR TITLE
return currentURL() rather than path, ref #3719

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -21,6 +21,6 @@ test('visiting /<%= dasherizedModuleName %>', function(assert) {
   visit('/<%= dasherizedModuleName %>');
 
   andThen(function() {
-    assert.equal(currentPath(), '<%= dasherizedModuleName %>');
+    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -21,6 +21,6 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {
-    assert.equal(currentPath(), 'foo');
+    assert.equal(currentURL(), '/foo');
   });
 });


### PR DESCRIPTION
Originally referenced on #3719, in this PR I have:

- Updated the fixture, replacing `currentPath()` for `currentUrl()`
- Changed the template accordingly