### PR TITLE
[ENHANCEMENT] Name blueprint in generate and destroy output message

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -65,7 +65,7 @@ module.exports = {
         root: options.project.root,
         path: options.path
       });
-
+      this.ui.writeLine('updating router');
       this._writeStatusToUI(chalk.green, 'add route', entity.name);
     }
   },
@@ -78,6 +78,7 @@ module.exports = {
         root: options.project.root
       });
 
+      this.ui.writeLine('updating router');
       this._writeStatusToUI(chalk.red, 'remove route', entity.name);
     }
   }

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -477,7 +477,7 @@ Blueprint.prototype.install = function(options) {
 
   podDeprecations(this.project.config(), ui);
 
-  ui.writeLine('installing');
+  ui.writeLine('installing ' + this.name);
 
   if (dryRun) {
     ui.writeLine(chalk.yellow('You specified the dry-run flag, so no' +
@@ -509,7 +509,7 @@ Blueprint.prototype.uninstall = function(options) {
 
   podDeprecations(this.project.config(), ui);
 
-  ui.writeLine('uninstalling');
+  ui.writeLine('uninstalling ' + this.name);
 
   if (dryRun) {
     ui.writeLine(chalk.yellow('You specified the dry-run flag, so no' +


### PR DESCRIPTION
resolves #4307 

I also added a line to denote when the router is being modified. New output looks like:
```
installing route
  create app/routes/foo.js
  create app/templates/foo.hbs
updating router
  add route foo
installing route-test
  create tests/unit/routes/foo-test.js
```
```
uninstalling route
  remove app/routes/foo.js
  remove app/templates/foo.hbs
updating router
  remove route foo
uninstalling route-test
  remove tests/unit/routes/foo-test.js
```