### PR TITLE
Use shorthand ES6 re-export for addon-imports as well, which landed in #3690

### DIFF
--- a/blueprints/addon-import/files/__root__/__path__/__name__.js
+++ b/blueprints/addon-import/files/__root__/__path__/__name__.js
@@ -1,3 +1,1 @@
-import <%= camelizedModuleName %> from '<%= modulePath %>';
-
-export default <%= camelizedModuleName %>;
+export { default } from '<%= modulePath %>';

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -67,8 +67,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/controllers/foo.js', {
         contains: [
-          "import foo from 'my-addon/controllers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/controllers/foo';"
         ]
       });
       assertFile('tests/unit/controllers/foo-test.js', {
@@ -93,8 +92,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/controllers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/controllers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/controllers/foo/bar';"
         ]
       });
       assertFile('tests/unit/controllers/foo/bar-test.js', {
@@ -182,8 +180,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/helpers/foo-bar.js', {
         contains: [
-          "import fooBar from 'my-addon/helpers/foo-bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/helpers/foo-bar';"
         ]
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
@@ -205,8 +202,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/helpers/foo/bar-baz.js', {
         contains: [
-          "import fooBarBaz from 'my-addon/helpers/foo/bar-baz';",
-          "export default fooBarBaz;"
+          "export { default } from 'my-addon/helpers/foo/bar-baz';"
         ]
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
@@ -227,8 +223,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/models/foo.js', {
         contains: [
-          "import foo from 'my-addon/models/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/models/foo';"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
@@ -284,8 +279,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/models/foo.js', {
         contains: [
-          "import foo from 'my-addon/models/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/models/foo';"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
@@ -317,8 +311,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/models/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/models/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/models/foo/bar';"
         ]
       });
       assertFile('tests/unit/models/foo/bar-test.js', {
@@ -362,8 +355,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/views/foo.js', {
         contains: [
-          "import foo from 'my-addon/views/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/views/foo';"
         ]
       });
       assertFile('tests/unit/views/foo-test.js', {
@@ -388,8 +380,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/views/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/views/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/views/foo/bar';"
         ]
       });
       assertFile('tests/unit/views/foo/bar-test.js', {
@@ -425,8 +416,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/initializers/foo.js', {
         contains: [
-          "import foo from 'my-addon/initializers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/initializers/foo';"
         ]
       });
       assertFile('tests/unit/initializers/foo-test.js');
@@ -447,8 +437,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/initializers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/initializers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/initializers/foo/bar';"
         ]
       });
       assertFile('tests/unit/initializers/foo/bar-test.js');
@@ -507,8 +496,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/adapters/application.js', {
         contains: [
-          "import application from 'my-addon/adapters/application';",
-          "export default application;"
+          "export { default } from 'my-addon/adapters/application';"
         ]
       });
       assertFile('tests/unit/adapters/application-test.js', {
@@ -533,8 +521,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/adapters/foo.js', {
         contains: [
-          "import foo from 'my-addon/adapters/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/adapters/foo';"
         ]
       });
       assertFile('tests/unit/adapters/foo-test.js', {
@@ -559,8 +546,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/adapters/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/adapters/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/adapters/foo/bar';"
         ]
       });
     });
