### PR TITLE
allow custom configPath

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -125,7 +125,7 @@ EmberApp.prototype._initProject = function(options) {
   this.project = options.project || Project.closestSync(process.cwd());
 
   if (options.configPath) {
-    this.project.configPath = function() { return options.configPath; };
+    this.project.setConfigPath(options.configPath);
   }
 };
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -132,6 +132,16 @@ Project.prototype.isEmberCLIAddon = function() {
 };
 
 /**
+  sets the exact path to the config file
+
+  @private
+  @method setConfigPath
+ */
+Project.prototype.setConfigPath = function(configPath) {
+  this._configPath = configPath;
+};
+
+/**
   Returns the path to the configuration.
 
   @private
@@ -140,6 +150,12 @@ Project.prototype.isEmberCLIAddon = function() {
  */
 Project.prototype.configPath = function() {
   var configPath = 'config';
+
+  if(this._configPath) { return this._configPath; }
+
+  if(this.pkg['directories'] && this.pkg['directories']['configPath']) {
+    configPath = this.pkg['directories']['configPath'];
+  }
 
   if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
     configPath = this.pkg['ember-addon']['configPath'];

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -32,7 +32,7 @@ describe('broccoli/ember-app', function() {
 
   describe('constructor', function() {
     it('should override project.configPath if configPath option is specified', function() {
-      project.configPath = function() { return 'original value'; };
+      project.setConfigPath('original value');
 
       new EmberApp({
         project: project,


### PR DESCRIPTION
Currently, the EmberApp allows passing in a `configPath` to specify where the `config/environment.js` file lives. This works for the build, but falls over if the `project` object is used outside of the build, like in the `serverMiddleware` hook.

This PR allows specifying the configPath in `package.json` - directories.configPath so that addons can properly hook into the config file.