### PR TITLE
Drop unused line from app blueprint

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import Application from '../../app';
-import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {


### PR DESCRIPTION
This line is unnecessary and it causes JSHint failure if you're using `unused: true` on your tests tree.