### PR TITLE
Add a test-page option to the test command

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -22,7 +22,8 @@ module.exports = Command.extend({
     { name: 'module',      type: String,  description: 'The name of a test module to run', aliases: ['m'] },
     { name: 'watcher',     type: String,  default: 'events', aliases: ['w'] },
     { name: 'launch',      type: String,  default: false, description: 'A comma separated list of browsers to launch for tests.' },
-    { name: 'reporter',    type: String,  description: 'Test reporter to use [tap|dot|xunit]', aliases: ['r']}
+    { name: 'reporter',    type: String,  description: 'Test reporter to use [tap|dot|xunit]', aliases: ['r']},
+    { name: 'test-page',   type: String,  description: 'Test page to invoke'}
   ],
 
   init: function() {
@@ -48,16 +49,18 @@ module.exports = Command.extend({
   },
 
   _generateCustomConfigFile: function(options) {
-    if (!options.filter && !options.module && !options.launch) { return options.configFile; }
+    if (!options.filter && !options.module && !options.launch && !options['test-page']) { return options.configFile; }
 
     var tmpPath = this.quickTemp.makeOrRemake(this, '-customConfigFile');
     var customPath = path.join(tmpPath, 'testem.json');
     var originalContents = JSON.parse(fs.readFileSync(options.configFile, { encoding: 'utf8' }));
-
-    var containsQueryString = originalContents['test_page'].indexOf('?') > -1;
+    
+    var testPage = options['test-page']?options['test-page']:originalContents['test_page'];
+    
+    var containsQueryString = testPage.indexOf('?') > -1;
     var testPageJoinChar    = containsQueryString ? '&' : '?';
 
-    originalContents['test_page'] = originalContents['test_page'] + testPageJoinChar + this.buildTestPageQueryString(options);
+    originalContents['test_page'] = testPage + testPageJoinChar + this.buildTestPageQueryString(options);
     if (options.launch) {
       originalContents['launch'] = options.launch;
     }

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -138,18 +138,19 @@ describe('test command', function() {
       expect(existsSync(newPath));
     });
 
-    it('should return the original path if filter or module or launch isn\'t present', function() {
+    it('should return the original path if options are not present', function() {
       var originalPath = runOptions.configFile;
       var newPath = command._generateCustomConfigFile(runOptions);
 
       expect(newPath).to.equal(originalPath);
     });
 
-    it('when module and filter and launch option is present the new file path returned exists', function() {
+    it('when options are present the new file path returned exists', function() {
       var originalPath = runOptions.configFile;
       runOptions.module = 'fooModule';
       runOptions.filter = 'bar';
       runOptions.launch = 'fooLauncher';
+      runOptions['test-page'] = 'foo/test.html?foo';
       var newPath = command._generateCustomConfigFile(runOptions);
 
       expect(newPath).to.not.equal(originalPath);
@@ -183,6 +184,15 @@ describe('test command', function() {
       expect(existsSync(newPath), 'file should exist');
     });
 
+    it('when test-page option is present the new file path returned exists', function() {
+      var originalPath = runOptions.configFile;
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var newPath = command._generateCustomConfigFile(runOptions);
+
+      expect(newPath).to.not.equal(originalPath);
+      expect(existsSync(newPath), 'file should exist');
+    });
+
     it('when provided filter and module the new file returned contains the both option values in test_page', function() {
       runOptions.module = 'fooModule';
       runOptions.filter = 'bar';
@@ -190,6 +200,24 @@ describe('test command', function() {
       var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
 
       expect(contents['test_page']).to.be.equal('tests/index.html?module=fooModule&filter=bar');
+    });
+
+    it('when provided test-page the new file returned contains the value in test_page', function() {
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var newPath = command._generateCustomConfigFile(runOptions);
+      var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
+
+      expect(contents['test_page']).to.be.equal('foo/test.html?foo&');
+    });
+
+    it('when provided test-page with filter and module the new file returned contains those values in test_page', function() {
+      runOptions.module = 'fooModule';
+      runOptions.filter = 'bar';
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var newPath = command._generateCustomConfigFile(runOptions);
+      var contents = JSON.parse(fs.readFileSync(newPath, { encoding: 'utf8' }));
+
+      expect(contents['test_page']).to.be.equal('foo/test.html?foo&module=fooModule&filter=bar');
     });
 
     it('when provided launch the new file returned contains the value in launch', function() {


### PR DESCRIPTION
I took the less controversial path for fixing #4365.  This adds a --test-page option to the test command which allows arbitrary query parameters to be passed  for something like ember-cli-blankets ?coverage option.

eg 
```bash
ember test --test-page=tests/index.html?hidepassedtests&coverage
```

The (admittedly biased) discussion in #4365 was in favor of adding a --coverage option.  I'm worried that adding the option would imply coverage would run for new users even without an addon.  On the other hand its a lot clearer what to do with --coverage as opposed to --test-page.  Its a pretty simple change either way so all feedback welcome.

