### PR TITLE
[ENHANCEMENT] Add --directory flag to `ember new`

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -10,7 +10,7 @@ var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 
 module.exports = Command.extend({
   name: 'new',
-  description: 'Creates a new folder and runs ' + chalk.green('ember init') + ' in it.',
+  description: 'Creates a new directory and runs ' + chalk.green('ember init') + ' in it.',
   works: 'outsideProject',
 
   availableOptions: [
@@ -20,6 +20,7 @@ module.exports = Command.extend({
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
+    { name: 'directory', type: String , aliases: ['dir'] }
   ],
 
   anonymousOptions: [
@@ -44,7 +45,7 @@ module.exports = Command.extend({
     }
 
     if (packageName === '.') {
-      message = 'Trying to generate an application structure on this folder? Use `ember init` instead.';
+      message = 'Trying to generate an application structure in this directory? Use `ember init` instead.';
 
       return Promise.reject(new SilentError(message));
     }
@@ -56,6 +57,10 @@ module.exports = Command.extend({
     }
 
     commandOptions.blueprint = normalizeBlueprint(commandOptions.blueprint);
+
+    if (!commandOptions.directory) {
+      commandOptions.directory = packageName;
+    }
 
     var createAndStepIntoDirectory  = new this.tasks.CreateAndStepIntoDirectory({
       ui: this.ui,
@@ -77,10 +82,10 @@ module.exports = Command.extend({
 
     return createAndStepIntoDirectory
       .run({
-        directoryName: packageName,
+        directoryName: commandOptions.directory,
         dryRun: commandOptions.dryRun
       })
       .then(initCommand.run.bind(initCommand, commandOptions, rawArgs))
       .then(gitInit.run.bind(gitInit, commandOptions, rawArgs));
-  },
+  }
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -36,7 +36,7 @@ describe('Acceptance: ember new', function() {
       var blueprintPath = path.join(root, dir, 'files');
       var expected      = walkSync(blueprintPath);
       var actual        = walkSync('.').sort();
-      var folder        = path.basename(process.cwd());
+      var directory     = path.basename(process.cwd());
 
       forEach(Blueprint.renamedFiles, function(destFile, srcFile) {
         expected[expected.indexOf(srcFile)] = destFile;
@@ -44,7 +44,7 @@ describe('Acceptance: ember new', function() {
 
       expected.sort();
 
-      expect(folder).to.equal('foo');
+      expect(directory).to.equal('foo');
       expect(expected).to.deep.equal(actual, EOL + ' expected: ' +  util.inspect(expected) +
                                              EOL + ' but got: ' +  util.inspect(actual));
 
@@ -191,6 +191,27 @@ describe('Acceptance: ember new', function() {
       expect(cwd).to.not.match(/foo/, 'does not change cwd to foo in a dry run');
       expect(!fs.existsSync(path.join(cwd, 'foo')), 'does not create new directory');
       expect(!fs.existsSync(path.join(cwd, '.git')), 'does not create git in current directory');
+    });
+  });
+
+  it('ember new with --directory uses given directory name and has correct package name', function() {
+    return ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--directory=bar'
+    ]).then(function() {
+      var cwd = process.cwd();
+      expect(cwd).to.not.match(/foo/, 'does not use app name for directory name');
+      expect(!fs.existsSync(path.join(cwd, 'foo')), 'does not create new directory with app name');
+
+      expect(cwd).to.match(/bar/, 'uses given directory name');
+      expect(fs.existsSync(path.join(cwd, 'bar')), 'creates new directory with specified name');
+
+      var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
     });
   });
 });

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -89,7 +89,7 @@ describe('new command', function() {
       expect(false, 'should have rejected with a name `.`');
     })
     .catch(function(error) {
-      expect(error.message).to.equal('Trying to generate an application structure on this folder? Use `ember init` instead.');
+      expect(error.message).to.equal('Trying to generate an application structure in this directory? Use `ember init` instead.');
     });
   });
 


### PR DESCRIPTION
This allows a `--directory` flag to be passed to `ember new foo`. This will let you keep the package name of `foo` while choosing the directory name.

I often find myself wanting to generate an ember-cli app as a sub-directory in an app's root directory.

For example, you might have an ember-cli app living beside a Rails app in the same directory:

```
-- foo_app
  |-- rails
  |-- ember
```

I'll typically want the applications themselves to be named the same thing (such as `foo`) but the directories that they live in would look more like:

```
-- foo_app
  |-- backend
  |-- frontend
```

Currently this requires generating the ember-cli app with `ember new foo` and then renaming the directory.