### PR TITLE
BUGFIX: Updating heading for addon Component section

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -236,7 +236,7 @@ var app = new EmberAddon({
 module.exports = app.toTree();
 {% endhighlight %}
 
-### Components
+### Addon Components
 The actual code for the addon goes in `addon/components/x-button.js`
 
 {% highlight javascript %}


### PR DESCRIPTION
The Component heading anchor in the 'Developing Addons and Blueprints' was linking to the 'Naming Conventions' section of the site.