### PR TITLE
fixup some common  failure scenarios

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -42,7 +42,14 @@ AddonDiscovery.prototype.discoverProjectAddons = function(project) {
   var projectAsAddon = this.discoverFromProjectItself(project);
   var internalAddons = this.discoverFromInternalProjectAddons(project);
   var cliAddons = this.discoverFromCli(project.cli);
-  var dependencyAddons = this.discoverFromDependencies(project.root, project.nodeModulesPath, project.pkg, false);
+  var dependencyAddons;
+
+  if (project.hasDependencies()) {
+    dependencyAddons = this.discoverFromDependencies(project.root, project.nodeModulesPath, project.pkg, false);
+  }  else {
+    dependencyAddons = [];
+  }
+
   var inRepoAddons = this.discoverInRepoAddons(project.root, project.pkg);
   var addons = projectAsAddon.concat(cliAddons, internalAddons, dependencyAddons, inRepoAddons);
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -97,7 +97,9 @@ Command.prototype.constructor = Command;
   @method beforeRun
   @return {Promise|null}
 */
-Command.prototype.beforeRun = function() {};
+Command.prototype.beforeRun = function() {
+
+};
 
 /*
   @method validateAndRun
@@ -130,6 +132,12 @@ Command.prototype.validateAndRun = function(args) {
     this.ui.writeLine('You cannot use the '+  chalk.green(this.name) +
                         ' command inside an ember-cli project.');
     return Promise.resolve();
+  }
+
+  if (this.works === 'insideProject') {
+    if (!this.project.hasDependencies()) {
+      throw new SilentError('node_modules appears empty, you may need to run `npm install`');
+    }
   }
 
   return Watcher.detectWatcher(this.ui, commandOptions.options).then(function(options) {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -73,6 +73,9 @@ Project.prototype.setupBowerDirectory = function() {
   debug('bowerDirectory: %s', this.bowerDirectory);
 };
 
+Project.prototype.hasDependencies = function() {
+  return !!this.nodeModulesPath;
+};
 /**
   Sets the path to the node_modules directory for this
   project.

--- a/tests/factories/command-options.js
+++ b/tests/factories/command-options.js
@@ -3,19 +3,17 @@
 var defaults      = require('lodash/object/defaults');
 var MockUI        = require('../helpers/mock-ui');
 var MockAnalytics = require('../helpers/mock-analytics');
+var MockProject   = require('../helpers/mock-project');
 
 module.exports = function CommandOptionsFactory(options) {
+  var project = new MockProject();
+  project.isEmberCLIProject = function() { return true; };
+  project.config = function() { return {}; };
+
   return defaults(options || { }, {
     ui:        new MockUI(),
     analytics: new MockAnalytics(),
     tasks:     {},
-    project:   {
-      isEmberCLIProject: function isEmberCLIProject() {
-        return true;
-      },
-      config: function() {
-        return {};
-      }
-    }
+    project:   project
   });
 };

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -34,11 +34,17 @@ MockProject.prototype.name = function() {
 };
 
 MockProject.prototype.initializeAddons = Project.prototype.initializeAddons;
+MockProject.prototype.hasDependencies = function() {
+  return true;
+};
 MockProject.prototype.discoverAddons = Project.prototype.discoverAddons;
 MockProject.prototype.addIfAddon = Project.prototype.addIfAddon;
 MockProject.prototype.supportedInternalAddonPaths = Project.prototype.supportedInternalAddonPaths;
 MockProject.prototype.setupBowerDirectory = Project.prototype.setupBowerDirectory;
 MockProject.prototype.setupNodeModulesPath = Project.prototype.setupNodeModulesPath;
+MockProject.prototype.isEmberCLIProject = Project.prototype.isEmberCLIProject;
+MockProject.prototype.isEmberCLIAddon = Project.prototype.isEmberCLIAddon;
+MockProject.prototype.findAddonByName = Project.prototype.findAddonByName;
 MockProject.prototype.dependencies = function() {
   return [];
 };

--- a/tests/unit/analytics-test.js
+++ b/tests/unit/analytics-test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var expect  = require('chai').expect;
+var expect = require('chai').expect;
 var Command = require('../../lib/models/command');
 var MockUI = require('../helpers/mock-ui');
+var MockProject = require('../helpers/mock-project');
 var command;
 var called = false;
 
@@ -18,10 +19,13 @@ beforeEach(function() {
     run: function() {}
   });
 
+  var project = new MockProject();
+  project.isEmberCLIProject = function() { return true; };
+
   command = new FakeCommand({
     ui: new MockUI(),
     analytics: analytics,
-    project: { isEmberCLIProject: function(){ return true; }}
+    project: project
   });
 });
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -28,6 +28,9 @@ function ember(args) {
       isEmberCLIProject: function() {  // similate being inside or outside of a project
         return isWithinProject;
       },
+      hasDependencies: function() {
+        return true;
+      },
       blueprintLookupPaths: function() {
         return [];
       }

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -5,26 +5,29 @@ var Promise         = require('../../../lib/ext/promise');
 var Task            = require('../../../lib/models/task');
 var expect          = require('chai').expect;
 var commandOptions  = require('../../factories/command-options');
+var MockProject     = require('../../helpers/mock-project');
 
 describe('generate command', function() {
   var command;
 
   beforeEach(function() {
+    var project = new MockProject();
+
+    project.name = function() {
+      return 'some-random-name';
+    };
+
+    project.isEmberCLIProject = function isEmberCLIProject() {
+      return true;
+    };
+
     command = new DestroyCommand(commandOptions({
       settings: {},
 
-      project:   {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function isEmberCLIProject() {
-          return true;
-        }
-      },
-
+      project: project,
       tasks: {
         DestroyFromBlueprint: Task.extend({
+          project: project,
           run: function(options) {
             return Promise.resolve(options);
           }

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -5,35 +5,49 @@ var Promise         = require('../../../lib/ext/promise');
 var Task            = require('../../../lib/models/task');
 var expect          = require('chai').expect;
 var commandOptions  = require('../../factories/command-options');
+var SilentError     = require('silent-error');
+var MockProject     = require('../../helpers/mock-project');
 
 describe('generate command', function() {
   var command;
 
   beforeEach(function() {
+    var project = new MockProject();
+    project.name = function() {
+      return 'some-random-name';
+    };
+
+    project.isEmberCLIProject = function isEmberCLIProject() {
+      return true;
+    };
+
+    project.blueprintLookupPaths = function() {
+      return [];
+    };
+
+    //nodeModulesPath: 'somewhere/over/the/rainbow'
     command = new GenerateCommand(commandOptions({
       settings: {},
 
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function isEmberCLIProject() {
-          return true;
-        },
-        blueprintLookupPaths: function() {
-          return [];
-        }
-      },
+      project: project,
 
       tasks: {
         GenerateFromBlueprint: Task.extend({
+          project: project,
           run: function(options) {
             return Promise.resolve(options);
           }
         })
       }
     }));
+  });
+
+  it('runs GenerateFromBlueprint but with null nodeModulesPath', function() {
+    command.project.hasDependencies = function() { return false; };
+
+    expect(function() {
+      command.validateAndRun(['controller', 'foo']);
+    }).to.throw(SilentError, 'node_modules appears empty, you may need to run `npm install`');
   });
 
   it('runs GenerateFromBlueprint with expected options', function() {

--- a/tests/unit/commands/install-addon-test.js
+++ b/tests/unit/commands/install-addon-test.js
@@ -7,7 +7,7 @@ var AddonInstall = require('../../../lib/tasks/addon-install');
 var Task = require('../../../lib/models/task');
 var Promise = require('../../../lib/ext/promise');
 var stub = require('../../helpers/stub').stub;
-var Project = require('../../../lib/models/project');
+var MockProject = require('../../helpers/mock-project');
 
 describe('install:addon command', function() {
   var command, options, tasks, npmInstance, generateBlueprintInstance;
@@ -28,30 +28,25 @@ describe('install:addon command', function() {
       })
     };
 
+    var project = new MockProject();
+
+    project.name              = function() { return 'some-random-name'; };
+    project.isEmberCLIProject = function() { return true; };
+    project.initializeAddons  = function() { };
+    project.reloadAddons = function() {
+      this.addons = [{
+        pkg: {
+          name: 'ember-cli-photoswipe',
+          'ember-addon': {
+            defaultBlueprint: 'photoswipe'
+          }
+        }
+      }];
+    };
+
     options = commandOptions({
       settings: {},
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-        isEmberCLIProject: function() {
-          return true;
-        },
-        initializeAddons: function() {  },
-        reloadAddons: function() {
-          this.addons = [{
-            pkg: {
-              name: 'ember-cli-photoswipe',
-              'ember-addon': {
-                defaultBlueprint: 'photoswipe'
-              }
-            }
-          }];
-        },
-
-        findAddonByName: Project.prototype.findAddonByName
-      },
-
+      project: project,
       tasks: tasks
     });
 

--- a/tests/unit/commands/install-bower-test.js
+++ b/tests/unit/commands/install-bower-test.js
@@ -3,23 +3,24 @@
 var expect         = require('chai').expect;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-bower');
+var MockProject    = require('../../helpers/mock-project');
 
 describe('install:bower command', function() {
   var command, options, msg;
 
   beforeEach(function() {
+    var project = new MockProject();
+    project.name = function() {
+      return 'some-random-name';
+    };
+
+    project.isEmberCLIProject = function() {
+      return true;
+    };
+
     options = commandOptions({
       settings: {},
-
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function() {
-          return true;
-        }
-      },
+      project: project
     });
 
     command  = new InstallCommand(options);

--- a/tests/unit/commands/install-npm-test.js
+++ b/tests/unit/commands/install-npm-test.js
@@ -3,23 +3,25 @@
 var expect         = require('chai').expect;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install-npm');
+var MockProject    = require('../../helpers/mock-project');
 
 describe('install:npm command', function() {
   var command, options, msg;
 
   beforeEach(function() {
+    var project = new MockProject();
+
+    project.name = function() {
+      return 'some-random-name';
+    };
+
+    project.isEmberCLIProject =function() {
+      return true;
+    };
+
     options = commandOptions({
       settings: {},
-
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function() {
-          return true;
-        }
-      }
+      project: project
     });
 
     command  = new InstallCommand(options);

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -5,23 +5,59 @@ var stub           = require('../../helpers/stub').stub;
 var commandOptions = require('../../factories/command-options');
 var InstallCommand = require('../../../lib/commands/install');
 var Task           = require('../../../lib/models/task');
-var Project        = require('../../../lib/models/project');
 var Promise        = require('../../../lib/ext/promise');
 var AddonInstall   = require('../../../lib/tasks/addon-install');
+var MockProject    = require('../../helpers/mock-project');
 
 describe('install command', function() {
   var command, options, tasks, generateBlueprintInstance, npmInstance;
 
   beforeEach(function() {
+    var project = new MockProject();
+
+    project.name = function() {
+      return 'some-random-name';
+    };
+
+    project.isEmberCLIProject = function() {
+      return true;
+    };
+
+    project.initializeAddons = function() { };
+    project.reloadAddons = function() {
+      this.addons = [
+        {
+          pkg: {
+            name: 'ember-data',
+          }
+        },
+        {
+          pkg: {
+            name: 'ember-cli-cordova',
+            'ember-addon': {
+              defaultBlueprint: 'cordova-starter-kit'
+            }
+          }
+        },
+        {
+          pkg: {
+            name: 'ember-cli-qunit'
+          }
+        }
+      ];
+    };
+
     tasks = {
       AddonInstall: AddonInstall,
       NpmInstall: Task.extend({
+        project: project,
         init: function() {
           npmInstance = this;
         }
       }),
 
       GenerateFromBlueprint: Task.extend({
+        project: project,
         init: function() {
           generateBlueprintInstance = this;
         }
@@ -30,43 +66,7 @@ describe('install command', function() {
 
     options = commandOptions({
       settings: {},
-
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function() {
-          return true;
-        },
-
-        initializeAddons: function() { },
-        reloadAddons: function() {
-          this.addons = [
-            {
-              pkg: {
-                name: 'ember-data',
-              }
-            },
-            {
-              pkg: {
-                name: 'ember-cli-cordova',
-                'ember-addon': {
-                  defaultBlueprint: 'cordova-starter-kit'
-                }
-              }
-            },
-            {
-              pkg: {
-                name: 'ember-cli-qunit'
-              }
-            }
-          ];
-        },
-
-        findAddonByName: Project.prototype.findAddonByName
-      },
-
+      project: project,
       tasks: tasks
     });
 

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -10,6 +10,7 @@ var CoreObject     = require('core-object');
 var path           = require('path');
 var fs             = require('fs');
 var TestCommand    = require('../../../lib/commands/test');
+var MockProject    = require('../../helpers/mock-project');
 
 describe('test command', function() {
   var tasks;
@@ -25,10 +26,13 @@ describe('test command', function() {
       TestServer: Task.extend()
     };
 
+    var project = new MockProject();
+    project.isEmberCLIProject = function() { return true; };
     options = commandOptions({
       tasks: tasks,
       testing: true,
-      settings: {}
+      settings: {},
+      project: project
     });
 
     stub(tasks.Test.prototype,  'run', Promise.resolve());
@@ -100,7 +104,7 @@ describe('test command', function() {
 
     it('builds a watcher with verbose set to false', function() {
       return new TestCommand(options).validateAndRun(['--server']).then(function() {
-        var testOptions  = testServerRun.calledWith[0][0];
+        var testOptions = testServerRun.calledWith[0][0];
 
         expect(testOptions.watcher.verbose, false);
       });

--- a/tests/unit/commands/uninstall-npm-test.js
+++ b/tests/unit/commands/uninstall-npm-test.js
@@ -3,23 +3,19 @@
 var expect           = require('chai').expect;
 var commandOptions   = require('../../factories/command-options');
 var UninstallCommand = require('../../../lib/commands/uninstall-npm');
+var MockProject      = require('../../helpers/mock-project');
 
 describe('uninstall:npm command', function() {
   var command, options, msg;
 
   beforeEach(function() {
+    var project = new MockProject();
+    project.name = function() { return 'some-random-name'; };
+    project.isEmberCLIProject = function() { return true; };
+
     options = commandOptions({
       settings: {},
-
-      project: {
-        name: function() {
-          return 'some-random-name';
-        },
-
-        isEmberCLIProject: function() {
-          return true;
-        }
-      }
+      project: project
     });
 
     command  = new UninstallCommand(options);

--- a/tests/unit/models/addon-discovery-test.js
+++ b/tests/unit/models/addon-discovery-test.js
@@ -388,6 +388,9 @@ describe('models/addon-discovery.js', function() {
           devDependencies: {
             'dev-dep-bar': 'latest'
           }
+        },
+        hasDependencies: function() {
+          return true;
         }
       };
 


### PR DESCRIPTION
* don’t fail during command lookup if node_modules is empty
* commands that require node_modules should error in a helpful way.

fixes #4486 

- [x] fixing up the failing tests