### PR TITLE
Disable directory listings on development server

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -29,7 +29,9 @@ HistorySupportAddon.prototype.serverMiddleware = function(config) {
 
         if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
           var assetPath = req.path.slice(baseURL.length);
-          if (!fs.existsSync(path.join(results.directory, assetPath))) {
+          var isFile = false;
+          try { isFile = fs.statSync(path.join(results.directory, assetPath)).isFile(); } catch (err) { }
+          if (!isFile) {
             req.serveUrl = baseURL + 'index.html';
           }
         }

--- a/lib/tasks/server/middleware/serve-files/index.js
+++ b/lib/tasks/server/middleware/serve-files/index.js
@@ -15,7 +15,8 @@ ServeFilesAddon.prototype.serverMiddleware = function(options) {
 
   var broccoliMiddleware = options.middleware || require('broccoli/lib/middleware');
   var middleware = broccoliMiddleware(options.watcher, {
-    liveReloadPath: '/ember-cli-live-reload.js'
+    liveReloadPath: '/ember-cli-live-reload.js',
+    autoIndex: false // disable directory listings
   });
 
   var baseURL = cleanBaseURL(options.baseURL);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "abbrev": "^1.0.5",
     "bower": "^1.3.12",
     "bower-config": "0.5.2",
-    "broccoli": "0.15.3",
+    "broccoli": "0.15.4",
     "broccoli-caching-writer": "0.5.5",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "^2.0.0",


### PR DESCRIPTION
@rwjblue, you mentioned that you want this...

My only worry would be that anybody trying to have an `/assets` route in their Ember app *might* have a bad surprise when they deploy to production, depending on how their server or CDN is set up, and now that `autoIndex` is false we're not catching that in development anymore. But I'm unsure.