### PR TITLE
Always use Brocfile (with deprecation messaging) if it exists

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -21,10 +21,12 @@ module.exports = Task.extend({
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
     var broccoli = require('broccoli');
+    var hasBrocfile = existsSync(path.join('.', 'Brocfile.js'));
     var buildFile = findBuildFile('ember-cli-build.js');
 
-    if (!buildFile) {
-      deprecate('Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.');
+    deprecate('Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.', hasBrocfile);
+
+    if (hasBrocfile) {
       this.tree = broccoli.loadBrocfile();
     } else if (buildFile) {
       this.tree = buildFile({ project: this.project });

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -120,6 +120,22 @@ describe('Acceptance: brocfile-smoke-test', function() {
     });
   });
 
+  it('should use the Brocfile if both a Brocfile and ember-cli-build exist', function() {
+    this.timeout(100000);
+    return copyFixtureFiles('brocfile-tests/both-build-files').then(function() {
+      return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--silent');
+    }).then(function(result) {
+      var vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
+        encoding: 'utf8'
+      });
+
+      var expected = 'var usingBrocfile = true;';
+
+      expect(vendorContents).to.contain(expected, 'includes file imported from Brocfile');
+      expect(result.output[0]).to.include('Brocfile.js has been deprecated');
+    });
+  });
+
   it('should throw if no build file is found', function() {
     this.timeout(100000);
 

--- a/tests/fixtures/brocfile-tests/both-build-files/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/Brocfile.js
@@ -1,0 +1,6 @@
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var app = new EmberApp();
+
+app.import('vendor/brocfile-script.js');
+
+module.exports = app.toTree();

--- a/tests/fixtures/brocfile-tests/both-build-files/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/ember-cli-build.js
@@ -1,0 +1,10 @@
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+
+  });
+
+  return app.toTree();
+};

--- a/tests/fixtures/brocfile-tests/both-build-files/vendor/brocfile-script.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/vendor/brocfile-script.js
@@ -1,0 +1,1 @@
+var usingBrocfile = true;


### PR DESCRIPTION
A number of people have been tripped up by the addition of `ember-cli-build.js`, not realizing that their `Brocfile.js` is ignored. This updates the build logic to always use the `Brocfile.js` if it is present.