### PR TITLE
Prevent live-reload-port collisions (by default)

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,6 +5,11 @@ var path        = require('path');
 var Command     = require('../models/command');
 var Promise     = require('../ext/promise');
 var SilentError = require('silent-error');
+var PortFinder = require('portfinder');
+
+PortFinder.basePort = 49152;
+
+var getPort = Promise.denodeify(PortFinder.getPort);
 
 module.exports = Command.extend({
   name: 'serve',
@@ -19,7 +24,7 @@ module.exports = Command.extend({
     { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },
     { name: 'live-reload',  type: Boolean, default: true, aliases: ['lr'] },
     { name: 'live-reload-host', type: String, description: 'Defaults to host', aliases: ['lrh'] },
-    { name: 'live-reload-port', default: 35729, type: Number, description: '(Defaults to port number + 31529)', aliases: ['lrp']},
+    { name: 'live-reload-port', type: Number, description: '(Defaults to port number within [49152...65535] )', aliases: ['lrp']},
     { name: 'environment', type: String, default: 'development', aliases: ['e', {'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'output-path', type: path, default: 'dist/', aliases: ['op', 'out'] },
     { name: 'ssl', type: Boolean, default: false },
@@ -28,27 +33,32 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions) {
-    commandOptions = assign({}, commandOptions, {
-      liveReloadPort: commandOptions.liveReloadPort  || (parseInt(commandOptions.port, 10) + 31529),
-      liveReloadHost: commandOptions.liveReloadHost  || commandOptions.host,
-      baseURL: this.project.config(commandOptions.environment).baseURL || '/'
-    });
+    var liveReloadPort = commandOptions.liveReloadPort ? Promise.resolve(commandOptions.liveReloadPort) :
+                                                         getPort();
 
-    if (commandOptions.proxy) {
-      if (!commandOptions.proxy.match(/^(http:|https:)/)) {
-        var message = 'You need to include a protocol with the proxy URL.\nTry --proxy http://' + commandOptions.proxy;
+    return liveReloadPort.then(function(liveReloadPort) {
+      commandOptions = assign({}, commandOptions, {
+        liveReloadPort: liveReloadPort,
+        liveReloadHost: commandOptions.liveReloadHost  || commandOptions.host,
+        baseURL: this.project.config(commandOptions.environment).baseURL || '/'
+      });
 
-        return Promise.reject(new SilentError(message));
+      if (commandOptions.proxy) {
+        if (!commandOptions.proxy.match(/^(http:|https:)/)) {
+          var message = 'You need to include a protocol with the proxy URL.\nTry --proxy http://' + commandOptions.proxy;
+
+          return Promise.reject(new SilentError(message));
+        }
       }
-    }
 
-    var ServeTask = this.tasks.Serve;
-    var serve = new ServeTask({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project
-    });
+      var ServeTask = this.tasks.Serve;
+      var serve = new ServeTask({
+        ui: this.ui,
+        analytics: this.analytics,
+        project: this.project
+      });
 
-    return serve.run(commandOptions);
+      return serve.run(commandOptions);
+    }.bind(this));
   }
 });

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -68,7 +68,7 @@ module.exports = Task.extend({
   },
 
   displayHost: function(specifiedHost) {
-        return specifiedHost === '0.0.0.0' ? 'localhost' : specifiedHost;
+    return specifiedHost === '0.0.0.0' ? 'localhost' : specifiedHost;
   },
 
   writeBanner: function(url) {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "nopt": "^3.0.1",
     "npm": "^2.7.6",
     "pleasant-progress": "^1.0.2",
+    "portfinder": "^0.4.0",
     "process-relative-require": "^1.0.0",
     "promise-map-series": "^0.2.1",
     "proxy-middleware": "0.13.0",

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -45,7 +45,7 @@ describe('server command', function() {
       expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
       expect(ops.port).to.equal(4000,            'has correct port');
-      expect(ops.liveReloadPort).to.equal(35729, 'has correct liveReload port');
+      expect(ops.liveReloadPort).to.be.within(49152, 65535, 'has correct liveReload port');
       expect(ops.liveReloadHost).to.equal('0.0.0.0', 'has correct liveReload host');
     });
   });

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -15,7 +15,6 @@ var EOL               = require('os').EOL;
 var nock              = require('nock');
 var express           = require('express');
 
-
 describe('express-server', function() {
   var subject, ui, project, proxy, nockProxy;
   nock.enableNetConnect();


### PR DESCRIPTION
Unless explicitly overridden with `—live-reload-port`, use `PortFinder` to find a free port between `49152` and `65535`

- [x] confirm this works on windows...
- [x] confirm this works with CSP add-on (a quick skim says it should) cc @rwjblue 