### PR TITLE
Don't ban website crawling by default

### DIFF
--- a/blueprints/app/files/public/robots.txt
+++ b/blueprints/app/files/public/robots.txt
@@ -1,2 +1,5 @@
-# http://www.robotstxt.org
-User-agent: *
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# To ban all spiders from the entire site uncomment the next two lines:
+# User-agent: *
+# Disallow: /


### PR DESCRIPTION
With fastboot generated apps we don't want to prevent website crawling by default

I copied the robots.txt from Rails