### PR TITLE
moving coverage repo key to travis env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,5 @@ install:
   - git --version
   - npm install
 
-addons:
-  code_climate:
-    repo_token: d349d39a60a008df5ae452af716ad6b8b45d82bf21ff3b60c230af2b34fcc759
-
 after_script:
   - cat coverage/lcov.info | codeclimate


### PR DESCRIPTION
I think it would be better to move this key to a Travis env variable. I already added the key, CODECLIMATE_REPO_TOKEN, and it will be automatically picked up. This will prevent anyone that forked accidentally pushing their metrics to the main Code Climate repo.