### PR TITLE
Windows CI: Removed npm upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,13 +16,10 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # Install PhantomJS
   - cinst PhantomJS -y
+  # hide python so node-gyp won't try to build native extentions
+  - rename C:\Python27 Python27hidden
   # Typical npm stuff.
   - md C:\nc
-  - npm install -g npm@latest
-  -  # hide python so node-gyp won't try to build native extentions
-  - rename C:\Python27 Python27hidden
-  # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
-  - set PATH=%APPDATA%\npm;%PATH%
   - npm config set cache C:\nc
   - npm version
   - npm install --no-optional


### PR DESCRIPTION
0.12 ships a recent enough npm version

Follow up of https://github.com/ember-cli/ember-cli/pull/4619