### PR TITLE
[FEATURE] use package.json key/values from outside project directory

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -46,7 +46,43 @@ function Project(root, pkg, ui, cli) {
   this.setupNodeModulesPath();
   this.addonDiscovery = new AddonDiscovery(this.ui);
   this.addonsFactory = new AddonsFactory(this, this);
+
+  if ( this.pkg.alternateKeys && this.pkg.alternateKeys.length ) {
+      this.setupAlternatePackageKeys();
+  }
 }
+
+/**
+ Use package.json data from an alternate location
+
+ @private
+ @method setupAlternates
+ */
+Project.prototype.setupAlternatePackageKeys = function() {
+    var alternates = this.pkg.alternateKeys;
+
+    debug('list of alternate package.json keys: %j', alternates);
+
+    alternates.forEach(function(a) {
+        var key         = a.key;
+        var packageFile = path.resolve(this.root, a.file);
+
+        if (fs.existsSync(packageFile)) {
+            var packageContents = fs.readFileSync(packageFile);
+            var originalValue = this.pkg[key];
+
+            try {
+                var alternateContents = JSON.parse(packageContents)[key];
+                this.pkg[key] = alternateContents;
+            } catch(exception) {
+                debug('failed to parse replacement package file: %s', exception);
+                this.pkg[key] = originalValue;
+            }
+
+            debug('package key %s set to %j', key, this.pkg[key]);
+        }
+    }, this);
+};
 
 /**
   Sets the name of the bower directory for this project

--- a/tests/fixtures/project-with-alternate-keys/alternate-package.json
+++ b/tests/fixtures/project-with-alternate-keys/alternate-package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+  },
+  "ember-addon": {
+  },
+  "devDependencies": {
+    "ember-cli": "alternate-version"
+  }
+}
+
+

--- a/tests/fixtures/project-with-alternate-keys/package.json
+++ b/tests/fixtures/project-with-alternate-keys/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+  },
+  "ember-addon": {
+  },
+  "devDependencies": {
+    "ember-cli": "latest"
+  },
+  "alternateKeys": [
+    { "key": "devDependencies", "file": "./alternate-package.json" }
+  ]
+}
+

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -527,4 +527,24 @@ describe('models/project.js', function() {
       expect(Project.nullProject()).to.equal(Project.nullProject());
     });
   });
+
+  describe('setupAlternatePackageKeys', function() {
+
+    it('Projects should be initialized with alternate keys', function() {
+      var projectPath = path.resolve(__dirname, '../../fixtures/project-with-alternate-keys');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+      var alternates = packageContents['alternateKeys'];
+
+      project = new Project(projectPath, packageContents, new MockUI());
+
+      alternates.forEach(function(a) {
+        var key = a.key;
+        var file = a.file;
+        var otherFile = require(path.join(projectPath, file));
+
+        // alternateKeys are objects. strict equality is not possible
+        expect(project.pkg[key]).to.eql(otherFile[key]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
In complicated web apps, one can find themselves with a folder structure like so (truncated):
```
complicated-web-app/
|
|__package.json
|
|__node_modules/
|
|__ember-app-one/
|   |__package.json
|   |__node_modules/
|
|__ember-app-two/
    |__package.json
    |__node_modules/
```

When it comes time to deploy, part of the process will require remembering to run `npm install` at the `complicated-web-app/` root as well as inside each `ember-app-one/` and `ember-app-two/`. 

This patch allows one to manage an ember app's dependencies from a location outside of its project directory using a package.json property named `alternateKeys`.

### alternateKeys
In an ember-cli project's package.json, specify an array of Objects, each containing two keys: `key String` and `file String`. 

`key` is the name of the key from the other package.json file you want use in this package. `file` is the path to that file. The path must relative to the project root. 

During cli commands, the instantiated `Project` object will have these values set on its `pkg` property for use in tasks.
```
// complicated-web-app/package.json
{ 
  "name": "complicated-web-app", 
  "version": 1.2.3, 
  "devDependencies": {
    "ember-cli": "1.13.1,
    "grunt": "0.4.5",
    // other complicated-web-app and ember deps
    },
}

// complicated-web-app/ember-app-one/package.json
{
  "name": "ember-app-one",
  "version": 0.1.1,
  "alternateKeys": [
    { "key": "devDependencies", "file": "../package.json" }
  ]
}

// imagine doing the same thing for ember-app-two
```

So this means you can put all your ember-cli deps into one package.json file at the root, tell the ember apps to look to that file for the dependencies and versions it should use, and symlink from the ember-app to the root node_modules.
```
$ cd complicated-web-app
$ npm install
$ rm -rf ember-app-one/node_modules && rm -rf ember-app-two/node_modules
$ cd ember-app-one
$ ln -s ../node_modules node_modules
$ cd ../ember-app-two
$ ln -s ../node_modules node_modules
```

### Why? Why do this?

I might have a bit of an edge case here, but I have myself in a situation as described above, and I don't want to be updating multiple package.json files during development and tracking how many folders need to be descended into to run `npm install`.

I'm hoping this functionality can be merged in so my team and I can continue to track the ember-cli project. Maybe there's a way to put this into an add-on, but dependency version mismatch happens pretty early on in the initialization process. 