### PR TITLE
Detect ember-cli from deps as well as devDeps

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -118,7 +118,7 @@ Project.prototype.name = function() {
   @return {Boolean} Whether this is an Ember CLI project
  */
 Project.prototype.isEmberCLIProject = function() {
-  return this.pkg.devDependencies && 'ember-cli' in this.pkg.devDependencies;
+  return 'ember-cli' in this.dependencies();
 };
 
 /**

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -364,6 +364,29 @@ describe('models/project.js', function() {
     });
   });
 
+  describe('isEmberCLIProject', function() {
+    beforeEach(function() {
+      projectPath = process.cwd() + '/tmp/test-app';
+      project = new Project(projectPath, {}, new MockUI());
+    });
+
+    it('returns false when `ember-cli` is not a dependency', function(){
+      expect(project.isEmberCLIProject()).to.equal(false);
+    });
+
+    it('returns true when `ember-cli` is a devDependency', function(){
+      project.pkg.devDependencies = {'ember-cli': '*'};
+
+      expect(project.isEmberCLIProject()).to.equal(true);
+    });
+
+    it('returns true when `ember-cli` is a dependency', function(){
+      project.pkg.dependencies = {'ember-cli': '*'};
+
+      expect(project.isEmberCLIProject()).to.equal(true);
+    });
+  });
+
   describe('isEmberCLIAddon', function() {
     beforeEach(function() {
       projectPath = process.cwd() + '/tmp/test-app';


### PR DESCRIPTION
This is useful to folks who, for whatever reason, need to have access to 
ember-cli with production dependencies (certain shrinkwrap scenarios,
installation into some build server configs, and probably other cases).

Looks like #3015 was closed prematurely when @rwjblue gave a bit of good
implementation advice. Also addresses #2207.