### PR TITLE
remove pre-mature process.exit when existing `ember test —server`

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -9,23 +9,29 @@ module.exports = TestTask.extend({
   init: function() {
     this.testem = this.testem || new (require('testem'))();
   },
+
   invokeTestem: function(options) {
-    this.testem.startDev(this.testemOptions(options), function(code) {
-      remove(options.outputPath)
+    var task = this;
+
+    return new Promise(function(resolve) {
+      task.testem.startDev(task.testemOptions(options), function(code) {
+        remove(options.outputPath)
         .finally(function() {
-          process.exit(code);
+          resolve(code);
         });
+      });
     });
   },
+
   run: function(options) {
     var ui = this.ui;
     var testem = this.testem;
-    var self = this;
+    var task = this;
 
     // The building has actually started already, but we want some output while we wait for the server
     ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
-    return new Promise(function() {
+    return new Promise(function(resolve) {
       var watcher = options.watcher;
       var started = false;
 
@@ -37,7 +43,7 @@ module.exports = TestTask.extend({
           started = true;
 
           ui.stopProgress();
-          self.invokeTestem(options);
+          resolve(task.invokeTestem(options));
         }
       });
     });


### PR DESCRIPTION
This should prevent the tmp files from leaking in this scenario