### PR TITLE
Add .watchmanconfig to .npmignore

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -8,6 +8,7 @@ dist/
 .ember-cli
 .travis.yml
 .npmignore
+.watchmanconfig
 **/.gitkeep
 bower.json
 ember-cli-build.js


### PR DESCRIPTION
I don't believe it adds any value in npm packages and causes watchman to pick up addons in the watch-list.

Running `watchman watch-list` within your app's root folder will validate this.