### PR TITLE
Cache `node_modules` and `bower_components` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
+cache:
+  directories:
+    - node_modules
+    - bower_components
 env:
   - NODE_VERSION=0.10
   - NODE_VERSION=0.12


### PR DESCRIPTION
Enable dependency caching in Travis