### PR TITLE
Use exec to run Jekyll site

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -1,1 +1,1 @@
-`jekyll server --watch --baseurl ""`
+exec('jekyll server --watch --baseurl ""')


### PR DESCRIPTION
If we use `exec` to run the Jekyll site we get the nice Jekyll output in the command line:

```
$ ~/Code/ember-cli: ruby run.rb                                                                                                            gh-pages-runner ✗
Configuration file: /Users/Max/Code/ember-cli/_config.yml
            Source: /Users/Max/Code/ember-cli
       Destination: /Users/Max/Code/ember-cli/_site
      Generating...
                    done.
 Auto-regeneration: enabled
Configuration file: /Users/Max/Code/ember-cli/_config.yml
    Server address: http://0.0.0.0:4000/
  Server running... press ctrl-c to stop.
```

Bonus: You can CMD-click on the URL to open the site (I had to look up which port this would be running on in the `README`).