### PR TITLE
Removes bower install command.

### DIFF
--- a/lib/commands/install-bower.js
+++ b/lib/commands/install-bower.js
@@ -1,27 +1,21 @@
 'use strict';
 
 var Command = require('../models/command');
+var SilentError = require('../errors/silent');
+var Promise     = require('../ext/promise');
 
 module.exports = Command.extend({
   name: 'install:bower',
-  description: 'Installs bower packages.',
+  description: 'Bower package install are now managed by the user.',
   works: 'insideProject',
 
   anonymousOptions: [
     '<package-names...>'
   ],
 
-  run: function(commandOptions, rawArgs) {
-    var BowerInstallTask = this.tasks.BowerInstall;
-    var bowerInstall     = new BowerInstallTask({
-      ui:         this.ui,
-      analytics:  this.analytics,
-      project:    this.project
-    });
-
-    return bowerInstall.run({
-      packages: rawArgs,
-      installOptions: { save: true }
-    });
+  run: function() {
+    var err  = 'This command has been deprecated. Please use `bower install ';
+    err     += '<packageName> --save-dev --save-exact` instead.';
+    return Promise.reject(new SilentError(err));
   }
 });

--- a/tests/unit/commands/install-bower-test.js
+++ b/tests/unit/commands/install-bower-test.js
@@ -1,23 +1,13 @@
 'use strict';
 
 var expect         = require('chai').expect;
-var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-bower');
-var Task           = require('../../../lib/models/task');
 
 describe('install:bower command', function() {
-  var command, options, tasks, bowerInstance;
+  var command, options, msg;
 
   beforeEach(function() {
-    tasks = {
-      BowerInstall: Task.extend({
-        init: function() {
-          bowerInstance = this;
-        }
-      })
-    };
-
     options = commandOptions({
       settings: {},
 
@@ -30,49 +20,33 @@ describe('install:bower command', function() {
           return true;
         }
       },
-
-      tasks: tasks
     });
 
-    stub(tasks.BowerInstall.prototype, 'run');
-
-    command = new InstallCommand(options);
+    command  = new InstallCommand(options);
+    msg      = 'This command has been deprecated. Please use `bower install ';
+    msg     += '<packageName> --save-dev --save-exact` instead.';
   });
 
-  afterEach(function() {
-    tasks.BowerInstall.prototype.run.restore();
-  });
-
-  it('initializes bower task with ui, project and analytics', function() {
-    return command.validateAndRun([]).then(function() {
-      expect(bowerInstance.ui, 'ui was set');
-      expect(bowerInstance.project, 'project was set');
-      expect(bowerInstance.analytics, 'analytics was set');
-    });
-  });
-
-  describe('with no args', function() {
-    it('runs the bower install task with no packages and save true', function() {
-      return command.validateAndRun([]).then(function() {
-        var bowerRun = tasks.BowerInstall.prototype.run;
-        expect(bowerRun.called).to.equal(1, 'expected bower install run was called once');
-        expect(bowerRun.calledWith[0][0]).to.deep.equal({
-          packages: [],
-          installOptions: { save: true }
-        }, 'expected bower install called with no packages and save true');
+  describe('with args', function() {
+    it('it throws a friendly silent error', function() {
+      return command.validateAndRun(['moment', 'lodash']).then(function() {
+        expect(false, 'should reject with error');
+      }).catch(function(err) {
+        expect(err.message).to.equal(
+          msg, 'expect error to have a helpful message'
+        );
       });
     });
   });
 
-  describe('with args', function() {
-    it('runs the bower install task with given packages and save true', function() {
-      return command.validateAndRun(['moment', 'lodash']).then(function() {
-        var bowerRun = tasks.BowerInstall.prototype.run;
-        expect(bowerRun.called).to.equal(1, 'expected bower install run was called once');
-        expect(bowerRun.calledWith[0][0]).to.deep.equal({
-          packages: ['moment', 'lodash'],
-          installOptions: { save: true }
-        }, 'expected bower install called with given packages and save true');
+  describe('without args', function() {
+    it('it throws a friendly slient error', function() {
+       return command.validateAndRun([]).then(function() {
+        expect(false, 'should reject with error');
+      }).catch(function(err) {
+        expect(err.message).to.equal(
+          msg, 'expect error to have a helpful message'
+        );
       });
     });
   });


### PR DESCRIPTION
I think this command was deprecated in https://github.com/ember-cli/ember-cli/pull/3598. The npm command was removed but it looks like the bower one was missed.