### PR TITLE
[INTERNAL] Prefer globs over RegExps as funnel arguments

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -534,8 +534,8 @@ EmberApp.prototype._filterAppTree = function() {
   var excludePatterns = podPatterns.concat([
     // note: do not use path.sep here Funnel uses
     // walk-sync which always joins with `/` (not path.sep)
-    new RegExp('^styles/'),
-    new RegExp('^templates/'),
+    'styles/**/*',
+    'templates/**/*',
   ]);
 
   return this._cachedFilterAppTree = new Funnel(this.trees.app, {
@@ -643,7 +643,7 @@ EmberApp.prototype._processedTemplatesTree = function() {
 
   var podTemplates = new Funnel(this.trees.app, {
     include: this._podTemplatePatterns(),
-    exclude: [ /^templates/ ],
+    exclude: [ 'templates/**/*' ],
     destDir: this.name + '/',
     description: 'Funnel: Pod Templates'
   });
@@ -666,7 +666,7 @@ EmberApp.prototype._processedTemplatesTree = function() {
 */
 EmberApp.prototype._podTemplatePatterns = function() {
   return this.registry.extensionsForType('template').map(function(extension) {
-    return new RegExp('template.' + extension + '$');
+    return '**/*/template.' + extension;
   });
 };
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -472,7 +472,7 @@ Addon.prototype.compileTemplates = function(tree) {
     }
 
     var includePatterns = this.registry.extensionsForType('template').map(function(extension) {
-      return new RegExp('template.' + extension + '$');
+      return '**/*/template.' + extension;
     });
 
     var podTemplates = new Funnel(tree, {


### PR DESCRIPTION
Use globs instead of regexps to benefit (one day) from some of @stefanpenner 's latest performance work.

WIP:
- [x] all tests are passing
- [x] ~~port `shouldCompileTemplates`~~ (it's only run once on initial build and would require porting ember-cli to walk-sync-matcher completely now)

