### PR TITLE
Bump ember-cli-qunit to v0.3.13 (ember-qunit@0.3.3).

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.0.0-beta.17",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.2",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.12",
+    "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.17",
     "ember-disable-proxy-controllers": "^0.7.0",


### PR DESCRIPTION
Ember Qunit changes:

* Remove clearing of views just before each test function (this prevented
  adding/rendering in the setup of a module because any views that were
  rendered would be removed before the tests are ran).
* Update ember-test-helpers to 0.4.5.  This fixes an issue when calling
  `moduleForComponent` with only a component name argument (previously
  it would throw an error regarding calling `needs` on `undefined`).