### PR TITLE
Order bower dependencies alphabetically

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "jquery": "^1.11.1",
     "ember": "1.11.0",
-    "ember-data": "1.0.0-beta.16.1",
-    "ember-resolver": "~0.1.15",
-    "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.3.0",
     "ember-qunit-notifications": "0.0.7",
+    "ember-resolver": "~0.1.15",
+    "jquery": "^1.11.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }
 }


### PR DESCRIPTION
The blueprint for `package.json` has dependencies ordered alphabetically. This makes diffs easy to read when upgrading Ember CLI. This PR applies alphabetical ordering to the `bower.json` blueprint to make diffs against it similarly easy.