### PR TITLE
[BUGFIX] acceptance-test blueprint no longer generates addon re-export in app folder

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin'];
+    var noAddonBlueprint = ['mixin', 'acceptance-test'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -2,19 +2,21 @@
 
 'use strict';
 
-var Promise          = require('../../lib/ext/promise');
-var assertFile       = require('../helpers/assert-file');
-var conf             = require('../helpers/conf');
-var ember            = require('../helpers/ember');
-var fs               = require('fs-extra');
-var path             = require('path');
-var remove           = Promise.denodeify(fs.remove);
-var root             = process.cwd();
-var tmp              = require('tmp-sync');
-var tmproot          = path.join(root, 'tmp');
-var EOL              = require('os').EOL;
-var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
-var expect           = require('chai').expect;
+var Promise              = require('../../lib/ext/promise');
+var assertFile           = require('../helpers/assert-file');
+var assertFileEquals     = require('../helpers/assert-file-equals');
+var assertFileToNotExist = require('../helpers/assert-file-to-not-exist');
+var conf                 = require('../helpers/conf');
+var ember                = require('../helpers/ember');
+var fs                   = require('fs-extra');
+var path                 = require('path');
+var remove               = Promise.denodeify(fs.remove);
+var root                 = process.cwd();
+var tmp                  = require('tmp-sync');
+var tmproot              = path.join(root, 'tmp');
+var EOL                  = require('os').EOL;
+var BlueprintNpmTask     = require('../helpers/disable-npm-on-blueprint');
+var expect               = require('chai').expect;
 
 describe('Acceptance: ember generate in-addon', function() {
   this.timeout(20000);
@@ -495,6 +497,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "import FooMixin from '../../../mixins/foo';"
         ]
       });
+      assertFileToNotExist('app/mixins/foo.js');
     });
   });
 
@@ -511,6 +514,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "import FooBarMixin from '../../../mixins/foo/bar';"
         ]
       });
+      assertFileToNotExist('app/mixins/foo/bar.js');
     });
   });
 
@@ -521,6 +525,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "import FooBarBazMixin from '../../../mixins/foo/bar/baz';"
         ]
       });
+      assertFileToNotExist('app/mixins/foo/bar/baz.js');
     });
   });
 
@@ -955,4 +960,14 @@ describe('Acceptance: ember generate in-addon', function() {
         assertFile('server/.jshintrc');
       });
     });
+
+    it('in-addon acceptance-test foo', function() {
+      return generateInAddon(['acceptance-test', 'foo']).then(function() {
+        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-expected.js');
+
+        assertFileEquals('tests/acceptance/foo-test.js', expected);
+        assertFileToNotExist('app/acceptance-tests/foo.js');
+      });
+    });
+
 });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -2,19 +2,21 @@
 
 'use strict';
 
-var Promise          = require('../../lib/ext/promise');
-var assertFile       = require('../helpers/assert-file');
-var conf             = require('../helpers/conf');
-var ember            = require('../helpers/ember');
-var fs               = require('fs-extra');
-var path             = require('path');
-var remove           = Promise.denodeify(fs.remove);
-var root             = process.cwd();
-var tmp              = require('tmp-sync');
-var tmproot          = path.join(root, 'tmp');
-var EOL              = require('os').EOL;
-var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
-var expect           = require('chai').expect;
+var Promise              = require('../../lib/ext/promise');
+var assertFile           = require('../helpers/assert-file');
+var assertFileEquals     = require('../helpers/assert-file-equals');
+var assertFileToNotExist = require('../helpers/assert-file-to-not-exist');
+var conf                 = require('../helpers/conf');
+var ember                = require('../helpers/ember');
+var fs                   = require('fs-extra');
+var path                 = require('path');
+var remove               = Promise.denodeify(fs.remove);
+var root                 = process.cwd();
+var tmp                  = require('tmp-sync');
+var tmproot              = path.join(root, 'tmp');
+var EOL                  = require('os').EOL;
+var BlueprintNpmTask     = require('../helpers/disable-npm-on-blueprint');
+var expect               = require('chai').expect;
 
 describe('Acceptance: ember generate in-repo-addon', function() {
   this.timeout(20000);
@@ -776,6 +778,14 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "moduleFor('service:foo/bar'"
         ]
       });
+    });
+  });
+  it('in-addon acceptance-test foo', function() {
+    return generateInRepoAddon(['acceptance-test', 'foo']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/acceptance-test-expected.js');
+
+      assertFileEquals('tests/acceptance/foo-test.js', expected);
+      assertFileToNotExist('app/acceptance-tests/foo.js');
     });
   });
 

--- a/tests/fixtures/generate/addon-acceptance-test-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-expected.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from 'my-addon/tests/helpers/start-app';
+
+var application;
+
+module('Acceptance | foo', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('visiting /foo', function(assert) {
+  visit('/foo');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/foo');
+  });
+});

--- a/tests/helpers/assert-file-to-not-exist.js
+++ b/tests/helpers/assert-file-to-not-exist.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var expect = require('chai').expect;
+var fs     = require('fs');
+
+/*
+  Assert that a file does not exist, for ensuring certain files aren't generated
+
+  @method assertFileToNotExist
+  @param {String} pathToCheck
+*/
+module.exports = function assertFileToNotExist(pathToCheck) {
+  var exists;
+  try {
+    exists = fs.readFileSync(pathToCheck, { encoding: 'utf-8' });
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+        exists = null;
+    } else {
+        throw e;
+    }
+  }
+  expect(exists).to.not.exist;
+};


### PR DESCRIPTION
fixes #4192

Added tests and helper to verify additional files aren't being generated in the `app` folder.