### PR TITLE
[BUGFIX] fixes #4595 limiting blueprint template interpolation to <%= %>

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -10,7 +10,12 @@ var EOL          = require('os').EOL;
 var isBinaryFile = require('isbinaryfile');
 
 function processTemplate(content, context) {
-  return require('lodash/string/template')(content)(context);
+  var options = {
+    evaluate:    /<%([\s\S]+?)%>/g,
+    interpolate: /<%=([\s\S]+?)%>/g,
+    escape:      /<%-([\s\S]+?)%>/g
+  };
+  return require('lodash/string/template')(content, options)(context);
 }
 
 function diffHighlight(line) {

--- a/tests/fixtures/file-info/interpolate.txt
+++ b/tests/fixtures/file-info/interpolate.txt
@@ -1,0 +1,1 @@
+{{ name }} ${ name } <% name %> <%- name %> <%= name %>

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -43,6 +43,16 @@ describe('Unit - FileInfo', function(){
     new FileInfo(validOptions);
   });
 
+  it('does not interpolate {{ }} or ${ }', function () {
+    var options = {};
+    assign(options, validOptions, {inputPath:  path.resolve(__dirname,
+      '../../fixtures/file-info/interpolate.txt'), templateVariables: { name: 'tacocat' }});
+    var fileInfo = new FileInfo(options);
+    return fileInfo.render().then(function(output) {
+      expect(output.trim()).to.equal('{{ name }} ${ name }  tacocat tacocat');
+    });
+  });
+
   it('renders an input file', function(){
     validOptions.templateVariables.friend = 'Billy';
     var fileInfo = new FileInfo(validOptions);


### PR DESCRIPTION
Fixes #4595
The file-info model, which processes the blueprint templates, uses the [lodash template method](https://lodash.com/docs#template) under the hood. Previously we were not limiting the interpolation tokens to `<%= %>` as we describe in the docs. This was causing instances of `{{ }}` and `${ }` to interpolate as well, causing unexpected results for some blueprint creators.

This PR limits the interpolation token to `<%= %>`.