### PR TITLE
Re-order postBuild hook

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -116,8 +116,8 @@ module.exports = Task.extend({
        .then(function() {
          return self.builder.build.apply(self.builder, args);
        })
-      .then(this.processBuildResult.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
+      .then(this.processBuildResult.bind(this))
       .catch(function(error) {
 
         this.processAddonBuildSteps('buildError', error);

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -187,6 +187,22 @@ describe('models/builder.js', function() {
       });
     });
 
+    it('should call postBuild before processBuildResult', function() {
+      var called = [];
+      
+      addon.postBuild = function() {
+        called.push('postBuild');
+      };
+      
+      builder.processBuildResult = function() {
+        called.push('processBuildResult');
+      };
+
+      return builder.build().then(function() {
+        expect(called).to.deep.equal(['postBuild', 'processBuildResult']);
+      });
+    });
+
     it('buildError receives the error object from the errored step', function() {
       var thrownBuildError = new Error('buildError');
       var receivedBuildError;


### PR DESCRIPTION
Currently the postbuild is not very useful as it is called after everything is already in dist. The `results.directory` folder points to a directory that is going to get cleaned up soon after. This allows you to write to the final tree right before it is copied to dist.

__History__

We need to generate some configs off of the app tree, writing that config (a json file) to the destDir of the preprocessor was not merging into the final output.  Instead it caused the multiple rebuilds to occur.

Example:

1. Change router.js
2. Rebuild happens
3. Write config
4. Rebuild occurs again because we wrote the config

We then tried just writing the config to the root of the project and then merging it in during the postBuild hook. The `results.directory` is not the destDir that ends up in the dist, thus the file was lost again.

/cc @dosco 