### PR TITLE
Add ember-disable-proxy-controllers to app blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -31,6 +31,7 @@
     "ember-cli-qunit": "0.3.12",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
+    "ember-disable-proxy-controllers": "^0.7.0",
     "ember-export-application-global": "^1.0.2"
   }
 }


### PR DESCRIPTION
This addon reexports `Ember.Controller` as `App.ObjectController` and `App.ArrayController`.

Including this addon in new apps will make generated controllers be always regular `Ember.Controller`, remove lots of deprecation warnings and make migration to ember 2 easier.

Idea from @rwjblue in https://github.com/emberjs/ember.js/pull/11070