### PR TITLE
[fixes #4328] patch engion.io-client to use any XMLHTTPRequest, but t…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,13 @@ install:
   # Typical npm stuff.
   - md C:\nc
   - npm install -g npm@latest
-  # hide python so node-gyp won't try to build native extentions
+  -  # hide python so node-gyp won't try to build native extentions
   - rename C:\Python27 Python27hidden
   # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
   - set PATH=%APPDATA%\npm;%PATH%
   - npm config set cache C:\nc
   - npm version
-  - npm install
+  - npm install --no-optional
 
 # Post-install test scripts.
 test_script:

--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-rm -rf node_modules
-rm -rf ./ember-cli-*.tgz
-npm cache clear
-npm i --no-optional
-npm link
-npm pack
-npm uninstall -g ember-cli
-npm i -g ./ember-cli-*.tgz
+rm -rf node_modules && \
+rm -rf ./ember-cli-*.tgz && \
+npm cache clear && \
+npm i --no-optional && \
+./patches/patch-engine-io-client.js && \
+npm link --no-optional && \
+npm pack && \
+npm uninstall -g ember-cli && \
+npm i --no-optional -g ./ember-cli-*.tgz

--- a/patches/patch-engine-io-client.js
+++ b/patches/patch-engine-io-client.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/*
+ * patch engion.io-client to use any XMLHTTPRequest, but then bundle the one it
+ * wanted in ember-cli’s tarball
+ *
+ * pending: https://github.com/socketio/engine.io-client/issues/405
+ */
+
+var fs = require('fs');
+var packagePath = __dirname + '/../node_modules/testem/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/package.json';
+var pkg = JSON.parse(fs.readFileSync(packagePath, 'UTF-8'));
+
+if (pkg.dependencies.xmlhttprequest !== 'https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz') {
+  throw new Error('engine.io-clients deps changed, XMLHTTPRequest may be fixed');
+}
+pkg.dependencies.xmlhttprequest === '*';
+
+fs.writeFileSync(packagePath, JSON.stringify(packagePath));


### PR DESCRIPTION
…hen bundle the one it wanted in ember-cli’s tarball

pending: https://github.com/socketio/engine.io-client/issues/405