### PR TITLE
[fixes #3712] rethrow errors in build task

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -45,9 +45,8 @@ module.exports = Task.extend({
       })
       .catch(function(err) {
         ui.writeLine(chalk.red('Build failed.'));
-        ui.writeError(err);
 
-        return 1;
+        throw err;
       });
   }
 });

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -63,6 +63,21 @@ describe('Acceptance: smoke-test', function() {
       });
   });
 
+  it('ember test exits with non-zero when build fails', function() {
+    this.timeout(450000);
+
+    return copyFixtureFiles('smoke-tests/test-with-syntax-error')
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--silent')
+          .then(function() {
+            expect(false, 'should have rejected with a failing test');
+          })
+          .catch(function(result) {
+            expect(result.code).to.equal(1);
+          });
+      });
+  });
+
   it('ember test exits with non-zero when no tests are run', function() {
     this.timeout(450000);
 

--- a/tests/fixtures/smoke-tests/test-with-syntax-error/tests/unit/some-test.js
+++ b/tests/fixtures/smoke-tests/test-with-syntax-error/tests/unit/some-test.js
@@ -1,0 +1,7 @@
+/*jshint strict:false */
+/* globals QUnit */
+
+QUnit.test('syntax error', function(assert) {
+  # syntax error
+});
+


### PR DESCRIPTION
The build task was catching the failure and returning 1, which moves the promise to a fulfilled state.

The side effect of this is that in the test command the test task will run even if the build fail, and for some reason when the test task is invoked in this state the command hangs forever.

To fix this we rethrow the error so the test command won't run. And since `CLI.prototype.logError` already exit with 1 when some promise gets rejected, there is no need to return 1 within the task.
