### PR TITLE
Update ember-cli-htmlbars to 0.7.9.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,7 +25,7 @@
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.8",
+    "ember-cli-htmlbars": "0.7.9",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",


### PR DESCRIPTION
Adds support for using ember-legacy-views addon for precompilation.