### PR TITLE
Improved serializer-test blueprint

### DIFF
--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -1,15 +1,18 @@
 import {
-  moduleFor,
+  moduleForModel,
   test
 } from 'ember-qunit';
 
-moduleFor('serializer:<%= dasherizedModuleName %>', {
+moduleForModel('<%= dasherizedModuleName %>', {
   // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['serializer:<%= dasherizedModuleName %>']
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
-  var serializer = this.subject();
-  assert.ok(serializer);
+test('it serializes records', function(assert) {
+  var record = this.subject();
+
+  var serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
 });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -657,7 +657,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/unit/serializers/foo-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
         ]
@@ -676,10 +676,10 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/unit/serializers/foo/bar-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -989,7 +989,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/foo/serializer-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
         ]
@@ -1008,7 +1008,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/pods/foo/serializer-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
         ]
@@ -1027,10 +1027,10 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/foo/bar/serializer-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });
@@ -1047,10 +1047,10 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/unit/pods/foo/bar/serializer-test.js', {
         contains: [
           "import {" + EOL +
-          "  moduleFor," + EOL +
+          "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleFor('serializer:foo/bar'"
+          "moduleForModel('foo/bar'"
         ]
       });
     });


### PR DESCRIPTION
The existing serializer-test blueprint makes it hard for the user to test the behavior of the serializer. This is because most serializer methods that a user may override to add custom behavior expect the `store` and a `snapshot` to be passed into the method as an argument. Currently these are painful to create in tests because accessing them often requires user's know about private API methods to setup this state. 

This change takes advantage of the existing the `moduleForModel` helper to make it easy to get access to a record instance in a test. Using the record's `serialize` method we can easily pass the `store` and `snapshot` into the serializer without having to worry about creating a `store` or `snapshot` instance. 

I'm very interested in receiving feedback on this pr so don't hesitate to comment if you are using a better technique to test your serializers.