### PR TITLE
[INTERNAL] Allow internal cli parameters to be configurable by other cli tools

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -12,9 +12,12 @@ var emberCLIVersion      = versionUtils.emberCLIVersion;
 var InstallationChecker  = require('../models/installation-checker');
 
 function CLI(options) {
+  this.name = options.name;
   this.ui = options.ui;
   this.analytics = options.analytics;
   this.testing = options.testing;
+  this.cliRoot = options.cliRoot;
+  this.npmPackage = options.npmPackage;
 
   debug('testing %o', !!this.testing);
 }
@@ -41,7 +44,8 @@ CLI.prototype.run = function(environment) {
       tasks:     environment.tasks,
       project:   environment.project,
       settings:  environment.settings,
-      testing:   this.testing
+      testing:   this.testing,
+      cli: this
     });
 
     getOptionArgs('--verbose', commandArgs).forEach(function(arg){

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -11,6 +11,7 @@ var CLI           = require('./cli');
 var packageConfig = require('../../package.json');
 var debug         = require('debug')('ember-cli:cli/index');
 var merge         = require('lodash/object/merge');
+var path          = require('path');
 
 var version      = packageConfig.version;
 var name         = packageConfig.name;
@@ -46,10 +47,8 @@ function cli(options) {
     writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
   });
 
-  var project = Project.projectOrNullProject(ui);
-
   var config = new Yam('ember-cli', {
-    primary: project.root
+    primary: Project.getProjectRoot()
   });
 
   var leekOptions;
@@ -81,6 +80,18 @@ function cli(options) {
   debug('leek: %o', leekOptions);
 
   var leek = new Leek(leekOptions);
+
+  var cliInstance = new CLI({
+    ui:        ui,
+    analytics: leek,
+    testing:   options.testing,
+    name: options.cli ? options.cli.name : 'ember',
+    cliRoot: options.cli ? options.cli.cliRoot : path.resolve(__dirname, '..', '..'),
+    npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli'
+  });
+
+  var project = Project.projectOrNullProject(ui, cliInstance);
+
   var environment = {
     tasks:    tasks,
     cliArgs:  options.cliArgs,
@@ -89,9 +100,5 @@ function cli(options) {
     settings: merge(defaultUpdateCheckerOptions, config.getAll())
   };
 
-  return new CLI({
-    ui:        ui,
-    analytics: leek,
-    testing:   options.testing
-  }).run(environment);
+  return cliInstance.run(environment);
 }

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -3,7 +3,7 @@
 var chalk        = require('chalk');
 var Command      = require('../models/command');
 var Promise      = require('../ext/promise');
-var NULL_PROJECT = require('../models/project').NULL_PROJECT;
+var Project      = require('../models/project');
 var SilentError        = require('../errors/silent');
 var validProjectName   = require('../utilities/valid-project-name');
 var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
@@ -77,7 +77,7 @@ module.exports = Command.extend({
       ui: this.ui,
       analytics: this.analytics,
       tasks: this.tasks,
-      project: NULL_PROJECT
+      project: Project.createNullProject(this.ui, this.cli)
     });
 
     return createAndStepIntoDirectory

--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -41,9 +41,10 @@ AddonDiscovery.prototype.constructor = AddonDiscovery;
 AddonDiscovery.prototype.discoverProjectAddons = function(project) {
   var projectAsAddon = this.discoverFromProjectItself(project);
   var internalAddons = this.discoverFromInternalProjectAddons(project);
+  var cliAddons = this.discoverFromCli(project.cli);
   var dependencyAddons = this.discoverFromDependencies(project.root, project.nodeModulesPath, project.pkg, false);
   var inRepoAddons = this.discoverInRepoAddons(project.root, project.pkg);
-  var addons = projectAsAddon.concat(internalAddons, dependencyAddons, inRepoAddons);
+  var addons = projectAsAddon.concat(cliAddons, internalAddons, dependencyAddons, inRepoAddons);
 
   return addons;
 };
@@ -168,6 +169,13 @@ AddonDiscovery.prototype.discoverFromInternalProjectAddons = function(project) {
   return project.supportedInternalAddonPaths().map(function(path){
     return discovery.discoverAtPath(path);
   }).filter(Boolean);
+};
+
+AddonDiscovery.prototype.discoverFromCli = function (cli) {
+  if (!cli) { return []; }
+
+  var cliPkg = require(path.resolve(cli.cliRoot, 'package.json'));
+  return this.discoverInRepoAddons(cli.cliRoot, cliPkg);
 };
 
 /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -766,4 +766,5 @@ Addon.lookup = function(addon) {
   @method buildError
   @param {Error} error The error that was caught during the processes listed above
 */
+
 module.exports = Addon;

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -31,11 +31,12 @@ var emberCLIVersion  = versionUtils.emberCLIVersion;
   @param {String} root Root directory for the project
   @param {Object} pkg  Contents of package.json
 */
-function Project(root, pkg, ui) {
+function Project(root, pkg, ui, cli) {
   debug('init root: %s', root);
   this.root          = root;
   this.pkg           = pkg;
   this.ui            = ui;
+  this.cli           = cli;
   this.addonPackages = {};
   this.addons = [];
   this.liveReloadFilterPatterns = [];
@@ -82,21 +83,26 @@ Project.prototype.setupNodeModulesPath = function(){
   debug('nodeModulesPath: %s', this.nodeModulesPath);
 };
 
-var NULL_PROJECT = new Project(process.cwd(), {});
+var processCwd = process.cwd();
+Project.createNullProject = function (ui, cli) {
+  var NULL_PROJECT = new Project(processCwd, {}, ui, cli);
 
-NULL_PROJECT.isEmberCLIProject = function() {
-  return false;
+  NULL_PROJECT.isEmberCLIProject = function() {
+    return false;
+  };
+
+  NULL_PROJECT.isEmberCLIAddon = function() {
+    return false;
+  };
+
+  NULL_PROJECT.name = function() {
+    return path.basename(process.cwd());
+  };
+
+  NULL_PROJECT.initializeAddons();
+
+  return NULL_PROJECT;
 };
-
-NULL_PROJECT.isEmberCLIAddon = function() {
-  return false;
-};
-
-NULL_PROJECT.name = function() {
-  return path.basename(process.cwd());
-};
-
-Project.NULL_PROJECT = NULL_PROJECT;
 
 /**
   Returns the name from package.json.
@@ -118,7 +124,7 @@ Project.prototype.name = function() {
   @return {Boolean} Whether this is an Ember CLI project
  */
 Project.prototype.isEmberCLIProject = function() {
-  return 'ember-cli' in this.dependencies();
+  return (this.cli ? this.cli.npmPackage : 'ember-cli') in this.dependencies();
 };
 
 /**
@@ -407,7 +413,7 @@ Project.prototype.blueprintLookupPaths = function() {
 
     return lookupPaths.concat(addonLookupPaths);
   } else {
-    return [];
+    return this.addonBlueprintLookupPaths();
   }
 };
 
@@ -490,17 +496,16 @@ Project.prototype.findAddonByName = function(name) {
   @param  {String} pathName Path to your project
   @return {Promise}         Promise which resolves to a {Project}
  */
-Project.closest = function(pathName, _ui) {
+Project.closest = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
-
   return closestPackageJSON(pathName)
     .then(function(result) {
       debug('closest %s -> %s', pathName, result);
       if (result.pkg && result.pkg.name === 'ember-cli') {
-        return NULL_PROJECT;
+        return Project.createNullProject(_ui, _cli);
       }
 
-      return new Project(result.directory, result.pkg, ui);
+      return new Project(result.directory, result.pkg, ui, _cli);
     })
     .catch(function(reason) {
       handleFindupError(pathName, reason);
@@ -518,7 +523,7 @@ Project.closest = function(pathName, _ui) {
   @param  {UI} ui The UI instance to provide to the created Project.
   @return {Project}         Project instance
  */
-Project.closestSync = function(pathName, _ui) {
+Project.closestSync = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
 
   try {
@@ -526,11 +531,11 @@ Project.closestSync = function(pathName, _ui) {
     var pkg = require(path.join(directory, 'package.json'));
 
     if (pkg && pkg.name === 'ember-cli') {
-      return NULL_PROJECT;
+      return Project.createNullProject(_ui, _cli);
     }
 
     debug('closestSync %s -> %s', pathName, directory);
-    return new Project(directory, pkg, ui);
+    return new Project(directory, pkg, ui, _cli);
   } catch(reason) {
     handleFindupError(pathName, reason);
   }
@@ -549,13 +554,40 @@ Project.closestSync = function(pathName, _ui) {
   @param  {UI} ui The UI instance to provide to the created Project.
   @return {Project}         Project instance
  */
-Project.projectOrNullProject = function(_ui) {
+Project.projectOrNullProject = function(_ui, _cli) {
   try {
-    return Project.closestSync(process.cwd(), _ui);
+    return Project.closestSync(process.cwd(), _ui, _cli);
   } catch(reason) {
     if (reason instanceof Project.NotFoundError) {
-      return Project.NULL_PROJECT;
+      return Project.createNullProject(_ui, _cli);
     } else {
+      throw reason;
+    }
+  }
+};
+
+/**
+  Returns the project root based on the first package.json that is found
+
+  @return {String} The project root directory
+ */
+Project.getProjectRoot = function () {
+  try {
+    var directory = findup.sync(process.cwd(), 'package.json');
+    var pkg = require(path.join(directory, 'package.json'));
+
+    if (pkg && pkg.name === 'ember-cli') {
+      debug('getProjectRoot: named \'ember-cli\'. Will use cwd: %s', process.cwd());
+      return process.cwd();
+    }
+
+    debug('getProjectRoot %s -> %s', process.cwd(), directory);
+    return directory;
+  } catch(reason) {
+    if (isFindupError(reason)) {
+      debug('getProjectRoot: not found. Will use cwd: %s', process.cwd());
+      return process.cwd();
+    } else{
       throw reason;
     }
   }
@@ -598,9 +630,13 @@ function closestPackageJSON(pathName) {
     });
 }
 
-function handleFindupError(pathName, reason) {
+function isFindupError(reason) {
   // Would be nice if findup threw error subclasses
-  if (reason && /not found/i.test(reason.message)) {
+  return reason && /not found/i.test(reason.message);
+}
+
+function handleFindupError(pathName, reason) {
+  if (isFindupError(reason)) {
     throw new NotFoundError('No project found at or up from: `' + pathName + '`');
   } else {
     throw reason;

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -47,7 +47,9 @@ module.exports = Task.extend({
       });
     } else {
       var blueprintName = blueprintOption || 'app';
-      var blueprint = Blueprint.lookup(blueprintName);
+      var blueprint = Blueprint.lookup(blueprintName, {
+        paths: this.project.blueprintLookupPaths()
+      });
 
       return blueprint.install(installOptions);
     }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -267,12 +267,12 @@ describe('models/project.js', function() {
       expect(project.blueprintLookupPaths()).to.deep.equal(expected);
     });
 
-    it('returns an empty list of blueprint paths if outside a project', function() {
+    it('does not include blueprint path relative to root if outside a project', function() {
       project.isEmberCLIProject = function() {
         return false;
       };
 
-      expect(project.blueprintLookupPaths()).to.deep.equal([]);
+      expect(project.blueprintLookupPaths()).to.deep.equal(project.addonBlueprintLookupPaths());
     });
 
     it('returns an instance of an addon with an object export', function() {


### PR DESCRIPTION
This PR allows for more configuration of the ember-cli, when it's used by another cli tool. Example of configuration [here](https://github.com/rodyhaddad/wrenchjs/blob/1ff0ec8e450522d47308f336b5d109e579bef45a/lib/cli/index.js#L8-L10).

In practice, this adds new properties to the `cli` object:

* name: The name of the cli tool. Although this doesn't change anything now, it will later by outputting the proper cli name for error and help messages
* cliRoot: The root of the cli project. This is used to discover more "in-repo" addons
* npmPackage: This is the npm package name used to see if the project is an "ember-cli" project (as opposed to an ember addon, or a null project)

Also with this PR, the `Project` and `Command` instances get a reference to the `cli` object, so they can make use of the information described above.

----

I tried to do the least changes possible to reach my goal of making these things configurable and expanding `ember-cli`'s flexibility. Don't hesitate to tear up and question any change I did, if there's need for more details about my motives/thought process when making this PR.

/cc @stefanpenner 