### PR TITLE
Disable any file watching done by testem

### DIFF
--- a/blueprints/app/files/testem.json
+++ b/blueprints/app/files/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "^0.8.2",
+    "testem": "^0.8.3",
     "through": "^2.3.6",
     "tiny-lr": "0.1.5",
     "walk-sync": "0.1.3",


### PR DESCRIPTION
Every watching should be done already by ember-cli. This should fix random reloads when using `ember test --serve` and save resources.