### PR TITLE
Flag component unit tests as such

### DIFF
--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -2,7 +2,8 @@ import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar']
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true
 });
 
 test('it renders', function(assert) {


### PR DESCRIPTION
I think there could be some clarification shared on the future direction of component unit and integration testing in Ember-CLI. On a freshly generated addon I get a deprecation notice that at some future time all `moduleForComponent` tests will switch from being unit tests to the new-style integration tests.

This would seem to break a large number of existing test suites.

Regardless, it appears units need to be whitelisted, and should be whitelisted in generated tests.