### PR TITLE
Replace ember-cli-ic-ajax in favour of ember-ajax

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,6 @@
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
-    "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.1",
     "ember-cli-release": "0.2.3",
@@ -36,6 +35,8 @@
     "ember-data": "2.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.4",
-    "ember-resolver": "^2.0.2"
+    "ember-resolver": "^2.0.2",
+    "ember-ajax": "0.6.2",
+    "ember-export-application-global": "^1.0.3"
   }
 }


### PR DESCRIPTION
In this PR, I'm proposing that we replace [`ember-cli-ic-ajax`](https://github.com/rwjblue/ember-cli-ic-ajax) with [`ember-ajax`](https://github.com/embersherpa/ember-ajax) as the default mechanism for making ajax requests. 

**Notable difference**
- ajax code pulled from Ember Data
- doesn't wrap in Ember.run (with Ember 1.13+ in mind)
- uses a service which can be extended and customized
- uses Ember Data like error handing
- allows `ember-cli-mirage` to provide fixture functionality
- provides backwards compatibility for `ic-ajax` but `request` and `raw` are deprecated and will be removed in the future

The addon doesn't automatically provide an `app/services/ajax.js` service because it's designed to be opt-in. I added it to the blueprint, so the new apps opt-in to use it right away. 

I want to start a discussion.
Please, share your thoughts.

/cc @stefanpenner @rwjblue @mixonic @bcardarella @bmac 