### PR TITLE
add os to version output

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -15,8 +15,9 @@ module.exports = Command.extend({
   run: function(options) {
     var versions = process.versions;
     versions['npm'] = require('npm').version;
+    versions['os'] = process.platform + ' ' + process.arch;
 
-    var alwaysPrint = ['node','npm'];
+    var alwaysPrint = ['node','npm', 'os'];
 
     for(var module in versions) {
       if(options.verbose || alwaysPrint.indexOf(module) > -1) {

--- a/tests/unit/commands/version-test.js
+++ b/tests/unit/commands/version-test.js
@@ -26,11 +26,12 @@ describe('version command', function() {
     command = new VersionCommand(options);
   });
 
-  it('reports node and npm versions', function() {
+  it('reports node, npm, and os versions', function() {
     return command.validateAndRun().then(function() {
       var lines = ui.output.split(EOL);
       expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
       expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
+      expect(someLineStartsWith(lines, 'os:'), 'contains the version of os');
     });
   });
 
@@ -39,6 +40,7 @@ describe('version command', function() {
       var lines = ui.output.split(EOL);
       expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
       expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
+      expect(someLineStartsWith(lines, 'os:'), 'contains the version of os');
       expect(someLineStartsWith(lines, 'v8:'), 'contains the version of v8');
     });
   });


### PR DESCRIPTION
I've noticed that some of the first things asked of people reporting bugs is to give as much version info as possible. This adds some OS info to the version output so the second question doesn't have to be "can you also tell us which OS you're using".

Sample output:
```
C:\Users\kelly>ember -v
version: 1.13.1-master-dd6e931f5a
node: 0.12.5
npm: 2.7.4
os: win32 x64
```
My only concern is any side-effects of using `process.platform` and `process.arch`.