### PR TITLE
Update QUnit version to 1.18.0.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -11,6 +11,6 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.18.0"
   }
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.1.1",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.19",
+    "ember-cli-qunit": "0.3.20",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.1",
     "ember-cli-uglify": "^1.0.1",


### PR DESCRIPTION
[Changelog](https://github.com/jquery/qunit/blob/1.18.0/History.md):

* Assert: throws uses push method only
* Assert: Fix missing test on exported throws
* Assert: Implements notOk to assert falsy values
* Core: More graceful handling of AMD
* Core: Simplify stack trace methods
* Core: Expose Dump maxDepth property
* Core: Expose QUnit version as QUnit.version property
* Core: Handle multiple testId parameters
* Dump: Fix .name/.property doublettes
* HTML Reporter: New diff using Google's Diff-Patch-Match Library
* HTML Reporter: Make it more obvious why diff is suppressed.
* HTML Reporter: Change display text for bad tests
* HTML Reporter: Fix checkbox and select handling in IE <9
* HTML Reporter: Fix test filter without any module
* HTML Reporter: Retain failed tests numbers
* Test: lowercase the valid test filter before using it