### PR TITLE
writeError now looks for filename as well as file

### DIFF
--- a/lib/ui/write-error.js
+++ b/lib/ui/write-error.js
@@ -4,12 +4,13 @@ var chalk = require('chalk');
 module.exports = function writeError(ui, error){
   if (!error) { return; }
 
-  if (error.file) {
-    var file = error.file;
+  // Uglify errors have a filename instead
+  var fileName = error.file || error.filename;
+  if (fileName) {
     if (error.line) {
-      file += error.col ? ' (' + error.line + ':' + error.col + ')' : ' (' + error.line + ')';
+      fileName += error.col ? ' (' + error.line + ':' + error.col + ')' : ' (' + error.line + ')';
     }
-    ui.writeLine(chalk.red('File: ' + file), 'ERROR');
+    ui.writeLine(chalk.red('File: ' + fileName), 'ERROR');
   }
 
   if (error.message) {

--- a/tests/helpers/build-error.js
+++ b/tests/helpers/build-error.js
@@ -6,6 +6,7 @@ function BuildError(input){
   Error.call(this);
   this.message = input.message;
   this.file = input.file;
+  this.filename = input.filename; // For testing errors from Uglify
   this.line = input.line;
   this.col = input.col;
   this.stack = input.stack;

--- a/tests/unit/ui/write-error-test.js
+++ b/tests/unit/ui/write-error-test.js
@@ -42,6 +42,14 @@ describe('writeError', function() {
     expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
+  it('error with filename (as from Uglify)', function() {
+    writeError(ui, new BuildError({
+      filename: 'the file'
+    }));
+
+    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+  });
+
   it('error with file + line', function() {
     writeError(ui, new BuildError({
       file: 'the file',


### PR DESCRIPTION
UglifyJS sets the filename but not the file. This change now gives
us line and column for UglifyJS errors.