### PR TITLE
Support a (now deprecated) single-argument use of addBowerPackageToProject

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -989,7 +989,23 @@ Blueprint.prototype.removePackagesFromProject = function(packages) {
   @return {Promise}
 */
 Blueprint.prototype.addBowerPackageToProject = function(localPackageName, target, installOptions) {
-  var packageObject = bowEpParser.json2decomposed(localPackageName, target);
+  var lpn = localPackageName;
+  var tar = target;
+  if (localPackageName.indexOf('#') >= 0) {
+    if (arguments.length === 1) {
+      var parts = localPackageName.split('#');
+      lpn = parts[0];
+      tar = parts[1];
+      deprecateUI(this.ui)('passing ' + localPackageName +
+        ' directly to `addBowerPackageToProject` will soon be unsupported. \n' + 
+        'You may want to replace this with ' +
+        '`addBowerPackageToProject(\'' + lpn +'\', \'' + tar + '\')`', true);
+    } else {
+      deprecateUI(this.ui)('passing ' + localPackageName +
+        ' directly to `addBowerPackageToProject` will soon be unsupported', true);
+    }
+  }
+  var packageObject = bowEpParser.json2decomposed(lpn, tar);
   return this.addBowerPackagesToProject([packageObject], installOptions);
 };
 

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -879,7 +879,7 @@ describe('Blueprint', function() {
       tmpdir    = tmp.in(tmproot);
       blueprint = new Blueprint(basicBlueprint);
       ui        = new MockUI();
-
+      blueprint.ui = ui;
       blueprint.taskFor = function(name) {
         taskNameLookedUp = name;
 
@@ -922,7 +922,15 @@ describe('Blueprint', function() {
 
       blueprint.addBowerPackageToProject('foo-bar-local', 'http://twitter.github.io/bootstrap/assets/bootstrap');
     });
+    
+    it('correctly handles a single versioned package descriptor as argument (1) (DEPRECATED)', function() {
+      blueprint.ui = ui;
+      blueprint.addBowerPackagesToProject = function(packages) {
+        expect(packages).to.deep.equal([{name: 'foo-bar', target: '1.11.1', source: 'foo-bar'}]);
+      };
 
+      blueprint.addBowerPackageToProject('foo-bar#1.11.1');
+    });
   });
 
   describe('addBowerPackagesToProject', function() {


### PR DESCRIPTION
A single-argument use of `addBowerPackageToProject` used to work, until #4430 . This is causing some problems ( https://github.com/Gaurav0/ember-cli-jquery-ui/issues/14 )

For example
```js
addBowerPackageToProject('jquery-ui#1.11.1');
```

This PR adds support for this use back in to ember-cli, and deprecates it since we eventually want to get everyone using the two-argument variant
```js
addBowerPackageToProject('jquery-ui', '1.11.1');
```
