### PR TITLE
[INTERNAL] Updating test runner to run jshint first

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
 node_modules/*
-blueprints/*
+coverage/*
+blueprints/**/files/**/*.js
 tests/fixtures/*

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -16,18 +16,24 @@ var mocha = new Mocha({
   timeout: 5000,
   reporter: 'spec'
 });
+var testFiles = glob.sync(root + '/**/*-test.js');
+var jshintPosition = testFiles.indexOf('tests/unit/jshint-test.js');
+var jshint = testFiles.splice(jshintPosition, 1);
+
+testFiles = jshint.concat(testFiles);
 
 if (optionOrFile === 'all') {
-  addFiles(mocha, '/**/*-test.js');
+  addFiles(mocha, testFiles);
   addFiles(mocha, '/**/*-slow.js');
 } else if (optionOrFile)  {
   mocha.addFile(optionOrFile);
 } else {
-  addFiles(mocha, '/**/*-test.js');
+  addFiles(mocha, testFiles);
 }
 
 function addFiles(mocha, files) {
-  glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
+  files = (typeof files === 'string') ? glob.sync(root + files) : files;
+  files.forEach(mocha.addFile.bind(mocha));
 }
 
 function checkOnlyInTests() {

--- a/tests/unit/jshint-test.js
+++ b/tests/unit/jshint-test.js
@@ -1,8 +1,4 @@
 'use strict';
 
-require('mocha-jshint')([
-  'tests',
-  'lib',
-  'bin',
-  'blueprints'
-]);
+// configuration is based on settings found in .jshintrc and .jshintignore
+require('mocha-jshint')();


### PR DESCRIPTION
I fail hard sometimes and go crazy with parentheses, and my mistakes might not show themselves until two or three minutes into a run of `npm test`. I believe `jshint-test.js` should always run first to help poor, flubby fingers like mine.