### PR TITLE
Mitigate Native installs even for initial npm install ember-cli with …

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "^0.9.0",
+    "testem": "0.9.1",
     "through": "^2.3.6",
     "tiny-lr": "0.1.5",
     "walk-sync": "0.1.3",

--- a/patches/patch-engine-io-client.js
+++ b/patches/patch-engine-io-client.js
@@ -15,4 +15,4 @@ if (pkg.dependencies.xmlhttprequest !== 'https://github.com/rase-/node-XMLHttpRe
 }
 pkg.dependencies.xmlhttprequest === '*';
 
-fs.writeFileSync(packagePath, JSON.stringify(packagePath));
+fs.writeFileSync(packagePath, JSON.stringify(pkg));

--- a/patches/patch-ws.js
+++ b/patches/patch-ws.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/*
+ * patch engion.io-client to use any XMLHTTPRequest, but then bundle the one it
+ * wanted in ember-cli’s tarball
+ *
+ * pending: https://github.com/socketio/engine.io-client/issues/405
+ */
+
+var fs = require('fs');
+var packagePath = __dirname + '/../node_modules/testem/node_modules/socket.io/node_modules/engine.io/node_modules/ws/package.json';
+var pkg = JSON.parse(fs.readFileSync(packagePath, 'UTF-8'));
+
+delete pkg.optionalDependencies;
+delete pkg.dependencies['bufferutil'];
+delete pkg.dependencies['utf-8-validate'];
+console.log(packagePath);
+fs.writeFileSync(packagePath, JSON.stringify(pkg));


### PR DESCRIPTION
…more aggressive testem/engine.io/ws patching.

also lock tested, so we mitigate atleast some of the drift.