### PR TITLE
Revert "Remove podModulePrefix from app.js"

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -9,6 +9,7 @@ Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
   Resolver: Resolver
 });
 


### PR DESCRIPTION
Reverts ember-cli/ember-cli#3913

We still need podModulePrefix for the time being. We can remove it again when the state of pods has been finalized.