### PR TITLE
Disable leek for `ember -v`

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -55,7 +55,9 @@ function cli(options) {
   var leekOptions;
 
   var disableAnalytics = options.cliArgs &&
-    (options.cliArgs.indexOf('--disable-analytics') > -1 ) ||
+    (options.cliArgs.indexOf('--disable-analytics') > -1 ||
+    options.cliArgs.indexOf('-v') > -1 ||
+    options.cliArgs.indexOf('--version') > -1) ||
     config.get('disableAnalytics');
 
   var defaultLeekOptions = {


### PR DESCRIPTION
Ensures that leek is disabled for `ember -v` and `ember --version'.

related to https://github.com/ember-cli/ember-cli/issues/3699