### PR TITLE
[ENHANCEMENT] Adding Report option to 'ember test'

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -22,6 +22,7 @@ module.exports = Command.extend({
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
     { name: 'launch',      type: String,  default: false, description: 'A comma seperated list of browsers to launch for tests.' },
+    { name: 'reporter',    type: String,  description: 'Test reporter to use [tap|dot|xunit]', aliases: ['r']}
   ],
 
   init: function() {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -40,6 +40,7 @@ module.exports = Task.extend({
       host: options.host,
       port: options.port,
       cwd: options.outputPath,
+      reporter: options.reporter,
       middleware: this.addonMiddlewares()
     };
   },

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -84,6 +84,14 @@ describe('test command', function() {
     });
   });
 
+  it('passes through custom reporter option', function() {
+    return new TestCommand(options).validateAndRun(['--reporter=xunit']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.reporter).to.equal('xunit');
+    });
+  });
+
   describe('--server option', function() {
     beforeEach(function() {
       options.Builder = CoreObject.extend();

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -25,6 +25,7 @@ describe('test server', function() {
           expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           done();
         }
@@ -35,6 +36,7 @@ describe('test server', function() {
       configFile: 'blahzorz.conf',
       host: 'greatwebsite.com',
       port: 123324,
+      reporter: 'xunit',
       outputPath: 'blerpy-derpy',
       watcher: watcher
     });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -19,6 +19,7 @@ describe('test', function() {
           expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
+          expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           cb(0);
         },
@@ -30,6 +31,7 @@ describe('test', function() {
       configFile: 'blahzorz.conf',
       host: 'greatwebsite.com',
       port: 123324,
+      reporter: 'xunit',
       outputPath: 'blerpy-derpy'
     });
   });


### PR DESCRIPTION
This passes a `reporter` option to testem, which will invoke test reporting option in testem using the specified test reporter.
This option will only be invoked in testem CI, it will be ignored in testem development mode.
