### PR TITLE
Export test output dir via ENV

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -80,6 +80,7 @@ module.exports = Command.extend({
 
   run: function(commandOptions) {
     var outputPath  = this.tmp();
+    process.env['EMBER_CLI_TEST_OUTPUT'] = outputPath;
     var testOptions = this.assign({}, commandOptions, {
       outputPath: outputPath,
       project: this.project,


### PR DESCRIPTION
This allows custom testem launchers to discover the location of the build output. Browser-based launchers don't need this because they all point at the server URL, but process-based launchers have no other way of finding the build.

For example, I have a project that outputs some node-formatted tests alongside the usual browser-formatted stuff. With this PR I can add a node-based launcher to testem.json:

```js
  "launchers": {
    "NodeTests": {
      "command": "mocha -R tap $EMBER_CLI_TEST_OUTPUT/node-tests",
      "protocol": "tap"
    }
```