### PR TITLE
[ENHANCEMENT] Change blueprint command options to type String to avoid nopt transformations

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var NewCommand = require('./new');
-var path       = require('path');
 
 module.exports = NewCommand.extend({
   name: 'addon',
@@ -10,7 +9,7 @@ module.exports = NewCommand.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'blueprint', type: path, default: 'addon', aliases: ['b'] },
+    { name: 'blueprint', type: String, default: 'addon', aliases: ['b'] },
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var path      = require('path');
 var Command   = require('../models/command');
 var Promise   = require('../ext/promise');
 
-var SilentError      = require('../errors/silent');
-var validProjectName = require('../utilities/valid-project-name');
+var SilentError        = require('../errors/silent');
+var validProjectName   = require('../utilities/valid-project-name');
+var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 
 module.exports = Command.extend({
   name: 'init',
@@ -16,7 +16,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'blueprint', type: ['gitUrl', path], aliases: ['b'] },
+    { name: 'blueprint', type: String, aliases: ['b'] },
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'name', type: String, default: '', aliases: ['n'] }
@@ -71,6 +71,8 @@ module.exports = Command.extend({
     if (!validProjectName(packageName)) {
       return Promise.reject(new SilentError('We currently do not support a name of `' + packageName + '`.'));
     }
+
+    blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint);
 
     return installBlueprint.run(blueprintOpts)
       .then(function() {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var chalk        = require('chalk');
-var path         = require('path');
 var Command      = require('../models/command');
 var Promise      = require('../ext/promise');
 var NULL_PROJECT = require('../models/project').NULL_PROJECT;
-var SilentError      = require('../errors/silent');
-var validProjectName = require('../utilities/valid-project-name');
+var SilentError        = require('../errors/silent');
+var validProjectName   = require('../utilities/valid-project-name');
+var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 
 module.exports = Command.extend({
   name: 'new',
@@ -16,7 +16,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'blueprint', type: ['gitUrl', path], default: 'app', aliases: ['b'] },
+    { name: 'blueprint', type: String, default: 'app', aliases: ['b'] },
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
@@ -54,6 +54,8 @@ module.exports = Command.extend({
 
       return Promise.reject(new SilentError(message));
     }
+
+    commandOptions.blueprint = normalizeBlueprint(commandOptions.blueprint);
 
     var createAndStepIntoDirectory  = new this.tasks.CreateAndStepIntoDirectory({
       ui: this.ui,

--- a/lib/utilities/normalize-blueprint-option.js
+++ b/lib/utilities/normalize-blueprint-option.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = function normalizeBlueprintOption(blueprint) {
+  return blueprint[0] === '.' ? path.resolve(process.cwd(), blueprint) : blueprint;
+};

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -112,7 +112,7 @@ describe('Acceptance: ember new', function() {
     }).then(confirmBlueprinted);
   });
 
-  it('ember new with blueprint uses the specified blueprint directory', function() {
+  it('ember new with blueprint uses the specified blueprint directory with a relative path', function() {
     return tmp.setup('./tmp/my_blueprint')
       .then(function() {
         return tmp.setup('./tmp/my_blueprint/files');
@@ -127,7 +127,28 @@ describe('Acceptance: ember new', function() {
           '--skip-npm',
           '--skip-bower',
           '--skip-git',
-          '--blueprint=my_blueprint'
+          '--blueprint=./my_blueprint'
+        ]);
+      })
+      .then(confirmBlueprintedForDir('tmp/my_blueprint'));
+  });
+
+  it('ember new with blueprint uses the specified blueprint directory with an absolute path', function() {
+    return tmp.setup('./tmp/my_blueprint')
+      .then(function() {
+        return tmp.setup('./tmp/my_blueprint/files');
+      })
+      .then(function() {
+        fs.writeFileSync('./tmp/my_blueprint/files/gitignore');
+        process.chdir('./tmp');
+
+        return ember([
+          'new',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+          '--blueprint=' + path.resolve(process.cwd(), './my_blueprint')
         ]);
       })
       .then(confirmBlueprintedForDir('tmp/my_blueprint'));


### PR DESCRIPTION
Before this PR, the `--blueprint` option in the `new` and `init` commands got validated as a `gitUrl` or a `path`.

When used as a `path`, it would get resolved to an absolute path, making it point to a specific blueprint on the filesystem depending on the current working directory.

This PR changes it to a String, so it won't be modified before getting lookup'ed up by `Blueprint.lookup`

This doesn't break it being used as a `gitUrl`, because that check happens again in the [InstallBlueprint task](https://github.com/ember-cli/ember-cli/blob/38256ce796861951c6acadab0eed1e8125fc95da/lib/tasks/install-blueprint.js#L38).

It does break it from being used as a path to a blueprint on the filesystem. Instead now it's used as a blueprint in one of the regular lookup paths.

I don't believe this will affect many people, if any. I imagine people always rely on the default `app` blueprint when using `new` or `init`. 

I considered keeping it backward compatible, but the new behaviour might be what we actually want moving forward.

The only test this breaks is [this one](https://github.com/ember-cli/ember-cli/blob/38256ce796861951c6acadab0eed1e8125fc95da/tests/acceptance/new-test.js#L115-L134), which I'm for removing/modifying, but wanted someone else's opinion.

\cc @stefanpenner 