### PR TITLE
blueprints/app/package.json: Sort scripts alphabetically

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -8,8 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember test"
   },
   "repository": "",


### PR DESCRIPTION
Using `npm install --save <something>` will reorder the scripts automatically which leads to an unnecessary diff. (I'm using npm v3)