### PR TITLE
Don't include non javascript files in es6 trees

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -637,7 +637,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
   });
 
   var addonES6 = new Funnel(addonTrees, {
-    srcDir: 'modules',
+    include: [new RegExp('^modules.*\\.js$')],
     allowEmpty: true,
     description: 'Funnel: Addon JS'
   });

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -210,4 +210,19 @@ describe('Acceptance: addon-smoke-test', function() {
     });
 
   });
+
+  it('doesn\'t include non javascript files in es6 trees', function() {
+    return copyFixtureFiles('addon/component-with-invalid-file')
+      .then(function() {
+        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
+        var packageJson = require(packageJsonPath);
+        packageJson.dependencies = packageJson.dependencies || {};
+        packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
+
+        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+      })
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      });
+  });
 });

--- a/tests/fixtures/addon/component-with-invalid-file/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/component-with-invalid-file/addon/components/basic-thing.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import template from '../templates/components/basic-thing';
+
+export default Ember.Component.extend({
+  layout: template
+});

--- a/tests/fixtures/addon/component-with-invalid-file/addon/index.js
+++ b/tests/fixtures/addon/component-with-invalid-file/addon/index.js
@@ -1,0 +1,2 @@
+import BasicThing from "./components/basic-thing";
+export default BasicThing;

--- a/tests/fixtures/addon/component-with-invalid-file/addon/templates/components/basic-thing.hbs
+++ b/tests/fixtures/addon/component-with-invalid-file/addon/templates/components/basic-thing.hbs
@@ -1,0 +1,3 @@
+<div class="basic-thing">
+  {{yield}}
+</div>

--- a/tests/fixtures/addon/component-with-invalid-file/addon/templates/components/file.answer
+++ b/tests/fixtures/addon/component-with-invalid-file/addon/templates/components/file.answer
@@ -1,0 +1,1 @@
+the answer for everything is 42

--- a/tests/fixtures/addon/component-with-invalid-file/app/components/basic-thing.js
+++ b/tests/fixtures/addon/component-with-invalid-file/app/components/basic-thing.js
@@ -1,0 +1,3 @@
+import BasicThing from 'some-cool-addon/components/basic-thing';
+
+export default BasicThing;

--- a/tests/fixtures/addon/component-with-invalid-file/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-invalid-file/tests/acceptance/main-test.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance', {
+  beforeEach: function() {
+    application = startApp();
+  },
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('renders properly', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    var element = find('.basic-thing');
+    assert.equal(element.first().text().trim(), 'WOOT!!');
+  });
+});
+
+test('renders imported component', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    var element = find('.second-thing');
+    assert.equal(element.first().text().trim(), 'SECOND!!');
+  });
+});

--- a/tests/fixtures/addon/component-with-invalid-file/tests/dummy/app/components/second-thing.js
+++ b/tests/fixtures/addon/component-with-invalid-file/tests/dummy/app/components/second-thing.js
@@ -1,0 +1,4 @@
+import BasicThing from "some-cool-addon";
+export default BasicThing.extend({
+  classNames: ['second-thing']
+});

--- a/tests/fixtures/addon/component-with-invalid-file/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/component-with-invalid-file/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{#basic-thing}}WOOT!!{{/basic-thing}}
+{{#second-thing}}SECOND!!{{/second-thing}}


### PR DESCRIPTION
Looks like the es6 trees passed to broccoli-es6modules might contain non javascript files.
This could be a problem when editors like vim generates tmp swapfiles inside the project, since these files aren't parseable for esperanto which throws error.
Also note this issue just happens in addons/in-repo-addons because the ember app trees already filter the js files in ember-app.js [here](https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/ember-app.js#L888)

This is related to #3941