### PR TITLE
[ENHANCEMENT] Generate component pods outside components folder

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -12,7 +12,7 @@ module.exports = {
     return {
       __path__: function(options) {
         if (options.pod) {
-          return path.join(options.podPath, 'components', options.dasherizedModuleName);
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
         }
         return 'components';
       },
@@ -54,7 +54,8 @@ module.exports = {
     }
 
     return {
-      modulePath: pathName
+      modulePath: pathName,
+      path: options.path
     };
   }
 };

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForComponent('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
+moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
 });

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -2,24 +2,31 @@
 
 var path = require('path');
 var testInfo = require('../../lib/utilities/test-info');
+var stringUtil  = require('../../lib/utilities/string');
 
 module.exports = {
   description: 'Generates a component unit test.',
-
-  locals: function(options) {
-    return {
-      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
-    };
-  },
 
   fileMapTokens: function() {
     return {
       __path__: function(options) {
         if (options.pod) {
-          return path.join(options.podPath, 'components', options.dasherizedModuleName);
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
         }
         return 'components';
       }
+    };
+  },
+  locals: function(options) {
+    var dasherizedModuleName = stringUtil.dasherize(options.entity.name);
+    var componentPathName = dasherizedModuleName;
+    if(options.pod && options.path !== 'components' && options.path !== '') {
+      componentPathName = [options.path, dasherizedModuleName].join('/');
+    }
+    return {
+      path: options.path,
+      componentPathName: componentPathName,
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
     };
   }
 };

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -7,18 +7,27 @@ var path        = require('path');
 
 module.exports = {
   description: 'Generates a component. Name must contain a hyphen.',
+  
+  availableOptions: [
+    {
+      name: 'path',
+      type: String,
+      default: 'components'
+    }
+  ],
 
   fileMapTokens: function() {
     return {
       __path__: function(options) {
+        console.log(options.locals.path);
         if (options.pod) {
-          return path.join(options.podPath, 'components', options.dasherizedModuleName);
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
         }
         return 'components';
       },
       __templatepath__: function(options) {
         if (options.pod) {
-          return path.join(options.podPath, 'components', options.dasherizedModuleName);
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
         }
         return 'templates/components';
       },
@@ -61,7 +70,8 @@ module.exports = {
 
     return {
       importTemplate: importTemplate,
-      contents: contents
+      contents: contents,
+      path: options.path
     };
   }
 };

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -12,14 +12,16 @@ module.exports = {
     {
       name: 'path',
       type: String,
-      default: 'components'
+      default: 'components',
+      aliases:[
+        {'no-path': ''}
+      ]
     }
   ],
 
   fileMapTokens: function() {
     return {
       __path__: function(options) {
-        console.log(options.locals.path);
         if (options.pod) {
           return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
         }

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -123,6 +123,54 @@ describe('Acceptance: ember generate', function() {
       });
     });
   });
+  
+  it('component foo/x-foo', function() {
+    return generate(['component', 'foo/x-foo']).then(function() {
+      assertFile('app/components/foo/x-foo.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/templates/components/foo/x-foo.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/components/foo/x-foo-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component x-foo ignores --path option', function() {
+    return generate(['component', 'x-foo', '--path', 'foo']).then(function() {
+      assertFile('app/components/x-foo.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/templates/components/x-foo.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/components/x-foo-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('x-foo'"
+        ]
+      });
+    });
+  });
 
   it('helper foo-bar', function() {
     return generate(['helper', 'foo-bar']).then(function() {

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -325,6 +325,342 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
+  it('component foo/x-foo --pod', function() {
+    return generate(['component', 'foo/x-foo', '--pod']).then(function() {
+      assertFile('app/components/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/components/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/components/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component foo/x-foo --pod podModulePrefix', function() {
+    return generateWithPrefix(['component', 'foo/x-foo', '--pod']).then(function() {
+      assertFile('app/pods/components/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/components/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/components/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component x-foo --pod --path', function() {
+    return generate(['component', 'x-foo', '--pod', '--path', 'bar']).then(function() {
+      assertFile('app/bar/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/bar/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/bar/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component x-foo --pod --path podModulePrefix', function() {
+    return generateWithPrefix(['component', 'x-foo', '--pod', '--path', 'bar']).then(function() {
+      assertFile('app/pods/bar/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/bar/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/bar/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component foo/x-foo --pod --path', function() {
+    return generate(['component', 'foo/x-foo', '--pod', '--path', 'bar']).then(function() {
+      assertFile('app/bar/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/bar/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/bar/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component foo/x-foo --pod --path podModulePrefix', function() {
+    return generateWithPrefix(['component', 'foo/x-foo', '--pod', '--path', 'bar']).then(function() {
+      assertFile('app/pods/bar/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/bar/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/bar/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/foo/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component x-foo --pod --path nested', function() {
+    return generate(['component', 'x-foo', '--pod', '--path', 'bar/baz']).then(function() {
+      assertFile('app/bar/baz/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/bar/baz/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/bar/baz/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/baz/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component x-foo --pod --path nested podModulePrefix', function() {
+    return generateWithPrefix(['component', 'x-foo', '--pod', '--path', 'bar/baz']).then(function() {
+      assertFile('app/pods/bar/baz/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/bar/baz/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/bar/baz/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/baz/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component foo/x-foo --pod --path nested', function() {
+    return generate(['component', 'foo/x-foo', '--pod', '--path', 'bar/baz']).then(function() {
+      assertFile('app/bar/baz/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/bar/baz/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/bar/baz/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/baz/foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component foo/x-foo --pod --path nested podModulePrefix', function() {
+    return generateWithPrefix(['component', 'foo/x-foo', '--pod', '--path', 'bar/baz']).then(function() {
+      assertFile('app/pods/bar/baz/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/bar/baz/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/bar/baz/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('bar/baz/foo/x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component x-foo --pod -no-path', function() {
+    return generate(['component', 'x-foo', '--pod', '-no-path']).then(function() {
+      assertFile('app/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component x-foo --pod -no-path podModulePrefix', function() {
+    return generateWithPrefix(['component', 'x-foo', '--pod', '-no-path']).then(function() {
+      assertFile('app/pods/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('x-foo'"
+        ]
+      });
+    });
+  });
+
+  it('component foo/x-foo --pod -no-path', function() {
+    return generate(['component', 'foo/x-foo', '--pod', '-no-path']).then(function() {
+      assertFile('app/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('foo/x-foo'"
+        ]
+      });
+    });
+  });
+  
+  it('component foo/x-foo --pod -no-path podModulePrefix', function() {
+    return generateWithPrefix(['component', 'foo/x-foo', '--pod', '-no-path']).then(function() {
+      assertFile('app/pods/foo/x-foo/component.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Component.extend({",
+          "});"
+        ]
+      });
+      assertFile('app/pods/foo/x-foo/template.hbs', {
+        contains: "{{yield}}"
+      });
+      assertFile('tests/unit/pods/foo/x-foo/component-test.js', {
+        contains: [
+          "import {" + EOL +
+          "  moduleForComponent," + EOL +
+          "  test" + EOL +
+          "} from 'ember-qunit';",
+          "moduleForComponent('foo/x-foo'"
+        ]
+      });
+    });
+  });
+
   it('helper foo-bar --pod', function() {
     return generate(['helper', 'foo-bar', '--pod']).then(function() {
       assertFile('app/helpers/foo-bar.js', {


### PR DESCRIPTION
Adds `--path` option to the component blueprint to generate pod components outside 'components' folder. 
By using the `--path` option when generating a component blueprint in a path other than `app/components/`( or `app/pods/components` if you have `podModulePrefix` defined) so you can generate components in associated routes, or just in the root folder if you want. So you can generate as described here: https://github.com/dockyard/styleguides/blob/master/ember.md#use-pods-structure or like here: https://github.com/stefanpenner/ember-jobs/tree/master/app/pods

I'm putting this up early for comments, will be adding tests later today.

### Usage
 `ember g component foo-bar -p -path foo` generates into `app/foo/foo-bar/component.js`

the flag only works for component pods, and the value is `components` by default

so if undefined `ember g component foo-bar -p` generates `app/components/foo-bar/component.js` as it currently does

with `usePods:true` you’d only need to pass the `-path` option obviously