### PR TITLE
Code Quality: npm-install.js, npm-uninstall.js D -> A

### DIFF
--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -2,61 +2,10 @@
 
 // Runs `npm install` in cwd
 
-var Promise = require('../ext/promise');
-var chalk   = require('chalk');
-var Task    = require('../models/task');
+var NpmTask = require('./npm-task');
 
-module.exports = Task.extend({
-
-  init: function() {
-    this.npm = this.npm || require('npm');
-  },
-  // Options: Boolean verbose
-  run: function(options) {
-    this.ui.startProgress(chalk.green('Installing packages for tooling via npm'), chalk.green('.'));
-
-    var npmOptions = {
-      loglevel: options.verbose ? 'verbose' : 'error',
-      logstream: this.ui.outputStream,
-      color: 'always',
-      'save-dev': !!options['save-dev'],
-      'save-exact': !!options['save-exact']
-    };
-    var packages = options.packages || [];
-
-    // npm otherwise is otherwise noisy, already submitted PR for npm to fix
-    // misplaced console.log
-    this.disableLogger();
-
-    var load = Promise.denodeify(this.npm.load);
-
-    return load(npmOptions)
-      .then(function() {
-        // if install is denodeified outside load.then(),
-        // it throws "Call npm.load(config, cb) before using this command."
-        var install = Promise.denodeify(this.npm.commands.install);
-
-        return install(packages);
-      }.bind(this))
-      .finally(this.finally.bind(this))
-      .then(this.announceCompletion.bind(this));
-  },
-
-  announceCompletion: function() {
-    this.ui.writeLine(chalk.green('Installed packages for tooling via npm.'));
-  },
-
-  finally: function() {
-    this.ui.stopProgress();
-    this.restoreLogger();
-  },
-
-  disableLogger: function() {
-    this.oldLog = console.log;
-    console.log = function() {};
-  },
-
-  restoreLogger: function() {
-    console.log = this.oldLog; // Hack, see above
-  }
+module.exports = NpmTask.extend({
+  command: 'install',
+  startProgressMessage: 'Installing packages for tooling via npm',
+  completionMessage: 'Installed packages for tooling via npm.'
 });

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Runs `npm install` in cwd
+
+var Promise = require('../ext/promise');
+var chalk   = require('chalk');
+var Task    = require('../models/task');
+
+module.exports = Task.extend({
+  // The command to run: can be 'install' or 'uninstall'
+  command: '',
+  // Message to send to ui.startProgress
+  startProgressMessage: '',
+  // Message to send to ui.writeLine on completion
+  completionMessage: '',
+
+  init: function() {
+    this.npm = this.npm || require('npm');
+  },
+  // Options: Boolean verbose
+  run: function(options) {
+    this.ui.startProgress(chalk.green(this.startProgressMessage), chalk.green('.'));
+
+    var npmOptions = {
+      loglevel: options.verbose ? 'verbose' : 'error',
+      logstream: this.ui.outputStream,
+      color: 'always',
+      'save-dev': !!options['save-dev'],
+      'save-exact': !!options['save-exact']
+    };
+    var packages = options.packages || [];
+
+    // npm otherwise is otherwise noisy, already submitted PR for npm to fix
+    // misplaced console.log
+    this.disableLogger();
+
+    var load = Promise.denodeify(this.npm.load);
+
+    return load(npmOptions)
+      .then(function() {
+        // if install is denodeified outside load.then(),
+        // it throws "Call npm.load(config, cb) before using this command."
+        var install = Promise.denodeify(this.npm.commands[this.command]);
+
+        return install(packages);
+      }.bind(this))
+      .finally(this.finally.bind(this))
+      .then(this.announceCompletion.bind(this));
+  },
+
+  announceCompletion: function() {
+    this.ui.writeLine(chalk.green(this.completionMessage));
+  },
+
+  finally: function() {
+    this.ui.stopProgress();
+    this.restoreLogger();
+  },
+
+  disableLogger: function() {
+    this.oldLog = console.log;
+    console.log = function() {};
+  },
+
+  restoreLogger: function() {
+    console.log = this.oldLog; // Hack, see above
+  }
+});

--- a/lib/tasks/npm-uninstall.js
+++ b/lib/tasks/npm-uninstall.js
@@ -2,61 +2,10 @@
 
 // Runs `npm uninstall` in cwd
 
-var Promise = require('../ext/promise');
-var chalk   = require('chalk');
-var Task    = require('../models/task');
+var NpmTask = require('./npm-task');
 
-module.exports = Task.extend({
-
-  init: function() {
-    this.npm = this.npm || require('npm');
-  },
-  // Options: Boolean verbose
-  run: function(options) {
-    this.ui.startProgress(chalk.green('Uninstalling packages for tooling via npm'), chalk.green('.'));
-
-    var npmOptions = {
-      loglevel: options.verbose ? 'verbose' : 'error',
-      logstream: this.ui.outputStream,
-      color: 'always',
-      'save-dev': !!options['save-dev'],
-      'save-exact': !!options['save-exact']
-    };
-    var packages = options.packages || [];
-
-    // npm otherwise is otherwise noisy, already submitted PR for npm to fix
-    // misplaced console.log
-    this.disableLogger();
-
-    var load = Promise.denodeify(this.npm.load);
-
-    return load(npmOptions)
-      .then(function() {
-        // if uninstall is denodeified outside load.then(),
-        // it throws "Call npm.load(config, cb) before using this command."
-        var uninstall = Promise.denodeify(this.npm.commands.uninstall);
-
-        return uninstall(packages);
-      }.bind(this))
-      .finally(this.finally.bind(this))
-      .then(this.announceCompletion.bind(this));
-  },
-
-  announceCompletion: function() {
-    this.ui.writeLine(chalk.green('Uninstalled packages for tooling via npm.'));
-  },
-
-  finally: function() {
-    this.ui.stopProgress();
-    this.restoreLogger();
-  },
-
-  disableLogger: function() {
-    this.oldLog = console.log;
-    console.log = function() {};
-  },
-
-  restoreLogger: function() {
-    console.log = this.oldLog; // Hack, see above
-  }
+module.exports = NpmTask.extend({
+  command: 'uninstall',
+  startProgressMessage: 'Uninstalling packages for tooling via npm',
+  completionMessage: 'Uninstalled packages for tooling via npm.'
 });


### PR DESCRIPTION
This removes a pretty big duplication penalty, but I'm not really sure this kind of abstraction is worth it :see_no_evil: It refactors the `npm-install` and `npm-uninstall` tasks to use an `npm-task` with a command and some nice messages. 

Yay or nay? 