### PR TITLE
update outdated reference to emblem compilation

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -180,10 +180,10 @@ Note that the ES6 module transpiler is not directly supported with Emberscript, 
 For [Emblem](http://emblemjs.com/), run the following commands:
 
 {% highlight bash %}
-ember install ember-cli-emblem-hbs-printer
+ember install ember-cli-emblem
 {% endhighlight %}
 
-If you're using the older broccoli-emblem-compiler addon, you need to switch over the above ember-cli-emblem-hbs-printer. The older broccoli-emblem-compiler compiles directly to JS instead of Handlebars and therefore is broken on all newer version of HTMLBars.
+If you're using the older broccoli-emblem-compiler addon, you need to switch to ember-cli-emblem. The older broccoli-emblem-compiler compiles directly to JS instead of Handlebars and therefore is broken on all newer version of HTMLBars.
 
 ### Fingerprinting and CDN URLs
 


### PR DESCRIPTION
ember-cli-emblem-hbs-printer has been renamed and moved to ember-cli-emblem. Future development will occur there.