### PR TITLE
Do not pack ember-cli-build.js

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -10,5 +10,6 @@ dist/
 .npmignore
 **/.gitkeep
 bower.json
+ember-cli-build.js
 Brocfile.js
 testem.json


### PR DESCRIPTION
Blacklist ember-cli-build.js from getting into the tarballed npm packages.