### PR TITLE
Upgrade ember-cli-htmlbars to 0.7.6

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,7 +25,7 @@
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.1.0",
-    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.12",


### PR DESCRIPTION
Adds module names to compiled templates.