### PR TITLE
[ENHANCEMENT] Add block-template assertion to generated component integration test

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -42,11 +42,18 @@ module.exports = {
     var testImports = EOL + "import hbs from 'htmlbars-inline-precompile';" + EOL;
     var testOptions = "integration: true";
     var friendlyTestDescription = testInfo.description(options.entity.name, "Integration", "Component");
-    var testContent = "assert.expect(1);" + EOL + EOL +
+    var testContent = "assert.expect(2);" + EOL + EOL +
       "  // Set any properties with this.set('myProperty', 'value');" + EOL +
       "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
       "  this.render(hbs`{{" + dasherizedModuleName + "}}`);" + EOL + EOL +
-      "  assert.equal(this.$().text(), '')";
+      "  assert.equal(this.$().text(), '')" + EOL + EOL +
+      "  // Template block usage:" + EOL +
+      "  this.render(hbs`" + EOL +
+      "    {{#" + dasherizedModuleName + "}}" + EOL +
+      "      template block text" + EOL +
+      "    {{/" + dasherizedModuleName + "}}" + EOL +
+      "  `);" + EOL + EOL +
+      "  assert.equal(this.$().text().trim(), 'template block text');";
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
@@ -57,13 +64,12 @@ module.exports = {
       testOptions = "// Specify the other units that are required for this test" +
         EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
 
-      testContent = "assert.expect(2);" + EOL + EOL +
+      testContent = "assert.expect(1);" + EOL + EOL +
         "  // Creates the component instance" + EOL +
         "  var component = this.subject();" + EOL +
-        "  assert.equal(component._state, 'preRender');" + EOL + EOL +
         "  // Renders the component to the page" + EOL +
         "  this.render();" + EOL +
-        "  assert.equal(component._state, 'inDOM');";
+        "  assert.equal(this.$().text(), '');";
 
       friendlyTestDescription = testInfo.description(options.entity.name, "Unit", "Component");
     }


### PR DESCRIPTION
This PR continues work from #4272 adding a block-template assertion to the generated component integration test.

Also fixes #4201 and removed component._state from generated unit test