### PR TITLE
Upgrade to Broccoli 0.16.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bower": "^1.3.12",
     "bower-config": "0.6.1",
     "bower-endpoint-parser": "0.2.2",
-    "broccoli": "0.16.3",
+    "broccoli": "0.16.5",
     "broccoli-caching-writer": "0.6.1",
     "broccoli-clean-css": "0.2.0",
     "broccoli-es3-safe-recast": "^2.0.0",


### PR DESCRIPTION
This allows us to use the `BROCCOLI_WARN_READ_API=y` environment variable.