### PR TITLE
[BUGFIX] add default for path option in component blueprint locals

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -3,6 +3,7 @@
 var Blueprint          = require('../../lib/models/blueprint');
 var stringUtil         = require('../../lib/utilities/string');
 var validComponentName = require('../../lib/utilities/valid-component-name');
+var getPathOption      = require('../../lib/utilities/get-component-path-option');
 var path               = require('path');
 
 module.exports = {
@@ -49,7 +50,7 @@ module.exports = {
 
     return {
       modulePath: importPathName,
-      path: options.path || 'components'
+      path: getPathOption(options)
     };
   }
 };

--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -41,15 +41,15 @@ module.exports = {
     var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.pkg.name;
     var addonName      = stringUtil.dasherize(addonRawName);
     var fileName       = stringUtil.dasherize(options.entity.name);
-    var pathName       = [addonName, 'components', fileName].join('/');
+    var importPathName       = [addonName, 'components', fileName].join('/');
 
     if (options.pod) {
-      pathName = [addonName, 'components', fileName,'component'].join('/');
+      importPathName = [addonName, 'components', fileName,'component'].join('/');
     }
 
     return {
-      modulePath: pathName,
-      path: options.path
+      modulePath: importPathName,
+      path: options.path || 'components'
     };
   }
 };

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,8 +1,10 @@
 /*jshint node:true*/
 
-var path = require('path');
-var testInfo = require('../../lib/utilities/test-info');
-var stringUtil  = require('../../lib/utilities/string');
+var path          = require('path');
+var testInfo      = require('../../lib/utilities/test-info');
+var stringUtil    = require('../../lib/utilities/string');
+var getPathOption = require('../../lib/utilities/get-component-path-option');
+
 
 module.exports = {
   description: 'Generates a component unit test.',
@@ -24,7 +26,7 @@ module.exports = {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
     return {
-      path: options.path || 'components',
+      path: getPathOption(options),
       componentPathName: componentPathName,
       friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
     };

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -24,7 +24,7 @@ module.exports = {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
     return {
-      path: options.path,
+      path: options.path || 'components',
       componentPathName: componentPathName,
       friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
     };

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -4,6 +4,7 @@ var Blueprint          = require('../../lib/models/blueprint');
 var stringUtil         = require('../../lib/utilities/string');
 var pathUtil           = require('../../lib/utilities/path');
 var validComponentName = require('../../lib/utilities/valid-component-name');
+var getPathOption      = require('../../lib/utilities/get-component-path-option');
 var path               = require('path');
 
 module.exports = {
@@ -68,7 +69,7 @@ module.exports = {
     return {
       importTemplate: importTemplate,
       contents: contents,
-      path: options.path || 'components'
+      path: getPathOption(options)
     };
   }
 };

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -68,7 +68,7 @@ module.exports = {
     return {
       importTemplate: importTemplate,
       contents: contents,
-      path: options.path
+      path: options.path || 'components'
     };
   }
 };

--- a/lib/utilities/get-component-path-option.js
+++ b/lib/utilities/get-component-path-option.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function getPathOption(options) {
+  var outputPath     = 'components';
+  if (options.path) {
+    outputPath = options.path;
+  } else {
+    if (options.path === '') {
+      outputPath = '';
+    }
+  }
+  return outputPath;
+};

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -296,8 +296,9 @@ describe('Acceptance: smoke-test', function() {
         });
     });
   });
-  
+
   it('ember can override and reuse the built-in blueprints', function() {
+    this.timeout(450000);
     return copyFixtureFiles('addon/with-blueprint-override')
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'component', 'foo-bar', '-p');

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -296,4 +296,18 @@ describe('Acceptance: smoke-test', function() {
         });
     });
   });
+  
+  it('ember can override and reuse the built-in blueprints', function() {
+    return copyFixtureFiles('addon/with-blueprint-override')
+      .then(function() {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'component', 'foo-bar', '-p');
+      })
+      .then(function() {
+        // because we're overriding, the fileMapTokens is default, sans 'component'
+        var componentPath = path.join('app','foo-bar','component.js');
+        var contents = fs.readFileSync(componentPath, { encoding: 'utf8' });
+
+        expect(contents).to.contain('generated component successfully');
+      });
+  });
 });

--- a/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
+++ b/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+<%= importTemplate %>
+export default Ember.Component.extend({<%= contents %>
+});
+//generated component successfully

--- a/tests/fixtures/addon/with-blueprint-override/blueprints/component/index.js
+++ b/tests/fixtures/addon/with-blueprint-override/blueprints/component/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  locals: function(options) {
+    return this.lookupBlueprint('component').locals(options);
+  } 
+};


### PR DESCRIPTION
Fixes #4183

Added `'components'` as the default value for the `--path` option in the component blueprint. Also added test to verify that blueprints that override built-in blueprints can still call methods of the built-in blueprint they are overriding. For instance:
```
// my-addon/blueprints/component/index.js

locals: function(options) {
    return this.lookupBlueprint('component').locals(options);
}
```