### PR TITLE
Allow custom history location types.

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -10,34 +10,45 @@ function HistorySupportAddon(project) {
   this.name = 'history-support-middleware';
 }
 
+HistorySupportAddon.prototype.shouldAddMiddleware = function(environment) {
+  var config = this.project.config(environment);
+  var locationType = config.locationType;
+  var historySupportMiddlewareEnabled = config.historySupportMiddleware;
+
+  return ['auto', 'history'].indexOf(locationType) !== -1 || historySupportMiddlewareEnabled;
+};
+
 HistorySupportAddon.prototype.serverMiddleware = function(config) {
+  if (this.shouldAddMiddleware(config.options.environment)) {
+    this.addMiddleware(config);
+  }
+};
+
+HistorySupportAddon.prototype.addMiddleware = function(config) {
   var app = config.app;
   var options = config.options;
   var watcher = options.watcher;
 
   var baseURL = cleanBaseURL(options.baseURL);
   var baseURLRegexp = new RegExp('^' + baseURL);
-  var locationType = this.project.config(options.environment).locationType;
 
-  if (['auto', 'history'].indexOf(locationType) !== -1) {
-    app.use(function(req, res, next) {
-      watcher.then(function(results) {
+  app.use(function(req, res, next) {
+    watcher.then(function(results) {
 
-        var acceptHeaders = req.headers.accept || [];
-        var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
-        var isForBaseURL = baseURLRegexp.test(req.path);
+      var acceptHeaders = req.headers.accept || [];
+      var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
+      var isForBaseURL = baseURLRegexp.test(req.path);
 
-        if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
-          var assetPath = req.path.slice(baseURL.length);
-          var isFile = false;
-          try { isFile = fs.statSync(path.join(results.directory, assetPath)).isFile(); } catch (err) { }
-          if (!isFile) {
-            req.serveUrl = baseURL + 'index.html';
-          }
+      if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
+        var assetPath = req.path.slice(baseURL.length);
+        var isFile = false;
+        try { isFile = fs.statSync(path.join(results.directory, assetPath)).isFile(); } catch (err) { }
+        if (!isFile) {
+          req.serveUrl = baseURL + 'index.html';
         }
-      }).finally(next);
-    });
-  }
+      }
+    }).finally(next);
+  });
 };
 
 module.exports = HistorySupportAddon;

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -523,6 +523,29 @@ describe('express-server', function() {
           });
       });
 
+      it('serves index.html when file not found (with baseURL) with custom history location', function(done) {
+        project._config = {
+          baseURL: '/',
+          locationType: 'blahr',
+          historySupportMiddleware: true
+        };
+
+        return startServer('/foo')
+          .then(function() {
+            request(subject.app)
+              .get('/foo/someurl')
+              .set('accept', 'text/html')
+              .expect(200)
+              .expect('Content-Type', /html/)
+              .end(function(err) {
+                if (err) {
+                  return done(err);
+                }
+                done();
+              });
+          });
+      });
+
       it('returns a 404 when file not found with hash location', function(done) {
         project._config = {
           baseURL: '/',


### PR DESCRIPTION
Hard coding the HistorySupportMiddleware to only working for `auto` and
`history` prevents users from implementing a custom location that extends
from history.