### PR TITLE
Update initializer-test blueprint

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import { initialize } from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-var container, application;
+var registry, application;
 
 module('<%= friendlyTestName %>', {
   beforeEach: function() {
     Ember.run(function() {
       application = Ember.Application.create();
-      container = application.__container__;
+      registry = application.registry;
       application.deferReadiness();
     });
   }
@@ -16,7 +16,7 @@ module('<%= friendlyTestName %>', {
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  initialize(container, application);
+  initialize(registry, application);
 
   // you would normally confirm the results of the initializer here
   assert.ok(true);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -462,6 +462,20 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('initializer-test foo', function() {
+    return generate(['initializer-test', 'foo']).then(function() {
+      assertFile('tests/unit/initializers/foo-test.js', {
+        contains: [
+          "import { initialize } from '../../../initializers/foo';",
+          "module('Unit | Initializer | foo'",
+          "var registry, application;",
+          "registry = application.registry;",
+          "initialize(registry, application);"
+        ]
+      });
+    });
+  });
+
   it('initializer foo/bar', function() {
     return generate(['initializer', 'foo/bar']).then(function() {
       assertFile('app/initializers/foo/bar.js', {


### PR DESCRIPTION
This is to avoid deprecation warning:
```
DEPRECATION: register should be called on the registry instead of the container
```