### PR TITLE
[Bugfix] addAddonToProject fix for 1.13.5

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1040,7 +1040,7 @@ Blueprint.prototype.addAddonToProject = function(options) {
   var taskOptions = {};
 
   if (typeof options === 'string') {
-    taskOptions['package'] = options;
+    taskOptions['packages'] = [options];
   } else {
     if (!options.name) {
       throw new SilentError('You must provide a `name` to addAddonToProject');
@@ -1050,14 +1050,14 @@ Blueprint.prototype.addAddonToProject = function(options) {
       options.name += '@' + options.target;
     }
 
-    taskOptions['package']       = options.name;
+    taskOptions['packages']      = [options.name];
     taskOptions.extraArgs        = options.extraArgs || [];
     taskOptions.blueprintOptions = options.blueprintOptions || {};
   }
 
   var task = this.taskFor('addon-install');
 
-  this._writeStatusToUI(chalk.green, 'install addon', taskOptions['package']);
+  this._writeStatusToUI(chalk.green, 'install addon', taskOptions['packages']);
 
   return task.run(taskOptions);
 };

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -1072,13 +1072,13 @@ describe('Blueprint', function() {
 
       AddonInstallTask = Task.extend({
         run: function(options) {
-          pkg = options['package'];
+          pkg = options['packages'];
         }
       });
 
       blueprint.addAddonToProject('foo-bar');
 
-      expect(pkg).to.equal('foo-bar');
+      expect(pkg).to.deep.equal(['foo-bar']);
     });
 
     it('calls the task with correctly parsed options', function() {
@@ -1086,7 +1086,7 @@ describe('Blueprint', function() {
 
       AddonInstallTask = Task.extend({
         run: function(options) {
-          pkg  = options['package'];
+          pkg  = options['packages'];
           args = options['extraArgs'];
         }
       });
@@ -1097,7 +1097,7 @@ describe('Blueprint', function() {
         extraArgs: ['baz']
       });
 
-      expect(pkg).to.equal('foo-bar@1.0.0');
+      expect(pkg).to.deep.equal(['foo-bar@1.0.0']);
       expect(args).to.deep.equal(['baz']);
     });
 


### PR DESCRIPTION
Fixes #4551 

The gist is https://github.com/ember-cli/ember-cli/pull/4406 changes the shape of the npm install options object by renaming `package` to `packages` and it just seems `addAddonToProject` needs to be updated to reflect that along with the packageName should be an array.

Appveyor needs to be kicked, doesn't appear to be failing for any reason related to the changes.

Please validate @stefanpenner @DanielOchoa 