### PR TITLE
[ENHANCEMENT] `ember generate route foo` within addon should create extendable route

### DIFF
--- a/blueprints/route-addon/files/__root__/__path__/__name__.js
+++ b/blueprints/route-addon/files/__root__/__path__/__name__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= routeModulePath %>';

--- a/blueprints/route-addon/files/__root__/__templatepath__/__templatename__.js
+++ b/blueprints/route-addon/files/__root__/__templatepath__/__templatename__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= templateModulePath %>';

--- a/blueprints/route-addon/index.js
+++ b/blueprints/route-addon/index.js
@@ -1,0 +1,61 @@
+/*jshint node:true*/
+
+var stringUtil  = require('../../lib/utilities/string');
+var path        = require('path');
+var inflector   = require('inflection');
+
+module.exports = {
+  description: 'Generates import wrappers for a route and its template.',
+
+  fileMapTokens: function() {
+    return {
+      __templatepath__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+        return 'templates';
+      },
+      __templatename__: function(options) {
+        if (options.pod) {
+          return 'template';
+        }
+        return options.dasherizedModuleName;
+      },
+      __path__: function(options) {
+        var blueprintName = options.originBlueprintName;
+
+        if (options.pod && options.hasPathToken) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+
+        return inflector.pluralize(blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        }
+
+        return 'app';
+      }
+    };
+  },
+
+  locals: function (options) {
+    var locals = {};
+    var addonRawName = options.inRepoAddon ? options.inRepoAddon : options.project.pkg.name;
+    var addonName = stringUtil.dasherize(addonRawName);
+    var fileName = stringUtil.dasherize(options.entity.name);
+
+    ['route', 'template'].forEach(function (blueprint) {
+      var pathName = [addonName, inflector.pluralize(blueprint), fileName].join('/');
+
+      if (options.pod) {
+        pathName = [addonName, fileName, blueprint].join('/');
+      }
+
+      locals[blueprint + 'ModulePath'] = pathName;
+    });
+
+    return locals;
+  }
+};

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -32,8 +32,13 @@ module.exports = {
       },
       __root__: function(options) {
         if (options.inRepoAddon) {
-          return path.join('lib', options.inRepoAddon, 'app');
+          return path.join('lib', options.inRepoAddon, 'addon');
         }
+
+        if (options.inAddon) {
+          return 'addon';
+        }
+
         return 'app';
       }
     };

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin', 'route'];
+    var noAddonBlueprint = ['mixin'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);
@@ -25,7 +25,7 @@ module.exports = Task.extend({
     if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
-    
+
     if (options.ignoreMissingMain && !mainBlueprint) {
       return Promise.resolve();
     }
@@ -66,7 +66,7 @@ module.exports = Task.extend({
       .then(function() {
         if (!addonBlueprint) { return; }
         if (!this.project.isEmberCLIAddon() && blueprintOptions.inRepoAddon === null) { return; }
-        
+
         if (addonBlueprint.locals === Blueprint.prototype.locals) {
           addonBlueprint.locals = function(options) {
             return mainBlueprint.locals(options);

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -167,7 +167,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-  
+
   it('in-addon component-test x-foo', function() {
     return generateInAddon(['component-test', 'x-foo']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {
@@ -178,7 +178,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-  
+
   it('in-addon helper foo-bar', function() {
     return generateInAddon(['helper', 'foo-bar']).then(function() {
       assertFile('addon/helpers/foo-bar.js', {
@@ -328,14 +328,22 @@ describe('Acceptance: ember generate in-addon', function() {
 
   it('in-addon route foo', function() {
     return generateInAddon(['route', 'foo']).then(function() {
-      assertFile('app/routes/foo.js', {
+      assertFile('addon/routes/foo.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Route.extend({" + EOL + "});"
         ]
       });
-      assertFile('app/templates/foo.hbs', {
+      assertFile('app/routes/foo.js', {
+        contains: [
+          "export { default } from 'my-addon/routes/foo';"
+        ]
+      });
+      assertFile('addon/templates/foo.hbs', {
         contains: '{{outlet}}'
+      });
+      assertFile('app/templates/foo.js', {
+        contains: "export { default } from 'my-addon/templates/foo';"
       });
       assertFile('tests/unit/routes/foo-test.js', {
         contains: [
@@ -348,14 +356,17 @@ describe('Acceptance: ember generate in-addon', function() {
 
   it('in-addon route foo/bar', function() {
     return generateInAddon(['route', 'foo/bar']).then(function() {
-      assertFile('app/routes/foo/bar.js', {
+      assertFile('addon/routes/foo/bar.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Route.extend({" + EOL + "});"
         ]
       });
-      assertFile('app/templates/foo/bar.hbs', {
-        contains: '{{outlet}}'
+      assertFile('app/routes/foo/bar.js', {
+        contains: "export { default } from 'my-addon/routes/foo/bar';"
+      });
+      assertFile('app/templates/foo/bar.js', {
+        contains: "export { default } from 'my-addon/templates/foo/bar';"
       });
       assertFile('tests/unit/routes/foo/bar-test.js', {
         contains: [
@@ -761,7 +772,7 @@ describe('Acceptance: ember generate in-addon', function() {
     });
   });
 
-  
+
     it('in-addon blueprint foo', function() {
       return generateInAddon(['blueprint', 'foo']).then(function() {
         assertFile('blueprints/foo/index.js', {
@@ -782,7 +793,7 @@ describe('Acceptance: ember generate in-addon', function() {
         });
       });
     });
-  
+
     it('in-addon blueprint foo/bar', function() {
       return generateInAddon(['blueprint', 'foo/bar']).then(function() {
         assertFile('blueprints/foo/bar/index.js', {
@@ -803,7 +814,7 @@ describe('Acceptance: ember generate in-addon', function() {
         });
       });
     });
-  
+
     it('in-addon http-mock foo', function() {
       return generateInAddon(['http-mock', 'foo']).then(function() {
         assertFile('server/index.js', {
@@ -852,7 +863,7 @@ describe('Acceptance: ember generate in-addon', function() {
         });
       });
     });
-  
+
     it('in-addon http-mock foo-bar', function() {
       return generateInAddon(['http-mock', 'foo-bar']).then(function() {
         assertFile('server/index.js', {
@@ -901,7 +912,7 @@ describe('Acceptance: ember generate in-addon', function() {
         });
       });
     });
-  
+
     it('in-addon http-proxy foo', function() {
       return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
         assertFile('server/index.js', {

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -138,7 +138,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
     });
   });
-  
+
   it('in-repo-addon component-test x-foo', function() {
     return generateInRepoAddon(['component-test', 'x-foo', '--in-repo-addon=my-addon']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {
@@ -328,14 +328,20 @@ describe('Acceptance: ember generate in-repo-addon', function() {
 
   it('in-repo-addon route foo', function() {
     return generateInRepoAddon(['route', 'foo', '--in-repo-addon=my-addon']).then(function() {
-      assertFile('lib/my-addon/app/routes/foo.js', {
+      assertFile('lib/my-addon/addon/routes/foo.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Route.extend({" + EOL + "});"
         ]
       });
-      assertFile('lib/my-addon/app/templates/foo.hbs', {
+      assertFile('lib/my-addon/app/routes/foo.js', {
+        contains: "export { default } from 'my-addon/routes/foo';"
+      });
+      assertFile('lib/my-addon/addon/templates/foo.hbs', {
         contains: '{{outlet}}'
+      });
+      assertFile('lib/my-addon/app/templates/foo.js', {
+        contains: "export { default } from 'my-addon/templates/foo';"
       });
       assertFile('tests/unit/routes/foo-test.js', {
         contains: [
@@ -348,14 +354,20 @@ describe('Acceptance: ember generate in-repo-addon', function() {
 
   it('in-repo-addon route foo/bar', function() {
     return generateInRepoAddon(['route', 'foo/bar', '--in-repo-addon=my-addon']).then(function() {
-      assertFile('lib/my-addon/app/routes/foo/bar.js', {
+      assertFile('lib/my-addon/addon/routes/foo/bar.js', {
         contains: [
           "import Ember from 'ember';",
           "export default Ember.Route.extend({" + EOL + "});"
         ]
       });
-      assertFile('lib/my-addon/app/templates/foo/bar.hbs', {
+      assertFile('lib/my-addon/app/routes/foo/bar.js', {
+        contains: "export { default } from 'my-addon/routes/foo/bar';"
+      });
+      assertFile('lib/my-addon/addon/templates/foo/bar.hbs', {
         contains: '{{outlet}}'
+      });
+      assertFile('lib/my-addon/app/templates/foo/bar.js', {
+        contains: "export { default } from 'my-addon/templates/foo/bar';"
       });
       assertFile('tests/unit/routes/foo/bar-test.js', {
         contains: [
@@ -365,7 +377,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
     });
   });
-  
+
   it('in-repo-addon template foo', function() {
     return generateInRepoAddon(['template', 'foo', '--in-repo-addon=my-addon']).then(function() {
       assertFile('lib/my-addon/addon/templates/foo.hbs');


### PR DESCRIPTION
I’m working on building addon “modules” that can expose ready-made routes to a consuming application. I’d like these routes to be extendable, but, within an addon, the `route` blueprint only creates its files within `app`. I’ve changed the `route` blueprint to generate files within `addon` if it’s within an addon and created a `route-addon` blueprint to create the addon-import wrappers within `app`.