### PR TITLE
[BUGFIX] correct relative import path for nested adapters

### DIFF
--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -2,6 +2,7 @@
 
 var stringUtil  = require('../../lib/utilities/string');
 var SilentError = require('../../lib/errors/silent');
+var pathUtil    = require('../../lib/utilities/path');
 
 module.exports = {
   description: 'Generates an ember-data adapter.',
@@ -15,6 +16,11 @@ module.exports = {
     var baseClass       = 'DS.RESTAdapter';
     var importStatement = 'import DS from \'ember-data\';';
     var isAddon         = options.inRepoAddon || options.project.isEmberCLIAddon();
+    var relativePath    = pathUtil.getRelativePath(options.entity.name);
+
+    if (options.pod && options.podPath) {
+        relativePath = pathUtil.getRelativePath(options.podPath + options.entity.name);
+    }
 
     if (!isAddon && !options.baseClass && adapterName !== 'application') {
       options.baseClass = 'application';
@@ -27,8 +33,7 @@ module.exports = {
     if (options.baseClass) {
       baseClass = stringUtil.classify(options.baseClass.replace('\/', '-'));
       baseClass = baseClass + 'Adapter';
-
-      importStatement = 'import ' + baseClass + ' from \'./' + options.baseClass + '\';';
+      importStatement = 'import ' + baseClass + ' from \'' + relativePath + options.baseClass + '\';';
     }
 
     return {

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -2,6 +2,7 @@
 
 var Blueprint          = require('../../lib/models/blueprint');
 var stringUtil         = require('../../lib/utilities/string');
+var pathUtil           = require('../../lib/utilities/path');
 var validComponentName = require('../../lib/utilities/valid-component-name');
 var path               = require('path');
 
@@ -57,7 +58,7 @@ module.exports = {
       if(options.pod) {
         templatePath   = './template';
       } else {
-        templatePath   = getPathLevel(options.entity.name) +
+        templatePath   = pathUtil.getRelativeParentPath(options.entity.name) +
           'templates/components/' + stringUtil.dasherize(options.entity.name);
       }
       importTemplate   = 'import layout from \'' + templatePath + '\';\n';
@@ -71,7 +72,3 @@ module.exports = {
     };
   }
 };
-
-function getPathLevel(name) {
-  return new Array(name.split('/').length + 1).join('../');
-}

--- a/lib/utilities/path.js
+++ b/lib/utilities/path.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+    /**
+      Returns a relative parent path string using the path provided
+
+      @method getRelativeParentPath
+      @param {String} path The path to relatively get to.
+      @return {String} the relative path string.
+    */
+    getRelativeParentPath: function getRelativeParentPath(path, offset) {
+      var offsetValue = offset || 0;
+      return new Array(path.split('/').length + 1 - offsetValue).join('../');
+  },
+
+    /**
+      Returns a relative path string using the path provided
+
+      @method getRelativePath
+      @param {String} path The path to relatively get to.
+      @return {String} the relative path string.
+    */
+    getRelativePath: function getRelativePath(path, offset) {
+      var offsetValue = offset || 0;
+      var relativePath = new Array(path.split('/').length - offsetValue).join('../');
+      return relativePath || './';
+    }
+};

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -577,7 +577,7 @@ describe('Acceptance: ember generate in-addon', function() {
     return generateInAddon(['adapter', 'foo/bar', '--base-class=foo']).then(function() {
       assertFile('addon/adapters/foo/bar.js', {
         contains: [
-          "import FooAdapter from \'./foo\';",
+          "import FooAdapter from \'../foo\';",
           "export default FooAdapter.extend({" + EOL + "});"
         ]
       });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -115,7 +115,7 @@ describe('Acceptance: ember generate', function() {
       });
     });
   });
-  
+
   it('component foo/x-foo', function() {
     return generate(['component', 'foo/x-foo']).then(function() {
       assertFile('app/components/foo/x-foo.js', {
@@ -136,7 +136,7 @@ describe('Acceptance: ember generate', function() {
       });
     });
   });
-  
+
   it('component x-foo ignores --path option', function() {
     return generate(['component', 'x-foo', '--path', 'foo']).then(function() {
       assertFile('app/components/x-foo.js', {
@@ -561,7 +561,18 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'foo/bar']).then(function() {
       assertFile('app/adapters/foo/bar.js', {
         contains: [
-          "import ApplicationAdapter from \'./application\';",
+          "import ApplicationAdapter from \'../application\';",
+          "export default ApplicationAdapter.extend({" + EOL + "});"
+        ]
+      });
+    });
+  });
+
+  it('adapter foo/bar/baz', function() {
+    return generate(['adapter', 'foo/bar/baz']).then(function() {
+      assertFile('app/adapters/foo/bar/baz.js', {
+        contains: [
+          "import ApplicationAdapter from \'../../application\';",
           "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
@@ -599,7 +610,7 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'foo/baz', '--base-class=foo/bar']).then(function() {
       assertFile('app/adapters/foo/baz.js', {
         contains: [
-          "import FooBarAdapter from './foo/bar';",
+          "import FooBarAdapter from '../foo/bar';",
           "export default FooBarAdapter.extend({" + EOL + "});"
         ]
       });
@@ -1124,7 +1135,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('lib/.jshintrc');
     });
   });
-  
+
   it('custom blueprint availableOptions', function() {
     return initApp()
       .then(function() {
@@ -1134,7 +1145,7 @@ describe('Acceptance: ember generate', function() {
               'module.exports = {' + EOL + 'availableOptions: [ ' + EOL +
               '{ name: \'foo\',' + EOL + 'type: String, '+ EOL +
               'values: [\'one\', \'two\'],' + EOL +
-              'default: \'one\',' + EOL + 
+              'default: \'one\',' + EOL +
               'aliases: [ {\'one\': \'one\'}, {\'two\': \'two\'} ] } ],' + EOL +
               'locals: function(options) {' + EOL +
               'return { foo: options.foo };' + EOL +

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -575,7 +575,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
     return generateInRepoAddon(['adapter', 'foo/bar', '--in-repo-addon=my-addon', '--base-class=foo']).then(function() {
       assertFile('lib/my-addon/addon/adapters/foo/bar.js', {
         contains: [
-          "import FooAdapter from \'./foo\';",
+          "import FooAdapter from \'../foo\';",
           "export default FooAdapter.extend({" + EOL + "});"
         ]
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1156,7 +1156,7 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'foo/bar', '--pod']).then(function() {
       assertFile('app/foo/bar/adapter.js', {
         contains: [
-          "import ApplicationAdapter from \'./application\';",
+          "import ApplicationAdapter from \'../application\';",
           "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
@@ -1167,7 +1167,7 @@ describe('Acceptance: ember generate pod', function() {
     return generateWithPrefix(['adapter', 'foo/bar', '--pod']).then(function() {
       assertFile('app/pods/foo/bar/adapter.js', {
         contains: [
-          "import ApplicationAdapter from \'./application\';",
+          "import ApplicationAdapter from \'../application\';",
           "export default ApplicationAdapter.extend({" + EOL + "});"
         ]
       });
@@ -1205,7 +1205,7 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'foo/baz', '--base-class=foo/bar', '--pod']).then(function() {
       assertFile('app/foo/baz/adapter.js', {
         contains: [
-          "import FooBarAdapter from './foo/bar';",
+          "import FooBarAdapter from '../foo/bar';",
           "export default FooBarAdapter.extend({" + EOL + "});"
         ]
       });

--- a/tests/unit/utilities/path-test.js
+++ b/tests/unit/utilities/path-test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var expect       = require('chai').expect;
+var pathUtils = require('../../../lib/utilities/path');
+
+describe('path.getRelativeParentPath', function() {
+  it('should return parent paths', function() {
+    expect(pathUtils.getRelativeParentPath('')).to.equal('../');
+    expect(pathUtils.getRelativeParentPath('foo')).to.equal('../');
+    expect(pathUtils.getRelativeParentPath('foo/bar')).to.equal('../../');
+    expect(pathUtils.getRelativeParentPath('foo/bar/baz')).to.equal('../../../');
+  });
+
+  it('should allow an offset value', function() {
+    expect(pathUtils.getRelativeParentPath('',1)).to.equal('');
+    expect(pathUtils.getRelativeParentPath('foo',1)).to.equal('');
+    expect(pathUtils.getRelativeParentPath('foo/bar', 1)).to.equal('../');
+    expect(pathUtils.getRelativeParentPath('foo/bar/baz', 2)).to.equal('../');
+  });
+});
+
+describe('path.getRelativePath', function() {
+  it('should return the relative path', function() {
+    expect(pathUtils.getRelativePath('')).to.equal('./');
+    expect(pathUtils.getRelativePath('foo')).to.equal('./');
+    expect(pathUtils.getRelativePath('foo/bar')).to.equal('../');
+    expect(pathUtils.getRelativePath('foo/bar/baz')).to.equal('../../');
+  });
+
+  it('should allow an offset value', function() {
+    expect(pathUtils.getRelativePath('', 1)).to.equal('./');
+    expect(pathUtils.getRelativePath('foo', 1)).to.equal('./');
+    expect(pathUtils.getRelativePath('foo/bar', 1)).to.equal('./');
+    expect(pathUtils.getRelativePath('foo/bar/baz', 1)).to.equal('../');
+    expect(pathUtils.getRelativePath('foo/bar/baz', 2)).to.equal('./');
+  });
+});


### PR DESCRIPTION
fixes #3733 

Created path utility to generate relative path from a given path, which is now used to generate the import path for the adapter.