### PR TITLE
Update app.js - fix warning

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -10,7 +10,7 @@ Ember.MODEL_FACTORY_INJECTIONS = true;
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver
 });
 
 loadInitializers(App, config.modulePrefix);


### PR DESCRIPTION
Fix warning
Property assignment should use enhanced object literal function. `{ propName: propName}` is not allowed.