### PR TITLE
Always create addon trees when developing an addon

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -490,7 +490,7 @@ Addon.prototype.compileTemplates = function(tree) {
 Addon.prototype.compileAddon = function(tree) {
   this._requireBuildPackages();
 
-  if (Object.keys(this.includedModules()).length === 0) {
+  if (!this.isDevelopingAddon() && Object.keys(this.includedModules()).length === 0) {
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "^0.8.0-0",
+    "testem": "^0.8.2",
     "through": "^2.3.6",
     "tiny-lr": "0.1.5",
     "walk-sync": "0.1.3",

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -175,4 +175,39 @@ describe('Acceptance: addon-smoke-test', function() {
       handleError(error, 'npm');
     });
   });
+
+  function wait(time) {
+    return new Promise(function(resolve) {
+      setTimeout(function() {
+        resolve();
+      }, time);
+    });
+  }
+
+  it('doesn\'t fail to build new files', function() {
+    var testemOutput = '';
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--launch=PhantomJS', '--server', {
+      onOutput: function(string) {
+        testemOutput += string;
+      },
+      onChildSpawned: function(child) {
+        return wait(12000).then(function() {
+
+          return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'initializer', 'foo')
+          .then(function() {
+            return wait(5000);
+          })
+          .then(function() {
+            child.stdin.write('q'); // quit test server
+            child.stdin.end();
+            expect(testemOutput).to.contain('✔');
+            expect(testemOutput).to.not.contain('✘');
+          });
+
+        });
+
+      }
+    });
+
+  });
 });

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -359,7 +359,11 @@ describe('models/addon.js', function() {
       });
 
       afterEach(function() {
-        process.env.EMBER_ADDON_ENV = originalEnvValue;
+        if(originalEnvValue === undefined) {
+          delete process.env.EMBER_ADDON_ENV;
+        } else {
+          process.env.EMBER_ADDON_ENV = originalEnvValue;
+        }
       });
 
       it('returns true when `EMBER_ADDON_ENV` is set to development', function() {


### PR DESCRIPTION
If we create a new addon and start the server `includedModules()` will return an empty object, since there isn't any module, so the addon tree is skipped.
But if later we add a new file, for instance using `ember g initializer foo`, these files aren't included in the pipeline because no tree was created initially and tests will fail with `Could not find module ember-simple-validate/initializers/foo imported from dummy/initializers/foo`

Fixes #3906