### PR TITLE
[ENHANCEMENT] Add host option to `ember test`.

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -16,6 +16,7 @@ module.exports = Command.extend({
     { name: 'environment', type: String, default: 'test', aliases: ['e'] },
     { name: 'config-file', type: String,  default: './testem.json', aliases: ['c', 'cf'] },
     { name: 'server',      type: Boolean, default: false, aliases: ['s'] },
+    { name: 'host',        type: String,  aliases: ['H'] },
     { name: 'port',        type: Number,  default: 7357, description: 'The port to use when running with --server.', aliases: ['p'] },
     { name: 'filter',      type: String,  description: 'A string to filter tests to run', aliases: ['f'] },
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -37,6 +37,7 @@ module.exports = Task.extend({
   testemOptions: function(options) {
     return {
       file: options.configFile,
+      host: options.host,
       port: options.port,
       cwd: options.outputPath,
       middleware: this.addonMiddlewares()

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -68,6 +68,14 @@ describe('test command', function() {
     });
   });
 
+  it('passes through custom host option', function() {
+    return new TestCommand(options).validateAndRun(['--host=greatwebsite.com']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.host).to.equal('greatwebsite.com');
+    });
+  });
+
   it('passes through custom port option', function() {
     return new TestCommand(options).validateAndRun(['--port=5678']).then(function() {
       var testOptions  = testRun.calledWith[0][0];

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -22,6 +22,7 @@ describe('test server', function() {
       testem: {
         startDev: function(options) {
           expect(options.file).to.equal('blahzorz.conf');
+          expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
@@ -32,6 +33,7 @@ describe('test server', function() {
 
     subject.run({
       configFile: 'blahzorz.conf',
+      host: 'greatwebsite.com',
       port: 123324,
       outputPath: 'blerpy-derpy',
       watcher: watcher

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -16,6 +16,7 @@ describe('test', function() {
       testem: {
         startCI: function(options, cb) {
           expect(options.file).to.equal('blahzorz.conf');
+          expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
@@ -27,6 +28,7 @@ describe('test', function() {
 
     subject.run({
       configFile: 'blahzorz.conf',
+      host: 'greatwebsite.com',
       port: 123324,
       outputPath: 'blerpy-derpy'
     });


### PR DESCRIPTION
One of the problems we've run into while running acceptance tests on ember-cli is the ability to hit different backends. We'd like to hit a real database while performing acceptance tests. Unfortunately, `ember-test` doesn't allow you to change the hostname from where the tests are running. This means that if you have any sort of CORs rules, then you won't be able to actually use your production backends for your acceptance tests.

This PR changes that by allowing you to specify `ember test --host="your_host_name"`, which will pass a `host` option to testem. This will launch ember-cli tests on a host that can be specified by the user, since testem already has support for the `host` option (see the [testem option reference guide](https://github.com/airportyh/testem/blob/master/docs/config_file.md#cli-level-options)).