### PR TITLE
Allow io.js-next in development in 'valid-platform-version'

### DIFF
--- a/lib/utilities/valid-platform-version.js
+++ b/lib/utilities/valid-platform-version.js
@@ -5,6 +5,7 @@ var semver = require('semver');
 module.exports = function(version) {
 
   return semver.satisfies(version, '^1.0.0')  || // io.js
+         semver.satisfies(version, '^2.0.0')  || // io.js (dev)
          semver.satisfies(version, '^0.12.0') || // node 0.12.x
          semver.satisfies(version, '^0.13.0');   // node 0.13.x
 };


### PR DESCRIPTION
https://github.com/iojs/io.js/blob/master/src/node_version.h

I thought this change for io.js v2.0.0 because added Node v0.13.x already.