### PR TITLE
Run jekyll via bundler and tell jekyll not to build vendor/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ baseurl: ''
 
 highlighter: pygments
 markdown:    kramdown
-exclude: [node_modules]
+exclude: [node_modules, vendor]
 
 # TODO: Automate version bump on release
 version: 0.2.7

--- a/run.rb
+++ b/run.rb
@@ -1,1 +1,1 @@
-exec('jekyll server --watch --baseurl ""')
+exec('bundle exec jekyll server --watch --baseurl ""')


### PR DESCRIPTION
- `ruby run.rb` uses bundled jekyll
- jekyll ignores `vendor/` dir when it builds, stops jekyll build error with locally installed bundles in `vendor`
