### PR TITLE
Add some warning to anyone using "/tests"

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -16,7 +16,7 @@ ember test --server   # will run your tests on every file-change
 {% endhighlight %}
 
 
-Alternatively you can run the tests in your regular browser using the QUnit interface. Run `ember server` and navigate to `http://localhost:4200/tests`. In this case, the tests will run in your default environment, usually 'development'.
+Alternatively you can run the tests in your regular browser using the QUnit interface. Run `ember server` and navigate to `http://localhost:4200/tests`. Beware, however, that this route will run the tests with your app's 'development' environment variables. As a result, larger projects are likely to run into issues running tests in this way as their 'development' and 'test' environment variables diverge.
 
 ### Writing a test
 


### PR DESCRIPTION
After attempting to use /tests yesterday, I wish this text had read a bit more like a warning (it would have flagged me off from even trying, because our app has a bunch of test-specific env flags.)