### PR TITLE
Ember.ObjectController gives deprecation warning

### DIFF
--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -36,7 +36,7 @@ export default Ember.TextField.extend({});
 // app/controllers/stop-watch.js
 import Ember from "ember";
 
-export default Ember.ObjectController.extend({});
+export default Ember.Controller.extend({});
 {% endhighlight %}
 
 And if it's a nested controller, we can declare nested/child controllers


### PR DESCRIPTION
Trying to use ObjectController gives a deprecation warning. Just a minor fix based on the warning suggestion.