### PR TITLE
Fixed type annotations

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1203,10 +1203,11 @@ EmberApp.prototype._importAssetTree = function(directory, subdirectory) {
 /**
   @private
   @method _getAssetPath
-  @param {Object} asset
-  @return {String} assetPath
+  @param {(Object|String)} asset
+  @return {(String|undefined)} assetPath
  */
 EmberApp.prototype._getAssetPath = function(asset) {
+  /** @type {String} */
   var assetPath;
 
   if (typeof asset === 'object') {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1106,8 +1106,8 @@ EmberApp.prototype.dependencies = function(pkg) {
 
   @public
   @method import
-  @param  {mixed}  asset   Either a path to the asset or an object with envirnoment names and paths as key-value pairs.
-  @param  {Object} options Options object
+  @param  {(Object|String)}  asset   Either a path to the asset or an object with envirnoment names and paths as key-value pairs.
+  @param  {Object=} options Options object
  */
 EmberApp.prototype.import = function(asset, options) {
   var assetPath = this._getAssetPath(asset);


### PR DESCRIPTION
IntelliJ was complaining that `import()` expects 2 parameters, but the second one is actually optional. Using `{Object=}` instead of `{Object}` is fixing that problem (see http://usejsdoc.org/tags-type.html#overview).

While I was already on it I adjusted the type information for the first parameter too.