### PR TITLE
Fix code of conduct markdown formatting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
-+The Ember team and community are committed to everyone having a safe and inclusive experience.
-+
-+**Our Community Guidelines / Code of Conduct can be found here**:
-+
-+http://emberjs.com/guidelines/
-+
-+For a history of updates, see the page history here:
-+
-+https://github.com/emberjs/website/commits/master/source/guidelines.html.erb
+The Ember team and community are committed to everyone having a safe and inclusive experience.
+
+**Our Community Guidelines / Code of Conduct can be found here**:
+
+http://emberjs.com/guidelines/
+
+For a history of updates, see the page history here:
+
+https://github.com/emberjs/website/commits/master/source/guidelines.html.erb


### PR DESCRIPTION
The code of conduct includes version control artifacts (`+` in front of every line). This PR fixes the parsing.