### PR TITLE
Adding support for private npm modules in blueprints. Closes #4256.

### DIFF
--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -6,7 +6,7 @@ var inflector   = require('inflection');
 
 module.exports = {
   description: 'Generates an import wrapper.',
-  
+
   fileMapTokens: function() {
     return {
       __name__: function(options) {
@@ -32,7 +32,7 @@ module.exports = {
     };
   },
   locals: function(options) {
-    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.pkg.name;
+    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
     var addonName      = stringUtil.dasherize(addonRawName);
     var fileName       = stringUtil.dasherize(options.entity.name);
     var pathName       = [addonName, inflector.pluralize(options.originBlueprintName), fileName].join('/');

--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -39,7 +39,7 @@ module.exports = {
   },
 
   locals: function(options) {
-    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.pkg.name;
+    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
     var addonName      = stringUtil.dasherize(addonRawName);
     var fileName       = stringUtil.dasherize(options.entity.name);
     var importPathName       = [addonName, 'components', fileName].join('/');

--- a/blueprints/route-addon/index.js
+++ b/blueprints/route-addon/index.js
@@ -49,7 +49,7 @@ module.exports = {
 
   locals: function (options) {
     var locals = {};
-    var addonRawName = options.inRepoAddon ? options.inRepoAddon : options.project.pkg.name;
+    var addonRawName = options.inRepoAddon ? options.inRepoAddon : options.project.name();
     var addonName = stringUtil.dasherize(addonRawName);
     var fileName = stringUtil.dasherize(options.entity.name);
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -3,24 +3,25 @@
 /**
 @module ember-cli
 */
-var Promise          = require('../ext/promise');
-var path             = require('path');
-var findup           = Promise.denodeify(require('findup'));
-var resolve          = Promise.denodeify(require('resolve'));
-var fs               = require('fs');
-var find             = require('lodash/collection/find');
-var assign           = require('lodash/object/assign');
-var forOwn           = require('lodash/object/forOwn');
-var merge            = require('lodash/object/merge');
-var debug            = require('debug')('ember-cli:project');
-var AddonDiscovery   = require('../models/addon-discovery');
-var AddonsFactory    = require('../models/addons-factory');
-var Command          = require('../models/command');
-var UI               = require('../ui');
-var nodeModulesPath  = require('node-modules-path');
+var Promise             = require('../ext/promise');
+var path                = require('path');
+var findup              = Promise.denodeify(require('findup'));
+var resolve             = Promise.denodeify(require('resolve'));
+var fs                  = require('fs');
+var find                = require('lodash/collection/find');
+var assign              = require('lodash/object/assign');
+var forOwn              = require('lodash/object/forOwn');
+var merge               = require('lodash/object/merge');
+var debug               = require('debug')('ember-cli:project');
+var AddonDiscovery      = require('../models/addon-discovery');
+var AddonsFactory       = require('../models/addons-factory');
+var Command             = require('../models/command');
+var UI                  = require('../ui');
+var nodeModulesPath     = require('node-modules-path');
 
-var versionUtils     = require('../utilities/version-utils');
-var emberCLIVersion  = versionUtils.emberCLIVersion;
+var getPackageBaseName  = require('../utilities/get-package-base-name');
+var versionUtils        = require('../utilities/version-utils');
+var emberCLIVersion     = versionUtils.emberCLIVersion;
 
 /**
   The Project model is tied to your package.json. It is instiantiated
@@ -117,7 +118,7 @@ Project.nullProject = function (ui, cli) {
   @return {String} Package name
  */
 Project.prototype.name = function() {
-  return this.pkg.name;
+  return getPackageBaseName(this.pkg.name);
 };
 
 /**

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var Task        = require('../models/task');
-var SilentError = require('silent-error');
-var merge       = require('lodash/object/merge');
+var Task                = require('../models/task');
+var SilentError         = require('silent-error');
+var merge               = require('lodash/object/merge');
+var getPackageBaseName  = require('../utilities/get-package-base-name');
 
 module.exports = Task.extend({
   init: function() {
@@ -72,6 +73,6 @@ module.exports = Task.extend({
       return emberAddon.defaultBlueprint;
     }
 
-    return addon.pkg.name;
+    return getPackageBaseName(addon.pkg.name);
   }
 });

--- a/lib/utilities/get-package-base-name.js
+++ b/lib/utilities/get-package-base-name.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function (name) {
+  var packageParts;
+
+  if (!name) {
+    return null;
+  }
+
+  packageParts = name.split('/');
+  return packageParts[(packageParts.length - 1)];
+};

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -42,19 +42,24 @@ describe('Acceptance: ember generate in-addon', function() {
     return remove(tmproot);
   });
 
-  function initAddon() {
+  function initAddon(name) {
     return ember([
       'addon',
-      'my-addon',
+      name,
       '--skip-npm',
       '--skip-bower'
     ]);
   }
 
   function generateInAddon(args) {
+    var name = 'my-addon';
     var generateArgs = ['generate'].concat(args);
 
-    return initAddon().then(function() {
+    if (arguments.length > 1) {
+      name = arguments[1];
+    }
+
+    return initAddon(name).then(function() {
       return ember(generateArgs);
     });
   }
@@ -380,7 +385,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-  
+
   it('in-addon route-test foo', function() {
     return generateInAddon(['route-test', 'foo']).then(function() {
       assertFile('tests/unit/routes/foo-test.js', {
@@ -608,7 +613,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-  
+
   it('in-addon adapter-test foo', function() {
     return generateInAddon(['adapter-test', 'foo']).then(function() {
       assertFile('tests/unit/adapters/foo-test.js', {
@@ -663,7 +668,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
     });
   });
-  
+
   it('in-addon serializer-test foo', function() {
     return generateInAddon(['serializer-test', 'foo']).then(function() {
       assertFile('tests/unit/serializers/foo-test.js', {
@@ -820,7 +825,7 @@ describe('Acceptance: ember generate in-addon', function() {
     });
   });
 
-  
+
   it('in-addon service-test foo', function() {
     return generateInAddon(['service-test', 'foo']).then(function() {
       assertFile('tests/unit/services/foo-test.js', {
@@ -1018,7 +1023,7 @@ describe('Acceptance: ember generate in-addon', function() {
         assertFileToNotExist('app/acceptance-tests/foo.js');
       });
     });
-    
+
     it('in-addon acceptance-test foo/bar', function() {
       return generateInAddon(['acceptance-test', 'foo/bar']).then(function() {
         var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');

--- a/tests/unit/utilities/get-package-base-name-test.js
+++ b/tests/unit/utilities/get-package-base-name-test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var expect              = require('chai').expect;
+var getPackageBaseName  = require('../../../lib/utilities/get-package-base-name');
+
+describe('getPackageBaseName', function() {
+  it('should return the full package name if it is unscoped', function() {
+    expect(getPackageBaseName('my-addon')).to.equal('my-addon');
+  });
+
+  it('should return the package name without its scope', function() {
+    expect(getPackageBaseName('@scope/my-addon')).to.equal('my-addon');
+  });
+});


### PR DESCRIPTION
This updates all current blueprints to use the unscoped name from `package.json` (if a project's name is `@scope/my-addon`, the base name will be `my-addon`). The `*-addon` import paths will now be correct.

I'd like to add tests for this, but I ran into some trouble implementing `ember addon @<scope>/<name>`. The `addon` blueprint uses `process.cwd()` for the `package.json` `name` (https://github.com/ember-cli/ember-cli/blob/master/lib/models/project.js#L104), and I can't seem to find a good way to get the original arguments from `ember addon` inside of `NULL_PROJECT.name()`.