### PR TITLE
Babel 5.0 now separates codeFrame from error.{message, stack}

### DIFF
--- a/lib/ui/write-error.js
+++ b/lib/ui/write-error.js
@@ -18,6 +18,10 @@ module.exports = function writeError(ui, error){
     ui.writeLine(chalk.red(error), 'ERROR');
   }
 
+  if (error.codeFrame) {
+    ui.writeLine(error.codeFrame, 'ERROR');
+  }
+
   if (error.stack) {
     ui.writeLine(error.stack, 'ERROR');
   }


### PR DESCRIPTION
but we should continue to print it