### PR TITLE
Fix Managing Dependencies link

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -179,7 +179,7 @@ ember server
  `.jshintrc`         | [JSHint](http://jshint.com/) configuration.
  `.gitignore`        | Git configuration for ignored files.
  `Brocfile.js`       | Contains build specification for [Broccoli](https://github.com/joliss/broccoli).
- `bower.json`        | Bower configuration and dependency list. See [Managing Dependencies](managing-dependencies).
+ `bower.json`        | Bower configuration and dependency list. See [Managing Dependencies](#managing-dependencies).
  `package.json`      | NPM configuration. Mainly used to list the dependencies needed for asset compilation.
 
 ### Layout within `app` directory


### PR DESCRIPTION
It is currently linking to http://www.ember-cli.com/user-guide/managing-dependencies