@@ -577,8 +563,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/serializers/foo.js', {
         contains: [
-          "import foo from 'my-addon/serializers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/serializers/foo';"
         ]
       });
       assertFile('tests/unit/serializers/foo-test.js', {
@@ -602,8 +587,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/serializers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/serializers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/serializers/foo/bar';"
         ]
       });
       assertFile('tests/unit/serializers/foo/bar-test.js', {
@@ -636,8 +620,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/transforms/foo.js', {
         contains: [
-          "import foo from 'my-addon/transforms/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/transforms/foo';"
         ]
       });
       assertFile('tests/unit/transforms/foo-test.js', {
@@ -670,8 +653,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/transforms/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/transforms/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/transforms/foo/bar';"
         ]
       });
       assertFile('tests/unit/transforms/foo/bar-test.js', {
@@ -695,8 +677,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/utils/foo-bar.js', {
         contains: [
-          "import fooBar from 'my-addon/utils/foo-bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/utils/foo-bar';"
         ]
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
@@ -716,8 +697,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/utils/foo/bar-baz.js', {
         contains: [
-          "import fooBarBaz from 'my-addon/utils/foo/bar-baz';",
-          "export default fooBarBaz;"
+          "export { default } from 'my-addon/utils/foo/bar-baz';"
         ]
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
@@ -738,8 +718,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/services/foo.js', {
         contains: [
-          "import foo from 'my-addon/services/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/services/foo';"
         ]
       });
       assertFile('tests/unit/services/foo-test.js', {
@@ -764,8 +743,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('app/services/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/services/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/services/foo/bar';"
         ]
       });
       assertFile('tests/unit/services/foo/bar-test.js', {

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -77,8 +77,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/controllers/foo.js', {
         contains: [
-          "import foo from 'my-addon/controllers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/controllers/foo';"
         ]
       });
       assertFile('tests/unit/controllers/foo-test.js', {
@@ -103,8 +102,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/controllers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/controllers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/controllers/foo/bar';"
         ]
       });
       assertFile('tests/unit/controllers/foo/bar-test.js', {
@@ -192,8 +190,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/helpers/foo-bar.js', {
         contains: [
-          "import fooBar from 'my-addon/helpers/foo-bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/helpers/foo-bar';"
         ]
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
@@ -215,8 +212,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/helpers/foo/bar-baz.js', {
         contains: [
-          "import fooBarBaz from 'my-addon/helpers/foo/bar-baz';",
-          "export default fooBarBaz;"
+          "export { default } from 'my-addon/helpers/foo/bar-baz';"
         ]
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
@@ -237,8 +233,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/models/foo.js', {
         contains: [
-          "import foo from 'my-addon/models/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/models/foo';"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
@@ -295,8 +290,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/models/foo.js', {
         contains: [
-          "import foo from 'my-addon/models/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/models/foo';"
         ]
       });
       assertFile('tests/unit/models/foo-test.js', {
@@ -328,8 +322,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/models/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/models/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/models/foo/bar';"
         ]
       });
       assertFile('tests/unit/models/foo/bar-test.js', {
@@ -373,8 +366,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/views/foo.js', {
         contains: [
-          "import foo from 'my-addon/views/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/views/foo';"
         ]
       });
       assertFile('tests/unit/views/foo-test.js', {
@@ -399,8 +391,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/views/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/views/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/views/foo/bar';"
         ]
       });
       assertFile('tests/unit/views/foo/bar-test.js', {
@@ -436,8 +427,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/initializers/foo.js', {
         contains: [
-          "import foo from 'my-addon/initializers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/initializers/foo';"
         ]
       });
       assertFile('tests/unit/initializers/foo-test.js');
@@ -458,8 +448,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/initializers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/initializers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/initializers/foo/bar';"
         ]
       });
       assertFile('tests/unit/initializers/foo/bar-test.js');
@@ -518,8 +507,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/adapters/application.js', {
         contains: [
-          "import application from 'my-addon/adapters/application';",
-          "export default application;"
+          "export { default } from 'my-addon/adapters/application';"
         ]
       });
       assertFile('tests/unit/adapters/application-test.js', {
@@ -544,8 +532,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/adapters/foo.js', {
         contains: [
-          "import foo from 'my-addon/adapters/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/adapters/foo';"
         ]
       });
       assertFile('tests/unit/adapters/foo-test.js', {
@@ -570,8 +557,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/adapters/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/adapters/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/adapters/foo/bar';"
         ]
       });
     });
@@ -588,8 +574,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/serializers/foo.js', {
         contains: [
-          "import foo from 'my-addon/serializers/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/serializers/foo';"
         ]
       });
       assertFile('tests/unit/serializers/foo-test.js', {
@@ -613,8 +598,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/serializers/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/serializers/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/serializers/foo/bar';"
         ]
       });
       assertFile('tests/unit/serializers/foo/bar-test.js', {
@@ -647,8 +631,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/transforms/foo.js', {
         contains: [
-          "import foo from 'my-addon/transforms/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/transforms/foo';"
         ]
       });
       assertFile('tests/unit/transforms/foo-test.js', {
@@ -681,8 +664,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/transforms/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/transforms/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/transforms/foo/bar';"
         ]
       });
       assertFile('tests/unit/transforms/foo/bar-test.js', {
@@ -706,8 +688,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/utils/foo-bar.js', {
         contains: [
-          "import fooBar from 'my-addon/utils/foo-bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/utils/foo-bar';"
         ]
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
@@ -727,8 +708,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/utils/foo/bar-baz.js', {
         contains: [
-          "import fooBarBaz from 'my-addon/utils/foo/bar-baz';",
-          "export default fooBarBaz;"
+          "export { default } from 'my-addon/utils/foo/bar-baz';"
         ]
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
@@ -749,8 +729,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/services/foo.js', {
         contains: [
-          "import foo from 'my-addon/services/foo';",
-          "export default foo;"
+          "export { default } from 'my-addon/services/foo';"
         ]
       });
       assertFile('tests/unit/services/foo-test.js', {
@@ -775,8 +754,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('lib/my-addon/app/services/foo/bar.js', {
         contains: [
-          "import fooBar from 'my-addon/services/foo/bar';",
-          "export default fooBar;"
+          "export { default } from 'my-addon/services/foo/bar';"
         ]
       });
       assertFile('tests/unit/services/foo/bar-test.js', {


### PR DESCRIPTION
Continues work from #3851