### PR TITLE
Fix for npm for Emblem

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -161,7 +161,7 @@ Note that the ES6 module transpiler is not directly supported with Emberscript, 
 For [Emblem](http://emblemjs.com/), run the following commands:
 
 {% highlight bash %}
-ember install:npm ember-cli-emblem-hbs-printer
+ember install ember-cli-emblem-hbs-printer
 {% endhighlight %}
 
 If you're using the older broccoli-emblem-compiler addon, you need to switch over the above ember-cli-emblem-hbs-printer. The older broccoli-emblem-compiler compiles directly to JS instead of Handlebars and therefore is broken on all newer version of HTMLBars.


### PR DESCRIPTION
Running the install:npm command returns `This command has been deprecated. Please use `npm install <packageName> --save-dev --save-exact` instead.` and blocks the install.  Removing `:npm` allows for it to install.