### PR TITLE
Update helper blueprint to use `Ember.Helper.helper`

### DIFF
--- a/blueprints/helper/files/__root__/helpers/__name__.js
+++ b/blueprints/helper/files/__root__/helpers/__name__.js
@@ -4,4 +4,4 @@ export function <%= camelizedModuleName %>(params/*, hash*/) {
   return params;
 }
 
-export default Ember.HTMLBars.makeBoundHelper(<%= camelizedModuleName %>);
+export default Ember.Helper.helper(<%= camelizedModuleName %>);

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -138,7 +138,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFileToNotExist('app/helpers/foo-bar.js');
       assertFileToNotExist('tests/unit/helpers/foo-bar-test.js');
@@ -152,7 +152,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFileToNotExist('app/helpers/foo/bar-baz.js');
       assertFileToNotExist('tests/unit/helpers/foo/bar-baz-test.js');

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -183,7 +183,7 @@ describe('Acceptance: ember generate in-addon', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFile('app/helpers/foo-bar.js', {
         contains: [
@@ -203,7 +203,7 @@ describe('Acceptance: ember generate in-addon', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFile('app/helpers/foo/bar-baz.js', {
         contains: [

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -165,7 +165,7 @@ describe('Acceptance: ember generate', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import { fooBar } from '../../../helpers/foo-bar';"
@@ -180,7 +180,7 @@ describe('Acceptance: ember generate', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import { fooBarBaz } from '../../../../helpers/foo/bar-baz';"

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -187,7 +187,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFile('lib/my-addon/app/helpers/foo-bar.js', {
         contains: [
@@ -207,7 +207,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFile('lib/my-addon/app/helpers/foo/bar-baz.js', {
         contains: [

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -599,7 +599,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import { fooBar } from '../../../helpers/foo-bar';"
@@ -614,7 +614,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBar(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" +  EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBar);"
+                  "export default Ember.Helper.helper(fooBar);"
       });
       assertFile('tests/unit/helpers/foo-bar-test.js', {
         contains: "import { fooBar } from '../../../helpers/foo-bar';"
@@ -629,7 +629,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import { fooBarBaz } from '../../../../helpers/foo/bar-baz';"
@@ -644,7 +644,7 @@ describe('Acceptance: ember generate pod', function() {
                   "export function fooBarBaz(params/*, hash*/) {" + EOL +
                   "  return params;" + EOL +
                   "}" + EOL + EOL +
-                  "export default Ember.HTMLBars.makeBoundHelper(fooBarBaz);"
+                  "export default Ember.Helper.helper(fooBarBaz);"
       });
       assertFile('tests/unit/helpers/foo/bar-baz-test.js', {
         contains: "import { fooBarBaz } from '../../../../helpers/foo/bar-baz';"


### PR DESCRIPTION
This is line with the new Helper API as described on
http://emberjs.com/blog/2015/06/12/ember-1-13-0-released.html#toc_new-ember-js-helper-api .

I assume here that the next version of Ember CLI will install Ember 1.13.x by default. If this is not the case, merging this PR should probably be postponed.