### PR TITLE
Code Quality: addon.js, project.js D -> C

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -226,5 +226,15 @@ AddonDiscovery.prototype.dependencies = function(pkg, excludeDevDeps) {
   return assign({}, devDependencies, pkg['dependencies']);
 };
 
+AddonDiscovery.prototype.addonPackages = function(addonsList) {
+  var addonPackages = {};
+
+  addonsList.forEach(function(addonPkg) {
+    addonPackages[addonPkg.name] = addonPkg;
+  });
+
+  return addonPackages;
+};
+
 // Export
 module.exports = AddonDiscovery;

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -202,11 +202,8 @@ Addon.prototype.isDevelopingAddon = function() {
  */
 Addon.prototype.discoverAddons = function() {
   var addonsList = this.addonDiscovery.discoverChildAddons(this);
-  var addonPackages = {};
-  addonsList.forEach(function(addonPkg) {
-    addonPackages[addonPkg.name] = addonPkg;
-  });
-  this.addonPackages = addonPackages;
+
+  this.addonPackages = this.addonDiscovery.addonPackages(addonsList);
 };
 
 Addon.prototype.initializeAddons = function() {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -303,11 +303,7 @@ Project.prototype.supportedInternalAddonPaths = function(){
 Project.prototype.discoverAddons = function() {
   var addonsList = this.addonDiscovery.discoverProjectAddons(this);
 
-  var addonPackages = {};
-  addonsList.forEach(function(addonPkg) {
-    addonPackages[addonPkg.name] = addonPkg;
-  });
-  this.addonPackages = addonPackages;
+  this.addonPackages = this.addonDiscovery.addonPackages(addonsList);
 };
 
 /**


### PR DESCRIPTION
This improves some duplication in `lib/models/addon.js` and `lib/models/project.js`, as listed in #3730.

It adds a new method to `lib/models/addon-discovery.js` to map the discovered packages.

@stefanpenner This can be improved even further, but we should probably discuss if it's worth it in terms of readability.  