### PR TITLE
Display the LiveReload server address as url

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -40,6 +40,7 @@ module.exports = Task.extend({
   start: function(options) {
     var tlroptions = {};
     tlroptions.ssl = options.ssl || false;
+    tlroptions.host = '0.0.0.0';
     tlroptions.port = options.liveReloadPort || 35729;
 
     if (options.liveReload !== true) {
@@ -58,18 +59,23 @@ module.exports = Task.extend({
     // Reload on express server restarts
     this.expressServer.on('restart', this.didRestart.bind(this));
 
+    var url = 'http' + (options.ssl ? 's' : '') + '://' + this.displayHost(tlroptions.host) + ':' + tlroptions.port;
     // Start LiveReload server
     return this.listen(tlroptions)
-      .then(this.writeBanner.bind(this, options.liveReloadPort, tlroptions.ssl))
-      .catch(this.writeErrorBanner.bind(this, tlroptions.port));
+      .then(this.writeBanner.bind(this, url))
+      .catch(this.writeErrorBanner.bind(this, url));
   },
 
-  writeBanner: function(port, ssl) {
-    this.ui.writeLine('Livereload server on port ' + port + ' ' + (ssl ? '(https)' : '(http)'));
+  displayHost: function(specifiedHost) {
+        return specifiedHost === '0.0.0.0' ? 'localhost' : specifiedHost;
   },
 
-  writeErrorBanner: function(port) {
-    throw new SilentError('Livereload failed on port ' + port + '.  It is either in use or you do not have permission.');
+  writeBanner: function(url) {
+    this.ui.writeLine('Livereload server on ' + url);
+  },
+
+  writeErrorBanner: function(url) {
+    throw new SilentError('Livereload failed on ' + url + '.  It is either in use or you do not have permission.');
   },
 
   didChange: function(results) {

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -56,7 +56,7 @@ describe('livereload-server', function() {
         liveReloadPort: 1337,
         liveReload: true
       }).then(function() {
-        expect(ui.output).to.equal('Livereload server on port 1337 (http)' + EOL);
+        expect(ui.output).to.equal('Livereload server on http://localhost:1337' + EOL);
       });
     });
 
@@ -69,7 +69,7 @@ describe('livereload-server', function() {
           liveReload: true
         })
         .catch(function(reason) {
-          expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
+          expect(reason).to.equal('Livereload failed on http://localhost:1337.  It is either in use or you do not have permission.' + EOL);
         })
         .finally(function() {
           preexistingServer.close(done);
@@ -86,7 +86,7 @@ describe('livereload-server', function() {
         sslKey: 'tests/fixtures/ssl/server.key',
         sslCert: 'tests/fixtures/ssl/server.crt'
       }).then(function() {
-        expect(ui.output).to.equal('Livereload server on port 1337 (https)' + EOL);
+        expect(ui.output).to.equal('Livereload server on https://localhost:1337' + EOL);
       });
     });
 
@@ -102,7 +102,7 @@ describe('livereload-server', function() {
           sslCert: 'tests/fixtures/ssl/server.crt'
         })
         .catch(function(reason) {
-          expect(reason).to.equal('Livereload failed on port 1337.  It is either in use or you do not have permission.' + EOL);
+          expect(reason).to.equal('Livereload failed on https://localhost:1337.  It is either in use or you do not have permission.' + EOL);
         })
         .finally(function() {
           preexistingServer.close(done);


### PR DESCRIPTION
This changes the LR server startup banners to show a URL instead of just telling us the port and ssl status.

I plan on submitting a PR for `options.liveReloadHost` next if this gets accepted. `options.liveReloadHost` will default to `options.host`.

With `options.liveReloadHost`, we can fix https://github.com/rwjblue/ember-cli-content-security-policy/issues/18 and help solve https://github.com/rwjblue/ember-cli-inject-live-reload/issues/13

