### PR TITLE
[ENHANCEMENT] Add --skip-router flag to route blueprint generator

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -1,6 +1,5 @@
 /*jshint node:true*/
 
-var SilentError = require('silent-error');
 var fs          = require('fs-extra');
 var path        = require('path');
 var chalk       = require('chalk');
@@ -14,6 +13,11 @@ module.exports = {
       name: 'path',
       type: String,
       default: ''
+    },
+    {
+      name: 'skip-router',
+      type: Boolean,
+      default: false
     }
   ],
 
@@ -60,7 +64,7 @@ module.exports = {
   afterInstall: function(options) {
     var entity  = options.entity;
 
-    if (this.shouldTouchRouter(entity.name) && !options.dryRun && !options.project.isEmberCLIAddon() && !options.inRepoAddon) {
+    if (this.shouldTouchRouter(entity.name) && !options.dryRun && !options.project.isEmberCLIAddon() && !options.inRepoAddon && !options.skipRouter) {
       addRouteToRouter(entity.name, {
         root: options.project.root,
         path: options.path
@@ -73,7 +77,7 @@ module.exports = {
   afterUninstall: function(options) {
     var entity  = options.entity;
 
-    if (this.shouldTouchRouter(entity.name) && !options.dryRun && !options.project.isEmberCLIAddon() && !options.inRepoAddon) {
+    if (this.shouldTouchRouter(entity.name) && !options.dryRun && !options.project.isEmberCLIAddon() && !options.inRepoAddon && !options.skipRouter) {
       removeRouteFromRouter(entity.name, {
         root: options.project.root
       });

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -254,6 +254,23 @@ describe('Acceptance: ember destroy', function() {
       });
   });
 
+    it('route foo --skip-router', function() {
+    this.timeout(20000);
+    var commandArgs = ['route', 'foo', '--skip-router'];
+    var files       = [
+      'app/routes/foo.js',
+      'app/templates/foo.hbs',
+      'tests/unit/routes/foo-test.js'
+    ];
+
+    return assertDestroyAfterGenerate(commandArgs, files)
+      .then(function() {
+        assertFile('app/router.js', {
+          doesContain: "this.route('foo');"
+        });
+      });
+  });
+
   it('route index', function() {
     this.timeout(20000);
     var commandArgs = ['route', 'index'];

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -347,6 +347,29 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+    it('route foo with --skip-router', function() {
+    return generate(['route', 'foo', '--skip-router']).then(function() {
+      assertFile('app/router.js', {
+        doesNotContain: 'this.route(\'foo\')'
+      });
+      assertFile('app/routes/foo.js', {
+        contains: [
+          "import Ember from 'ember';",
+          "export default Ember.Route.extend({" + EOL + "});"
+        ]
+      });
+      assertFile('app/templates/foo.hbs', {
+        contains: '{{outlet}}'
+      });
+      assertFile('tests/unit/routes/foo-test.js', {
+        contains: [
+          "import { moduleFor, test } from 'ember-qunit';",
+          "moduleFor('route:foo'"
+        ]
+      });
+    });
+  });
+
   it('route foo with --path', function() {
     return generate(['route', 'foo', '--path=:foo_id/show']).then(function() {
       assertFile('app/router.js', {


### PR DESCRIPTION
In `ember generate route` blueprint I've added a `--skip-router` option to skip mutating the router.js file when generating or destroying routes. This fixes #4396.