### PR TITLE
Update ADDON_HOOKS.md

### DIFF
--- a/ADDON_HOOKS.md
+++ b/ADDON_HOOKS.md
@@ -49,7 +49,7 @@ Augments the applications configuration settings.  Object returned from this hoo
 Addon.prototype.config = function (env, baseConfig) {
   var configPath = path.join(this.root, 'config', 'environment.js');
 
-  if (fs.existsSync(configPath)) {
+  if (existsSync(configPath)) {
     var configGenerator = require(configPath);
 
     return configGenerator(env, baseConfig);
@@ -85,7 +85,7 @@ Tells the application where your blueprints exist.
 Addon.prototype.blueprintsPath = function() {
   var blueprintPath = path.join(this.root, 'blueprints');
 
-  if (fs.existsSync(blueprintPath)) {
+  if (existsSync(blueprintPath)) {
     return blueprintPath;
   }
 };


### PR DESCRIPTION
removed references to fs.existsSyncs with existsSync although there are no references to var fs.existsSync as this delivers example code for reference.