### PR TITLE
Remove typo

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -31,7 +31,7 @@ rebuilding each time you change a file.
 
 ### Modules
 
-Ember CLI uses the [Esperanto](https://github.com/esperantojs/esperanto),
+Ember CLI uses [Esperanto](https://github.com/esperantojs/esperanto),
 which turns [ES6 module syntax](http://jsmodules.io/)
 into AMD (RequireJS'esq) modules. Using the transpiler, you can write code
 using tomorrow's syntax, today.


### PR DESCRIPTION
I'm guessing we didn't mean to include this "the" before "Esperanto".