### PR TITLE
[ENHANCEMENT] Friendly test names and descriptions

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -7,7 +7,7 @@ import startApp from '<%= dasherizedPackageName %>/tests/helpers/start-app';
 
 var application;
 
-module('Acceptance: <%= classifiedModuleName %>', {
+module('<%= friendlyTestName %>', {
   beforeEach: function() {
     application = startApp();
   },

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates an acceptance test for a feature.'
+  description: 'Generates an acceptance test for a feature.',
+  locals: function(options) {
+    return {
+      friendlyTestName: testInfo.name(options.entity.name, "Acceptance", null)
+    };
+  }
 };

--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('adapter:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Adapter', {
+moduleFor('adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/blueprints/adapter-test/index.js
+++ b/blueprints/adapter-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates an ember-data adapter unit test'
+  description: 'Generates an ember-data adapter unit test',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Adapter")
+    };
+  }
 };

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForComponent('<%= dasherizedModuleName %>', {
+moduleForComponent('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
 });

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,9 +1,17 @@
 /*jshint node:true*/
 
 var path = require('path');
+var testInfo = require('../../lib/utilities/test-info');
 
 module.exports = {
   description: 'Generates a component unit test.',
+
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
+    };
+  },
+
   fileMapTokens: function() {
     return {
       __path__: function(options) {

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -3,7 +3,7 @@ import {
 } from '<%= dependencyDepth %>/helpers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= classifiedModuleName %>Helper');
+module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,12 +1,14 @@
 /*jshint node:true*/
 
 var getDependencyDepth = require('../../lib/utilities/get-dependency-depth');
+var testInfo = require('../../lib/utilities/test-info');
 
 module.exports = {
   description: 'Generates a helper unit test.',
   locals: function(options) {
     return {
+      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Helper"),
       dependencyDepth: getDependencyDepth(options)
-    }
+    };
   }
 };

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 var container, application;
 
-module('<%= classifiedModuleName %>Initializer', {
+module('<%= friendlyTestName %>', {
   beforeEach: function() {
     Ember.run(function() {
       application = Ember.Application.create();

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,12 +1,14 @@
 /*jshint node:true*/
 
 var getDependencyDepth = require('../../lib/utilities/get-dependency-depth');
+var testInfo = require('../../lib/utilities/test-info');
 
 module.exports = {
   description: 'Generates an initializer unit test.',
   locals: function(options) {
     return {
+      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Initializer"),
       dependencyDepth: getDependencyDepth(options)
-    }
+    };
   }
 };

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import <%= classifiedModuleName %>Mixin from '../../../mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= classifiedModuleName %>Mixin');
+module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a mixin unit test.'
+  description: 'Generates a mixin unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Mixin")
+    };
+  }
 };

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('<%= dasherizedModuleName %>', {
+moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyDescription %>', {
   // Specify the other units that are required for this test.
 <%= typeof needs !== 'undefined' ? needs : '' %>
 });

--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,5 +1,16 @@
 /*jshint node:true*/
 
+var ModelBlueprint = require('../model');
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a model unit test.'
+  description: 'Generates a model unit test.',
+
+  locals: function(options) {
+    var result = ModelBlueprint.locals.apply(this, arguments);
+
+    result.friendlyDescription = testInfo.description(options.entity.name, "Unit", "Model");
+
+    return result;
+  }
 };

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('route:<%= dasherizedModuleName %>', {
+moduleFor('route:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a route unit test.'
+  description: 'Generates a route unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Route")
+    };
+  },
 };

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('<%= dasherizedModuleName %>', {
+moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   needs: ['serializer:<%= dasherizedModuleName %>']
 });

--- a/blueprints/serializer-test/index.js
+++ b/blueprints/serializer-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a serializer unit test.'
+  description: 'Generates a serializer unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Serializer")
+    };
+  },
 };

--- a/blueprints/service-test/files/tests/unit/services/__name__-test.js
+++ b/blueprints/service-test/files/tests/unit/services/__name__-test.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('service:<%= dasherizedModuleName %>', {
+moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
 });

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a service unit test.'
+  description: 'Generates a service unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Service")
+    };
+  },
 };

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('transform:<%= dasherizedModuleName %>', {
+moduleFor('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/blueprints/transform-test/index.js
+++ b/blueprints/transform-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a transform unit test.'
+  description: 'Generates a transform unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Service")
+    };
+  },
 };

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,7 +1,7 @@
 import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= camelizedModuleName %>');
+module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a util unit test.'
+  description: 'Generates a util unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Utility")
+    };
+  }
 };

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleFor('view:<%= dasherizedModuleName %>');
+moduleFor('view:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>');
 
 // Replace this with your real tests.
 test('it exists', function(assert) {

--- a/blueprints/view-test/index.js
+++ b/blueprints/view-test/index.js
@@ -1,5 +1,12 @@
 /*jshint node:true*/
 
+var testInfo = require('../../lib/utilities/test-info');
+
 module.exports = {
-  description: 'Generates a view unit test.'
+  description: 'Generates a view unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "View")
+    };
+  },
 };

