### PR TITLE
ENHANCEMENT More advanced detection of whether outputPath is a parent of the project directory

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -9,6 +9,7 @@ var SilentError = require('../errors/silent');
 var chalk       = require('chalk');
 var cpd         = require('ember-cli-copy-dereference');
 var attemptNeverIndex = require('../utilities/attempt-never-index');
+var parents     = require('parents');
 
 var signalsTrapped = false;
 
@@ -36,8 +37,15 @@ module.exports = Task.extend({
     this.trapSignals();
   },
 
+  /**
+    Determine whether the output path is safe to delete. If the outputPath
+    appears anywhere in the parents of the project root, the build would 
+    delete the project directory. In this case return `false`, otherwise
+    return `true`.
+  */
   canDeleteOutputPath: function(outputPath) {
-    return this.project.root.indexOf(outputPath) === -1;
+    var rootPathParents = parents(this.project.root);
+    return rootPathParents.indexOf(outputPath) === -1;
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "multiline": "^1.0.2",
     "nock": "^1.2.1",
     "node-require-timings": "0.0.2",
+    "parents": "^1.0.1",
     "supertest": "0.15.0",
     "tmp-sync": "^1.0.1",
     "yuidocjs": "0.6.0"

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -91,10 +91,7 @@ describe('models/builder.js', function() {
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
     });
 
     it('when outputPath is project root ie., `--output-path=.`', function() {
@@ -102,10 +99,7 @@ describe('models/builder.js', function() {
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
     });
 
     it('when outputPath is a parent directory ie., `--output-path=../../`', function() {
@@ -113,10 +107,16 @@ describe('models/builder.js', function() {
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
+    });
+
+    it('allow outputPath to contain the root path as a substring, as long as it is not a parent', function() {
+      var outputPathArg = '--output-path=.';
+      var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+      outputPath = outputPath.substr(0, outputPath.length - 1);
+      builder.outputPath = outputPath;
+
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Updated canDeleteOutputPath() to explicitly examine all parent directories of the project root instead of doing a simple substring check. Included a new test for this case.

The existing tests that call clearOutputPath() will actually nuke your checkout and its sibling directories if you break canDeleteOutputPath(). Testing canDeleteOutputPath() directly eliminates the risk of deleting important files when the test fails.