### PR TITLE
Passing options to tiny-lr (live reload) for HTTPS support

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -62,7 +62,7 @@ module.exports = Task.extend({
     if(!fs.existsSync(this.startOptions.sslKey)) {
       throw new TypeError('SSL key couldn\'t be found in "' + this.startOptions.sslKey + '", please provide a path to an existing ssl key file with --ssl-key');
     }
-    if(!fs.existsSync(this.startOptions.sslKey)) {
+    if(!fs.existsSync(this.startOptions.sslCert)) {
       throw new TypeError('SSL certificate couldn\'t be found in "' + this.startOptions.sslCert + '", please provide a path to an existing ssl certificate file with --ssl-cert');
     }
     var options = {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -2,41 +2,53 @@
 
 var Promise     = require('../../ext/promise');
 var path        = require('path');
+var fs          = require('fs');
 var Task        = require('../../models/task');
 var SilentError = require('silent-error');
 
-function createServer() {
+function createServer(options) {
   var instance;
+
   var Server = (require('tiny-lr')).Server;
   Server.prototype.error = function() {
     instance.error.apply(instance, arguments);
   };
-  instance = new Server();
+  instance = new Server(options);
   return instance;
 }
 
 module.exports = Task.extend({
-  liveReloadServer: function() {
+  liveReloadServer: function(options) {
     if (this._liveReloadServer) {
       return this._liveReloadServer;
     }
 
-    this._liveReloadServer = createServer();
+    this._liveReloadServer = createServer(options);
     return this._liveReloadServer;
   },
 
 
-  listen: function(port) {
-    var server = this.liveReloadServer();
+  listen: function(options) {
+    var server = this.liveReloadServer(options);
+
     return new Promise(function(resolve, reject) {
       server.error = reject;
-      server.listen(port, resolve);
+      server.listen(options.liveReloadPort, resolve);
     });
   },
 
   start: function(options) {
+    var tlroptions = {};
+    tlroptions.ssl = options.ssl || false;
+    tlroptions.port = options.liveReloadPort || 35729;
+
     if (options.liveReload !== true) {
       return Promise.resolve('Livereload server manually disabled.');
+    }
+
+    if (options.ssl) {
+      tlroptions.key = fs.readFileSync(options.sslKey);
+      tlroptions.cert = fs.readFileSync(options.sslCert);
     }
 
     // Reload on file changes
@@ -47,13 +59,13 @@ module.exports = Task.extend({
     this.expressServer.on('restart', this.didRestart.bind(this));
 
     // Start LiveReload server
-    return this.listen(options.liveReloadPort)
-      .then(this.writeBanner.bind(this, options.liveReloadPort))
-      .catch(this.writeErrorBanner.bind(this, options.liveReloadPort));
+    return this.listen(tlroptions)
+      .then(this.writeBanner.bind(this, options.liveReloadPort, tlroptions.ssl))
+      .catch(this.writeErrorBanner.bind(this, tlroptions.port));
   },
 
-  writeBanner: function(port) {
-    this.ui.writeLine('Livereload server on port ' + port);
+  writeBanner: function(port, ssl) {
+    this.ui.writeLine('Livereload server on port ' + port + ' ' + (ssl ? '(https)' : '(http)'));
   },
 
   writeErrorBanner: function(port) {

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -56,7 +56,7 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: true
       }).then(function() {
-        expect(ui.output).to.equal('Livereload server on port 1337' + EOL);
+        expect(ui.output).to.equal('Livereload server on port 1337 (http)' + EOL);
       });
     });
 
@@ -67,6 +67,39 @@ describe('livereload-server', function() {
       return subject.start({
           liveReloadPort: 1337,
           liveReload: true
+        })
+        .catch(function(reason) {
+          expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
+        })
+        .finally(function() {
+          preexistingServer.close(done);
+        });
+    });
+  });
+
+  describe('start with https', function() {
+    it('correctly indicates which port livereload is present on and running in https mode', function() {
+      return subject.start({
+        liveReloadPort: 1337,
+        liveReload: true,
+        ssl: true,
+        sslKey: 'tests/fixtures/ssl/server.key',
+        sslCert: 'tests/fixtures/ssl/server.crt'
+      }).then(function() {
+        expect(ui.output).to.equal('Livereload server on port 1337 (https)' + EOL);
+      });
+    });
+
+    it('informs of error during startup', function(done) {
+      var preexistingServer = net.createServer();
+      preexistingServer.listen(1337);
+
+      return subject.start({
+          liveReloadPort: 1337,
+          liveReload: true,
+          ssl: true,
+          sslKey: 'tests/fixtures/ssl/server.key',
+          sslCert: 'tests/fixtures/ssl/server.crt'
         })
         .catch(function(reason) {
           expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);


### PR DESCRIPTION
Ember CLI is currently creating an instance of tiny-lr server without passing an options object which causes the live reload to always start to HTTP mode, with the newly added HTTPS support in express-server we an now pass the key and cert to tiny-lr allowing it to also launch in HTTPS mode.

Currently when ember serve is launched in HTTPS mode live reload will not work due to mixed-content issues in the browser.