### PR TITLE
[BUGFIX] Blueprint.load verify blueprint is in a directory

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -14,6 +14,7 @@ var path          = require('path');
 var sequence      = require('../utilities/sequence');
 var stat          = Promise.denodeify(fs.stat);
 var stringUtils   = require('../utilities/string');
+var compact       = require('lodash/array/compact');
 var intersect     = require('lodash/array/intersection');
 var uniq          = require('lodash/array/uniq');
 var zipObject     = require('lodash/array/zipObject');
@@ -1228,21 +1229,24 @@ Blueprint.lookup = function(name, options) {
 Blueprint.load = function(blueprintPath) {
   var constructorPath = path.resolve(blueprintPath, 'index.js');
   var blueprintModule;
-  var Constructor;
+  var Constructor = Blueprint;
+  
+  if (fs.lstatSync(blueprintPath).isDirectory()) {
+    
+    if (fs.existsSync(constructorPath)) {
+      blueprintModule = require(constructorPath);
 
-  if (fs.existsSync(constructorPath)) {
-    blueprintModule = require(constructorPath);
-
-    if (typeof blueprintModule === 'function') {
-      Constructor = blueprintModule;
-    } else {
-      Constructor = Blueprint.extend(blueprintModule);
+      if (typeof blueprintModule === 'function') {
+        Constructor = blueprintModule;
+      } else {
+        Constructor = Blueprint.extend(blueprintModule);
+      }  
     }
-  } else {
-    Constructor = Blueprint;
-  }
 
-  return new Constructor(blueprintPath);
+    return new Constructor(blueprintPath);
+  }
+  
+  return;
 };
 
 /**
@@ -1272,18 +1276,22 @@ Blueprint.list = function(options) {
 
     blueprints = blueprints.map(function(blueprintPath) {
       var blueprint   = Blueprint.load(blueprintPath);
-      var name        = blueprint.name;
+      var name;
+      
+      if (blueprint) {
+        name = blueprint.name;
+        blueprint.overridden = contains(seen, name);
+        seen.push(name);
 
-      blueprint.overridden = contains(seen, name);
-
-      seen.push(name);
-
-      return blueprint;
+        return blueprint;
+      }
+      
+      return;
     });
 
     return {
       source: source,
-      blueprints: blueprints
+      blueprints: compact(blueprints)
     };
   });
 };

--- a/tests/fixtures/blueprints/.notablueprint
+++ b/tests/fixtures/blueprints/.notablueprint
@@ -1,0 +1,1 @@
+not a blueprint

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -1084,6 +1084,18 @@ describe('Blueprint', function() {
       expect(output).to.not.match(/install addon.*foo-bar/);
     });
   });
+  
+  describe('load', function(){
+    var blueprint;
+    it('loads and returns a blueprint object', function() {
+      blueprint = Blueprint.load(basicBlueprint);
+      expect(blueprint).to.be.an('object');
+      expect(blueprint.name).to.equal('basic');
+    });
+    it('loads only blueprints with an index.js', function() {
+      expect(Blueprint.load(path.join(fixtureBlueprints, '.notablueprint'))).to.be.empty;      
+    });
+  });
 
   describe('insertIntoFile', function() {
     var blueprint;


### PR DESCRIPTION
Fixes #4136

Verifies that the blueprint path to be loaded is a directory, preventing non-blueprint files, like `.jshintrc` and `.DS_Store` from turning up in the generated blueprint list.