### PR TITLE
[ENHANCEMENT] Add watchmanconfig file to blueprints

### DIFF
--- a/blueprints/app/files/.watchmanconfig
+++ b/blueprints/app/files/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp"]
+}


### PR DESCRIPTION
As discussed in #4101 a .watchmanconfig file is added to the base blueprint. Per @wez it will ignore the tmp dir but not node_modules.

cc @stefanpenner 