### PR TITLE
Adds information about `"demoURL"`

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -177,12 +177,15 @@ Optionally, you may specify whether your `ember-addon` must run `"before"` or `"
 
 Optionally, you may specify a different name for the `"defaultBlueprint"`. It defaults to the name in the `package.json`. This blueprint will be run automatically when your addon is installed with the `ember install` command.
 
+Optinally, you may specify the `"demoURL"` property with the fully qualified URL of a website showing your addon in action. Sites likes [Ember Addons](http://emberaddons.com/) and [Ember Observer](http://emberobserver.com/) will display a link to `"demoURL"`.
+
 {% highlight javascript %}
 "ember-addon": {
   // addon configuration properties
   "configPath": "tests/dummy/config",
   "before": "single-addon",
   "defaultBlueprint": "blueprint-that-isnt-package-name",
+  "demoURL": "http://example.com/ember-addon/demo.html",
   "after": [
     "after-addon-1",
     "after-addon-2"


### PR DESCRIPTION
Added a new paragraph talking about the optional `"demoURL"` property. Sites like [Ember Addons](http://emberaddons.com) and [Ember Observer](http://emberobserver.com) can use this URL to better showcase addons.

[Ember Addons](http://emberaddons.com) is already displaying a DEMO link on addons that set the `"demoURL"` property. Here's a screenshot:

![4ac7f776-072d-11e5-91a5-acf5b280f742](https://cloud.githubusercontent.com/assets/61048/7902597/7b4bd3fe-078c-11e5-86af-edb8223fda24.png)

Related issue: https://github.com/gcollazo/ember-cli-addon-search/issues/48