### PR TITLE
[WIP][ENHANCEMENT]  Add blueprint for ember-cli-command-test

### DIFF
--- a/blueprints/ember-cli-command-test/files/tests/runner.js
+++ b/blueprints/ember-cli-command-test/files/tests/runner.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var glob = require('glob');
+var Mocha = require('mocha');
+
+var mocha = new Mocha({
+  reporter: 'spec'
+});
+
+var arg = process.argv[2];
+var root = 'tests/';
+
+function addFiles(mocha, files) {
+  glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
+}
+
+addFiles(mocha, '/**/*-nodetest.js');
+
+if (arg === 'all') {
+  addFiles(mocha, '/**/*-nodetest-slow.js');
+}
+
+mocha.run(function(failures) {
+  process.on('exit', function() {
+    process.exit(failures);
+  });
+});

--- a/blueprints/ember-cli-command-test/files/tests/unit/commands/__name__-nodetest.js
+++ b/blueprints/ember-cli-command-test/files/tests/unit/commands/__name__-nodetest.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var assert        = require('chai').assert;
+var MockUI        = require('ember-cli/tests/helpers/mock-ui');
+var MockAnalytics = require('ember-cli/tests/helpers/mock-analytics');
+var Command       = require('ember-cli/lib/models/command');
+var Task          = require('ember-cli/lib/models/task');
+var RSVP          = require('rsvp');
+
+var <%= classifiedCommandName %>CommandBase = require('../../../lib/commands/<%= commandName %>');
+
+describe('<%= commandName %> command', function() {
+  var ui;
+  var tasks;
+  var analytics;
+  var project;
+  var fakeSpawn;
+  var CommandUnderTest;
+  var buildTaskCalled;
+  var buildTaskReceivedProject;
+
+  before(function() {
+    CommandUnderTest = Command.extend(<%= classifiedCommandName %>CommandBase);
+  });
+
+  beforeEach(function() {
+    buildTaskCalled = false;
+    ui = new MockUI();
+    analytics = new MockAnalytics();
+    tasks = {
+      Build: Task.extend({
+        run: function() {
+          buildTaskCalled = true;
+          buildTaskReceivedProject = !!this.project;
+
+          return RSVP.resolve();
+        }
+      })
+    };
+
+    project = {
+      isEmberCLIProject: function(){
+        return true;
+      }
+    };
+  });
+
+  it('<%= commandName %> command smoke test', function() {
+    return new CommandUnderTest({
+      ui: ui,
+      analytics: analytics,
+      project: project,
+      environment: { },
+      tasks: tasks,
+      settings: {},
+      runCommand: function(command, args) {
+        assert.deepEqual(args, []);
+      }
+    }).validateAndRun([]);
+  });
+});

--- a/blueprints/ember-cli-command-test/index.js
+++ b/blueprints/ember-cli-command-test/index.js
@@ -1,0 +1,39 @@
+/*jshint node:true*/
+
+var fs          = require('fs');
+var path        = require('path');
+var stringUtils = require('../../lib/utilities/string');
+
+module.exports = {
+  description: 'Node tests for ember-cli commands.',
+  
+  generatePackageJson: function() {
+    var packagePath  = path.join(this.project.root, 'package.json');
+    var contents     = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+
+    contents.scripts['nodetest'] = "node tests/runner.js";
+    
+    fs.writeFileSync(path.join(this.project.root, 'package.json'), JSON.stringify(contents, null, 2));
+  },
+  
+  afterInstall: function() {
+    this.generatePackageJson();
+    return this.addPackagesToProject([
+      {name: 'glob', target: '~4.0.5'},
+      {name: 'chai', target: '~1.9.1'},
+      {name: 'mocha', target: '^1.21.4'},
+      {name: 'mocha-jshint', target: '^0.0.9'},
+      {name: 'rsvp', target: '^3.0.17'},
+      {name: 'ember-cli', target: '^0.2.7'}
+    ]);
+  },
+  
+  locals: function(options) {
+    var classifiedCommandName = stringUtils.classify(options.entity.name);
+    
+    return {
+      commandName: options.entity.name,
+      classifiedCommandName: classifiedCommandName
+    };
+  }
+};


### PR DESCRIPTION
This PR adds a new blueprint to generate node tests for ember-cli commands. It is primarily for use in addons, but could be used in a project with an in-repo-addon. It generates the test, as well as a mocha runner (stolen from [ember-cli-divshot](https://github.com/rwjblue/ember-cli-divshot/blob/master/tests/runner.js)). Additionally, it updates the package.json devDependencies and adds `nodetest` to scripts.

I'm putting this up early (sans tests) for review, as I'm not totally sure what I'm doing here. Most of the code was extracted from ember-cli-divshot, since it was the only example of a test for an addon command I could find. My main motivation is that I'd like it to be easier for addon developers to test their commands by giving them a starting point to do so.