### PR TITLE
Fix Star button

### DIFF
--- a/_includes/description.html
+++ b/_includes/description.html
@@ -8,7 +8,7 @@
         npm install -g ember-cli
       </code>
       <a id="viewguide" href="#overview">View User Guide</a>
-        <iframe src="http://ghbtns.com/github-btn.html?user=stefanpenner&repo=ember-cli&type=watch&count=true"
+        <iframe src="http://ghbtns.com/github-btn.html?user=ember-cli&repo=ember-cli&type=watch&count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="84" height="20"></iframe>
     </div>
   </div>


### PR DESCRIPTION
Changes the user from `stefanpenner` to `ember-cli`.

While GitHub correctly redirects the repository, this behavior may not persist. By correcting the user, the number of stars associated with the  repository (2,057 at the time) are now displayed.