### PR TITLE
Update ember-load-initializers to 0.1.5

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.0.0-beta.18",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.17",


### PR DESCRIPTION
Removes Ember.keys deprecations (https://github.com/ember-cli/ember-load-initializers/pull/18)

cc @rwjblue