### PR TITLE
Pass the correct port property to LiveReload server

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -33,7 +33,7 @@ module.exports = Task.extend({
 
     return new Promise(function(resolve, reject) {
       server.error = reject;
-      server.listen(options.liveReloadPort, resolve);
+      server.listen(options.port, resolve);
     });
   },
 


### PR DESCRIPTION
I filed a ticket (https://github.com/ember-cli/ember-cli/issues/4279) about this issue, but showing is probably better.

Currently the tests pass only incidentally, but LiveReload doesn't actually listen on the specified port.

tinylr doesn't validate its input nor we do truly check that tinylr is listening on that port.

Here (https://github.com/mklabs/tiny-lr/blob/master/lib/server.js#L23) it coerces it to the default port if options.port is undefined, but not here (https://github.com/mklabs/tiny-lr/blob/master/lib/server.js#L150)