### PR TITLE
Testem v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "^0.9.0-2",
+    "testem": "^0.9.0",
     "through": "^2.3.6",
     "tiny-lr": "0.1.5",
     "walk-sync": "0.1.3",


### PR DESCRIPTION
Testem v0.9.0 was now officially released

Changes: https://github.com/airportyh/testem/releases/tag/v0.9.0
Changes since `0.9.0-2`: none