### PR TITLE
fix typo in configuring output paths for index.html file

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -305,7 +305,7 @@ var app = new EmberApp({
 });
 {% endhighlight %}
 
-You may edit any of these output paths, but make sure to update your `app.outputPaths.app.index`, default it is `index.html`, and `tests/index.html`.
+You may edit any of these output paths, but make sure to update your `app.outputPaths.app.html`, default it is `index.html`, and `tests/index.html`.
 
 {% highlight javascript %}
 var app = new EmberApp({


### PR DESCRIPTION
When configuring output paths, the docs currently give instructions to edit the `app.outputPaths.app.index` property. This does not actually change the output path, I believe the correct property is `app.outputPaths.app.html`.