### PR TITLE
Documentation:  destination file of compiled templates is incorrect

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -188,7 +188,7 @@ ember server
  `app/index.html` | The only actual page of your single-page app! Includes dependencies and kickstarts your Ember application. See [app/index.html](#appindexhtml).
  `app/router.js` | Your route configuration. The routes defined here correspond to routes in `app/routes/`.
  `app/styles/` | Contains your stylesheets, whether SASS, LESS, Stylus, Compass, or plain CSS (though only one type is allowed, see [Asset Compilation](#asset-compilation)). These are all compiled into `app.css`.
- `app/templates/` | Your Handlebars templates. These are compiled to `templates.js`. The templates are named the same as their filename, minus the extension (i.e. `templates/foo/bar.hbs` -> `foo/bar`).
+ `app/templates/` | Your Handlebars templates. These are compiled to `/dist/assets/<yourapp>.js`. The templates are named the same as their filename, minus the extension (i.e. `templates/foo/bar.hbs` -> `foo/bar`).
  `app/controllers/`, `app/models/`, etc. | Modules resolved by the Ember CLI resolver. See [Using Modules &amp; the Resolver](using-modules).
 
 [PhantomJS]: http://phantomjs.org


### PR DESCRIPTION
Current docs say templates compiled to 'templates.js' whereas i think it should be 'dist/assets/<appname>.js'.  not sure if this is true in all circumstances.  