### PR TITLE
Fix default generated integration test.

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -46,7 +46,7 @@ module.exports = {
       "  // Set any properties with this.set('myProperty', 'value');" + EOL +
       "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
       "  this.render(hbs`{{" + dasherizedModuleName + "}}`);" + EOL + EOL +
-      "  assert.equal(this.$().text(), '');" + EOL + EOL +
+      "  assert.equal(this.$().text().trim(), '');" + EOL + EOL +
       "  // Template block usage:" + EOL +
       "  this.render(hbs`" + EOL +
       "    {{#" + dasherizedModuleName + "}}" + EOL +


### PR DESCRIPTION
The generated component integration test fails by default. It's because the result of:

```js
assert.equal(this.$().text().trim(), 'template block text');
```

is `' '` not `''`. We need to `.trim()` it.