### PR TITLE
[BUGFIX] Use posix path for in-repo-addons in package.json

### DIFF
--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -22,7 +22,7 @@ module.exports = {
     var packagePath = path.join(this.project.root, 'package.json');
     var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
     var name        = stringUtil.dasherize(options.entity.name);
-    var newPath     = path.join('lib', name);
+    var newPath     = ['lib', name].join('/');
     var paths;
 
     contents['ember-addon'] = contents['ember-addon'] || {};

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -760,5 +760,15 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
     });
   });
+  
+  it('in-repo-addon adds path to lib', function() {
+    return initInRepoAddon().then(function() {
+      assertFile('package.json', {
+        contains: [
+          'lib/my-addon'
+        ]
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
Fixes #3847 using a posix style path in package.json for in-repo-addons for Windows (and all other environments).