### PR TITLE
Bump to ember-cli-release 0.2.5 in blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -30,7 +30,7 @@
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",
-    "ember-cli-release": "0.2.3",
+    "ember-cli-release": "0.2.5",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "1.13.8",


### PR DESCRIPTION
Bumps ember-cli-release to 0.2.5 in app blueprint https://github.com/lytics/ember-cli-release/commit/f9022396b9bebdebee5e97d0ab198347725578e8