### PR TITLE
Remove ember update mention in update-checker

### DIFF
--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -29,8 +29,7 @@ UpdateChecker.prototype.checkForUpdates = function() {
       if (updateInfo.updateNeeded) {
         this.ui.writeLine('');
         this.ui.writeLine('A new version of ember-cli is available (' +
-                          updateInfo.newestVersion + '). To install it, type ' +
-                          chalk.green('ember update') + '.');
+                          updateInfo.newestVersion + ').');
       }
       return updateInfo;
     }.bind(this));


### PR DESCRIPTION
Re-PR: Since #4419, ember update is no longer available.

~~This can be merged instead of https://github.com/ember-cli/ember-cli/pull/4591 to fix the build.~~
Sorry for the trouble and breaking build in https://github.com/ember-cli/ember-cli/pull/4590.