### PR TITLE
ENHANCEMENT More advanced detection of whether outputPath is a parent of the project directory

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -36,8 +36,21 @@ module.exports = Task.extend({
     this.trapSignals();
   },
 
+  /**
+    Determine whether the output path is safe to delete. If the outputPath
+    appears anywhere in the parents of the project root, the build would 
+    delete the project directory. In this case return `false`, otherwise
+    return `true`.
+  */
   canDeleteOutputPath: function(outputPath) {
-    return this.project.root.indexOf(outputPath) === -1;
+    var rootPathParents = [this.project.root];
+    var dir = path.dirname(this.project.root);
+    rootPathParents.push(dir);
+    while (dir !== path.dirname(dir)) {
+      dir = path.dirname(dir);
+      rootPathParents.push(dir);
+    }
+    return rootPathParents.indexOf(outputPath) === -1;
   },
 
   /**

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -72,6 +72,7 @@ describe('models/builder.js', function() {
 
   describe('Prevent deletion of files for improper outputPath', function() {
     var command;
+    var parentPath = '..' + path.sep + '..' + path.sep;
 
     before(function() {
       command = new BuildCommand(commandOptions({
@@ -86,15 +87,13 @@ describe('models/builder.js', function() {
       });
     });
 
-    it('when outputPath is root directory ie., `--output-path=/`', function() {
-      var outputPathArg = '--output-path=/';
+    it('when outputPath is root directory ie., `--output-path=/` or `--output-path=C:`', function() {
+      var outputPathArg = '--output-path=.';
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+      outputPath = outputPath.split(path.sep)[0] + path.sep;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
     });
 
     it('when outputPath is project root ie., `--output-path=.`', function() {
@@ -102,21 +101,24 @@ describe('models/builder.js', function() {
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
     });
 
-    it('when outputPath is a parent directory ie., `--output-path=../../`', function() {
-      var outputPathArg = '--output-path=../../';
+    it('when outputPath is a parent directory ie., `--output-path=' + parentPath + '`', function() {
+      var outputPathArg = '--output-path=' + parentPath;
       var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
       builder.outputPath = outputPath;
 
-      return builder.clearOutputPath()
-        .catch(function(error) {
-          expect(error.message).to.equal('Using a build destination path of `' + outputPath + '` is not supported.');
-        });
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
+    });
+
+    it('allow outputPath to contain the root path as a substring, as long as it is not a parent', function() {
+      var outputPathArg = '--output-path=.';
+      var outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+      outputPath = outputPath.substr(0, outputPath.length - 1);
+      builder.outputPath = outputPath;
+
+      expect(builder.canDeleteOutputPath(outputPath)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Revision of: https://github.com/ember-cli/ember-cli/pull/4107

Updated tests so that OS-dependent paths (root, and relative paths) should work on *nix and Windows with the same code.