### PR TITLE
Add a verification step to fail the build when tests are filtered with .only

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "isbinaryfile": "^2.0.3",
     "mocha": "^2.2.1",
     "mocha-jshint": "1.0.0",
+    "mocha-only-detector": "0.0.2",
     "multiline": "^1.0.2",
     "nock": "^1.2.1",
     "node-require-timings": "1.0.0",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -2,34 +2,62 @@
 
 var glob = require('glob');
 var Mocha = require('mocha');
+var RSVP = require('rsvp');
+var mochaOnlyDetector = require('mocha-only-detector');
+
 if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
 }
 
+var root = 'tests/{unit,acceptance}';
+var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test,-slow}.js'));
+var optionOrFile = process.argv[2];
 var mocha = new Mocha({
   timeout: 5000,
   reporter: 'spec'
 });
 
-var arg = process.argv[2];
-var root = 'tests/{unit,acceptance}';
+if (optionOrFile === 'all') {
+  addFiles(mocha, '/**/*-test.js');
+  addFiles(mocha, '/**/*-slow.js');
+} else if (optionOrFile)  {
+  mocha.addFile(optionOrFile);
+} else {
+  addFiles(mocha, '/**/*-test.js');
+}
 
 function addFiles(mocha, files) {
   glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
 }
 
-
-if (arg === 'all') {
-  addFiles(mocha, '/**/*-test.js');
-  addFiles(mocha, '/**/*-slow.js');
-} else if (arg)  {
-  mocha.addFile(arg);
-} else {
-  addFiles(mocha, '/**/*-test.js');
+function checkOnlyInTests() {
+  console.log('Verifing `.only` in tests');
+  return _checkOnlyInTests().then(function() {
+    console.log('No `.only` found');
+  });
 }
 
-mocha.run(function(failures) {
-  process.on('exit', function() {
-    process.exit(failures);
+function runMocha() {
+  mocha.run(function(failures) {
+    process.on('exit', function() {
+      process.exit(failures);
+    });
   });
-});
+}
+
+function ciVerificationStep() {
+  if (process.env.CI === 'true') {
+    return checkOnlyInTests();
+  } else {
+    return RSVP.resolve();
+  }
+}
+
+ciVerificationStep()
+  .then(function() {
+    runMocha();
+  })
+  .catch(function(error) {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Previously I sent a PR with a missing `.only` in the tests, this made the whole build just run tests of one file. To prevent this problem I added a verification step as requested by @stefanpenner.