### PR TITLE
trying to improve source maps docs

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -39,8 +39,7 @@ minifyJS: {
 
 ### Source Maps
 
-Ember CLI supports producing source maps from your CSS and JS files.
-Source maps are configured by the `sourcemaps` option and
+Ember CLI supports producing source maps from your CSS and JS source files. For other source formats (sass, coffee, etc) refer to their addons. Source maps are configured by the `sourcemaps` option and
 are disabled in production by default.
 
 In dev, the default setting is equal to:
@@ -52,8 +51,8 @@ sourcemaps: {
 }
 {% endhighlight %}
 
-Pass `{enabled: true}` to your EmberApp constructor to enable source maps for javascript.
-Use the `extensions` option to configure CSS.
+Pass `sourcemaps: {enabled: true}` to your EmberApp constructor to enable source maps for javascript.
+Use the `extensions` option to add CSS source maps: `{extensions: ['js', 'css']}`.
 
 ### Stylesheets
 

--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -39,20 +39,23 @@ minifyJS: {
 
 ### Source Maps
 
-Ember CLI supports producing source maps from your CSS and JS source files. For other source formats (sass, coffee, etc) refer to their addons. Source maps are configured by the `sourcemaps` option and
-are disabled in production by default.
+Ember CLI supports producing source maps for your concatenated and minified JS source files. CSS is not currently supported. For other source formats (sass, coffee, etc) refer to their addons. 
 
-In dev, the default setting is equal to:
+Source maps are configured by the `sourcemaps` option and
+are disabled in production by default. Pass `sourcemaps: {enabled: true}` to your EmberApp constructor to enable source maps for javascript. Use the `extensions` option to add other formats, such as coffeescript and css: `{extensions: ['js', 'css', 'coffee']}`. Remember only js is currently supported out-of-the-box.
+
+Default Brocfile.js:
 
 {% highlight bash %}
-sourcemaps: {
-  enabled: true,
-  extensions: ['js']
-}
+import EmberApp from 'ember-cli/lib/broccoli/ember-app';
+var app = new EmberApp({
+  sourcemaps: {
+    enabled: EmberApp.env() !== 'production'
+    extensions: ['js']
+  }
+});
 {% endhighlight %}
 
-Pass `sourcemaps: {enabled: true}` to your EmberApp constructor to enable source maps for javascript.
-Use the `extensions` option to add CSS source maps: `{extensions: ['js', 'css']}`.
 
 ### Stylesheets
 


### PR DESCRIPTION
As mentioned in #4161 I found the new source maps docs a bit confusing on the website, and expected coffeescript and sass to work out of the box. I've tried not to change a lot, but hopefully it makes it a bit clearer that it isn't that simple :)

- Mention that other formats depend on their addons
- Shows how to turn on css
- Remove "configure" from the css bit, as that suggested there are options somewhere to pass to the subsystem.

I'm not familiar with the source maps code so suggest someone who knows it quickly checks what I've changed (in particular re: css).