### PR TITLE
Fix indentation in `crossdomain.xml`

### DIFF
--- a/blueprints/app/files/public/crossdomain.xml
+++ b/blueprints/app/files/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>


### PR DESCRIPTION
Seems weird that this was the only file using 4 spaces instead of 2.