### PR TITLE
[BUGFIX] generating tests inside addons does no longer generates addon export file

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -781,7 +781,7 @@ Blueprint.prototype.mapFile = function(file, locals) {
   @return {Boolean}
 */
 Blueprint.prototype.supportsAddon = function() {
-  return this.files().join().match(/(?:blueprints|__root__|server|tests)/);
+  return this.files().join().match(/__root__/);
 };
 
 /**
@@ -1230,9 +1230,9 @@ Blueprint.load = function(blueprintPath) {
   var constructorPath = path.resolve(blueprintPath, 'index.js');
   var blueprintModule;
   var Constructor = Blueprint;
-  
+
   if (fs.lstatSync(blueprintPath).isDirectory()) {
-    
+
     if (fs.existsSync(constructorPath)) {
       blueprintModule = require(constructorPath);
 
@@ -1240,12 +1240,12 @@ Blueprint.load = function(blueprintPath) {
         Constructor = blueprintModule;
       } else {
         Constructor = Blueprint.extend(blueprintModule);
-      }  
+      }
     }
 
     return new Constructor(blueprintPath);
   }
-  
+
   return;
 };
 
@@ -1277,7 +1277,7 @@ Blueprint.list = function(options) {
     blueprints = blueprints.map(function(blueprintPath) {
       var blueprint   = Blueprint.load(blueprintPath);
       var name;
-      
+
       if (blueprint) {
         name = blueprint.name;
         blueprint.overridden = contains(seen, name);
@@ -1285,7 +1285,7 @@ Blueprint.list = function(options) {
 
         return blueprint;
       }
-      
+
       return;
     });
 

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin', 'acceptance-test'];
+    var noAddonBlueprint = ['mixin'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -139,6 +139,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "moduleForComponent('x-foo'"
         ]
       });
+      assertFileToNotExist('app/component-test/x-foo.js');
     });
   });
 
@@ -165,17 +166,6 @@ describe('Acceptance: ember generate in-addon', function() {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
           "moduleForComponent('nested/x-foo'"
-        ]
-      });
-    });
-  });
-
-  it('in-addon component-test x-foo', function() {
-    return generateInAddon(['component-test', 'x-foo']).then(function() {
-      assertFile('tests/unit/components/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
         ]
       });
     });
@@ -328,6 +318,18 @@ describe('Acceptance: ember generate in-addon', function() {
     });
   });
 
+  it('in-addon model-test foo', function() {
+    return generateInAddon(['model-test', 'foo']).then(function() {
+      assertFile('tests/unit/models/foo-test.js', {
+        contains: [
+          "import { moduleForModel, test } from 'ember-qunit';",
+          "moduleForModel('foo'"
+        ]
+      });
+      assertFileToNotExist('app/model-test/foo.js');
+    });
+  });
+
   it('in-addon route foo', function() {
     return generateInAddon(['route', 'foo']).then(function() {
       assertFile('addon/routes/foo.js', {
@@ -376,6 +378,18 @@ describe('Acceptance: ember generate in-addon', function() {
           "moduleFor('route:foo/bar'"
         ]
       });
+    });
+  });
+  
+  it('in-addon route-test foo', function() {
+    return generateInAddon(['route-test', 'foo']).then(function() {
+      assertFile('tests/unit/routes/foo-test.js', {
+        contains: [
+          "import { moduleFor, test } from 'ember-qunit';",
+          "moduleFor('route:foo'"
+        ]
+      });
+      assertFileToNotExist('app/route-test/foo.js');
     });
   });
 
@@ -594,7 +608,18 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-
+  
+  it('in-addon adapter-test foo', function() {
+    return generateInAddon(['adapter-test', 'foo']).then(function() {
+      assertFile('tests/unit/adapters/foo-test.js', {
+        contains: [
+          "import { moduleFor, test } from 'ember-qunit';",
+          "moduleFor('adapter:foo'"
+        ]
+      });
+      assertFileToNotExist('app/adapter-test/foo.js');
+    });
+  });
 
   it('in-addon serializer foo', function() {
     return generateInAddon(['serializer', 'foo']).then(function() {
@@ -636,6 +661,18 @@ describe('Acceptance: ember generate in-addon', function() {
           "moduleForModel('foo/bar'"
         ]
       });
+    });
+  });
+  
+  it('in-addon serializer-test foo', function() {
+    return generateInAddon(['serializer-test', 'foo']).then(function() {
+      assertFile('tests/unit/serializers/foo-test.js', {
+        contains: [
+          "import { moduleForModel, test } from 'ember-qunit';",
+          "moduleForModel('foo'"
+        ]
+      });
+      assertFileToNotExist('app/serializer-test/foo.js');
     });
   });
 
@@ -783,24 +820,36 @@ describe('Acceptance: ember generate in-addon', function() {
     });
   });
 
+  
+  it('in-addon service-test foo', function() {
+    return generateInAddon(['service-test', 'foo']).then(function() {
+      assertFile('tests/unit/services/foo-test.js', {
+        contains: [
+          "import { moduleFor, test } from 'ember-qunit';",
+          "moduleFor('service:foo'"
+        ]
+      });
+      assertFileToNotExist('app/service-test/foo.js');
+    });
+  });
 
-    it('in-addon blueprint foo', function() {
-      return generateInAddon(['blueprint', 'foo']).then(function() {
-        assertFile('blueprints/foo/index.js', {
-          contains: "module.exports = {" + EOL +
-                    "  description: ''"+ EOL +
-                    EOL +
-                    "  // locals: function(options) {" + EOL +
-                    "  //   // Return custom template variables here." + EOL +
-                    "  //   return {" + EOL +
-                    "  //     foo: options.entity.options.foo" + EOL +
-                    "  //   };" + EOL +
-                    "  // }" + EOL +
-                    EOL +
-                    "  // afterInstall: function(options) {" + EOL +
-                    "  //   // Perform extra work here." + EOL +
-                    "  // }" + EOL +
-                    "};"
+  it('in-addon blueprint foo', function() {
+    return generateInAddon(['blueprint', 'foo']).then(function() {
+      assertFile('blueprints/foo/index.js', {
+        contains: "module.exports = {" + EOL +
+                  "  description: ''"+ EOL +
+                  EOL +
+                  "  // locals: function(options) {" + EOL +
+                  "  //   // Return custom template variables here." + EOL +
+                  "  //   return {" + EOL +
+                  "  //     foo: options.entity.options.foo" + EOL +
+                  "  //   };" + EOL +
+                  "  // }" + EOL +
+                  EOL +
+                  "  // afterInstall: function(options) {" + EOL +
+                  "  //   // Perform extra work here." + EOL +
+                  "  // }" + EOL +
+                  "};"
         });
       });
     });


### PR DESCRIPTION
Fixes #4192

As reported, generating a test inside an addon was generating an addon export file in the `app` folder:
```
ember g model-test foo => app/model-tests/foo.js
```

This PR removes blueprints, server, and tests from [the regex](https://github.com/ember-cli/ember-cli/blob/master/lib/models/blueprint.js#L784) in the `supportsAddon` method (introduced [here](https://github.com/ember-cli/ember-cli/pull/3845)), which it turns out are actually no longer necessary to check, as of the same PR (changed after realizing that the silent error [wasn't needed](https://github.com/ember-cli/ember-cli/issues/3840#issuecomment-91663904) I [removed it](https://github.com/ember-cli/ember-cli/issues/3840#issuecomment-94134647), but forgot to revert the regex afterwards.