### PR TITLE
[BUGFIX] Fix custom blueprint options for destroy command

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -4,6 +4,7 @@ var Command   = require('../models/command');
 var Promise   = require('../ext/promise');
 var Blueprint = require('../models/blueprint');
 var merge     = require('lodash/object/merge');
+var debug     = require('debug')('ember-cli/commands/destroy');
 
 var SilentError = require('../errors/silent');
 
@@ -27,14 +28,19 @@ module.exports = Command.extend({
   beforeRun: function(rawArgs){
     // merge in blueprint availableOptions
     var blueprint;
-    var debug = require('debug')('ember-cli/commands/destroy');
     try{
       blueprint = this.lookupBlueprint(rawArgs[0]);
       this.registerOptions( blueprint );
     }
     catch(e) {
-      // ignore this error, invalid blueprints are handled in run
-      debug(e);
+      // if the error is a SilentError, ignore
+      if(e.name === 'SilentError') {
+        // ignore this error, invalid blueprints are handled in run
+        debug(e);
+      } else {
+        // rethrow all other errors
+        throw(e);
+      }
     }
   },
 

--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -2,6 +2,7 @@
 
 var Command   = require('../models/command');
 var Promise   = require('../ext/promise');
+var Blueprint = require('../models/blueprint');
 var merge     = require('lodash/object/merge');
 
 var SilentError = require('../errors/silent');
@@ -22,6 +23,20 @@ module.exports = Command.extend({
   anonymousOptions: [
     '<blueprint>'
   ],
+  
+  beforeRun: function(rawArgs){
+    // merge in blueprint availableOptions
+    var blueprint;
+    var debug = require('debug')('ember-cli/commands/destroy');
+    try{
+      blueprint = this.lookupBlueprint(rawArgs[0]);
+      this.registerOptions( blueprint );
+    }
+    catch(e) {
+      // ignore this error, invalid blueprints are handled in run
+      debug(e);
+    }
+  },
 
   run: function(commandOptions, rawArgs) {
     var blueprintName = rawArgs[0];
@@ -62,6 +77,12 @@ module.exports = Command.extend({
     }
 
     return task.run(taskOptions);
+  },
+  
+  lookupBlueprint: function(name) {
+    return Blueprint.lookup(name, {
+      paths: this.project.blueprintLookupPaths()
+    });
   },
 
   printDetailedHelp: function() {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -10,6 +10,7 @@ var find      = require('lodash/collection/find');
 var pluck     = require('lodash/collection/pluck');
 var reject    = require('lodash/collection/reject');
 var EOL       = require('os').EOL;
+var debug     = require('debug')('ember-cli/commands/generate');
 
 var SilentError = require('../errors/silent');
 
@@ -33,15 +34,19 @@ module.exports = Command.extend({
   beforeRun: function(rawArgs){
     // merge in blueprint availableOptions
     var blueprint;
-    var debug = require('debug')('ember-cli/commands/generate');
-
     try{
       blueprint = this.lookupBlueprint(rawArgs[0]);
       this.registerOptions( blueprint );
     }
     catch(e) {
-      // ignore this error, invalid blueprints are handled in run
-      debug(e);
+      // if the error is a SilentError, ignore
+      if(e.name === 'SilentError') {
+        // ignore this error, invalid blueprints are handled in run
+        debug(e);
+      } else {
+        // rethrow all other errors
+        throw(e);
+      }
     }
   },
 

--- a/tests/acceptance/addon-destroy-test.js
+++ b/tests/acceptance/addon-destroy-test.js
@@ -87,7 +87,8 @@ describe('Acceptance: ember destroy in-addon', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -121,7 +121,8 @@ describe('Acceptance: ember destroy', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }
@@ -137,7 +138,8 @@ describe('Acceptance: ember destroy', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }
@@ -149,8 +151,9 @@ describe('Acceptance: ember destroy', function() {
       })
       .then(function() {
         return destroy(args);
-      })
-      .then(function() {
+      })      
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }

--- a/tests/acceptance/in-repo-addon-destroy-test.js
+++ b/tests/acceptance/in-repo-addon-destroy-test.js
@@ -93,7 +93,8 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -125,7 +125,8 @@ describe('Acceptance: ember destroy pod', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }
@@ -142,7 +143,8 @@ describe('Acceptance: ember destroy pod', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }
@@ -158,7 +160,8 @@ describe('Acceptance: ember destroy pod', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }
@@ -171,7 +174,8 @@ describe('Acceptance: ember destroy pod', function() {
       .then(function() {
         return destroy(args);
       })
-      .then(function() {
+      .then(function(result) {
+        expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
         assertFilesNotExist(files);
       });
   }

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -27,6 +27,9 @@ function ember(args) {
     project: {
       isEmberCLIProject: function() {  // similate being inside or outside of a project
         return isWithinProject;
+      },
+      blueprintLookupPaths: function() {
+        return [];
       }
     }
   });

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -67,4 +67,14 @@ describe('generate command', function() {
             'For more details, use `ember help`.');
       });
   });
+  
+  it('rethrows errors from beforeRun', function() {
+    return Promise.resolve(function(){ return command.beforeRun(['controller', 'foo']);})
+    .then(function() {
+      expect(false, 'should not have called run');
+    })
+    .catch(function(error) {
+      expect(error.message).to.equal('undefined is not a function');
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes #4099 by adding custom blueprint options to the destroy command (previously was only added to the generate command). The `ember destroy component foo-bar -p` command was failing because of the addition of an option that the `__path__` token depended upon.

This PR also fixes all of the internal destroy acceptance tests by asserting that the destroy command returns an object instead of an errorCode.