### PR TITLE
Suggestion: Adding test coverage to pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ install:
 
 after_script:
   - cat coverage/lcov.info | codeclimate
+  - cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
     "codeclimate-test-reporter": "0.0.4",
+    "coveralls": "^2.11.2",
     "ember-cli-ncp": "1.0.2",
     "github": "^0.2.3",
     "istanbul": "^0.3.13",


### PR DESCRIPTION
Coveralls will add test coverage status to every PR. You can easily see when new code is untested when the coverage decreases.

This can be very helpful, or a nuisance if it is going to be ignored/not enforced.

Here is a PR example: https://github.com/kellyselden/ember-cli/pull/11

![capture](https://cloud.githubusercontent.com/assets/602423/7033579/0aaf4d0a-dd49-11e4-9833-c8d309b3c7ef.PNG)
