### PR TITLE
Remove unnecessary `"use strict";`s in "app.js"

### DIFF
--- a/lib/broccoli/app-prefix.js
+++ b/lib/broccoli/app-prefix.js
@@ -1,3 +1,4 @@
+"use strict";
 /* jshint ignore:start */
 {{content-for 'app-prefix'}}
 /* jshint ignore:end */

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -270,6 +270,22 @@ describe('Acceptance: smoke-test', function() {
     });
   });
 
+  it('ember new foo, build production and verify single "use strict";', function() {
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production')
+      .then(function() {
+          var dirPath = path.join('.', 'dist', 'assets');
+          var dir = fs.readdirSync(dirPath);
+          var appNameRE = new RegExp(appName + '-([a-f0-9]+)\\.js','i');
+          dir.forEach(function(filepath) {
+            if (appNameRE.test(filepath)) {
+              var contents = fs.readFileSync(path.join('.', 'dist', 'assets', filepath), { encoding: 'utf8' });
+              var count = (contents.match(/(["'])use strict\1;/g) || []).length;
+              expect(count).to.equal(1);
+            }
+          });
+      });
+  });
+
   it('ember can override and reuse the built-in blueprints', function() {
     return copyFixtureFiles('addon/with-blueprint-override')
       .then(function() {


### PR DESCRIPTION
When using ember-cli it is understood that all code in "app.js" is strict by default. If we add `"use strict";` in app-prefix.js as the very first statement then Uglify is clever enough to remove all of the other generated `"use strict";`s throughout app.js. In my app this results in ~33kb on-disk savings.

This should be the default behavior.