### PR TITLE
[DOCS] Dummy generate support docs

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -171,7 +171,7 @@ end
 
 #### Watched Files
 
-The way Vagrant syncs folders between your desktop and the VM will break the default mechanism ember-cli uses to watch files and cause issues when updates are subsequently compiled. To restore this functionality, you'll have to make two changes:
+The way Vagrant syncs directories between your desktop and the VM will break the default mechanism ember-cli uses to watch files and cause issues when updates are subsequently compiled. To restore this functionality, you'll have to make two changes:
 
 1. Fall back to polling when invoking the serve command: `ember serve --watcher polling`.
 
@@ -179,7 +179,7 @@ The way Vagrant syncs folders between your desktop and the VM will break the def
 
 #### VM Setup
 
-When setting up your VM, install ember-cli dependencies as you normally would. If you've already run `ember install` in your project's folder from your host machine, you'll have to delete the `node_modules` folder and re-install those dependencies from the VM. This is particularly necessary if you have node dependencies that use native libraries (e.g., [broccoli-sass](#sass), which uses the libsass C library).
+When setting up your VM, install ember-cli dependencies as you normally would. If you've already run `ember install` in your project's directory from your host machine, you'll have to delete the `node_modules` directory and re-install those dependencies from the VM. This is particularly necessary if you have node dependencies that use native libraries (e.g., [broccoli-sass](#sass), which uses the libsass C library).
 
 #### Provider
 

--- a/_posts/2013-04-03-practices-windows.md
+++ b/_posts/2013-04-03-practices-windows.md
@@ -7,13 +7,13 @@ github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-
 
 ### Windows
 
