### PR TITLE
bump to ember-resolve 0.1.18 – which fixes deprecations while continu…

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.17",
+    "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"


### PR DESCRIPTION
…ing to support older IE8 code.