### PR TITLE
Exclude dist/ from addon npm publishes by default

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -1,6 +1,7 @@
 bower_components/
 tests/
 tmp/
+dist/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Just like #3539, I've seen `dist/` published on accident in a number of addons. AFAIK, 99.99+% of addons won't want their `dist/` published as it's just their `/tests/dummy` app output.

Maybe I'm missing something?