### PR TITLE
Bring tests jshintrc closer to app jshintrc

### DIFF
--- a/blueprints/app/files/tests/.jshintrc
+++ b/blueprints/app/files/tests/.jshintrc
@@ -26,7 +26,7 @@
   "node": false,
   "browser": false,
   "boss": true,
-  "curly": false,
+  "curly": true,
   "debug": false,
   "devel": false,
   "eqeqeq": true,
@@ -47,5 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true
+  "esnext": true,
+  "unused": true
 }

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -1,5 +1,5 @@
 /*jshint strict:false */
-/* globals QUnit, visit, andThen */
+/* globals visit, andThen */
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -1,5 +1,5 @@
 /*jshint strict:false */
-/* globals QUnit, visit, andThen */
+/* globals visit, andThen */
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -1,5 +1,5 @@
 /*jshint strict:false */
-/* globals QUnit, visit, andThen */
+/* globals visit, andThen */
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -1,5 +1,5 @@
 /*jshint strict:false */
-/* globals QUnit, visit, andThen */
+/* globals visit, andThen */
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';


### PR DESCRIPTION
These are both code-quality settings that have no reason to vary between app and tests, so I'm updating the tests version to match the app version.