### PR TITLE
Replace 'this.resource' with 'this.route' in generators

### DIFF
--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -54,7 +54,7 @@ module.exports = {
       }
     });
 
-    var routeOptions = merge({}, options, { type: 'resource' });
+    var routeOptions = merge({}, options);
 
     var self = this;
     return this._processBlueprint(type, 'model', modelOptions)

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -10,16 +10,6 @@ module.exports = {
 
   availableOptions: [
     {
-      name: 'type',
-      type: String,
-      values: ['route', 'resource'],
-      default: 'route',
-      aliases:[
-        {'route': 'route'},
-        {'resource': 'resource'}
-      ]
-    },
-    {
       name: 'path',
       type: String,
       default: ''
@@ -43,14 +33,6 @@ module.exports = {
     };
   },
 
-  beforeInstall: function(options) {
-    var type = options.type;
-
-    if (type && !/^(resource|route)$/.test(type)) {
-      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".');
-    }
-  },
-
   shouldTouchRouter: function(name) {
     var isIndex = name === 'index';
     var isBasic = name === 'basic';
@@ -64,18 +46,9 @@ module.exports = {
 
     if (this.shouldTouchRouter(entity.name) && !options.dryRun) {
       addRouteToRouter(entity.name, {
-        type: options.type,
         root: options.project.root,
         path: options.path
       });
-    }
-  },
-
-  beforeUninstall: function(options) {
-    var type = options.type;
-
-    if (type && !/^(resource|route)$/.test(type)) {
-      throw new SilentError('Unknown route type "' + type + '". Should be "route" or "resource".');
     }
   },
 
@@ -84,7 +57,6 @@ module.exports = {
 
     if (this.shouldTouchRouter(entity.name) && !options.dryRun) {
       removeRouteFromRouter(entity.name, {
-        type: options.type,
         root: options.project.root
       });
     }

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -60,7 +60,7 @@ describe('Acceptance: ember destroy', function() {
       '--skip-bower'
     ]);
   }
-  
+
   function initInRepoAddon() {
     return initApp().then(function() {
       return ember([
@@ -70,7 +70,7 @@ describe('Acceptance: ember destroy', function() {
       ]);
     });
   }
-  
+
   function generate(args) {
     var generateArgs = ['generate'].concat(args);
     return ember(generateArgs);
@@ -83,7 +83,7 @@ describe('Acceptance: ember destroy', function() {
       return ember(generateArgs);
     });
   }
-  
+
   function generateInRepoAddon(args) {
     var generateArgs = ['generate'].concat(args);
 
@@ -141,7 +141,7 @@ describe('Acceptance: ember destroy', function() {
         assertFilesNotExist(files);
       });
   }
-  
+
   function assertDestroyAfterGenerateInRepoAddon(args, files) {
     return generateInRepoAddon(args)
       .then(function() {
@@ -242,39 +242,10 @@ describe('Acceptance: ember destroy', function() {
       'tests/unit/routes/foo-test.js'
     ];
 
-    return assertDestroyAfterGenerate(commandArgs, files);
-  });
-
-  it('route foo --type=resource', function() {
-    this.timeout(20000);
-    var commandArgs = ['route', 'foo', '--type=resource'];
-    var files       = [
-      'app/routes/foo.js',
-      'app/templates/foo.hbs',
-      'tests/unit/routes/foo-test.js'
-    ];
-
     return assertDestroyAfterGenerate(commandArgs, files)
       .then(function() {
         assertFile('app/router.js', {
-          doesNotContain: "this.resource('foo');"
-        });
-      });
-  });
-
-  it('route foos --type=resource', function() {
-    this.timeout(20000);
-    var commandArgs = ['route', 'foos', '--type=resource'];
-    var files       = [
-      'app/routes/foos.js',
-      'app/templates/foos.hbs',
-      'tests/unit/routes/foos-test.js'
-    ];
-
-    return assertDestroyAfterGenerate(commandArgs, files)
-      .then(function() {
-        assertFile('app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -317,7 +288,7 @@ describe('Acceptance: ember destroy', function() {
     return assertDestroyAfterGenerate(commandArgs, files)
       .then(function() {
         assertFile('app/router.js', {
-          doesNotContain: "this.resource('foo');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -336,7 +307,7 @@ describe('Acceptance: ember destroy', function() {
     return assertDestroyAfterGenerate(commandArgs, files)
       .then(function() {
         assertFile('app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foos');"
         });
       });
   });
@@ -577,7 +548,7 @@ describe('Acceptance: ember destroy', function() {
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
   });
-  
+
   it('in-repo-addon component nested/x-foo', function() {
     var commandArgs = ['component', 'nested/x-foo', '--in-repo-addon=my-addon'];
     var files       = [

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -309,14 +309,6 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
-  it('route foos --type=resource', function() {
-    return generate(['route', 'foos', '--type=resource']).then(function() {
-      assertFile('app/router.js', {
-        contains: 'this.resource(\'foos\', function() {});'
-      });
-    });
-  });
-
   it('route index', function() {
     return generate(['route', 'index']).then(function() {
       assertFile('app/router.js', {
@@ -406,7 +398,7 @@ describe('Acceptance: ember generate', function() {
   it('resource foos', function() {
     return generate(['resource', 'foos']).then(function() {
       assertFile('app/router.js', {
-        contains: 'this.resource(\'foos\', function() {});'
+        contains: 'this.route(\'foos\');'
       });
       assertFile('app/models/foo.js', {
         contains: 'export default DS.Model.extend'
@@ -430,9 +422,9 @@ describe('Acceptance: ember generate', function() {
     return generate(['resource', 'foos', '--path=app/foos']).then(function() {
       assertFile('app/router.js', {
         contains: [
-          'this.resource(\'foos\', {',
+          'this.route(\'foos\', {',
           'path: \'app/foos\'',
-          '}, function() {});'
+          '});'
         ]
       });
     });
@@ -1131,9 +1123,9 @@ describe('Acceptance: ember generate', function() {
   });
 
   it('availableOptions work with aliases.', function() {
-    return generate(['route', 'foo', '-resource']).then(function() {
+    return generate(['route', 'foo', '-d']).then(function() {
       assertFile('app/router.js', {
-        contain: ["resource('foo')"]
+        doesNotContain: "route('foo')"
       });
     });
   });

--- a/tests/acceptance/in-repo-addon-destroy-test.js
+++ b/tests/acceptance/in-repo-addon-destroy-test.js
@@ -196,37 +196,10 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
       'tests/unit/routes/foo-test.js'
     ];
 
-    return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
-  });
-
-  it('in-repo-addon route foo --type=resource', function() {
-    var commandArgs = ['route', 'foo', '--type=resource'];
-    var files       = [
-      'lib/my-addon/app/routes/foo.js',
-      'lib/my-addon/app/templates/foo.hbs',
-      'tests/unit/routes/foo-test.js'
-    ];
-
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files)
       .then(function() {
         assertFile('lib/my-addon/app/router.js', {
-          doesNotContain: "this.resource('foo');"
-        });
-      });
-  });
-
-  it('in-repo-addon route foos --type=resource', function() {
-    var commandArgs = ['route', 'foos', '--type=resource'];
-    var files       = [
-      'lib/my-addon/app/routes/foos.js',
-      'lib/my-addon/app/templates/foos.hbs',
-      'tests/unit/routes/foos-test.js'
-    ];
-
-    return assertDestroyAfterGenerateInRepoAddon(commandArgs, files)
-      .then(function() {
-        assertFile('lib/my-addon/app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -266,7 +239,7 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files)
       .then(function() {
         assertFile('lib/my-addon/app/router.js', {
-          doesNotContain: "this.resource('foo');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -284,7 +257,7 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files)
       .then(function() {
         assertFile('lib/my-addon/app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foos');"
         });
       });
   });

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -63,7 +63,7 @@ describe('Acceptance: ember destroy pod', function() {
       '--skip-bower'
     ]);
   }
-  
+
   function initInRepoAddon() {
     return initApp().then(function() {
       return ember([
@@ -86,7 +86,7 @@ describe('Acceptance: ember destroy pod', function() {
       return ember(generateArgs);
     });
   }
-  
+
   function generateInRepoAddon(args) {
     var generateArgs = ['generate'].concat(args);
 
@@ -146,7 +146,7 @@ describe('Acceptance: ember destroy pod', function() {
         assertFilesNotExist(files);
       });
   }
-  
+
   function assertDestroyAfterGenerateInAddon(args, files) {
     return initAddon()
       .then(function() {
@@ -162,7 +162,7 @@ describe('Acceptance: ember destroy pod', function() {
         assertFilesNotExist(files);
       });
   }
-  
+
   function assertDestroyAfterGenerateInRepoAddon(args, files) {
     return generateInRepoAddon(args)
       .then(function() {
@@ -175,7 +175,7 @@ describe('Acceptance: ember destroy pod', function() {
         assertFilesNotExist(files);
       });
   }
-  
+
   function destroyAfterGenerateWithPodsByDefault(args) {
     return initApp()
       .then(function() {
@@ -186,7 +186,7 @@ describe('Acceptance: ember destroy pod', function() {
         return destroy(args);
       });
   }
-  
+
   function destroyAfterGenerate(args) {
     return initApp()
       .then(function() {
@@ -308,37 +308,10 @@ describe('Acceptance: ember destroy pod', function() {
       'tests/unit/pods/foo/route-test.js'
     ];
 
-    return assertDestroyAfterGenerate(commandArgs, files);
-  });
-
-  it('route foo --type=resource --pod', function() {
-    var commandArgs = ['route', 'foo', '--type=resource', '--pod'];
-    var files       = [
-      'app/pods/foo/route.js',
-      'app/pods/foo/template.hbs',
-      'tests/unit/pods/foo/route-test.js'
-    ];
-
     return assertDestroyAfterGenerate(commandArgs, files)
       .then(function() {
         assertFile('app/router.js', {
-          doesNotContain: "this.resource('foo', { path: 'foos/:foo_id' });"
-        });
-      });
-  });
-
-  it('route foos --type=resource --pod', function() {
-    var commandArgs = ['route', 'foos', '--type=resource', '--pod'];
-    var files       = [
-      'app/pods/foos/route.js',
-      'app/pods/foos/template.hbs',
-      'tests/unit/pods/foos/route-test.js'
-    ];
-
-    return assertDestroyAfterGenerate(commandArgs, files)
-      .then(function() {
-        assertFile('app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -378,25 +351,7 @@ describe('Acceptance: ember destroy pod', function() {
     return assertDestroyAfterGenerate(commandArgs, files)
       .then(function() {
         assertFile('app/router.js', {
-          doesNotContain: "this.resource('foo', { path: 'foos/:foo_id' });"
-        });
-      });
-  });
-
-  it('resource foos --pod', function() {
-    var commandArgs = ['resource', 'foos', '--pod'];
-    var files       = [
-      'app/pods/foo/model.js',
-      'tests/unit/pods/foo/model-test.js',
-      'app/pods/foos/route.js',
-      'tests/unit/pods/foos/route-test.js',
-      'app/pods/foos/template.hbs'
-    ];
-
-    return assertDestroyAfterGenerate(commandArgs, files)
-      .then(function() {
-        assertFile('app/router.js', {
-          doesNotContain: "this.resource('foos');"
+          doesNotContain: "this.route('foo');"
         });
       });
   });
@@ -602,7 +557,7 @@ describe('Acceptance: ember destroy pod', function() {
 
     return assertDestroyAfterGenerateInAddon(commandArgs, files);
   });
-  
+
   it('in-repo-addon component x-foo --pod', function(){
     var commandArgs = ['component', 'x-foo', '--in-repo-addon=my-addon', '--pod'];
     var files       = [
@@ -611,7 +566,7 @@ describe('Acceptance: ember destroy pod', function() {
       'lib/my-addon/app/components/x-foo/component.js',
       'tests/unit/components/x-foo/component-test.js'
     ];
-    
+
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
   });
 
@@ -623,7 +578,7 @@ describe('Acceptance: ember destroy pod', function() {
       'lib/my-addon/app/components/nested/x-foo/component.js',
       'tests/unit/components/nested/x-foo/component-test.js'
     ];
-    
+
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
   });
 
@@ -689,7 +644,7 @@ describe('Acceptance: ember destroy pod', function() {
         assertFilesNotExist(files);
       });
   });
-  
+
   // Skip until podModulePrefix is deprecated
   it.skip('podModulePrefix deprecation warning', function() {
     return destroyAfterGenerate(['controller', 'foo', '--pod']).then(function(result) {
@@ -698,7 +653,7 @@ describe('Acceptance: ember destroy pod', function() {
       " 'app/pods/' to 'app/'.");
     });
   });
-  
+
   it('usePodsByDefault deprecation warning', function() {
     return destroyAfterGenerateWithPodsByDefault(['controller', 'foo', '--pod']).then(function(result) {
       expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -54,7 +54,7 @@ describe('Acceptance: ember generate pod', function() {
       '--skip-bower'
     ]);
   }
-  
+
   function initAddon() {
     return ember([
       'addon',
@@ -63,7 +63,7 @@ describe('Acceptance: ember generate pod', function() {
       '--skip-bower'
     ]);
   }
-  
+
   function initInRepoAddon() {
     return initApp().then(function() {
       return ember([
@@ -107,7 +107,7 @@ describe('Acceptance: ember generate pod', function() {
       return ember(generateArgs);
     });
   }
-  
+
   function generateWithUsePodsDeprecated(args) {
     var generateArgs = ['generate'].concat(args);
 
@@ -573,14 +573,6 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
-  it('route foos --type=resource --pod', function() {
-    return generate(['route', 'foos', '--type=resource', '--pod']).then(function() {
-      assertFile('app/router.js', {
-        contains: 'this.resource(\'foos\', function() {});'
-      });
-    });
-  });
-
   it('route index --pod', function() {
     return generate(['route', 'index', '--pod']).then(function() {
       assertFile('app/router.js', {
@@ -722,7 +714,7 @@ describe('Acceptance: ember generate pod', function() {
   it('resource foos --pod', function() {
     return generate(['resource', 'foos', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: 'this.resource(\'foos\', function() {});'
+        contains: 'this.route(\'foos\');'
       });
       assertFile('app/foo/model.js', {
         contains: 'export default DS.Model.extend'
@@ -742,14 +734,14 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
-  it('resource foos --pod', function() {
+  it('resource foos --pod with --path', function() {
     return generate(['resource', 'foos', '--pod', '--path=app/foos'])
       .then(function() {
         assertFile('app/router.js', {
           contains: [
-            'this.resource(\'foos\', {',
+            'this.route(\'foos\', {',
             'path: \'app/foos\'',
-            '}, function() {});'
+            '});'
           ]
         });
       });
@@ -758,7 +750,7 @@ describe('Acceptance: ember generate pod', function() {
   it('resource foos --pod podModulePrefix', function() {
     return generateWithPrefix(['resource', 'foos', '--pod']).then(function() {
       assertFile('app/router.js', {
-        contains: 'this.resource(\'foos\', function() {});'
+        contains: 'this.route(\'foos\');'
       });
       assertFile('app/pods/foo/model.js', {
         contains: 'export default DS.Model.extend'
@@ -1456,7 +1448,7 @@ describe('Acceptance: ember generate pod', function() {
       });
     });
   });
-  
+
   it('in-repo-addon component x-foo --pod', function() {
     return generateInRepoAddon(['component', 'x-foo', '--in-repo-addon=my-addon', '--pod']).then(function() {
       assertFile('lib/my-addon/addon/components/x-foo/component.js', {
@@ -1487,7 +1479,7 @@ describe('Acceptance: ember generate pod', function() {
       });
     });
   });
-  
+
   it('in-repo-addon component nested/x-foo', function() {
     return generateInRepoAddon(['component', 'nested/x-foo', '--in-repo-addon=my-addon', '--pod']).then(function() {
       assertFile('lib/my-addon/addon/components/nested/x-foo/component.js', {
@@ -1624,7 +1616,7 @@ describe('Acceptance: ember generate pod', function() {
         });
       });
   });
-  
+
   // Skip until podModulePrefix is deprecated
   it.skip('podModulePrefix deprecation warning', function() {
     return generateWithPrefix(['controller', 'foo', '--pod']).then(function(result) {
@@ -1633,7 +1625,7 @@ describe('Acceptance: ember generate pod', function() {
       " 'app/pods/' to 'app/'.");
     });
   });
-  
+
   it('usePodsByDefault deprecation warning', function() {
     return generateWithUsePodsDeprecated(['controller', 'foo', '--pod']).then(function(result) {
       expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+
@@ -1650,9 +1642,9 @@ describe('Acceptance: ember generate pod', function() {
   });
 
   it('availableOptions work with aliases.', function() {
-    return generate(['route', 'foo', '-resource', '-p']).then(function() {
+    return generate(['route', 'foo', '-d', '-p']).then(function() {
       assertFile('app/router.js', {
-        contain: ["resource('foo')"]
+        doesNotContain: "route('foo')"
       });
     });
   });


### PR DESCRIPTION
Working on fixing https://github.com/ember-cli/ember-cli/issues/3935

The tests are passing when used with changes to ember-router-generator in https://github.com/ember-cli/ember-router-generator/pull/11

#### Changes

- `this.resource` is never generated. Always `this.route`
- `this.resource('foo', function() {})` is never generated unless you explicitly generate with `ember g route foo/index` or `ember g resource foo/index`.

#### Questions

- Are there some situations where the index route should be implicitly generated? I find it confusing but I saw this https://github.com/ember-cli/ember-cli/pull/1946