### PR TITLE
Update to ember-router-generator 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "debug": "^2.1.3",
     "diff": "^1.3.1",
     "ember-cli-copy-dereference": "^1.0.0",
-    "ember-router-generator": "^0.3.2",
+    "ember-router-generator": "^0.3.3",
     "exit": "^0.1.2",
     "express": "^4.12.3",
     "findup": "0.1.5",


### PR DESCRIPTION
It no longer crashes when you have any errant Expression Statements in `Router.map()`