### PR TITLE
Allow promise for locals function in blueprints

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -472,14 +472,15 @@ Blueprint.prototype._checkInRepoAddonExists = function(inRepoAddon) {
   @param {Function} afterHook
 */
 Blueprint.prototype._process = function(options, beforeHook, process, afterHook) {
+  var self = this;
   var intoDir = options.target;
-  var localsPromise  = this._locals(options);
+  var localsPromise = this._locals(options);
 
   return localsPromise.then(function (locals) {
     return Promise.resolve()
-      .then(beforeHook.bind(this, options, locals))
-      .then(process.bind(this, intoDir, locals)).map(this._commit.bind(this))
-      .then(afterHook.bind(this, options));
+      .then(beforeHook.bind(self, options, locals))
+      .then(process.bind(self, intoDir, locals)).map(self._commit.bind(self))
+      .then(afterHook.bind(self, options));
   });
 };
 
@@ -853,7 +854,6 @@ Blueprint.prototype._locals = function(options) {
     .then(function (customLocals) {
       var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
       var fileMap = this.generateFileMap(fileMapVariables);
-
       var standardLocals = {
         dasherizedPackageName: stringUtils.dasherize(packageName),
         classifiedPackageName: stringUtils.classify(packageName),
@@ -866,9 +866,10 @@ Blueprint.prototype._locals = function(options) {
         targetFiles: options.targetFiles,
         rawArgs: options.rawArgs
       };
+      console.log(standardLocals);
 
       return merge({}, standardLocals, customLocals);
-    });
+    }.bind(this));
 };
 
 /**

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -474,9 +474,8 @@ Blueprint.prototype._checkInRepoAddonExists = function(inRepoAddon) {
 Blueprint.prototype._process = function(options, beforeHook, process, afterHook) {
   var self = this;
   var intoDir = options.target;
-  var localsPromise = this._locals(options);
 
-  return localsPromise.then(function (locals) {
+  return this._locals(options).then(function (locals) {
     return Promise.resolve()
       .then(beforeHook.bind(self, options, locals))
       .then(process.bind(self, intoDir, locals)).map(self._commit.bind(self))
@@ -866,7 +865,6 @@ Blueprint.prototype._locals = function(options) {
         targetFiles: options.targetFiles,
         rawArgs: options.rawArgs
       };
-      console.log(standardLocals);
 
       return merge({}, standardLocals, customLocals);
     }.bind(this));

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -849,25 +849,26 @@ Blueprint.prototype._locals = function(options) {
   var moduleName = options.entity && options.entity.name || packageName;
   var sanitizedModuleName = moduleName.replace(/\//g, '-');
 
-  return Promise.resolve(this.locals(options))
-    .then(function (customLocals) {
-      var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
-      var fileMap = this.generateFileMap(fileMapVariables);
-      var standardLocals = {
-        dasherizedPackageName: stringUtils.dasherize(packageName),
-        classifiedPackageName: stringUtils.classify(packageName),
-        dasherizedModuleName: stringUtils.dasherize(moduleName),
-        classifiedModuleName: stringUtils.classify(sanitizedModuleName),
-        camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
-        decamelizedModuleName: stringUtils.decamelize(sanitizedModuleName),
-        fileMap: fileMap,
-        hasPathToken: this.hasPathToken,
-        targetFiles: options.targetFiles,
-        rawArgs: options.rawArgs
-      };
+  return new Promise(function(resolve) {
+    resolve(this.locals(options));
+  }.bind(this)).then(function (customLocals) {
+    var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
+    var fileMap = this.generateFileMap(fileMapVariables);
+    var standardLocals = {
+      dasherizedPackageName: stringUtils.dasherize(packageName),
+      classifiedPackageName: stringUtils.classify(packageName),
+      dasherizedModuleName: stringUtils.dasherize(moduleName),
+      classifiedModuleName: stringUtils.classify(sanitizedModuleName),
+      camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
+      decamelizedModuleName: stringUtils.decamelize(sanitizedModuleName),
+      fileMap: fileMap,
+      hasPathToken: this.hasPathToken,
+      targetFiles: options.targetFiles,
+      rawArgs: options.rawArgs
+    };
 
-      return merge({}, standardLocals, customLocals);
-    }.bind(this));
+    return merge({}, standardLocals, customLocals);
+  }.bind(this));
 };
 
 /**

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -473,11 +473,14 @@ Blueprint.prototype._checkInRepoAddonExists = function(inRepoAddon) {
 */
 Blueprint.prototype._process = function(options, beforeHook, process, afterHook) {
   var intoDir = options.target;
-  var locals  = this._locals(options);
-  return Promise.resolve()
-    .then(beforeHook.bind(this, options, locals))
-    .then(process.bind(this, intoDir, locals)).map(this._commit.bind(this))
-    .then(afterHook.bind(this, options));
+  var localsPromise  = this._locals(options);
+
+  return localsPromise.then(function (locals) {
+    return Promise.resolve()
+      .then(beforeHook.bind(this, options, locals))
+      .then(process.bind(this, intoDir, locals)).map(this._commit.bind(this))
+      .then(afterHook.bind(this, options));
+  });
 };
 
 /**
@@ -845,24 +848,27 @@ Blueprint.prototype._locals = function(options) {
   var packageName = options.project.name();
   var moduleName = options.entity && options.entity.name || packageName;
   var sanitizedModuleName = moduleName.replace(/\//g, '-');
-  var customLocals = this.locals(options);
-  var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
-  var fileMap = this.generateFileMap(fileMapVariables);
 
-  var standardLocals = {
-    dasherizedPackageName: stringUtils.dasherize(packageName),
-    classifiedPackageName: stringUtils.classify(packageName),
-    dasherizedModuleName: stringUtils.dasherize(moduleName),
-    classifiedModuleName: stringUtils.classify(sanitizedModuleName),
-    camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
-    decamelizedModuleName: stringUtils.decamelize(sanitizedModuleName),
-    fileMap: fileMap,
-    hasPathToken: this.hasPathToken,
-    targetFiles: options.targetFiles,
-    rawArgs: options.rawArgs
-  };
+  return Promise.resolve(this.locals(options))
+    .then(function (customLocals) {
+      var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
+      var fileMap = this.generateFileMap(fileMapVariables);
 
-  return merge({}, standardLocals, customLocals);
+      var standardLocals = {
+        dasherizedPackageName: stringUtils.dasherize(packageName),
+        classifiedPackageName: stringUtils.classify(packageName),
+        dasherizedModuleName: stringUtils.dasherize(moduleName),
+        classifiedModuleName: stringUtils.classify(sanitizedModuleName),
+        camelizedModuleName: stringUtils.camelize(sanitizedModuleName),
+        decamelizedModuleName: stringUtils.decamelize(sanitizedModuleName),
+        fileMap: fileMap,
+        hasPathToken: this.hasPathToken,
+        targetFiles: options.targetFiles,
+        rawArgs: options.rawArgs
+      };
+
+      return merge({}, standardLocals, customLocals);
+    });
 };
 
 /**

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -2022,7 +2022,9 @@ help in detail');
     it('should return a default object if no custom options are passed', function() {
       result = blueprint._locals(options);
 
-      expect(result).to.eql(expectation);
+      result.then(function (locals) {
+        expect(locals).to.eql(expectation);
+      });
     });
 
     it('it should call the locals method with the correct arguments', function() {
@@ -2071,7 +2073,9 @@ help in detail');
 
       result = blueprint._locals(options);
 
-      expect(result).to.eql(expectation);
+      result.then(function (locals) {
+        expect(locals).to.eql(expectation);
+      });
     });
 
     it('should update its fileMap values to match the generateFileMap result', function() {
@@ -2083,7 +2087,9 @@ help in detail');
 
       result = blueprint._locals(options);
 
-      expect(result).to.eql(expectation);
+      result.then(function (locals) {
+        expect(locals).to.eql(expectation);
+      });
     });
 
     it('should return an object containing custom local values', function() {
@@ -2095,7 +2101,9 @@ help in detail');
 
       result = blueprint._locals(options);
 
-      expect(result).to.eql(expectation);
+      result.then(function (locals) {
+        expect(locals).to.eql(expectation);
+      });
     });
   });
 });


### PR DESCRIPTION
This is a WIP for moving https://github.com/ember-cli/rfcs/pull/7 forward.
Basically you can test it with `ember new [name] --blueprint https://github.com/knownasilya/app-blueprint.git`

The issue is that you cannot select inquirer options using your keys. Basically this is the output:

![screen shot 2015-05-06 at 11 31 47 am](https://cloud.githubusercontent.com/assets/34726/7496673/89c54f94-f3e3-11e4-9ca8-c559cd985982.png)

"Leaflet" is the default here, and hitting up/down creates those characters below.
