### PR TITLE
Add ember-try for addons.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -34,6 +34,10 @@ module.exports = {
     // add `ember-disable-prototype-extensions` to addons by default
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.0.0';
 
+    // add `ember-try` to addons by default
+    contents.devDependencies['ember-try'] = '0.0.4';
+    contents.scripts.test = "ember try:testall";
+
     contents['ember-addon'] = contents['ember-addon'] || {};
     contents['ember-addon'].configPath = 'tests/dummy/config';
 


### PR DESCRIPTION
@kategengler has been doing an amazing job with [ember-try](https://github.com/kategengler/ember-try), and I think this is ready for default inclusion in the addon blueprint.