### PR TITLE
Add a breakline for 1.13.0 version in the changelog

### DIFF
--- a/_posts/2012-01-01-changelog.md
+++ b/_posts/2012-01-01-changelog.md
@@ -84,6 +84,7 @@ version:
 - [#4398](https://github.com/ember-cli/ember-cli/pull/4398) [BUGFIX] Fixes #4397 add silentError with deprecation [@trabus](https://github.com/trabus)
 
 Thank you to all who took the time to contribute!
+
 ### 1.13.0
 
 The following changes are required if you are upgrading from the previous


### PR DESCRIPTION
Add a breakline for 1.13.0 version in the changelog to properly break in the web