### PR TITLE
Add clarity for 0.2.7 to 1.13.x transition (build)

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -1,6 +1,11 @@
 # Brocfile Transition
 
-Transitioning your Brocfile is fairly straight forward. Simply take the contents of your Brocfile and place it in the body of the function in the new `ember-cli-build.js` file.  Instead of using `module.exports` to return the tree simply have the function return the tree.  Ensure you pass the defaults to the EmberApp constructor along with any options you were passing to `EmberApp` in the Brocfile.  Internally these two objects will be merged from right to left.
+Transitioning your Brocfile is fairly straight forward. Simply take the contents of your Brocfile and place it in the body of the function in the new `ember-cli-build.js` file.  Instead of using `module.exports` to return the tree simply have the function return the tree.  Ensure you pass the `defaults` to the EmberApp constructor along with any options you were passing to `EmberApp` in the Brocfile.  Internally these two objects will be merged from right to left.
+
+Two steps:
+
+1. Remove `Brocfile.js` and add contents into `ember-cli-build.js`
+2. Pass `defaults` into the `EmberApp` constructor
 
 ## Before
 


### PR DESCRIPTION
Call out:

```
1. Remove `Brocfile.js` and add contents into `ember-cli-build.js`
2. Pass `defaults` into the `EmberApp` constructor
```

[Fixes #4410]