-Build times on Windows are longer than on Linux or Mac OS X. Much of that penalty is not because of node or ember-cli, but because of Windows services monitoring your filesystem. [Microsoft wrote a configuration tool as well as an Ember Addon](http://www.felixrieseberg.com/improved-ember-cli-performance-with-windows/) to automatically configure Windows to optimize build performance. The automatic configuration instructs Windows Search and Windows Defender to ignore Ember Cli's `tmp` folder.
+Build times on Windows are longer than on Linux or Mac OS X. Much of that penalty is not because of node or ember-cli, but because of Windows services monitoring your filesystem. [Microsoft wrote a configuration tool as well as an Ember Addon](http://www.felixrieseberg.com/improved-ember-cli-performance-with-windows/) to automatically configure Windows to optimize build performance. The automatic configuration instructs Windows Search and Windows Defender to ignore Ember Cli's `tmp` directory.
 
 *Remember to always open the terminal with admin privileges
 
 #### Ember Addon
 
-The addon has the benefit of being shippable with your project, meaning that other developers on the project do not need to install anything to use the automatic configuration. To install the addon, run the following in the root of your project folder:
+The addon has the benefit of being shippable with your project, meaning that other developers on the project do not need to install anything to use the automatic configuration. To install the addon, run the following in the root of your project directory:
 
 {% highlight bash %}
 npm install --save-dev ember-cli-windows-addon
@@ -33,7 +33,7 @@ The automatic configuration tool can also be installed directly, making it avail
 npm install ember-cli-windows -g
 {% endhighlight %}
 
-Once the tool is installed, you can run it in any Ember Cli project folder.
+Once the tool is installed, you can run it in any Ember Cli project directory.
 
 {% highlight bash %}
 ember-cli-windows

--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -48,7 +48,7 @@ project directory.
     npm install ember-cli@X.X.X --save-dev
     {% endhighlight %}
 
-* Delete temporary development folders
+* Delete temporary development directories
 
     {% highlight bash %}
     rm -rf node_modules bower_components dist tmp

--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -31,14 +31,14 @@ git push heroku master
 Need to make a custom nginx configuration change? No problem. In your Ember CLI application, add a `config/nginx.conf.erb` file. You can copy the [existing configuration](https://github.com/tonycoco/heroku-buildpack-ember-cli/blob/master/config/nginx.conf.erb) file and make your changes to it.
 
 ### Azure
-Continuous deployment with [Azure Websites](http://www.azure.com) is enabled through Microsoft's module [ember-cli-azure-deploy](https://github.com/felixrieseberg/ember-cli-azure-deploy). The installation is simple - just run the following commands in your Ember Cli app's root folder:
+Continuous deployment with [Azure Websites](http://www.azure.com) is enabled through Microsoft's module [ember-cli-azure-deploy](https://github.com/felixrieseberg/ember-cli-azure-deploy). The installation is simple - just run the following commands in your Ember Cli app's root directory:
 
 {% highlight bash %}
 npm install --save-dev -g ember-cli-azure-deploy
 azure-deploy init
 {% endhighlight %}
 
-Next, set up your Azure Website's source control to point to your repo - [either via GitHub, BitBucket, VSO or any of the other available options](http://azure.microsoft.com/en-us/documentation/articles/web-sites-publish-source-control/#Step4). As soon as you push a new commit to your repository, Azure Websites will automatically run `ember build` and deploy the contents of the created `dist` folder to your website's `wwwroot`.
+Next, set up your Azure Website's source control to point to your repo - [either via GitHub, BitBucket, VSO or any of the other available options](http://azure.microsoft.com/en-us/documentation/articles/web-sites-publish-source-control/#Step4). As soon as you push a new commit to your repository, Azure Websites will automatically run `ember build` and deploy the contents of the created `dist` directory to your website's `wwwroot`.
 
 ### Firebase
 To deploy your Ember CLI application to Firebase, you'll first need to enable hosting from your Firebase's Dashboard. Then, install the [Firebase Tools](https://github.com/firebase/firebase-tools):
@@ -47,7 +47,7 @@ To deploy your Ember CLI application to Firebase, you'll first need to enable ho
 npm install -g firebase-tools
 {% endhighlight %}
 
-You can then configure your application for deployment by running the following in your app's root folder and following the prompts:
+You can then configure your application for deployment by running the following in your app's root directory and following the prompts:
 
 {% highlight bash %}
 firebase init

--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -84,7 +84,7 @@ The addon project created follows these structure conventions:
 
 - `app/` - merged with the application's namespace.
 - `addon/` - part of the addon's namespace.
-- `blueprints/` - contains any blueprints that come with the addon, each in a separate folder
+- `blueprints/` - contains any blueprints that come with the addon, each in a separate directory
 - `public/` - static files which will be available in the application as `/your-addon/*`
 - `test-support/` - merged with the application's `tests/`
 - `tests/` - test infrastructure including a "dummy" app and acceptance test helpers.
@@ -352,9 +352,9 @@ serverMiddleware:
 An example of advanced customization can be found [here](https://github.com/poetic/ember-cli-cordova/blob/master/index.js) and for server middleware [here](https://github.com/rwjblue/ember-cli-inject-live-reload/blob/master/index.js)
 
 ### Testing the addon with QUnit
-The addon project contains a `/tests` folder which contains the
+The addon project contains a `/tests` directory which contains the
 necessary infrastructure to run and configure tests for the addon. The
-`/tests` folder has the following structure:
+`/tests` directory has the following structure:
 
 {% highlight bash %}
  dummy/
@@ -364,13 +364,13 @@ necessary infrastructure to run and configure tests for the addon. The
  test-helper.js
 {% endhighlight %}
 
-The `/dummy` folder contains the basic layout of a dummy app to be
-used for to host your addon for testing. The `/helpers` folder
+The `/dummy` directory contains the basic layout of a dummy app to be
+used for to host your addon for testing. The `/helpers` directory
 contains various *QUnit* helpers that are provided and those you
 define yourself in order to keep your tests concise. The `/unit`
-folder should contain your unit tests that test your addon in various
+directory should contain your unit tests that test your addon in various
 usage scenarios. To add integration (acceptance) tests add an
-`integration/' folder.
+`integration/' directory.
 
 `test-helper.js` is the main helper file that you should reference
 from any of your unit test files. It imports the `resolver` helper
@@ -414,8 +414,8 @@ For how to run and configure tests, see the [Ember CLI Testing](#testing) sectio
 
 ### Generating files in the dummy app
 
-You can generate most of ember-cli's built-in blueprints into your `tests/dummy/app` folder 
-to speed up building a dummy app to use for testing. Any blueprint that generates into an `/app` folder is currently supported:
+You can generate most of ember-cli's built-in blueprints into your `tests/dummy/app` directory 
+to speed up building a dummy app to use for testing. Any blueprint that generates into an `/app` directory is currently supported:
 
 `ember g <blueprint-name> <name> --dummy`
 
@@ -439,7 +439,7 @@ tests/
 Note that in the above example, the addon-import and component-test were not generated. The
 `--dummy` option generates the blueprint as if you were in a non-addon project.
 
-You can also create your own blueprints that can generate into the dummy folder. The primary 
+You can also create your own blueprints that can generate into the dummy directory. The primary 
 requirement is that the blueprint contains a `__root__` token in the files directory path.
 
 {% highlight bash %}
@@ -473,7 +473,7 @@ In our example:
 
 `ember addon x-button --blueprint`
 
-This will generate a folder `blueprints/x-button` for the addon where
+This will generate a directory `blueprints/x-button` for the addon where
 you can define your logic and templates for the blueprint. You can
 define multiple blueprints for a single addon. The last loaded
 blueprint wins with respect to overriding existing (same name)
@@ -482,10 +482,10 @@ load order.)
 
 ### Blueprint conventions
 
-Blueprints are expected to be located under the `blueprints` folder in
+Blueprints are expected to be located under the `blueprints` directory in
 the addon root, just like blueprints overrides in your project root.
 
-If you have your blueprints in another folder in your addon, you need
+If you have your blueprints in another directory in your addon, you need
 to tell ember-cli where to find them by specifying a `blueprintsPath`
 property for the addon (see *advanced customization* section below).
 
@@ -505,14 +505,14 @@ blueprints/
           __name__/
 {% endhighlight %}
 
-Note that the special file or folder called `__name__` will create a
-file/folder at that location in your app with the `__name__` replaced
+Note that the special file or directory called `__name__` will create a
+file/directory at that location in your app with the `__name__` replaced
 by the first argument (name) you pass to the blueprint being
 generated.
 
 `ember g x-button my-button`
 
-Will thus generate a folder `app/components/my-button` in the
+Will thus generate a directory `app/components/my-button` in the
 application where the blueprint generator is run.
 
 ### Link to addon while developing
@@ -522,7 +522,7 @@ root of your addon project. This will make your addon locally
 available by name.
 
 Then run `npm link <addon-name>` in any hosting application project
-root to make a link to your addon in your `node_modules` folder. Any
+root to make a link to your addon in your `node_modules` directory. Any
 change in your addon will now directly take effect in any project that
 links to it this way (see
 [npm-tricks](http://www.devthought.com/2012/02/17/npm-tricks) for more

--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -412,6 +412,47 @@ test('is a button tag', function(assert) {
 
 For how to run and configure tests, see the [Ember CLI Testing](#testing) section.
 
+### Generating files in the dummy app
+
+You can generate most of ember-cli's built-in blueprints into your `tests/dummy/app` folder 
+to speed up building a dummy app to use for testing. Any blueprint that generates into an `/app` folder is currently supported:
+
+`ember g <blueprint-name> <name> --dummy`
+
+For instance:
+
+`ember g component taco-button --dummy`
+
+Will generate:
+
+{% highlight bash %}
+tests/
+  dummy/
+      app/
+        components/
+          taco-button.js
+        templates/
+          components/
+            taco-button.hbs
+{% endhighlight %}
+
+Note that in the above example, the addon-import and component-test were not generated. The
+`--dummy` option generates the blueprint as if you were in a non-addon project.
+
+You can also create your own blueprints that can generate into the dummy folder. The primary 
+requirement is that the blueprint contains a `__root__` token in the files directory path.
+
+{% highlight bash %}
+blueprints/
+  x-button/
+    index.js
+    files/
+      __root__/     <-- normally "app/"
+        components/
+          __name__/
+{% endhighlight %}
+
+
 ### Create blueprint
 A blueprint is a bundle of template files with optional installation logic.
 It is used to scaffold (generate) specific application files based on

--- a/_posts/2013-04-08-generators-and-blueprints.md
+++ b/_posts/2013-04-08-generators-and-blueprints.md
@@ -199,10 +199,10 @@ The __`__root__`__ token is substituted with either `app` or
 `addon` depending upon where it is being generated. This token
 is used to provide support for generating blueprints inside
 addons, and is only necessary if the blueprint needs to be
-generated into the `addon` folder of an addon. The
+generated into the `addon` directory of an addon. The
 presence of this token will cause an additional addon-import
 blueprint to be generated, which is simply a wrapper that
-re-exports the module in the `addon` folder to allow consumers
+re-exports the module in the `addon` directory to allow consumers
 to override addon modules easier.
 
 The __`__test__`__ token is substituted with the dasherized
@@ -353,7 +353,7 @@ following pattern:
 It will be merged with the default `fileMapTokens`, and can be used
 to override any of the default tokens.
 
-Tokens are used in the files folder (see `files`), and get replaced with
+Tokens are used in the files directory (see `files`), and get replaced with
 values when the `mapFile` method is called.
 
 ### beforeInstall & beforeUninstall
@@ -399,7 +399,7 @@ See the built-in `resource` blueprint for an example of this.
   * `ember generate adapter-test application`
 
 * **Addon Import**
-  * This blueprint generates an import wrapper in the `app` folder.
+  * This blueprint generates an import wrapper in the `app` directory.
     * Import wrappers simply import a corresponding module from `addon` to allow easier overriding of
     a module in a project using the addon.
   * Used by ember-cli internally, it is only used when generating from inside addon projects.
@@ -458,7 +458,7 @@ See the built-in `resource` blueprint for an example of this.
 
 * **In-Repo Addon**
   * Generates an addon within the same repository. Useful for project-specific addons.
-  * The generator also creates a 'lib' folder, in which it stores the new addon.
+  * The generator also creates a 'lib' directory, in which it stores the new addon.
   * `ember generate in-repo-addon calendar`
 
 * **Initializer**

--- a/_posts/2013-04-08-generators-and-blueprints.md
+++ b/_posts/2013-04-08-generators-and-blueprints.md
@@ -398,6 +398,12 @@ See the built-in `resource` blueprint for an example of this.
   * This blueprint generates a unit test for a given ember data adapter.
   * `ember generate adapter-test application`
 
+* **Addon Import**
+  * This blueprint generates an import wrapper in the `app` folder.
+    * Import wrappers simply import a corresponding module from `addon` to allow easier overriding of
+    a module in a project using the addon.
+  * Used by ember-cli internally, it is only used when generating from inside addon projects.
+
 * **Addon**
   * Generates an addon blueprint and its definition.
     * This is the base blueprint for ember-cli addons.

--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -9,7 +9,7 @@ github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-
 
 * `public/assets` vs `app/styles`
 
-To add images, fonts, or other assets, place them in the `public/assets` folder. For
+To add images, fonts, or other assets, place them in the `public/assets` directory. For
 example, if you place `logo.png` in `public/assets/images`, you can reference it in
 templates with `assets/images/logo.png` or in stylesheets with
 `url('/assets/images/logo.png')`.

--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -157,7 +157,7 @@ yourself. But there are a couple of things you should know.
 
 - Dashes
   - file names
-  - folder names
+  - directory names
   - html tags/ember components
   - CSS classes
   - URLs
@@ -173,7 +173,7 @@ import Ember from "ember";
 export default Ember.Model.extend();
 {% endhighlight %}
 
-##### Dasherized file and folder names are required
+##### Dasherized file and directory names are required
 
 {% highlight javascript %}
 // controllers/sign-up.js
@@ -259,13 +259,13 @@ Test filenames should be suffixed with `-test.js` in order to run.
 
 As your app gets bigger, a feature-driven structure may be better. Splitting your application by functionality/resource would give you more power and control to scale and maintain it. As a default, if the file is not found on the POD structure, the Resolver will look it up within the normal structure.
 
-In this case, you should name the file as its functionality. Given a resource `Users`, the folder structure would be:
+In this case, you should name the file as its functionality. Given a resource `Users`, the directory structure would be:
 
 - `app/users/controller.js`
 - `app/users/route.js`
 - `app/users/template.hbs`
 
-Rather than hold your resource folders on the root of your app you can define a POD path using the attribute `podModulePrefix` within your environment configs. The POD path should use the following format: `{appname}/{poddir}`.
+Rather than hold your resource directories on the root of your app you can define a POD path using the attribute `podModulePrefix` within your environment configs. The POD path should use the following format: `{appname}/{poddir}`.
 
 {% highlight javascript linenos %}
 // config/environment.js
@@ -284,7 +284,7 @@ module.exports = function(environment) {
 };
 {% endhighlight %}
 
-Then your folder structure would be:
+Then your directory structure would be:
 
 - `app/pods/users/controller.js`
 - `app/pods/users/route.js`

--- a/_posts/2014-04-02-using-modules-and-the-resolver.md
+++ b/_posts/2014-04-02-using-modules-and-the-resolver.md
@@ -96,7 +96,7 @@ Cyclic dependencies – are not yet supported at the moment, we are depending on
 
 ### Module Directory Naming Structure
 
-Folder              | Purpose
+Directory           | Purpose
 --------------------|
 `app/adapters/`     | Adapters with the convention `adapter-name.js`.
 `app/components/`   | Components with the convention `component-name.js`. Components must have a dash in their name. So `blog-post` is an acceptable name, but `post` is not.
@@ -111,7 +111,7 @@ Folder              | Purpose
 `app/utils/`        | Utility modules with the convention `utility-name.js`.
 `app/views/`        | Views with the convention `view-name.js`. Sub-directories can be used for organization.
 
-All modules in the `app` folder can be loaded by the resolver but typically
+All modules in the `app` directory can be loaded by the resolver but typically
 classes such as `mixins` and `utils` should be loaded manually with an import statement.
 
 For more information, see [Naming Conventions](#naming-conventions).

--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -111,7 +111,7 @@ Run the generator for your project:
 ember new my-new-app
 {% endhighlight %}
 
-This will create a new `my-new-app` folder and generate an application structure for you.
+This will create a new `my-new-app` directory and generate an application structure for you.
 
 Once the generation process finishes, launch the app:
 
@@ -155,8 +155,8 @@ ember server
  Command                                     | Purpose
  :------------------------------------------ | :-------
  `ember`                                     | Prints out a list of available commands.
- `ember new <app-name>`                      | Creates a folder called `<app-name>` and generates an application structure for you.  If git is available the folder will be initialized as a git repository and an initial commit will be created.  Use  `--skip-git` flag to disable this feature.
- `ember init`                                | Generates an application structure for you in the current folder.
+ `ember new <app-name>`                      | Creates a directory called `<app-name>` and generates an application structure for you.  If git is available the directory will be initialized as a git repository and an initial commit will be created.  Use  `--skip-git` flag to disable this feature.
+ `ember init`                                | Generates an application structure for you in the current directory.
  `ember build`                               | Builds the application to `dist/` directory (customize via `--output-path` flag). Use `--environment` flag to specify the environment to build for (defaults to `development`). Use `--watch` flag keep the process running, observing the filesystem and rebuilding when changes occur.
  `ember server`                              | Starts up the server. Default port is `4200`. Use `--proxy` flag to proxy all ajax requests to the given address. For example `ember server --proxy http://127.0.0.1:8080` will proxy all your apps XHR to your server running at port 8080.
  <span style="white-space:nowrap">`ember generate <generator-name> <options>`</span> | Runs a specific generator. To see available generators, run `ember help generate`.
@@ -166,11 +166,11 @@ ember server
 
 ### Folder Layout
 
- File/folder         | Purpose
+ File/directory         | Purpose
  :-------------      | :-------
- `app/`              | Contains your Ember application's code. Javascript files in this folder are *compiled* through the ES6 module transpiler and concatenated into a file called `app.js`. See the table below for more details.
+ `app/`              | Contains your Ember application's code. Javascript files in this directory are *compiled* through the ES6 module transpiler and concatenated into a file called `app.js`. See the table below for more details.
  `dist/`             | Contains the *distributable* (that is, optimized and self-contained) output of your application. Deploy this to your server!
- `public/`           | This folder will be copied verbatim into the root of your built application. Use this for assets that don't have a build step, such as images or fonts.
+ `public/`           | This directory will be copied verbatim into the root of your built application. Use this for assets that don't have a build step, such as images or fonts.
  `tests/`            | Includes unit and integration tests for your app, as well as various helpers to load and run your tests.
  `tmp/`              | Various temporary output of build steps, as well as the debug output of your application (`tmp/public`).
  `bower_components/` | Your dependencies, both those included with `Ember CLI` and those installed with `Bower`.
@@ -181,9 +181,9 @@ ember server
  `bower.json`        | Bower configuration and dependency list. See [Managing Dependencies](managing-dependencies).
  `package.json`      | NPM configuration. Mainly used to list the dependencies needed for asset compilation.
 
-### Layout within `app` folder
+### Layout within `app` directory 
 
- File/folder    | Purpose
+ File/directory    | Purpose
  :------------- | :-------
  `app/app.js` | Your application's entry point. This is the module that is first executed.
  `app/index.html` | The only actual page of your single-page app! Includes dependencies and kickstarts your Ember application. See [app/index.html](#appindexhtml).


### PR DESCRIPTION
Added a section about generating blueprints into the `testsj/dummy/app` folder of an addon. Also added `addon-import` to list of blueprint descriptions.