### PR TITLE
[BUGFIX] Prevent addon-import blueprint from generating if entity name is undefined

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin'];
+    var noAddonBlueprint = ['mixin', 'route'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);
@@ -22,7 +22,7 @@ module.exports = Task.extend({
     var addonBlueprint = this.lookupBlueprint(name + '-addon', true);
     // otherwise, use default addon-import
 
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprint.supportsAddon() && options.args[1]) {
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
     

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,16 +14,18 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin','route'];
+    var noAddonBlueprint = ['mixin'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);
     // lookup custom addon blueprint
     var addonBlueprint = this.lookupBlueprint(name + '-addon', true);
     // otherwise, use default addon-import
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprint.supportsAddon()) {
+
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprint.supportsAddon() && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
+    
     if (options.ignoreMissingMain && !mainBlueprint) {
       return Promise.resolve();
     }

--- a/tests/acceptance/install-test-slow.js
+++ b/tests/acceptance/install-test-slow.js
@@ -11,6 +11,7 @@ var remove     = Promise.denodeify(require('fs-extra').remove);
 var root       = process.cwd();
 var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
+var expect     = require('chai').expect;
 
 describe('Acceptance: ember install', function() {
   this.timeout(30000);
@@ -52,7 +53,7 @@ describe('Acceptance: ember install', function() {
   }
 
   it('installs via npm and runs generator', function() {
-    return installAddon(['ember-cli-fastclick']).then(function() {
+    return installAddon(['ember-cli-fastclick']).then(function(result) {
       assertFile('package.json', {
         contains: [
           /"ember-cli-fastclick": ".*"/
@@ -64,6 +65,11 @@ describe('Acceptance: ember install', function() {
           /"fastclick": ".*"/
         ]
       });
+      
+      expect(result.ui.output).not.to.include('The `ember generate` command '+
+        'requires an entity name to be specified. For more details, use `ember help`.');
+        
     });
   });
+  
 });


### PR DESCRIPTION
Fixes #3831 by preventing addon-import blueprint from generating if entity name is undefined.

When running `ember install:addon ember-cli-foo` the following silent error was being triggered:
```
The `ember generate` command requires an entity name to be specified. For more details, use `ember help`.
```
This PR fixes the silent error, but #3831 may require further work to solve any further root cause.