### PR TITLE
Allow blueprints to omit entity names

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -272,6 +272,7 @@ Blueprint.prototype.constructor = Blueprint;
 
 Blueprint.prototype.availableOptions = [];
 Blueprint.prototype.anonymousOptions = ['name'];
+Blueprint.prototype.entityNameRequired = true;
 
 /**
   Used to retrieve files for blueprint. The `file` param is an
@@ -309,8 +310,8 @@ Blueprint.prototype.srcPath = function(file) {
   @param {String} entityName
   @return {null}
 */
-Blueprint.prototype.normalizeEntityName = function(entityName) {
-  if (!entityName) {
+Blueprint.prototype.normalizeEntityName = function(entityName, required) {
+  if (!entityName && required) {
     throw new SilentError('The `ember generate` command requires an ' +
                           'entity name to be specified. ' +
                           'For more details, use `ember help`.');
@@ -425,9 +426,9 @@ Blueprint.prototype._checkForPod = function(verbose) {
   @method _normalizeEntityName
   @param {Object} entity
 */
-Blueprint.prototype._normalizeEntityName = function(entity) {
+Blueprint.prototype._normalizeEntityName = function(entity, required) {
   if (entity) {
-    entity.name = this.normalizeEntityName(entity.name);
+    entity.name = this.normalizeEntityName(entity.name, required);
   }
 };
 
@@ -485,7 +486,12 @@ Blueprint.prototype.install = function(options) {
       ' changes will be written.'));
   }
 
-  this._normalizeEntityName(options.entity);
+  var entityNameRequired = this.entityNameRequired;
+  if (typeof options.entityNameRequired !== 'undefined') {
+    entityNameRequired = options.entityNameRequired;
+  }
+  
+  this._normalizeEntityName(options.entity, entityNameRequired);
   this._checkForPod(options.verbose);
   this._checkInRepoAddonExists(options.inRepoAddon);
 

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -16,7 +16,7 @@ module.exports = Task.extend({
     var packageName      = options['package'];
     var extraArgs        = options.extraArgs || [];
     var blueprintOptions = options.blueprintOptions || {};
-    
+
     var npmInstall = new this.NpmInstallTask({
       ui:         this.ui,
       analytics:  this.analytics,
@@ -53,7 +53,8 @@ module.exports = Task.extend({
 
     var taskOptions = merge({
       args: [blueprintName].concat(extraArgs),
-      ignoreMissingMain: true
+      ignoreMissingMain: true,
+      entityNameRequired: false
     }, blueprintOptions || {});
 
     return install.run(taskOptions);

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -46,7 +46,8 @@ module.exports = Task.extend({
       settings: this.settings,
       testing: this.testing,
       taskOptions: options,
-      originBlueprintName: name
+      originBlueprintName: name,
+      entityNameRequired: options.entityNameRequired
     };
 
     blueprintOptions = merge(blueprintOptions, options || {});
@@ -66,11 +67,11 @@ module.exports = Task.extend({
         return testBlueprint[self.blueprintFunction](testBlueprintOptions);
       })
       .then(function() {
-        if (!addonBlueprint) { return; }
+        if (!addonBlueprint || options.entityNameRequired) { return; }
         if (!this.project.isEmberCLIAddon() && blueprintOptions.inRepoAddon === null) { return; }
-        
+
         // if (!mainBlueprint.supportsAddon()) { return; }
-        
+
         if (addonBlueprint.locals === Blueprint.prototype.locals) {
           addonBlueprint.locals = function(options) {
             return mainBlueprint.locals(options);

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -67,7 +67,7 @@ module.exports = Task.extend({
         return testBlueprint[self.blueprintFunction](testBlueprintOptions);
       })
       .then(function() {
-        if (!addonBlueprint || options.entityNameRequired) { return; }
+        if (!addonBlueprint || options.entityNameRequired === false) { return; }
         if (!this.project.isEmberCLIAddon() && blueprintOptions.inRepoAddon === null) { return; }
 
         // if (!mainBlueprint.supportsAddon()) { return; }

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -446,6 +446,14 @@ describe('Blueprint', function() {
       }).to.throw(SilentError, /The `ember generate` command requires an entity name to be specified./);
     });
 
+    it('does not throw when an entityName is not provided, but is not required', function(){
+      options.entity = { };
+      options.entityNameRequired = false;
+      expect(function() {
+        blueprint.install(options);
+      }).to.not.throw(SilentError, /The `ember generate` command requires an entity name to be specified./);
+    })
+
     it('throws error when an action does not exist', function() {
       blueprint._actions = {};
       return blueprint.install(options)


### PR DESCRIPTION
Change blueprints to allow for missing entity names. Entity names are required by default on all blueprints except for an addon's main blueprint (which will never have an entity name).

This setting can be modified in a blueprint's definition via the `entityNameRequired` flag, or at runtime by passing the `entityNameRequired` flag on the options hash to the blueprint's install method. The latter approach is how the main blueprints are exempted automatically.

This should get rid of the need for empty `normalizeEntityName` hooks such as https://github.com/poetic/ember-cli-cordova/blob/master/blueprints/cordova-starter-kit/index.js#L9. This should also fix #3831 and #3846 in a slightly more robust manner.