### PR TITLE
included modules is no longer needed

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -8,7 +8,6 @@ var fs           = require('fs');
 var path         = require('path');
 var deprecate    = require('../utilities/deprecate');
 var assign       = require('lodash/object/assign');
-var glob         = require('glob');
 var SilentError  = require('../errors/silent');
 var reexport     = require('../utilities/reexport');
 var debug        = require('debug')('ember-cli:addon');
@@ -348,40 +347,6 @@ Addon.prototype.included = function(/* app */) {
   this.eachAddonInvoke('included', [this]);
 };
 
-
-/**
-  Returns a list of all javascript files included with this addon
-
-  @public
-  @method includedModules
-  @return {Object} Paths and exported objects as key-value pairs
-*/
-Addon.prototype.includedModules = function() {
-  if (this._includedModules) {
-    return this._includedModules;
-  }
-
-  var _this    = this;
-  var treePath = path.join(this.root, this.treePaths['addon']).replace(/\\/g, '/');
-  var modulePath;
-
-  var globPattern = '**/*.+(' + this.registry.extensionsForType('js').join('|') + ')';
-
-  this._includedModules = glob.sync(path.join(treePath, globPattern)).reduce(function(ignoredModules, filePath) {
-    modulePath = filePath.replace(treePath, _this.moduleName());
-    modulePath = modulePath.slice(0, -(path.extname(modulePath).length));
-
-    ignoredModules[modulePath] = ['default'];
-    return ignoredModules;
-  }, {});
-
-  if (this._includedModules[this.moduleName() + '/index']) {
-    this._includedModules[this.moduleName()] = ['default'];
-  }
-
-  return this._includedModules;
-};
-
 /**
   Returns the tree for all public files
 
@@ -495,10 +460,6 @@ Addon.prototype.compileTemplates = function(tree) {
 */
 Addon.prototype.compileAddon = function(tree) {
   this._requireBuildPackages();
-
-  if (!this.isDevelopingAddon() && Object.keys(this.includedModules()).length === 0) {
-    return;
-  }
 
   var addonJs = this.processedAddonJsFiles(tree);
   var templatesTree = this.compileTemplates(this._treeFor('addon-templates'));

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -173,10 +173,10 @@ describe('models/addon.js', function() {
   });
 
   describe('initialized addon', function() {
+    this.timeout(40000);
     before(function() {
       projectPath = path.resolve(fixturePath, 'simple');
       var packageContents = require(path.join(projectPath, 'package.json'));
-
       project = new Project(projectPath, packageContents);
       project.initializeAddons();
     });
@@ -186,7 +186,6 @@ describe('models/addon.js', function() {
         addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
 
         // Clear the caches
-        delete addon._includedModules;
         delete addon._moduleName;
       });
 
@@ -196,24 +195,6 @@ describe('models/addon.js', function() {
 
       it('sets it\'s parent', function() {
         expect(addon.parent.name).to.equal(project.name);
-      });
-
-      it('generates a list of es6 modules to ignore', function() {
-        expect(addon.includedModules()).to.deep.equal({
-          'ember-cli-generated-with-export/controllers/people': ['default'],
-          'ember-cli-generated-with-export/mixins/thing': ['default']
-        });
-      });
-
-      it('generates a list of es6 modules to ignore with custom modulePrefix', function() {
-        addon.modulePrefix = 'custom-addon';
-
-        expect(addon.includedModules()).to.deep.equal({
-          'custom-addon/controllers/people': ['default'],
-          'custom-addon/mixins/thing': ['default']
-        });
-
-        delete addon.modulePrefix;
       });
 
       it('sets the root', function() {


### PR DESCRIPTION
* pre-packager will require an explicit dep-graph.json
* we no longer need module information for the module transpiler
* glob is basically broken in windows on shares – pending: https://github.com/isaacs/node-glob/pull/192

- [ ] this is clearly changes untested behavior, I suspect this iteration is ultimately invalid because now all add-ons are compiled. I would like to explore a better solution anyways.

cc @rwjblue / @chadhietala this is robs original work, but overlaps with some of the pre-packager future. so both your input would be great