### PR TITLE
Removing unknown command from `ember help`.

### DIFF
--- a/lib/commands/unknown.js
+++ b/lib/commands/unknown.js
@@ -5,6 +5,8 @@ var SilentError = require('silent-error');
 var chalk       = require('chalk');
 
 module.exports = Command.extend({
+  skipHelp: true,
+
   printBasicHelp: function() {
     this.ui.writeLine(chalk.red('No help entry for \'' + this.commandName + '\''));
   },


### PR DESCRIPTION
This addresses the original issue in #4409.