### PR TITLE
Support templates in addon pods

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -11,13 +11,13 @@ module.exports = {
   fileMapTokens: function() {
     return {
       __path__: function(options) {
-        if (options.pod) {
+        if (options.pod && options.inRepoAddon) {
           return path.join(options.podPath, 'components', options.dasherizedModuleName);
         }
         return 'components';
       },
       __name__: function(options) {
-        if (options.pod) {
+        if (options.pod && options.inRepoAddon) {
           return 'component';
         }
         return options.dasherizedModuleName;
@@ -50,7 +50,14 @@ module.exports = {
     var pathName       = [addonName, 'components', fileName].join('/');
 
     if (options.pod) {
-      pathName = [addonName, 'components', fileName,'component'].join('/');
+      var podModulePrefix = options.project.config().podModulePrefix || '';
+      var podPath = podModulePrefix.substr(podModulePrefix.lastIndexOf('/') + 1);
+      if (podPath) {
+        pathName = [addonName, podPath, 'components', fileName,'component'].join('/');
+      }
+      else {
+        pathName = [addonName, 'components', fileName,'component'].join('/');
+      }
     }
 
     return {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -448,38 +448,68 @@ Addon.prototype.compileStyles = function(tree) {
 
   @private
   @method compileTemplates
-  @param {Tree} tree Templates file tree
+  @param {Tree} addonTree Addon file tree
   @return {Tree} Compiled templates tree
 */
-Addon.prototype.compileTemplates = function(tree) {
+Addon.prototype.compileTemplates = function(addonTree) {
   this._requireBuildPackages();
 
-  if (tree) {
+  var isTemplateInAddon = false;
+
+  var templatePatterns = this.registry.extensionsForType('template').map(function (extension) {
+    return new RegExp('template.' + extension + '$');
+  });
+
+  var standardTemplatesTree = this._treeFor('addon-templates');
+  if (standardTemplatesTree) {
+    isTemplateInAddon = true;
+  }
+  else {
+    var addonTreeFiles = walkSync(addonTree);
+    for (var fileIndex = 0; fileIndex < addonTreeFiles.length; fileIndex++) {
+      for (var patternIndex = 0; patternIndex < templatePatterns.length; patternIndex++) {
+        if (templatePatterns[patternIndex].test(addonTreeFiles[fileIndex])) {
+          isTemplateInAddon = true;
+          break;
+        }
+      }
+
+      if (isTemplateInAddon) {
+        break;
+      }
+    }
+  }
+
+  if (isTemplateInAddon) {
     var plugins = this.registry.load('template');
     if (plugins.length === 0) {
-      throw new SilentError('An `addon/templates` tree was detected, but there ' +
-                            'are no template compilers registered for `' + this.name + '`. ' +
-                            'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
-                            'is listed in `dependencies` (NOT `devDependencies`) in ' +
-                            '`' + this.name + '`\'s `package.json`.');
+      throw new SilentError('Templates were detected in the addon tree, but there ' +
+      'are no template compilers registered for `' + this.name + '`. ' +
+      'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
+      'is listed in `dependencies` (NOT `devDependencies`) in ' +
+      '`' + this.name + '`\'s `package.json`.');
     }
 
-    var standardTemplates = new Funnel(tree, {
-      srcDir: '/',
-      destDir: 'modules/' + this.name + '/templates'
-    });
-
-    var includePatterns = this.registry.extensionsForType('template').map(function(extension) {
-      return new RegExp('template.' + extension + '$');
-    });
-
-    var podTemplates = new Funnel(tree, {
-      include: includePatterns,
+    var podTemplatesTree = new Funnel(addonTree, {
+      include: templatePatterns,
+      exclude: [new RegExp('^templates/')],
       destDir: 'modules/' + this.name + '/',
       description: 'Funnel: Addon Pod Templates'
     });
+    var addonTemplatesTree = podTemplatesTree;
 
-    return preprocessTemplates(mergeTrees([standardTemplates, podTemplates]), {
+    if (standardTemplatesTree) {
+      addonTemplatesTree = mergeTrees([
+        new Funnel(standardTemplatesTree, {
+          srcDir: '/',
+          destDir: 'modules/' + this.name + '/templates',
+          description: 'Funnel: Addon Standard Templates'
+        }),
+        podTemplatesTree
+      ]);
+    }
+
+    return preprocessTemplates(addonTemplatesTree, {
       registry: this.registry
     });
   }
@@ -501,7 +531,7 @@ Addon.prototype.compileAddon = function(tree) {
   }
 
   var addonJs = this.processedAddonJsFiles(tree);
-  var templatesTree = this.compileTemplates(this._treeFor('addon-templates'));
+  var templatesTree = this.compileTemplates(tree);
   var reexported = reexport(this.name, this.name + '.js');
   var trees = [addonJs, templatesTree, reexported].filter(Boolean);
 

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -551,7 +551,7 @@ describe('Acceptance: ember destroy pod', function() {
     var files       = [
       'addon/components/x-foo/component.js',
       'addon/components/x-foo/template.hbs',
-      'app/components/x-foo/component.js',
+      'app/components/x-foo.js',
       'tests/unit/components/x-foo/component-test.js'
     ];
 

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1432,7 +1432,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('addon/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('app/components/x-foo/component.js', {
+      assertFile('app/components/x-foo.js', {
         contains: [
           "export { default } from 'my-addon/components/x-foo/component';"
         ]

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -503,7 +503,7 @@ describe('models/addon.js', function() {
         expect(function() {
           addon.compileTemplates(tree);
         }).to.throw(
-          'An `addon/templates` tree was detected, but there ' +
+          'Templates were detected in the addon tree, but there ' +
           'are no template compilers registered for `' + addon.name + '`. ' +
           'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
           'is listed in `dependencies` (NOT `devDependencies`) in ' +


### PR DESCRIPTION
Addresses the following issues:
- Fixes the generator for addon components to reference the correct import path when a podModulePrefix is used.
- Allows addons using pods to store the template for a component as a child in the component directory
- Removes the requirement for consumer applications to use the same podModulePrefix as addons to find the templates in the addon

@rwjblue @trabus I would really appreciate your review on this.