### PR TITLE
[BUGFIX] Merge app/styles from addons with overwrite: true. Fixes #3930.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -963,7 +963,8 @@ EmberApp.prototype.styles = function() {
   trees.push(styles);
 
   var stylesAndVendor = mergeTrees(trees, {
-    description: 'TreeMerger (stylesAndVendor)'
+    description: 'TreeMerger (stylesAndVendor)',
+    overwrite: true
   });
 
   var options = { outputPaths: this.options.outputPaths.app.css };

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -312,11 +312,12 @@ describe('broccoli/ember-app', function() {
           expect(addonTreesForStub.calledWith[0][0]).to.equal('app');
         });
 
-        it('styles calls addonTreesFor', function() {
+        it('styles calls addonTreesFor and merges with overwrite', function() {
           var trees = emberApp.styles();
 
           expect(addonTreesForStub.calledWith[0][0]).to.equal('styles');
           expect(true, trees.inputTrees[0].inputTree.inputTrees.indexOf('batman') !== -1, 'contains addon tree');
+          expect(trees.inputTrees[0].inputTree.options.overwrite).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
This change brings treatment of `app/styles/*` in line with treatment of JS from `app/`. When javascript trees are merged (addons, external, app, etc), `overwrite: true` is passed. This commit makes the same thing be true for styles.

The semantics here are now that app/styles/* modules are merged with overwriting so that the "last" (as ordered by the DAG) wins, and the primary application's `app/styles/*` wins out over anything from addons.