### PR TITLE
Allow configuration of the LiveReload hostname

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -18,6 +18,7 @@ module.exports = Command.extend({
     { name: 'insecure-proxy', type: Boolean, default: false, description: 'Set false to proxy self-signed SSL certificates', aliases: ['inspr'] },
     { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },
     { name: 'live-reload',  type: Boolean, default: true, aliases: ['lr'] },
+    { name: 'live-reload-host',  type: String, description: 'Defaults to host', aliases: ['lrh'] },
     { name: 'live-reload-port', type: Number, description: '(Defaults to port number + 31529)', aliases: ['lrp']},
     { name: 'environment', type: String, default: 'development', aliases: ['e', {'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'output-path', type: path, default: 'dist/', aliases: ['op', 'out'] },
@@ -29,6 +30,7 @@ module.exports = Command.extend({
   run: function(commandOptions) {
     commandOptions = assign({}, commandOptions, {
       liveReloadPort: commandOptions.liveReloadPort  || (parseInt(commandOptions.port, 10) + 31529),
+      liveReloadHost: commandOptions.liveReloadHost  || commandOptions.host,
       baseURL: this.project.config(commandOptions.environment).baseURL || '/'
     });
 

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -33,14 +33,14 @@ module.exports = Task.extend({
 
     return new Promise(function(resolve, reject) {
       server.error = reject;
-      server.listen(options.port, resolve);
+      server.listen(options.port, options.host, resolve);
     });
   },
 
   start: function(options) {
     var tlroptions = {};
     tlroptions.ssl = options.ssl || false;
-    tlroptions.host = '0.0.0.0';
+    tlroptions.host = options.liveReloadHost || '0.0.0.0';
     tlroptions.port = options.liveReloadPort || 35729;
 
     if (options.liveReload !== true) {

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -62,6 +62,19 @@ describe('server command', function() {
     });
   });
 
+  it('has correct liveLoadHost', function() {
+    return new ServeCommand(options).validateAndRun([
+      '--live-reload-host', '127.0.0.1'
+    ]).then(function() {
+      var serveRun = tasks.Serve.prototype.run;
+      var ops = serveRun.calledWith[0][0];
+
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
+
+      expect(ops.liveReloadHost).to.equal('127.0.0.1', 'has correct liveReload host');
+    });
+  });
+
   it('has correct proxy', function() {
     return new ServeCommand(options).validateAndRun([
       '--proxy', 'http://localhost:3000/'

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -75,6 +75,16 @@ describe('livereload-server', function() {
           preexistingServer.close(done);
         });
     });
+
+    it('starts with custom host', function() {
+      return subject.start({
+        liveReloadHost: '127.0.0.1',
+        liveReloadPort: 1337,
+        liveReload: true
+      }).then(function() {
+        expect(ui.output).to.equal('Livereload server on http://127.0.0.1:1337' + EOL);
+      });
+    });
   });
 
   describe('start with https', function() {


### PR DESCRIPTION
This should help solve problems like:

 * https://github.com/rwjblue/ember-cli-content-security-policy/issues/18
 * https://github.com/rwjblue/ember-cli-inject-live-reload/issues/13

It can be configured on the cli as `ember server
--live-reload-host=example.org`

or in `.ember-cli`:

```json
{
  "liveReloadHost": "example.org"
}
```