### PR TITLE
Bump version of ember-cli-app-version to 0.5.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "<%= emberCLIVersion %>",
-    "ember-cli-app-version": "0.4.0",
+    "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",


### PR DESCRIPTION
- Fixed backwards compatibility with < Ember 1.12 by going back to using initializer but without using arguments because they're not necessary.
- Added `{{app-version}}` component for displaying version on frontend

Compare [v0.4.0 and v0.5.0](https://github.com/embersherpa/ember-cli-app-version/compare/v0.4.0...v0.5.0)