### PR TITLE
Update ember-qunit to 0.4.6.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.5",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.2",
+    "ember-qunit": "0.4.6",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.1.1",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.17",
+    "ember-cli-qunit": "0.3.18",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.1",
     "ember-cli-uglify": "^1.0.1",


### PR DESCRIPTION
Adds support for testing improved actions (aka closure actions).