### PR TITLE
Changed markdown-color blue to bright-blue to be the same on all platforms

### DIFF
--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -11,6 +11,10 @@ var merge             = require('lodash/object/merge');
 var colors = ['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black', 'white', 'grey', 'gray'];
 var backgroundColors = ['bgRed', 'bgGreen', 'bgBlue', 'bgCyan', 'bgMagenta', 'bgYellow', 'bgWhite', 'bgBlack'];
 
+// override blue to brightBlue. 
+// See: https://github.com/sindresorhus/chalk/blob/master/index.js#L15-L17
+chalk.styles.blue.open = '\u001b[94m';
+
 module.exports = MarkdownColor;
 
 /*

--- a/tests/unit/utilities/markdown-color-test.js
+++ b/tests/unit/utilities/markdown-color-test.js
@@ -37,7 +37,7 @@ function isAnsiSupported() {
   it('parses color tokens', function() {
     expect(mc.render('<red>red</red>')).to.equal('\u001b[0m\u001b[31mred\u001b[39m\u001b[0m\n\n');
     expect(mc.render('<green>green</green>')).to.equal('\u001b[0m\u001b[32mgreen\u001b[39m\u001b[0m\n\n');
-    expect(mc.render('<blue>blue</blue>')).to.equal('\u001b[0m\u001b[34mblue\u001b[39m\u001b[0m\n\n');
+    expect(mc.render('<blue>blue</blue>')).to.equal('\u001b[0m\u001b[94mblue\u001b[39m\u001b[0m\n\n');
     expect(mc.render('<cyan>cyan</cyan>')).to.equal('\u001b[0m\u001b[36mcyan\u001b[39m\u001b[0m\n\n');
     expect(mc.render('<magenta>magenta</magenta>')).to.equal('\u001b[0m\u001b[35mmagenta\u001b[39m\u001b[0m\n\n');
     expect(mc.render('<yellow>yellow</yellow>')).to.equal('\u001b[0m\u001b[33myellow\u001b[39m\u001b[0m\n\n');
@@ -70,13 +70,13 @@ function isAnsiSupported() {
         }
       }
     });
-    expect(mctemp.render('^foo^foo^foo^')).to.equal('\u001b[0m\u001b[34m\u001b[47mfoo\u001b[49m\u001b[39m\u001b[0m\n\n');
+    expect(mctemp.render('^foo^foo^foo^')).to.equal('\u001b[0m\u001b[94m\u001b[47mfoo\u001b[49m\u001b[39m\u001b[0m\n\n');
   });
 
   it('parses markdown files', function() {
     // console.log(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md')))
     expect(mc.renderFile(path.join(__dirname,'../../../tests/fixtures/markdown/foo.md'))).to
-      .equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[34mand I\u001b[39m enjoy eating them\u001b[39m\u001b[0m\n\n');
+      .equal('\u001b[0m\u001b[36mtacos are \u001b[33mdelicious\u001b[36m \u001b[94mand I\u001b[39m enjoy eating them\u001b[39m\u001b[0m\n\n');
   });
 
   it('allows tokens inside other token bounds', function() {


### PR DESCRIPTION
Chalk changes [blue to bright blue when on windows](https://github.com/sindresorhus/chalk/blob/master/index.js#L15-L17), causing the utilities/markdown-color unit tests to fail on windows.

This PR sets chalk's blue to bright blue for all platforms, fixing the tests for the time being [until it can be fixed upstream](https://github.com/sindresorhus/chalk/issues/63).