### PR TITLE
Cache processed styles tree to prevent double style builds.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1025,6 +1025,10 @@ EmberApp.prototype.javascript = function() {
   @return {Tree} Merged tree for styles
 */
 EmberApp.prototype.styles = function() {
+  if (this._processedStylesTree) {
+    return this._processedStylesTree;
+  }
+
   if (existsSync('app/styles/' + this.name + '.css')) {
     throw new SilentError('Style file cannot have the name of the application - ' + this.name);
   }
@@ -1068,7 +1072,8 @@ EmberApp.prototype.styles = function() {
     ], {
       description: 'styles'
     });
-  return this.addonPostprocessTree('css', mergedTrees);
+
+  return this._processedStylesTree = this.addonPostprocessTree('css', mergedTrees);
 };
 
 /**


### PR DESCRIPTION
In some scenarios a double build of `styles` tree is being triggered.  In the majority of the JS hooks we already do this sort of caching, this brings that setup to `styles`.