### PR TITLE
remove unused dependency on broccoli-filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "^2.0.0",
     "broccoli-es6modules": "^0.6.0",
-    "broccoli-filter": "0.1.12",
     "broccoli-funnel": "0.2.2",
     "broccoli-kitchen-sink-helpers": "0.2.6",
     "broccoli-merge-trees": "0.2.1",


### PR DESCRIPTION
i don't believe ember-cli still uses this directly, rather our dependencies do.