### PR TITLE
Store acceptance test application in test context.

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -2,15 +2,13 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '<%= testFolderRoot %>/tests/helpers/start-app';
 
-var application;
-
 module('<%= friendlyTestName %>', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -2,14 +2,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 
-var application;
-
 module('Acceptance', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -5,14 +5,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 
-var application;
-
 module('default-development - Integration', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -5,14 +5,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 
-var application;
-
 module('pods based templates', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -5,14 +5,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 
-var application;
-
 module('pods based templates', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -5,14 +5,12 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 
-var application;
-
 module('wrapInEval in-app test', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -2,15 +2,13 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'my-app/tests/helpers/start-app';
 
-var application;
-
 module('Acceptance | foo', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/generate/addon-acceptance-test-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-expected.js
@@ -2,15 +2,13 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 
-var application;
-
 module('Acceptance | foo', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 

--- a/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
@@ -2,15 +2,13 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../../tests/helpers/start-app';
 
-var application;
-
 module('Acceptance | foo/bar', {
   beforeEach: function() {
-    application = startApp();
+    this.application = startApp();
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    Ember.run(this.application, 'destroy');
   }
 });
 


### PR DESCRIPTION
This allows custom test assertions to access the application without manually passing in the application.