### PR TITLE
[BUGFIX] don't allow ember init to create an application without project name

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -60,6 +60,15 @@ module.exports = Command.extend({
 
     var project          = this.project;
     var packageName      = commandOptions.name !== '.' && commandOptions.name || project.name();
+
+    if(!packageName) {
+      var message = 'The `ember ' + this.name + '` command requires a ' +
+                    'package.json in current folder with name attribute or a specified name via arguments. ' +
+                    'For more details, use `ember help`.';
+
+      return Promise.reject(new SilentError(message));
+    }
+
     var blueprintOpts    = {
       dryRun: commandOptions.dryRun,
       blueprint: commandOptions.blueprint || this._defaultBlueprint(),

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -47,6 +47,23 @@ describe('init command', function() {
     });
   });
 
+  it('doesn\'t allow to create an application without project name', function() {
+    var command = new InitCommand({
+      ui: ui,
+      analytics: analytics,
+      project: new Project(process.cwd(), { name: undefined}),
+      tasks: tasks,
+      settings: {}
+    });
+
+    return command.validateAndRun([]).then(function() {
+      expect(false, 'should have rejected with an application without project name');
+    })
+    .catch(function(error) {
+      expect(error.message).to.equal('The `ember init` command requires a package.json in current folder with name attribute or a specified name via arguments. For more details, use `ember help`.');
+    });
+  });
+
   it('Uses the name of the closest project to when calling installBlueprint', function() {
     tasks.InstallBlueprint = Task.extend({
       run: function(blueprintOpts) {
@@ -93,7 +110,7 @@ describe('init command', function() {
 
 
   it('Uses process.cwd if no package is found when calling installBlueprint', function() {
-    // change the working dir so `process.cwd` can't be a invalid path for base directories 
+    // change the working dir so `process.cwd` can't be a invalid path for base directories
     // named `ember-cli`.
 
     var tmpDir = os.tmpdir();


### PR DESCRIPTION
When the users runs `ember init` in an empty folder and the parent folder has a package.json without name, the command thrown a `Cannot read property 'toLowerCase' of undefined`

To reproduce the bug, follow these steps:

``` shell
$ mkdir -p /tmp/f/o/o
$ echo '{}' > /tmp/f/package.json
$ cd /tmp/f/o/o
$ ember init                                                                                                                                                               
Cannot read property 'toLowerCase' of undefined
TypeError: Cannot read property 'toLowerCase' of undefined
    at module.exports (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/lib/utilities/valid-project-name.js:4:14)
    at Class.module.exports.Command.extend.run (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/lib/commands/init.js:71:10)
    at Class.<anonymous> (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/lib/models/command.js:136:17)
    at lib$rsvp$$internal$$tryCatch (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:489:16)
    at lib$rsvp$$internal$$invokeCallback (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:501:17)
    at lib$rsvp$$internal$$publish (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:472:11)
    at lib$rsvp$asap$$flush (/.nvm/versions/io.js/v2.0.2/lib/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1290:9)
    at doNTCallback0 (node.js:408:9)
    at process._tickCallback (node.js:337:13)
``` 