### PR TITLE
Updates to support ember-giftwrap

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -818,8 +818,8 @@ EmberApp.prototype.appAndDependencies = function() {
   });
 
   var postprocessedApp = this.addonPostprocessTree('js', preprocessedApp);
+
   var sourceTrees = [
-    external,
     postprocessedApp,
     templates,
     config
@@ -827,14 +827,34 @@ EmberApp.prototype.appAndDependencies = function() {
 
   this._addAppTests(sourceTrees);
 
+  var es6app = this._es6ifyAppModules(mergeTrees(sourceTrees, {
+    overwrite: true,
+    description: 'TreeMerger (appModules)'
+  }));
+
   var emberCLITree = this._processedEmberCLITree();
 
-  sourceTrees.push(emberCLITree);
-
-  return mergeTrees(sourceTrees, {
+  return mergeTrees([external, es6app, emberCLITree], {
     overwrite: true,
     description: 'TreeMerger (appAndDependencies)'
   });
+};
+
+EmberApp.prototype._es6ifyAppModules = function(tree) {
+  return new ES6Modules(
+    new Funnel(tree, {
+      include: [new RegExp('^' + escapeRegExp(this.name + '/') + '.*\\.js$')],
+      description: 'Funnel: App JS Files'
+    }),
+    {
+      description: 'ES6: App Tree',
+      esperantoOptions: {
+        absolutePaths: true,
+        strict: true,
+        _evilES3SafeReExports: this.options.es3Safe
+      }
+    }
+  );
 };
 
 /**
@@ -883,30 +903,7 @@ EmberApp.prototype.javascript = function() {
   var legacyFilesToAppend = this.legacyFilesToAppend;
   var appOutputPath       = this.options.outputPaths.app.js;
 
-  var appJs = new ES6Modules(
-    new Funnel(applicationJs, {
-      include: [new RegExp('^' + escapeRegExp(this.name + '/') + '.*\\.js$')],
-      description: 'Funnel: App JS Files'
-    }),
-
-    {
-      description: 'ES6: App Tree',
-      esperantoOptions: {
-        absolutePaths: true,
-        strict: true,
-        _evilES3SafeReExports: this.options.es3Safe
-      }
-    }
-  );
-
-  appJs = mergeTrees([
-    appJs,
-    this._processedEmberCLITree()
-  ], {
-    description: 'TreeMerger (appJS  & processedEmberCLITree)'
-  });
-
-  appJs = this.concatFiles(appJs, {
+  var appJs = this.concatFiles(applicationJs, {
     inputFiles: [this.name + '/**/*.js'],
     headerFiles: [
       'vendor/ember-cli/app-prefix.js'

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -18,7 +18,9 @@ module.exports = Task.extend({
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
     var broccoli = require('broccoli');
-    this.tree    = broccoli.loadBrocfile();
+    if (!this.tree) {
+      this.tree = broccoli.loadBrocfile();
+    }
     this.builder = new broccoli.Builder(this.tree);
   },
 


### PR DESCRIPTION
This PR has two small changes:

1. A small refactor of the app tree broccoli pipeline. I improved it by doing the ES6 module conversion slightly earlier, in a place which is actually more logical, avoiding the need to merge the `_processedEmberCLITree` twice.

2. It makes the builder tasks's broccoli tree overridable.

Both of these changes are intended to support [Giftwrap](https://github.com/ef4/ember-giftwrap), which is a new general-purpose tool for packaging arbitrary sets of Ember addons for use by non-ember-cli apps. Code review of Giftwrap would also be appreciated.