### PR TITLE
[BUGFIX] Closes #4253. Add `skipHelp` as an available option to commands.

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -100,7 +100,9 @@ module.exports = Command.extend({
   _printHelpForCommand: function(commandName, detailed, options) {
     var command = this._lookupCommand(commandName);
 
-    command.printBasicHelp(options);
+    if (!command.skipHelp || (command.skipHelp && detailed)) {
+      command.printBasicHelp(options);
+    }
 
     if (detailed) {
       command.printDetailedHelp(options);

--- a/lib/commands/install-addon.js
+++ b/lib/commands/install-addon.js
@@ -7,18 +7,16 @@ module.exports = InstallCommand.extend({
   name: 'install:addon',
   description: 'This command has been deprecated. Please use `ember install` instead.',
   works: 'insideProject',
+  skipHelp: true,
 
   anonymousOptions: [
     '<addon-name>'
   ],
 
-  init: function() {
-    var warning  = 'This command has been deprecated. Please use `ember ';
-    warning     += 'install <addonName>` instead.';
+  run: function() {
+    var warning = 'This command has been deprecated. Please use `ember ';
+    warning += 'install <addonName>` instead.';
     this.ui.writeLine(chalk.red(warning));
-
-    if (this._super.init) {
-      this._super.init.call(this);
-    }
+    return this._super.run.apply(this, arguments);
   }
 });

--- a/lib/commands/install-bower.js
+++ b/lib/commands/install-bower.js
@@ -8,14 +8,15 @@ module.exports = Command.extend({
   name: 'install:bower',
   description: 'Bower package install are now managed by the user.',
   works: 'insideProject',
+  skipHelp: true,
 
   anonymousOptions: [
     '<package-names...>'
   ],
 
   run: function() {
-    var err  = 'This command has been deprecated. Please use `bower install ';
-    err     += '<packageName> --save-dev --save-exact` instead.';
+    var err = 'This command has been removed. Please use `bower install ';
+    err += '<packageName> --save-dev --save-exact` instead.';
     return Promise.reject(new SilentError(err));
   }
 });

--- a/lib/commands/install-npm.js
+++ b/lib/commands/install-npm.js
@@ -8,14 +8,15 @@ module.exports = Command.extend({
   name: 'install:npm',
   description: 'Npm package installs are now managed by the user.',
   works: 'insideProject',
+  skipHelp: true,
 
   anonymousOptions: [
     '<package-names...>'
   ],
 
   run: function() {
-    var err  = 'This command has been removed. Please use `npm install ';
-    err     += '<packageName> --save-dev --save-exact` instead.';
+    var err = 'This command has been removed. Please use `npm install ';
+    err += '<packageName> --save-dev --save-exact` instead.';
     return Promise.reject(new SilentError(err));
   }
 });

--- a/lib/commands/uninstall-npm.js
+++ b/lib/commands/uninstall-npm.js
@@ -8,14 +8,15 @@ module.exports = Command.extend({
   name: 'uninstall:npm',
   description: 'Npm package uninstall are now managed by the user.',
   works: 'insideProject',
+  skipHelp: true,
 
   anonymousOptions: [
     '<package-names...>'
   ],
 
   run: function() {
-    var err  = 'This command has been deprecated. Please use `npm uninstall ';
-    err     += '<packageName> --save-dev` instead.';
+    var err = 'This command has been removed Please use `npm uninstall ';
+    err += '<packageName> --save-dev` instead.';
     return Promise.reject(new SilentError(err));
   }
 });

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -26,6 +26,13 @@ describe('help command', function() {
       name: 'test-command-2',
       aliases: ['t2', 'test-2'],
       run: function() {}
+    }),
+    'TestCommand3': Command.extend({
+      name: 'test-command-3',
+      description: 'This is test command 3 description',
+      skipHelp: true,
+      aliases: ['t3', 'test-3'],
+      run: function() {}
     })
   };
 
@@ -53,6 +60,7 @@ describe('help command', function() {
       expect(ui.output).to.include('(Required)');
       expect(ui.output).to.include('ember test-command-2');
       expect(ui.output).to.include('aliases:');
+      expect(ui.output).to.not.include('ember test-command-3');
     });
   });
 
@@ -66,6 +74,7 @@ describe('help command', function() {
     }).validateAndRun(['test-command-2']).then(function() {
       expect(ui.output).to.include('test-command-2');
       expect(ui.output).to.not.include('test-command-1');
+      expect(ui.output).to.not.include('test-command-3');
     });
   });
 
@@ -79,6 +88,7 @@ describe('help command', function() {
     }).validateAndRun(['t1']).then(function() {
       expect(ui.output).to.include('test-command-1');
       expect(ui.output).to.not.include('test-command-2');
+      expect(ui.output).to.not.include('test-command-3');
     });
   });
 
@@ -133,7 +143,6 @@ describe('help command', function() {
         expect(ui.output).to.not.include('No help entry for');
       });
     });
-
   });
 
   it('should generate "no help entry" message for non-existent commands', function() {
@@ -145,6 +154,20 @@ describe('help command', function() {
       settings: {}
     }).validateAndRun(['heyyy']).then(function() {
       expect(ui.output).to.include('No help entry for');
+    });
+  });
+
+  it('should generate specific help output for commands with skipHelp', function() {
+    return new HelpCommand({
+      ui: ui,
+      analytics: analytics,
+      commands: commands,
+      project: { isEmberCLIProject: function(){ return true; }},
+      settings: {}
+    }).validateAndRun(['test-command-3']).then(function() {
+      expect(ui.output).to.include('test-command-3');
+      expect(ui.output).to.not.include('test-command-1');
+      expect(ui.output).to.not.include('test-command-2');
     });
   });
 });

--- a/tests/unit/commands/install-bower-test.js
+++ b/tests/unit/commands/install-bower-test.js
@@ -23,7 +23,7 @@ describe('install:bower command', function() {
     });
 
     command  = new InstallCommand(options);
-    msg      = 'This command has been deprecated. Please use `bower install ';
+    msg      = 'This command has been removed. Please use `bower install ';
     msg     += '<packageName> --save-dev --save-exact` instead.';
   });
 

--- a/tests/unit/commands/uninstall-npm-test.js
+++ b/tests/unit/commands/uninstall-npm-test.js
@@ -23,7 +23,7 @@ describe('uninstall:npm command', function() {
     });
 
     command  = new UninstallCommand(options);
-    msg      = 'This command has been deprecated. Please use `npm uninstall ';
+    msg      = 'This command has been removed Please use `npm uninstall ';
     msg     += '<packageName> --save-dev` instead.';
   });
 


### PR DESCRIPTION
When setting `skipHelp: true` in a command, it will not show when calling `ember help` but it shows when calling `ember help <command-name>`. This allows us to remove certain deprecated and removed commands from showing under help. Fixes #4253.