### PR TITLE
[Enhancement] Ember-try & parallel travis-ci scenario tests for addons

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: node_js
+node_js:
+  - "0.12"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+env:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
+before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
+
+install:
+  - npm install -g bower
+  - npm install
+  - bower install
+
+script:
+  - ember try $EMBER_TRY_SCENARIO test

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -1,0 +1,35 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -113,6 +113,7 @@ module.exports = {
     '^public.*':     'tests/dummy/:path',
 
     '^addon-config/environment.js': 'config/environment.js',
+    '^addon-config/ember-try.js'  : 'config/ember-try.js',
 
     '^npmignore': '.npmignore'
   },


### PR DESCRIPTION
Thanks to @kategengler's add-on, inspired by @ef4's work for liquid-fire, we can easily test apps and addons against multiple versions of ember.js

This PR enhances the existing ember-try support for addons with a default configuration for testing against:
- ~~1.10~~ "default" -- may require some modification to ember-try
- components/ember#release
- components/ember#beta
- components/ember#canary

Additionally, the default travis-ci configuration will test these scenarios in parallel, while allowing builds to pass, even if tests fail using ember-canary. Benefits I see in this are:
* Developers get feedback on specific builds easily
* Test jobs are potentially run in parallel, depending on travis-ci worker node availability
* Apps and addons are tested against canary by default, with no downside to the developer. Build times are no longer than they otherwise would be, test failures in canary are tolerated
* Using the `component/ember` channels for scenarios instead of numbered versions allows the release team to get feedback on new releases (including canary builds) without any action required by addon and app developers
 
![screen shot 2015-04-17 at 10 52 19 am](https://cloud.githubusercontent.com/assets/558005/7210006/df190174-e502-11e4-9e77-ad0f61c349e5.png)

### TODO
* Updates to .travis.yml
  - [x] Rename environment variable to EMBER_TRY_SCENARIO
  - [x] `script: ember try $EMBER_TRY_SCENARIO test`
  - [x] Append build matrix
    - [x] Append env matrix
  - [x] Ensure that `config/ember-try.js` is in place for addons