### PR TITLE
[ENHANCEMENT] Generate component-tests into `tests/integration` by default

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,6 +26,7 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -1,9 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
-  // Specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar'],
-  unit: true
+  <%= testTypeDefinition %>
 });
 
 test('it renders', function(assert) {

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -5,13 +5,5 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
-
-  // Creates the component instance
-  var component = this.subject();
-  assert.equal(component._state, 'preRender');
-
-  // Renders the component to the page
-  this.render();
-  assert.equal(component._state, 'inDOM');
+  <%= testContent %>
 });

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -1,7 +1,7 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';<%= testImports %>
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
-  <%= testTypeDefinition %>
+  <%= testOptions %>
 });
 
 test('it renders', function(assert) {

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -41,6 +41,12 @@ module.exports = {
     var componentPathName = dasherizedModuleName;
     var testTypeDefinition = "integration: true";
     var friendlyTestDescription = testInfo.description(options.entity.name, "Integration", "Component");
+    var testContent = "assert.expect(1);" + EOL + EOL +
+      "  // Set any properties with this.set('myProperty', 'value');" + EOL +
+      "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+      "  // Provide a template (string or precompiled) for this.render()" + EOL +
+      "  this.render();" + EOL + EOL +
+      "  assert.equal(this.$().text(), '')";
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
@@ -49,13 +55,22 @@ module.exports = {
     if (options.testType === 'unit') {
       testTypeDefinition = "// Specify the other units that are required for this test" +
         EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
-        
+
+      testContent = "assert.expect(2);" + EOL + EOL +
+        "  // Creates the component instance" + EOL +
+        "  var component = this.subject();" + EOL +
+        "  assert.equal(component._state, 'preRender');" + EOL + EOL +
+        "  // Renders the component to the page" + EOL +
+        "  this.render();" + EOL +
+        "  assert.equal(component._state, 'inDOM');";
+
       friendlyTestDescription = testInfo.description(options.entity.name, "Unit", "Component");
     }
 
     return {
       path: getPathOption(options),
-      testType: options.testType ,
+      testType: options.testType,
+      testContent: testContent,
       componentPathName: componentPathName,
       testTypeDefinition: testTypeDefinition,
       friendlyTestDescription: friendlyTestDescription

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -4,13 +4,30 @@ var path          = require('path');
 var testInfo      = require('../../lib/utilities/test-info');
 var stringUtil    = require('../../lib/utilities/string');
 var getPathOption = require('../../lib/utilities/get-component-path-option');
-
+var EOL           = require('os').EOL;
 
 module.exports = {
-  description: 'Generates a component unit test.',
+  description: 'Generates a component integration or unit test.',
+  
+  availableOptions: [
+    {
+      name: 'test-type',
+      type: ['integration', 'unit'],
+      default: 'integration',
+      aliases:[
+        { 'i': 'integration'},
+        { 'u': 'unit'},
+        { 'integration': 'integration' },
+        { 'unit': 'unit' }
+      ]
+    }
+  ],
 
   fileMapTokens: function() {
     return {
+      __testType__: function(options) {
+        return options.locals.testType || 'integration';
+      },
       __path__: function(options) {
         if (options.pod) {
           return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
@@ -22,12 +39,21 @@ module.exports = {
   locals: function(options) {
     var dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     var componentPathName = dasherizedModuleName;
-    if(options.pod && options.path !== 'components' && options.path !== '') {
+    var testTypeDefinition = "integration: true";
+    if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
+    
+    if (options.testType === 'unit') {
+      testTypeDefinition = "// Specify the other units that are required for this test" + 
+        EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
+    }
+    
     return {
       path: getPathOption(options),
+      testType: options.testType ,
       componentPathName: componentPathName,
+      testTypeDefinition: testTypeDefinition,
       friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
     };
   }

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -8,7 +8,7 @@ var EOL           = require('os').EOL;
 
 module.exports = {
   description: 'Generates a component integration or unit test.',
-  
+
   availableOptions: [
     {
       name: 'test-type',
@@ -40,21 +40,25 @@ module.exports = {
     var dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     var componentPathName = dasherizedModuleName;
     var testTypeDefinition = "integration: true";
+    var friendlyTestDescription = testInfo.description(options.entity.name, "Integration", "Component");
+
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
-    
+
     if (options.testType === 'unit') {
-      testTypeDefinition = "// Specify the other units that are required for this test" + 
+      testTypeDefinition = "// Specify the other units that are required for this test" +
         EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
+        
+      friendlyTestDescription = testInfo.description(options.entity.name, "Unit", "Component");
     }
-    
+
     return {
       path: getPathOption(options),
       testType: options.testType ,
       componentPathName: componentPathName,
       testTypeDefinition: testTypeDefinition,
-      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Component")
+      friendlyTestDescription: friendlyTestDescription
     };
   }
 };

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -39,21 +39,22 @@ module.exports = {
   locals: function(options) {
     var dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     var componentPathName = dasherizedModuleName;
-    var testTypeDefinition = "integration: true";
+    var testImports = EOL + "import hbs from 'htmlbars-inline-precompile';" + EOL;
+    var testOptions = "integration: true";
     var friendlyTestDescription = testInfo.description(options.entity.name, "Integration", "Component");
     var testContent = "assert.expect(1);" + EOL + EOL +
       "  // Set any properties with this.set('myProperty', 'value');" + EOL +
       "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
-      "  // Provide a template (string or precompiled) for this.render()" + EOL +
-      "  this.render();" + EOL + EOL +
-      "  assert.equal(this.$().text(), '')";
+      "  this.render(hbs`{{" + options.entity.name + "}}`);" + EOL + EOL +
+      "  assert.equal(this.$().text(), '" + options.entity.name + "')";
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
 
     if (options.testType === 'unit') {
-      testTypeDefinition = "// Specify the other units that are required for this test" +
+      testImports = "";
+      testOptions = "// Specify the other units that are required for this test" +
         EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
 
       testContent = "assert.expect(2);" + EOL + EOL +
@@ -70,9 +71,10 @@ module.exports = {
     return {
       path: getPathOption(options),
       testType: options.testType,
+      testImports: testImports,
       testContent: testContent,
       componentPathName: componentPathName,
-      testTypeDefinition: testTypeDefinition,
+      testOptions: testOptions,
       friendlyTestDescription: friendlyTestDescription
     };
   }

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -45,8 +45,8 @@ module.exports = {
     var testContent = "assert.expect(1);" + EOL + EOL +
       "  // Set any properties with this.set('myProperty', 'value');" + EOL +
       "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
-      "  this.render(hbs`{{" + options.entity.name + "}}`);" + EOL + EOL +
-      "  assert.equal(this.$().text(), '" + options.entity.name + "')";
+      "  this.render(hbs`{{" + dasherizedModuleName + "}}`);" + EOL + EOL +
+      "  assert.equal(this.$().text(), '')";
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -513,16 +513,23 @@ function isValidParsedOption(option, parsedOption) {
 */
 function isValidAlias(alias, expectedType) {
   var type  = typeof alias;
-
+  var value, valueType;
   if (type === 'string') {
     return true;
   } else if (type === 'object') {
 
     // no arrays, no multi-key objects
     if (!Array.isArray(alias) && Object.keys(alias).length === 1) {
-      var valueType = typeof alias[Object.keys(alias)[0]];
-      if (valueType === expectedType.name.toLowerCase()) {
-        return true;
+      value = alias[Object.keys(alias)[0]];
+      valueType = typeof value;
+      if (!Array.isArray(expectedType)) {
+        if (valueType === expectedType.name.toLowerCase()) {
+          return true;
+        }
+      } else {
+        if (expectedType.indexOf(value) > -1) {
+          return true;
+        }
       }
     }
   }

--- a/tests/acceptance/addon-destroy-test.js
+++ b/tests/acceptance/addon-destroy-test.js
@@ -121,7 +121,7 @@ describe('Acceptance: ember destroy in-addon', function() {
       'addon/components/x-foo.js',
       'addon/templates/components/x-foo.hbs',
       'app/components/x-foo.js',
-      'tests/unit/components/x-foo-test.js'
+      'tests/integration/components/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInAddon(commandArgs, files);

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -104,9 +104,10 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
 
   it('dummy component-test x-foo', function() {
     return generateInAddon(['component-test', 'x-foo', '--dummy']).then(function() {
-      assertFile('tests/unit/components/x-foo-test.js', {
+      assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'"
         ]
       });

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -130,6 +130,7 @@ describe('Acceptance: ember generate in-addon', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -142,6 +143,7 @@ describe('Acceptance: ember generate in-addon', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -185,6 +187,7 @@ describe('Acceptance: ember generate in-addon', function() {
       assertFile('tests/integration/components/nested/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('nested/x-foo'",
           "integration: true" 
         ]

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -127,10 +127,11 @@ describe('Acceptance: ember generate in-addon', function() {
           "export { default } from 'my-addon/components/x-foo';"
         ]
       });
-      assertFile('tests/unit/components/x-foo-test.js', {
+      assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -138,16 +139,30 @@ describe('Acceptance: ember generate in-addon', function() {
 
   it('in-addon component-test x-foo', function() {
     return generateInAddon(['component-test', 'x-foo']).then(function() {
-      assertFile('tests/unit/components/x-foo-test.js', {
+      assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
       assertFileToNotExist('app/component-test/x-foo.js');
     });
   });
-
+  
+  it('in-addon component-test x-foo --unit', function() {
+    return generateInAddon(['component-test', 'x-foo', '--unit']).then(function() {
+      assertFile('tests/unit/components/x-foo-test.js', {
+        contains: [
+          "import { moduleForComponent, test } from 'ember-qunit';",
+          "moduleForComponent('x-foo'",
+          "unit: true"
+        ]
+      });
+      assertFileToNotExist('app/component-test/x-foo.js');
+    });
+  });
+  
   it('in-addon component nested/x-foo', function() {
     return generateInAddon(['component', 'nested/x-foo']).then(function() {
       assertFile('addon/components/nested/x-foo.js', {
@@ -167,10 +182,11 @@ describe('Acceptance: ember generate in-addon', function() {
           "export { default } from 'my-addon/components/nested/x-foo';"
         ]
       });
-      assertFile('tests/unit/components/nested/x-foo-test.js', {
+      assertFile('tests/integration/components/nested/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('nested/x-foo'"
+          "moduleForComponent('nested/x-foo'",
+          "integration: true" 
         ]
       });
     });

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -186,7 +186,7 @@ describe('Acceptance: ember destroy', function() {
     var files       = [
       'app/components/x-foo.js',
       'app/templates/components/x-foo.hbs',
-      'tests/unit/components/x-foo-test.js'
+      'tests/integration/components/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerate(commandArgs, files);
@@ -534,7 +534,7 @@ describe('Acceptance: ember destroy', function() {
       'addon/components/x-foo.js',
       'addon/templates/components/x-foo.hbs',
       'app/components/x-foo.js',
-      'tests/unit/components/x-foo-test.js'
+      'tests/integration/components/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInAddon(commandArgs, files);
@@ -546,7 +546,7 @@ describe('Acceptance: ember destroy', function() {
       'lib/my-addon/addon/components/x-foo.js',
       'lib/my-addon/addon/templates/components/x-foo.hbs',
       'lib/my-addon/app/components/x-foo.js',
-      'tests/unit/components/x-foo-test.js'
+      'tests/integration/components/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
@@ -558,7 +558,7 @@ describe('Acceptance: ember destroy', function() {
       'lib/my-addon/addon/components/nested/x-foo.js',
       'lib/my-addon/addon/templates/components/nested/x-foo.hbs',
       'lib/my-addon/app/components/nested/x-foo.js',
-      'tests/unit/components/nested/x-foo-test.js'
+      'tests/integration/components/nested/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -107,10 +107,11 @@ describe('Acceptance: ember generate', function() {
       assertFile('app/templates/components/x-foo.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/components/x-foo-test.js', {
+      assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -128,10 +129,11 @@ describe('Acceptance: ember generate', function() {
       assertFile('app/templates/components/foo/x-foo.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/components/foo/x-foo-test.js', {
+      assertFile('tests/integration/components/foo/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('foo/x-foo'"
+          "moduleForComponent('foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -149,10 +151,35 @@ describe('Acceptance: ember generate', function() {
       assertFile('app/templates/components/x-foo.hbs', {
         contains: "{{yield}}"
       });
+      assertFile('tests/integration/components/x-foo-test.js', {
+        contains: [
+          "import { moduleForComponent, test } from 'ember-qunit';",
+          "moduleForComponent('x-foo'",
+          "integration: true"
+        ]
+      });
+    });
+  });
+
+  it('component-test x-foo', function() {
+    return generate(['component-test', 'x-foo']).then(function() {
+      assertFile('tests/integration/components/x-foo-test.js', {
+        contains: [
+          "import { moduleForComponent, test } from 'ember-qunit';",
+          "moduleForComponent('x-foo'",
+          "integration: true"
+        ]
+      });
+    });
+  });
+  
+  it('component-test x-foo --unit', function() {
+    return generate(['component-test', 'x-foo', '--unit']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "unit: true"
         ]
       });
     });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -110,6 +110,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -132,6 +133,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/integration/components/foo/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
           "integration: true"
         ]
@@ -154,6 +156,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -166,6 +169,7 @@ describe('Acceptance: ember generate', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]

--- a/tests/acceptance/in-repo-addon-destroy-test.js
+++ b/tests/acceptance/in-repo-addon-destroy-test.js
@@ -127,7 +127,7 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
       'lib/my-addon/addon/components/x-foo.js',
       'lib/my-addon/addon/templates/components/x-foo.hbs',
       'lib/my-addon/app/components/x-foo.js',
-      'tests/unit/components/x-foo-test.js'
+      'tests/integration/components/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
@@ -139,7 +139,7 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
       'lib/my-addon/addon/components/nested/x-foo.js',
       'lib/my-addon/addon/templates/components/nested/x-foo.hbs',
       'lib/my-addon/app/components/nested/x-foo.js',
-      'tests/unit/components/nested/x-foo-test.js'
+      'tests/integration/components/nested/x-foo-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -132,7 +132,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "export { default } from 'my-addon/components/x-foo';"
         ]
       });
-      assertFile('tests/unit/components/x-foo-test.js', {
+      assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
           "moduleForComponent('x-foo'"
@@ -143,10 +143,23 @@ describe('Acceptance: ember generate in-repo-addon', function() {
 
   it('in-repo-addon component-test x-foo', function() {
     return generateInRepoAddon(['component-test', 'x-foo', '--in-repo-addon=my-addon']).then(function() {
+      assertFile('tests/integration/components/x-foo-test.js', {
+        contains: [
+          "import { moduleForComponent, test } from 'ember-qunit';",
+          "moduleForComponent('x-foo'",
+          "integration: true"
+        ]
+      });
+    });
+  });
+  
+  it('in-repo-addon component-test x-foo --unit', function() {
+    return generateInRepoAddon(['component-test', 'x-foo', '--in-repo-addon=my-addon', '--unit']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "unit: true"
         ]
       });
     });
@@ -171,10 +184,11 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "export { default } from 'my-addon/components/nested/x-foo';"
         ]
       });
-      assertFile('tests/unit/components/nested/x-foo-test.js', {
+      assertFile('tests/integration/components/nested/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('nested/x-foo'"
+          "moduleForComponent('nested/x-foo'",
+          "integration: true"
         ]
       });
     });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -135,7 +135,9 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "import hbs from 'htmlbars-inline-precompile';",
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -146,6 +148,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       assertFile('tests/integration/components/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -187,6 +190,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       assertFile('tests/integration/components/nested/x-foo-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('nested/x-foo'",
           "integration: true"
         ]

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -227,7 +227,7 @@ describe('Acceptance: ember destroy pod', function() {
     var files       = [
       'app/components/x-foo/component.js',
       'app/components/x-foo/template.hbs',
-      'tests/unit/components/x-foo/component-test.js'
+      'tests/integration/components/x-foo/component-test.js'
     ];
 
     return assertDestroyAfterGenerateWithUsePods(commandArgs, files);
@@ -258,7 +258,7 @@ describe('Acceptance: ember destroy pod', function() {
     var files       = [
       'app/pods/components/x-foo/component.js',
       'app/pods/components/x-foo/template.hbs',
-      'tests/unit/pods/components/x-foo/component-test.js'
+      'tests/integration/pods/components/x-foo/component-test.js'
     ];
 
     return assertDestroyAfterGenerate(commandArgs, files);
@@ -556,7 +556,7 @@ describe('Acceptance: ember destroy pod', function() {
       'addon/components/x-foo/component.js',
       'addon/components/x-foo/template.hbs',
       'app/components/x-foo/component.js',
-      'tests/unit/components/x-foo/component-test.js'
+      'tests/integration/components/x-foo/component-test.js'
     ];
 
     return assertDestroyAfterGenerateInAddon(commandArgs, files);
@@ -568,7 +568,7 @@ describe('Acceptance: ember destroy pod', function() {
       'lib/my-addon/addon/components/x-foo/component.js',
       'lib/my-addon/addon/components/x-foo/template.hbs',
       'lib/my-addon/app/components/x-foo/component.js',
-      'tests/unit/components/x-foo/component-test.js'
+      'tests/integration/components/x-foo/component-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);
@@ -580,7 +580,7 @@ describe('Acceptance: ember destroy pod', function() {
       'lib/my-addon/addon/components/nested/x-foo/component.js',
       'lib/my-addon/addon/components/nested/x-foo/template.hbs',
       'lib/my-addon/app/components/nested/x-foo/component.js',
-      'tests/unit/components/nested/x-foo/component-test.js'
+      'tests/integration/components/nested/x-foo/component-test.js'
     ];
 
     return assertDestroyAfterGenerateInRepoAddon(commandArgs, files);

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -179,10 +179,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/components/x-foo/component-test.js', {
+      assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -268,10 +269,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/components/x-foo/component-test.js', {
+      assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -289,10 +291,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/components/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/components/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -310,10 +313,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/components/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/components/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/components/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('foo/x-foo'"
+          "moduleForComponent('foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -331,10 +335,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/components/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/components/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/components/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('foo/x-foo'"
+          "moduleForComponent('foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -352,10 +357,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/bar/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/bar/x-foo/component-test.js', {
+      assertFile('tests/integration/bar/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/x-foo'"
+          "moduleForComponent('bar/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -373,10 +379,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/bar/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/bar/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/bar/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/x-foo'"
+          "moduleForComponent('bar/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -394,10 +401,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/bar/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/bar/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/bar/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/foo/x-foo'"
+          "moduleForComponent('bar/foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -415,10 +423,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/bar/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/bar/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/bar/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/foo/x-foo'"
+          "moduleForComponent('bar/foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -457,10 +466,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/bar/baz/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/bar/baz/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/bar/baz/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/baz/x-foo'"
+          "moduleForComponent('bar/baz/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -478,10 +488,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/bar/baz/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/bar/baz/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/bar/baz/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/baz/foo/x-foo'"
+          "moduleForComponent('bar/baz/foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -499,10 +510,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/bar/baz/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/bar/baz/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/bar/baz/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/baz/foo/x-foo'"
+          "moduleForComponent('bar/baz/foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -520,10 +532,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/x-foo/component-test.js', {
+      assertFile('tests/integration/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -541,10 +554,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -562,10 +576,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('foo/x-foo'"
+          "moduleForComponent('foo/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -583,10 +598,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/pods/foo/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/pods/foo/x-foo/component-test.js', {
+      assertFile('tests/integration/pods/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('foo/x-foo'"
+          "moduleForComponent('foo/x-foo'",
+          "integration: true"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -182,6 +182,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -272,6 +273,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -294,6 +296,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -316,6 +319,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/components/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
           "integration: true"
         ]
@@ -338,6 +342,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/components/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
           "integration: true"
         ]
@@ -360,6 +365,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/bar/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/x-foo'",
           "integration: true"
         ]
@@ -382,6 +388,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/bar/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/x-foo'",
           "integration: true"
         ]
@@ -404,6 +411,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/bar/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/foo/x-foo'",
           "integration: true"
         ]
@@ -448,6 +456,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/bar/baz/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/x-foo'",
           "integration: true"
         ]
@@ -470,6 +479,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/bar/baz/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/x-foo'",
           "integration: true"
         ]
@@ -492,6 +502,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/bar/baz/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/foo/x-foo'",
           "integration: true"
         ]
@@ -514,6 +525,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/bar/baz/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/foo/x-foo'",
           "integration: true"
         ]
@@ -536,6 +548,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -558,6 +571,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
           "integration: true"
         ]
@@ -580,6 +594,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
           "integration: true"
         ]
@@ -602,6 +617,7 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('tests/integration/pods/foo/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
+          "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
           "integration: true"
         ]

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -445,10 +445,11 @@ describe('Acceptance: ember generate pod', function() {
       assertFile('app/bar/baz/x-foo/template.hbs', {
         contains: "{{yield}}"
       });
-      assertFile('tests/unit/bar/baz/x-foo/component-test.js', {
+      assertFile('tests/integration/bar/baz/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('bar/baz/x-foo'"
+          "moduleForComponent('bar/baz/x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -1707,10 +1708,11 @@ describe('Acceptance: ember generate pod', function() {
           "export { default } from 'my-addon/components/x-foo/component';"
         ]
       });
-      assertFile('tests/unit/components/x-foo/component-test.js', {
+      assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -1735,10 +1737,11 @@ describe('Acceptance: ember generate pod', function() {
           "export { default } from 'my-addon/components/x-foo/component';"
         ]
       });
-      assertFile('tests/unit/components/x-foo/component-test.js', {
+      assertFile('tests/integration/components/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('x-foo'"
+          "moduleForComponent('x-foo'",
+          "integration: true"
         ]
       });
     });
@@ -1763,10 +1766,11 @@ describe('Acceptance: ember generate pod', function() {
           "export { default } from 'my-addon/components/nested/x-foo/component';"
         ]
       });
-      assertFile('tests/unit/components/nested/x-foo/component-test.js', {
+      assertFile('tests/integration/components/nested/x-foo/component-test.js', {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
-          "moduleForComponent('nested/x-foo'"
+          "moduleForComponent('nested/x-foo'",
+          "integration: true"
         ]
       });
     });


### PR DESCRIPTION
resolves #4178
By default component-tests now generate into `tests/integration`, with a new `--test-type` option allowing you to generate as a unit test intstead. The `--test-type` option can only be `unit` or `integration` and has the aliases `-unit`, `-u`, `-integration`, and `-i`.
```
ember g component-test foo-bar -unit
```

This PR also adds support for using an array of possible values as a command option type, accepting only the values in the array as valid arguments (essentially an enum type). For example, this is what the option for `test-type` looks like:

```
  availableOptions: [
    {
      name: 'test-type',
      type: ['integration', 'unit'],
      default: 'integration',
      aliases:[
        { 'i': 'integration'},
        { 'u': 'unit'},
        { 'integration': 'integration' },
        { 'unit': 'unit' }
      ]
    }
  ]
```