### PR TITLE
[BUGFIX] Fix generated addon acceptance test

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import startApp from '<%= dasherizedPackageName %>/tests/helpers/start-app';
+import startApp from '<%= testFolderRoot %>/tests/helpers/start-app';
 
 var application;
 

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,15 +1,17 @@
 /*jshint node:true*/
 
-var testInfo = require('../../lib/utilities/test-info');
-var pathUtil = require('../../lib/utilities/path');
+var testInfo    = require('../../lib/utilities/test-info');
+var pathUtil    = require('../../lib/utilities/path');
+var stringUtils = require('../../lib/utilities/string');
 
 module.exports = {
   description: 'Generates an acceptance test for a feature.',
   locals: function(options) {
-    var testFolderRoot = options.dasherizedPackageName;
+    var testFolderRoot = stringUtils.dasherize(options.project.name());
+    
     if (options.project.isEmberCLIAddon()) {
-      testFolderRoot = pathUtil.getRelativeParentPath(options.entity.name, -1);
-    }
+      testFolderRoot = pathUtil.getRelativeParentPath(options.entity.name, -1, false);
+    }  
     return {
       testFolderRoot: testFolderRoot,
       friendlyTestName: testInfo.name(options.entity.name, "Acceptance", null)

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,11 +1,17 @@
 /*jshint node:true*/
 
 var testInfo = require('../../lib/utilities/test-info');
+var pathUtil = require('../../lib/utilities/path');
 
 module.exports = {
   description: 'Generates an acceptance test for a feature.',
   locals: function(options) {
+    var testFolderRoot = options.dasherizedPackageName;
+    if (options.project.isEmberCLIAddon()) {
+      testFolderRoot = pathUtil.getRelativeParentPath(options.entity.name, -1);
+    }
     return {
+      testFolderRoot: testFolderRoot,
       friendlyTestName: testInfo.name(options.entity.name, "Acceptance", null)
     };
   }

--- a/lib/utilities/path.js
+++ b/lib/utilities/path.js
@@ -8,9 +8,12 @@ module.exports = {
       @param {String} path The path to relatively get to.
       @return {String} the relative path string.
     */
-    getRelativeParentPath: function getRelativeParentPath(path, offset) {
+    getRelativeParentPath: function getRelativeParentPath(path, offset, slash) {
       var offsetValue = offset || 0;
-      return new Array(path.split('/').length + 1 - offsetValue).join('../');
+      var trailingSlash = typeof slash === 'undefined' ? true : slash;
+      var outputPath = new Array(path.split('/').length + 1 - offsetValue).join('../');
+      
+      return trailingSlash ? outputPath : outputPath.substr(0, outputPath.length - 1);
   },
 
     /**

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -1018,5 +1018,14 @@ describe('Acceptance: ember generate in-addon', function() {
         assertFileToNotExist('app/acceptance-tests/foo.js');
       });
     });
+    
+    it('in-addon acceptance-test foo/bar', function() {
+      return generateInAddon(['acceptance-test', 'foo/bar']).then(function() {
+        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');
+
+        assertFileEquals('tests/acceptance/foo/bar-test.js', expected);
+        assertFileToNotExist('app/acceptance-tests/foo/bar.js');
+      });
+    });
 
 });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -780,8 +780,8 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
     });
   });
-  it('in-addon acceptance-test foo', function() {
-    return generateInRepoAddon(['acceptance-test', 'foo']).then(function() {
+  it('in-repo-addon acceptance-test foo', function() {
+    return generateInRepoAddon(['acceptance-test', 'foo', '--in-repo-addon=my-addon']).then(function() {
       var expected = path.join(__dirname, '../fixtures/generate/acceptance-test-expected.js');
 
       assertFileEquals('tests/acceptance/foo-test.js', expected);

--- a/tests/fixtures/generate/addon-acceptance-test-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-expected.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import startApp from 'my-addon/tests/helpers/start-app';
+import startApp from '../../tests/helpers/start-app';
 
 var application;
 

--- a/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../../tests/helpers/start-app';
+
+var application;
+
+module('Acceptance | foo/bar', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('visiting /foo/bar', function(assert) {
+  visit('/foo/bar');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/foo/bar');
+  });
+});

--- a/tests/unit/utilities/path-test.js
+++ b/tests/unit/utilities/path-test.js
@@ -18,6 +18,13 @@ describe('path.getRelativeParentPath', function() {
     expect(pathUtils.getRelativeParentPath('foo/bar/baz', 2)).to.equal('../');
     expect(pathUtils.getRelativeParentPath('foo', -1)).to.equal('../../');
   });
+  
+  it('should have an optional trailing slash', function() {
+    expect(pathUtils.getRelativeParentPath('', 0, false)).to.equal('..');
+    expect(pathUtils.getRelativeParentPath('foo', 0, false)).to.equal('..');
+    expect(pathUtils.getRelativeParentPath('foo/bar', 0, false)).to.equal('../..');
+    expect(pathUtils.getRelativeParentPath('foo', 1, false)).to.equal('');
+  });
 });
 
 describe('path.getRelativePath', function() {

--- a/tests/unit/utilities/path-test.js
+++ b/tests/unit/utilities/path-test.js
@@ -16,6 +16,7 @@ describe('path.getRelativeParentPath', function() {
     expect(pathUtils.getRelativeParentPath('foo',1)).to.equal('');
     expect(pathUtils.getRelativeParentPath('foo/bar', 1)).to.equal('../');
     expect(pathUtils.getRelativeParentPath('foo/bar/baz', 2)).to.equal('../');
+    expect(pathUtils.getRelativeParentPath('foo', -1)).to.equal('../../');
   });
 });
 


### PR DESCRIPTION
Fixes #4191 

Generates acceptance tests inside addons with a relative path instead of the addon namespace. Accounts for nested acceptance tests, generating the correct parent path.