### PR TITLE
small improvement to ember init to begin to help with test run times.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -94,7 +94,8 @@ module.exports = Command.extend({
         debug('after:installblueprint');
         if (!commandOptions.skipNpm) {
           return npmInstall.run({
-              verbose: commandOptions.verbose
+              verbose: commandOptions.verbose,
+              optional: false
             });
         }
       })

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -6,6 +6,7 @@ var Promise   = require('../ext/promise');
 var SilentError        = require('silent-error');
 var validProjectName   = require('../utilities/valid-project-name');
 var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
+var debug              = require('debug')('ember-cli:command:init');
 
 module.exports = Command.extend({
   name: 'init',
@@ -46,22 +47,26 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    var npmInstall = new this.tasks.NpmInstall({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project
-    });
+    if (!commandOptions.skipNpm) {
+      var npmInstall = new this.tasks.NpmInstall({
+        ui: this.ui,
+        analytics: this.analytics,
+        project: this.project
+      });
+    }
 
-    var bowerInstall = new this.tasks.BowerInstall({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project
-    });
+    if (!commandOptions.skipBower) {
+      var bowerInstall = new this.tasks.BowerInstall({
+        ui: this.ui,
+        analytics: this.analytics,
+        project: this.project
+      });
+    }
 
     var project          = this.project;
     var packageName      = commandOptions.name !== '.' && commandOptions.name || project.name();
 
-    if(!packageName) {
+    if (!packageName) {
       var message = 'The `ember ' + this.name + '` command requires a ' +
                     'package.json in current folder with name attribute or a specified name via arguments. ' +
                     'For more details, use `ember help`.';
@@ -83,8 +88,10 @@ module.exports = Command.extend({
 
     blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint);
 
+    debug('before:installblueprint');
     return installBlueprint.run(blueprintOpts)
       .then(function() {
+        debug('after:installblueprint');
         if (!commandOptions.skipNpm) {
           return npmInstall.run({
               verbose: commandOptions.verbose

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -32,6 +32,7 @@ var CoreObject    = require('core-object');
 var EOL           = require('os').EOL;
 var deprecateUI   = require('../utilities/deprecate').deprecateUI;
 var bowEpParser   = require('bower-endpoint-parser');
+var debug         = require('debug')('ember-cli:blueprint');
 module.exports = Blueprint;
 
 /**
@@ -489,11 +490,15 @@ Blueprint.prototype.install = function(options) {
   this._checkForPod(options.verbose);
   this._checkInRepoAddonExists(options.inRepoAddon);
 
+  debug('START: processing blueprint: `%s`', this.name);
+  var start = new Date();
   return this._process(
     options,
     this.beforeInstall,
     this.processFiles,
-    this.afterInstall);
+    this.afterInstall).finally(function() {
+      debug('END: processing blueprint: `%s` in (%dms)', this.name, new Date() - start);
+    }.bind(this));
 };
 
 /**

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -50,7 +50,6 @@ module.exports = Task.extend({
       var blueprint = Blueprint.lookup(blueprintName, {
         paths: this.project.blueprintLookupPaths()
       });
-
       return blueprint.install(installOptions);
     }
   }

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -26,7 +26,8 @@ module.exports = Task.extend({
       logstream: this.ui.outputStream,
       color: 'always',
       'save-dev': !!options['save-dev'],
-      'save-exact': !!options['save-exact']
+      'save-exact': !!options['save-exact'],
+      'optional': 'optional' in options ? options.optional : true
     };
     var packages = options.packages || [];
 

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -2,8 +2,7 @@
 
 var fs          = require('fs');
 var existsSync  = require('exists-sync');
-var markdown    = require('markdown-it');
-var terminal    = require('markdown-it-terminal');
+
 var chalk       = require('chalk');
 var SilentError = require('silent-error');
 var isArray     = require('lodash/lang/isArray');
@@ -41,7 +40,8 @@ function MarkdownColor(options) {
   var renderStyles = options && options.renderStyles || chalk;
   var tokens = this.generateTokens(renderStyles);
   var markdownOptions = options && options.markdownOptions || {};
-
+  var markdown = require('markdown-it');
+  var terminal = require('markdown-it-terminal');
   this.options = options || {};
   this.markdown = markdown().use(terminal, markdownOptions);
   this.tokens = merge(tokens, optionTokens);

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -54,7 +54,7 @@ function symLinkDir(projectPath, from, to) {
 
 function applyCommand(command, name /*, ...flags*/) {
   var flags = [].slice.call(arguments, 2, arguments.length);
-  var args = [path.join('..', 'bin', 'ember'), command, '--skip-git', name, onOutput];
+  var args = [path.join('..', 'bin', 'ember'), command, '--disable-analytics', '--watcher=node', '--skip-git', name, onOutput];
 
   flags.forEach(function(flag) {
     args.splice(2, 0, flag);

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -7,6 +7,8 @@ var Cli           = require('../../lib/cli');
 module.exports = function ember(args) {
   var cli;
 
+  args.push('--disable-analyitcs');
+  args.push('--watcher=node');
   cli = new Cli({
     inputStream:  [],
     outputStream: [],


### PR DESCRIPTION
this affectively cuts the affected tests run time in half (or more). Just the tip of the ice berg, but we can iterate slowly.

Also note, this is just low hanging fruit. Large wins will require more effort but have the potential to cut down the test time for the extremely slow tests dramatically. Build related performance improvements will also improve the e2e test runs.