### PR TITLE
Update ember-cli-qunit to 0.3.15.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.0.0-beta.18",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.3.3",
+    "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.13",
+    "ember-cli-qunit": "0.3.15",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",


### PR DESCRIPTION
Main updates are for ember-qunit 0.4.1:

* Fixes issue with using `moduleForComponent` with only two arguments
  (where the second argument is a string description).
* Includes major refactor of unit/integration test container/registry creation.
* Add compatibility for Ember 1.13
  * Fix `Ember.View` deprecations
  * Fix `Ember.keys` deprecations
  * Fix `Ember.create` deprecations
* Guard against errors in setup steps for `moduleFor` and friends.
* Fix `service:store` deprecation for recent Ember Data versions.