### PR TITLE
Remove podModulePrefix from app.js

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -9,7 +9,6 @@ Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
   Resolver: Resolver
 });
 


### PR DESCRIPTION
I think this was left over after removing `podModulePrefix` from the config. If not, just close this PR.