### PR TITLE
Add Code Climate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+languages:
+   JavaScript: true
+
+exclude_paths:
+ - "tests/acceptance/*"
+ - "tests/fixtures/*"
+ - "tests/unit/*"


### PR DESCRIPTION
Last month Code Climate added support for configuring project settings in a `.codeclimate.yml` file. Its settings supersede any project settings previously set via their web UI.

This allows contributors to see ongoing Code Climate scores while refactoring for https://github.com/ember-cli/ember-cli/issues/3730. The score for this branch on my fork hopped up to 3.15.

https://codeclimate.com/github/chrislopresto/ember-cli/compare/codeclimate-config#ratings