### PR TITLE
[ENHANCEMENT] Detect & skip lib install on http-mock gen

### DIFF
--- a/blueprints/http-mock/index.js
+++ b/blueprints/http-mock/index.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
-
+var fs   = require('fs-extra');
+var path = require('path');
 var Blueprint = require('../../lib/models/blueprint');
 
 module.exports = {
@@ -25,9 +26,16 @@ module.exports = {
     return serverBlueprint.install(options);
   },
 
-  afterInstall: function() {
-    return this.addPackagesToProject([
-      { name: 'express', target: '^4.8.5' }
-    ]);
+  afterInstall: function(options) {
+    var packagePath = path.join(this.project.root, 'package.json');
+    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    var isExpressMissing = !contents.devDependencies['express'];
+
+    if(!options.dryRun && isExpressMissing){
+      return this.addPackagesToProject([
+        { name: 'express', target: '^4.8.5' }
+      ]);  
+    } 
+
   }
 };

--- a/blueprints/http-mock/index.js
+++ b/blueprints/http-mock/index.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
 var Blueprint = require('../../lib/models/blueprint');
+var isPackageMissing = require('../../lib/utilities/is-package-missing');
 
 module.exports = {
   description: 'Generates a mock api endpoint in /api prefix.',
@@ -25,10 +26,8 @@ module.exports = {
   },
 
   afterInstall: function(options) {
-    var pkgContent = this.project.pkg;
-    var isExpressMissing = !( pkgContent.devDependencies['express'] || (pkgContent.dependencies && pkgContent.dependencies['express']) );
 
-    if (!options.dryRun && isExpressMissing) {
+    if (!options.dryRun && isPackageMissing(this, 'express')) {
       return this.addPackagesToProject([
         { name: 'express', target: '^4.8.5' }
       ]);  

--- a/blueprints/http-mock/index.js
+++ b/blueprints/http-mock/index.js
@@ -1,6 +1,4 @@
 /*jshint node:true*/
-var fs   = require('fs-extra');
-var path = require('path');
 var Blueprint = require('../../lib/models/blueprint');
 
 module.exports = {
@@ -27,11 +25,10 @@ module.exports = {
   },
 
   afterInstall: function(options) {
-    var packagePath = path.join(this.project.root, 'package.json');
-    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
-    var isExpressMissing = !contents.devDependencies['express'];
+    var pkgContent = this.project.pkg;
+    var isExpressMissing = !( pkgContent.devDependencies['express'] || (pkgContent.dependencies && pkgContent.dependencies['express']) );
 
-    if(!options.dryRun && isExpressMissing){
+    if (!options.dryRun && isExpressMissing) {
       return this.addPackagesToProject([
         { name: 'express', target: '^4.8.5' }
       ]);  

--- a/blueprints/server/index.js
+++ b/blueprints/server/index.js
@@ -1,4 +1,5 @@
 /*jshint node:true*/
+var isPackageMissing = require('../../lib/utilities/is-package-missing');
 
 module.exports = {
   description: 'Generates a server directory for mocks and proxies.',
@@ -6,10 +7,9 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function(options) {
-    var pkgContent = this.project.pkg;
 
-    var isMorganMissing = !( pkgContent.devDependencies['morgan'] ||  (pkgContent.dependencies && pkgContent.dependencies['morgan']) );
-    var isGlobMissing = !( pkgContent.devDependencies['glob'] ||  (pkgContent.dependencies && pkgContent.dependencies['glob']) );
+    var isMorganMissing = isPackageMissing(this, 'morgan');
+    var isGlobMissing = isPackageMissing(this, 'glob');
 
     var areDependenciesMissing = isMorganMissing || isGlobMissing;
     var libsToInstall = [];

--- a/blueprints/server/index.js
+++ b/blueprints/server/index.js
@@ -1,14 +1,32 @@
 /*jshint node:true*/
+var fs   = require('fs-extra');
+var path = require('path');
 
 module.exports = {
   description: 'Generates a server directory for mocks and proxies.',
 
   normalizeEntityName: function() {},
 
-  afterInstall: function() {
-    return this.addPackagesToProject([
-      { name: 'morgan', target: '^1.3.2' },
-      { name: 'glob', target: '^4.0.5' }
-    ]);
+  afterInstall: function(options) {
+    var packagePath = path.join(this.project.root, 'package.json');
+    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+
+    var isMorganMissing = !contents.devDependencies['morgan'];
+    var isGlobMissing = !contents.devDependencies['glob'];
+    var areDependenciesMissing = isMorganMissing || isGlobMissing;
+    var libsToInstall = [];
+
+    if(isMorganMissing) {
+      libsToInstall.push({ name: 'morgan', target: '^1.3.2' });
+    }
+
+    if(isGlobMissing) {
+      libsToInstall.push({ name: 'glob', target: '^4.0.5' });
+    }
+
+    if(!options.dryRun && areDependenciesMissing) {
+      return this.addPackagesToProject(libsToInstall);	
+    }
+    
   }
 };

--- a/blueprints/server/index.js
+++ b/blueprints/server/index.js
@@ -1,6 +1,4 @@
 /*jshint node:true*/
-var fs   = require('fs-extra');
-var path = require('path');
 
 module.exports = {
   description: 'Generates a server directory for mocks and proxies.',
@@ -8,23 +6,23 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function(options) {
-    var packagePath = path.join(this.project.root, 'package.json');
-    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    var pkgContent = this.project.pkg;
 
-    var isMorganMissing = !contents.devDependencies['morgan'];
-    var isGlobMissing = !contents.devDependencies['glob'];
+    var isMorganMissing = !( pkgContent.devDependencies['morgan'] ||  (pkgContent.dependencies && pkgContent.dependencies['morgan']) );
+    var isGlobMissing = !( pkgContent.devDependencies['glob'] ||  (pkgContent.dependencies && pkgContent.dependencies['glob']) );
+
     var areDependenciesMissing = isMorganMissing || isGlobMissing;
     var libsToInstall = [];
 
-    if(isMorganMissing) {
+    if (isMorganMissing) {
       libsToInstall.push({ name: 'morgan', target: '^1.3.2' });
     }
 
-    if(isGlobMissing) {
+    if (isGlobMissing) {
       libsToInstall.push({ name: 'glob', target: '^4.0.5' });
     }
 
-    if(!options.dryRun && areDependenciesMissing) {
+    if (!options.dryRun && areDependenciesMissing) {
       return this.addPackagesToProject(libsToInstall);	
     }
     

--- a/lib/utilities/is-package-missing.js
+++ b/lib/utilities/is-package-missing.js
@@ -13,5 +13,7 @@
  */
 module.exports = function (context, packageName) {
   var pkgContent = context.project.pkg;
-  return !( pkgContent.devDependencies[packageName] ||  (pkgContent.dependencies && pkgContent.dependencies[packageName]) );
+  var isAvailableInDevDependency = pkgContent.devDependencies && pkgContent.devDependencies[packageName];
+  var isAvailableInDependency = pkgContent.dependencies && pkgContent.dependencies[packageName];
+  return !(isAvailableInDevDependency || isAvailableInDependency);
 };

--- a/lib/utilities/is-package-missing.js
+++ b/lib/utilities/is-package-missing.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/*
+ *
+ * Given the context and library that's supposed to be looked up in the package.json,
+ * this method detects if its already available.
+ *
+ * @method isPackageMissing
+ * @param context The context of the method its called from (ie., this)
+ * @param packageName The package that's supposed to be looked up
+ * @return Boolean 
+ *
+ */
+module.exports = function (context, packageName) {
+  var pkgContent = context.project.pkg;
+  return !( pkgContent.devDependencies[packageName] ||  (pkgContent.dependencies && pkgContent.dependencies[packageName]) );
+};

--- a/tests/unit/utilities/is-package-missing-tests.js
+++ b/tests/unit/utilities/is-package-missing-tests.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var expect = require('chai').expect;
+var isPackageMissing  = require('../../../lib/utilities/is-package-missing');
+
+
+var getContext = function(setDevDependency, setDependency) {
+  var context = {
+    project: {
+      pkg: {}
+    }
+  };
+
+  if (setDevDependency) {
+    context.project.pkg['devDependencies'] = {
+      'sivakumar': 'kailasam'
+    };
+  }
+
+  if (setDependency) {
+    context.project.pkg['dependencies'] = {
+      'sivakumar': 'kailasam'
+    };
+  }
+  return context;
+};
+
+
+describe('Is package missing in package.json', function() {
+
+  it('Package is declared in dependencies', function() {
+    expect(isPackageMissing(getContext(false, true), 'sivakumar')).to.be.false;
+  });
+
+  it('Package is declared in dev dependencies', function() {
+    expect(isPackageMissing(getContext(true, false), 'sivakumar')).to.be.false;
+  });
+
+  it('Package is declared in both dependencies and dev dependencies', function() {
+   expect(isPackageMissing(getContext(true, true), 'sivakumar')).to.be.false;
+  });
+
+  it('Package is missing', function() {
+   expect(isPackageMissing(getContext(false, false), 'sivakumar')).to.be.true;
+  });
+
+});


### PR DESCRIPTION
Whenever `ember g http-mock` is run *express*, *morgan* and *glob* are installed even if they already exist the project. This is undesired and slows down the generate command since there's an `npm install` involved. (cc #4351)

The changes in this PR looks up the package.json to detect if the libraries are already added and skip installation. Also the existing code installed these packages even with the `--dry-run` flag which is also accounted for in this PR. 