### PR TITLE
[ENHANCEMENT] Fix typo in test command description.

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -21,7 +21,7 @@ module.exports = Command.extend({
     { name: 'filter',      type: String,  description: 'A string to filter tests to run', aliases: ['f'] },
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
-    { name: 'launch',      type: String,  default: false, description: 'A comma seperated list of browsers to launch for tests.' },
+    { name: 'launch',      type: String,  default: false, description: 'A comma separated list of browsers to launch for tests.' },
     { name: 'reporter',    type: String,  description: 'Test reporter to use [tap|dot|xunit]', aliases: ['r']}
   ],
 


### PR DESCRIPTION
Hi guys,

This PR just fixes a typo in the description of the  ```launch``` option of the ```test``` command.
