### PR TITLE
Code Climate: adding test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ common-tmp
 docs/build
 .node_modules-tmp
 .bower_components-tmp
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 os:
   - osx
   - linux
-script: npm run-script test-all
+script: npm run-script test-all:cover
 matrix:
   fast_finish: true
 
@@ -23,3 +23,10 @@ install:
   - npm --version
   - git --version
   - npm install
+
+addons:
+  code_climate:
+    repo_token: d349d39a60a008df5ae452af716ad6b8b45d82bf21ff3b60c230af2b34fcc759
+
+after_script:
+  - cat coverage/lcov.info | codeclimate

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "node tests/runner",
     "test:debug": "node debug tests/runner",
     "test-all": "node tests/runner all",
-    "test-all:debug": "node debug tests/runner all"
+    "test-all:debug": "node debug tests/runner all",
+    "test-all:cover": "istanbul cover tests/runner.js all"
   },
   "repository": {
     "type": "git",
@@ -132,8 +133,10 @@
   "devDependencies": {
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
+    "codeclimate-test-reporter": "0.0.4",
     "ember-cli-ncp": "1.0.2",
     "github": "^0.2.3",
+    "istanbul": "^0.3.13",
     "mocha": "^2.2.1",
     "mocha-jshint": "1.0.0",
     "multiline": "^1.0.2",


### PR DESCRIPTION
A task in #3730. Istanbul generates a `./coverage` folder, then Travis sends the info to Code Climate via web service. I believe coverage is only analyzed on the master branch, so you might not see it working until it is merged.

But you can see it in action on my master:
* [test coverage](https://codeclimate.com/github/kellyselden/ember-cli)
* [new travis output at the bottom](https://travis-ci.org/kellyselden/ember-cli/jobs/57241667)