### PR TITLE
Make ember destroy and ember generate give a better error when called…

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -25,6 +25,9 @@ module.exports = Command.extend({
   ],
 
   beforeRun: function(rawArgs){
+    if (!rawArgs.length) {
+      return;
+    }
     try {
     // merge in blueprint availableOptions
       this.registerOptions(this.lookupBlueprint(rawArgs[0]));

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -32,6 +32,9 @@ module.exports = Command.extend({
   ],
 
   beforeRun: function(rawArgs){
+    if (!rawArgs.length) {
+      return;
+    }
     // merge in blueprint availableOptions
     var blueprint;
     try{

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -67,7 +67,13 @@ describe('generate command', function() {
             'For more details, use `ember help`.');
       });
   });
-  
+
+  it('does not throws errors when beforeRun is invoked without the blueprint name', function() {
+    expect(function () {
+      command.beforeRun([]);
+    }).to.not.throw();
+  });
+
   it('rethrows errors from beforeRun', function() {
     return Promise.resolve(function(){ return command.beforeRun(['controller', 'foo']);})
     .then(function() {

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -46,6 +46,12 @@ describe('generate command', function() {
       });
   });
 
+  it('does not throws errors when beforeRun is invoked without the blueprint name', function() {
+    expect(function () {
+      command.beforeRun([]);
+    }).to.not.throw();
+  });
+
   it('complains if no blueprint name is given', function() {
     return command.validateAndRun([])
       .then(function() {


### PR DESCRIPTION
… without arguments

When calling `ember generate` or `ember destroy` without arguments an ugly error is threw

```
Arguments to path.resolve must be strings
TypeError: Arguments to path.resolve must be strings
    at Object.posix.resolve (path.js:439:13)
    at Function.Blueprint.lookup (/home/marcio/workspace/javascript/ember-cli/lib/models/blueprint.js:1220:26)
    at Class.module.exports.Command.extend.lookupBlueprint (/home/marcio/workspace/javascript/ember-cli/lib/commands/destroy.js:79:22)
    at Class.module.exports.Command.extend.beforeRun (/home/marcio/workspace/javascript/ember-cli/lib/commands/destroy.js:31:33)
    at CLI.<anonymous> (/home/marcio/workspace/javascript/ember-cli/lib/cli/cli.js:77:13)
    at lib$rsvp$$internal$$tryCatch (/home/marcio/workspace/javascript/ember-cli/node_modules/rsvp/dist/rsvp.js:489:16)
    at lib$rsvp$$internal$$invokeCallback (/home/marcio/workspace/javascript/ember-cli/node_modules/rsvp/dist/rsvp.js:501:17)
    at lib$rsvp$$internal$$publish (/home/marcio/workspace/javascript/ember-cli/node_modules/rsvp/dist/rsvp.js:472:11)
    at lib$rsvp$asap$$flush (/home/marcio/workspace/javascript/ember-cli/node_modules/rsvp/dist/rsvp.js:1290:9)
    at process._tickCallback (node.js:355:11)
```

This PR updates the `beforeRun` method of both the commands to do nothing in the case of the arguments were empty, since `this.lookupBlueprint` expect a non empty name to be provided. In this way the `run` method has the opportunity to give the proper error message, like ``` The `ember destroy` command requires a blueprint name to be specified. For more details, use `ember help`. ``` 