### PR TITLE
Upgrade to npm 2.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "morgan": "^1.5.2",
     "node-uuid": "^1.4.3",
     "nopt": "^3.0.1",
-    "npm": "^2.7.3",
+    "npm": "^2.7.6",
     "pleasant-progress": "^1.0.2",
     "promise-map-series": "^0.2.1",
     "proxy-middleware": "0.11.0",


### PR DESCRIPTION
The release notes for npm@2.7.6 say it all, but recent versions of npm broke installs for private Github repos. Since the CLI uses npm for a variety of uses (including installing addons from blueprint hooks via `addAddonToProject`), this means addons hosted in private Github repos don't work.

2.7.6 fixes this. It's currently pre-release, so we may want to wait to upgrade until it goes stable.