### PR TITLE
[BUGFIX] Adding check for undefined inRepoAddon option in Blueprint.prototype._locals.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -789,22 +789,18 @@ Blueprint.prototype.supportsAddon = function() {
 
 /**
   @private
-  @method _locals
+  @method _generateFileMapVariables
   @param {Object} options
   @return {Object}
 */
-Blueprint.prototype._locals = function(options) {
-  var packageName = options.project.name();
-  var moduleName = options.entity && options.entity.name || packageName;
+Blueprint.prototype._generateFileMapVariables = function(moduleName, locals, options) {
   var originBlueprintName = options.originBlueprintName || this.name;
   var podModulePrefix = this.project.config().podModulePrefix || '';
   var podPath = podModulePrefix.substr(podModulePrefix.lastIndexOf('/') + 1);
-  var inAddon = this.project.isEmberCLIAddon() || options.inRepoAddon !== null;
+  var inAddon = this.project.isEmberCLIAddon() || !!options.inRepoAddon;
   var inDummy = this.project.isEmberCLIAddon() ? options.dummy : false;
-  var sanitizedModuleName = moduleName.replace(/\//g, '-');
-  var customLocals = this.locals(options);
 
-  var fileMapVariables = {
+  return {
     pod: this.pod,
     podPath: podPath,
     hasPathToken: this.hasPathToken,
@@ -814,9 +810,22 @@ Blueprint.prototype._locals = function(options) {
     blueprintName: this.name,
     originBlueprintName: originBlueprintName,
     dasherizedModuleName: stringUtils.dasherize(moduleName),
-    locals: customLocals
+    locals: locals
   };
+};
 
+/**
+  @private
+  @method _locals
+  @param {Object} options
+  @return {Object}
+*/
+Blueprint.prototype._locals = function(options) {
+  var packageName = options.project.name();
+  var moduleName = options.entity && options.entity.name || packageName;
+  var sanitizedModuleName = moduleName.replace(/\//g, '-');
+  var customLocals = this.locals(options);
+  var fileMapVariables = this._generateFileMapVariables(moduleName, customLocals, options);
   var fileMap = this.generateFileMap(fileMapVariables);
 
   var standardLocals = {


### PR DESCRIPTION
When a nested addon's default blueprint is invoked after installing with `Blueprint.prototype.addAddonToProject`, the `inRepoAddon` option is `undefined`. Since the logic to determine the `isAddon` flag is using a strict comparison, `undefined` was not caught, and the addon thinks it's being installed in an addon context. This causes some `fileMapTokens` to be the wrong values.