### PR TITLE
Update ember-resolver to 0.1.17.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.15",
+    "ember-resolver": "~0.1.17",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"


### PR DESCRIPTION
The primary change was the addition of `knownForType` method that will allow Ember 1.13.0 to automatically register all helpers.