--- a/lib/utilities/test-info.js
+++ b/lib/utilities/test-info.js
@@ -1,0 +1,83 @@
+'use strict';
+var stringUtils      = require('../utilities/string');
+/**
+  Utility to provide more friendly test names and descriptions
+  allows for descriptive prefixes such as
+  - Unit | Component | x-foo
+  - Unit | Route | foo
+  - Unit | Controller | foo
+  - Acceptance | my cool feature
+  etc...
+*/
+
+var SEPARATOR = ' | ';
+
+module.exports = {
+  /**
+    Converts a string into friendly human form.
+
+    ```javascript
+    humanize("SomeCoolString") // 'some cool string'
+    ```
+
+    @method humanize
+    @param {String} str The string to humanize.
+    @return {String} the humanize string.
+  */
+  humanize: function(str) {
+    var ret; 
+    ret = stringUtils.dasherize(str).replace(/[-]/g,' ');
+    return ret;
+  },
+
+
+  /**
+    Return a friendly test name with type prefix
+    Unit | Components | x-foo
+
+    ```javascript
+    name("x-foo", "Unit", "Component") // Unit | Component | x foo 
+    ```
+
+    @method name
+    @param {String} name The name of the generated item.
+    @param {String} testType The type of test (Unit, Acceptance, etc).
+    @param {String} blueprintType The type of bluprint (Component, Mixin, etc).
+    @return {String} A normalized name with type and blueprint prefix.
+  */
+
+  name: function(name, testType, blueprintType) {
+    var ret;
+    if (blueprintType){
+      ret = testType + SEPARATOR + blueprintType + SEPARATOR + this.humanize(name);
+    } else {
+      ret = testType + SEPARATOR + this.humanize(name);
+    }
+    return ret;
+  },
+
+  /**
+    Return a friendly test description
+
+    ```javascript
+    description("x-foo", "Unit", "Component") // Unit | Component | x foo 
+    ```
+
+    @method description
+    @param {String} description The description of the generated item.
+    @param {String} testType The type of test (Unit, Acceptance, etc).
+    @param {String} blueprintType The type of bluprint (Component, Mixin, etc).
+    @return {String} A normalized description with type and blueprint prefix.
+  */
+
+  description: function(description, testType, blueprintType) {
+    var ret;
+    if (blueprintType){
+      ret = testType + SEPARATOR + blueprintType + SEPARATOR + this.humanize(description);
+    } else {
+      ret = testType + SEPARATOR + this.humanize(description);
+    }
+    return ret;
+  }
+
+};

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -172,7 +172,8 @@ describe('Acceptance: ember generate', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo'"
+          "moduleForModel('foo'",
+          "needs: []",
         ]
       });
     });
@@ -264,9 +265,9 @@ describe('Acceptance: ember generate', function() {
           "  moduleForModel," + EOL +
           "  test" + EOL +
           "} from 'ember-qunit';",
-          "moduleForModel('foo'"
-        ],
-        doesNotContain: 'needs'
+          "moduleForModel('foo'",
+          "needs: []",
+        ]
       });
     });
   });

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -7,7 +7,7 @@ import startApp from 'my-app/tests/helpers/start-app';
 
 var application;
 
-module('Acceptance: Foo', {
+module('Acceptance | foo', {
   beforeEach: function() {
     application = startApp();
   },

--- a/tests/unit/utilities/test-info-test.js
+++ b/tests/unit/utilities/test-info-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var testInfo     = require('../../../lib/utilities/test-info');
+var expect       = require('chai').expect;
+
+describe('testInfo.humanize()', function() {
+  it('should humanize strings correctly', function() {
+    expect(testInfo.humanize('my-cool-feature')).to.equal('my cool feature');
+    expect(testInfo.humanize('myCoolCamelCaseFeature')).to.equal('my cool camel case feature');
+    expect(testInfo.humanize('this_is_snake_case')).to.equal('this is snake case');
+    expect(testInfo.humanize('this-is-dasherized')).to.equal('this is dasherized');
+    expect(testInfo.humanize('runonstring')).to.equal('runonstring');
+  });
+});
+
+
+describe('testInfo.name()', function() {
+  it('should return friendly name correctly', function() {
+    expect(testInfo.name('my-cool-feature', 'Acceptance', null)).to.equal('Acceptance | my cool feature');
+    expect(testInfo.name('myCoolCamelCaseFeature', 'Acceptance', null)).to.equal('Acceptance | my cool camel case feature');
+    expect(testInfo.name('my-Mixin', 'Unit', 'Mixin')).to.equal('Unit | Mixin | my mixin');
+    expect(testInfo.name('Foo', 'Unit', 'Model')).to.equal('Unit | Model | foo');
+    expect(testInfo.name('foo-bar', 'Unit', 'Model')).to.equal('Unit | Model | foo bar');
+  });
+});
+
+describe('testInfo.description()', function() {
+  it('should return friendly description correctly', function() {
+    expect(testInfo.description('x-foo', 'Unit', 'Component')).to.equal('Unit | Component | x foo');
+  });
+});


### PR DESCRIPTION
Added a test-info utility and refactored test blueprints to provide more friendly names and or descriptions.

The test-info utility contains a few methods

humanize -> convert string to humanized form
name -> return a test name with prefix
description - > return a test description with prefix

The prefix includes the test type (Unit or Acceptance) as well as the blueprint type (model, adapter, component, mixin, etc)

The end result is that tests will have better names and descriptions when displayed inside qunit user interface.

Some examples

Unit | Component | x-foo
Unit | Route | foo
Unit | Controller | foo
Acceptance | my cool feature