### PR TITLE
CI: Remove useless npm upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ env:
   - NODE_VERSION=iojs
 
 before_install:
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
-  - "npm config set spin false"
+  - npm config set spin false
 
 os:
   - osx


### PR DESCRIPTION
npm was upgraded before the node version was switched, making the upgrade effectively useless

As tests are currently passing and node 0.12 ships npm 2.11.3 and iojs ships 2.13.3 I think this can be dropped instead of fixed.

The only old npm version (1.4.28) is shipped with 0.10, which will be removed in 0.3 https://github.com/ember-cli/ember-cli/issues/3329

https://travis-ci.org/ember-cli/ember-cli/jobs/74583522#L112