### PR TITLE
[ENHANCEMENT] install:addon command will show a deprecation message before running the install command.

### DIFF
--- a/lib/commands/install-addon.js
+++ b/lib/commands/install-addon.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var InstallCommand = require('./install');
+var chalk          = require('chalk');
+
+module.exports = InstallCommand.extend({
+  name: 'install:addon',
+  description: 'This command has been deprecated. Please use `ember install` instead.',
+  works: 'insideProject',
+
+  anonymousOptions: [
+    '<addon-name>'
+  ],
+
+  init: function() {
+    var warning  = 'This command has been deprecated. Please use `ember ';
+    warning     += 'install <addonName>` instead.';
+    this.ui.writeLine(chalk.red(warning));
+
+    if (this._super.init) {
+      this._super.init.call(this);
+    }
+  }
+});

--- a/lib/commands/install-npm.js
+++ b/lib/commands/install-npm.js
@@ -14,7 +14,7 @@ module.exports = Command.extend({
   ],
 
   run: function() {
-    var err  = 'This command has been deprecated. Please use `npm install ';
+    var err  = 'This command has been removed. Please use `npm install ';
     err     += '<packageName> --save-dev --save-exact` instead.';
     return Promise.reject(new SilentError(err));
   }

--- a/tests/unit/commands/install-addon-test.js
+++ b/tests/unit/commands/install-addon-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var expect = require('chai').expect;
+var InstallAddonCommand = require('../../../lib/commands/install-addon');
+var commandOptions = require('../../factories/command-options');
+var AddonInstall = require('../../../lib/tasks/addon-install');
+var Task = require('../../../lib/models/task');
+var Promise = require('../../../lib/ext/promise');
+var stub = require('../../helpers/stub').stub;
+var Project = require('../../../lib/models/project');
+
+describe('install:addon command', function() {
+  var command, options, tasks, npmInstance, generateBlueprintInstance;
+
+  beforeEach(function() {
+    tasks = {
+      AddonInstall: AddonInstall,
+      NpmInstall: Task.extend({
+        init: function() {
+          npmInstance = this;
+        }
+      }),
+
+      GenerateFromBlueprint: Task.extend({
+        init: function() {
+          generateBlueprintInstance = this;
+        }
+      })
+    };
+
+    options = commandOptions({
+      settings: {},
+      project: {
+        name: function() {
+          return 'some-random-name';
+        },
+        isEmberCLIProject: function() {
+          return true;
+        },
+        initializeAddons: function() {  },
+        reloadAddons: function() {
+          this.addons = [{
+            pkg: {
+              name: 'ember-cli-photoswipe',
+              'ember-addon': {
+                defaultBlueprint: 'photoswipe'
+              }
+            }
+          }];
+        },
+
+        findAddonByName: Project.prototype.findAddonByName
+      },
+
+      tasks: tasks
+    });
+
+    stub(tasks.NpmInstall.prototype, 'run', Promise.resolve());
+    stub(tasks.GenerateFromBlueprint.prototype, 'run', Promise.resolve());
+
+    command = new InstallAddonCommand(options);
+
+  });
+
+  afterEach(function() {
+    tasks.NpmInstall.prototype.run.restore();
+    tasks.GenerateFromBlueprint.prototype.run.restore();
+  });
+
+
+  it('will show a deprecation warning', function() {
+    return command.validateAndRun(['ember-cli-photoswipe']).then(function() {
+      var msg  = 'This command has been deprecated. Please use `ember install ';
+      msg     += '<addonName>` instead.';
+
+      expect(command.ui.output).to.include(msg);
+
+      expect(npmInstance.ui, 'ui was set');
+      expect(npmInstance.project, 'project was set');
+      expect(npmInstance.analytics, 'analytics was set');
+
+      expect(generateBlueprintInstance.ui, 'ui was set');
+      expect(generateBlueprintInstance.project, 'project was set');
+      expect(generateBlueprintInstance.analytics, 'analytics was set');
+
+    });
+  });
+});

--- a/tests/unit/commands/install-npm-test.js
+++ b/tests/unit/commands/install-npm-test.js
@@ -23,7 +23,7 @@ describe('install:npm command', function() {
     });
 
     command  = new InstallCommand(options);
-    msg      = 'This command has been deprecated. Please use `npm install ';
+    msg      = 'This command has been removed. Please use `npm install ';
     msg     += '<packageName> --save-dev --save-exact` instead.';
   });
 


### PR DESCRIPTION
Given that a lot of ember-cli addon projects tell you to install them through the `ember install:addon` command, I re-added the command so it can throw a friendly error that points to the now correct command `ember install`. This is related to https://github.com/ember-cli/ember-cli/pull/3598#issuecomment-90922380.