### PR TITLE
Bump safe_yaml to 1.0.4 to fix an issue with Ruby 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     rb-inotify (0.9.4)
       ffi (>= 0.5.0)
     redcarpet (3.1.2)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sass (3.3.7)
     timers (1.1.0)
     toml (0.1.1)


### PR DESCRIPTION
There was an issue when running the `ruby run.rb` command v1.0.3 of the `safe_yaml` gem. The following error would occur:

```
/Users/kelly/.rvm/gems/ruby-2.2.2/gems/safe_yaml-1.0.3/lib/safe_yaml/load.rb:43:in `<module:SafeYAML>': undefined method `tagged_classes' for Psych:Module (NoMethodError)
	from /Users/kelly/.rvm/gems/ruby-2.2.2/gems/safe_yaml-1.0.3/lib/safe_yaml/load.rb:26:in `<top (required)>'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/gems/jekyll-2.0.3/lib/jekyll.rb:21:in `require'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/gems/jekyll-2.0.3/lib/jekyll.rb:21:in `<top (required)>'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/gems/jekyll-2.0.3/bin/jekyll:6:in `require'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/gems/jekyll-2.0.3/bin/jekyll:6:in `<top (required)>'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/bin/jekyll:23:in `load'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/bin/jekyll:23:in `<main>'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
	from /Users/kelly/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
```

Bumping the gem version to 1.0.4 fixes this issue