### PR TITLE
Update examples to use Ember.Helper.helper

### DIFF
--- a/_posts/2014-04-02-using-modules-and-the-resolver.md
+++ b/_posts/2014-04-02-using-modules-and-the-resolver.md
@@ -108,9 +108,11 @@ under `app/helpers`. If your custom helper contains a dash(`upper-case`,
 // app/helpers/upper-case.js
 import Ember from "ember";
 
-export default Ember.Handlebars.makeBoundHelper(function(value, options) {
-  return value.toUpperCase();
+export function upperCase(args, options) {
+  return args[0].toUpperCase();
 });
+
+export default Ember.Helper.helper(upperCase);
 {% endhighlight %}
 
 In `some-template.hbs`:
@@ -129,15 +131,15 @@ explicitly:
 
 {% highlight javascript linenos %}
 // app/helpers/trim.js
-export default function(value, options) {
-  return value.trim();
+export default function(args, options) {
+  return args[0].trim();
 };
 
 // app.js
 import Ember from "ember";
 import trimHelper from './helpers/trim';
 
-Ember.Handlebars.registerBoundHelper('trim', trimHelper);
+Ember.Helper.helper('trim', trimHelper);
 {% endhighlight %}
 
 In `some-template.hbs`:
@@ -149,7 +151,7 @@ In `some-template.hbs`:
 {% endhighlight %}
 
 In this example the helper is loaded explicitly. It's the first
-argument to `registerBoundHelper` which makes the Handlebars renderer find it.
+argument to `helper` which allows the renderer to find it.
 The file name (`trim.js`) and the name of the variable it's been imported
 into (`trimHelper`) could have been anything.
 

--- a/_posts/2014-04-02-using-modules-and-the-resolver.md
+++ b/_posts/2014-04-02-using-modules-and-the-resolver.md
@@ -83,7 +83,7 @@ Directory           | Purpose
 --------------------|
 `app/adapters/`     | Adapters with the convention `adapter-name.js`.
 `app/components/`   | Components with the convention `component-name.js`. Components must have a dash in their name. So `blog-post` is an acceptable name, but `post` is not.
-`app/helpers/`      | Helpers with the convention `helper-name.js`. Helpers must have a dash in their name. Remember that you must register your helpers by exporting `makeBoundHelper` or calling `registerBoundHelper` explicitly.
+`app/helpers/`      | Helpers with the convention `helper-name.js`. Helpers must have a dash in their name. Remember that you must register your helpers by exporting `Ember.Helper.helper`.
 `app/initializers/` | Initializers with the convention `initializer-name.js`. Initializers are loaded automatically.
 `app/mixins/`       | Mixins with the convention `mixin-name.js`.
 `app/models/`       | Models with the convention `model-name.js`.


### PR DESCRIPTION
Thanks for all the work done on ember-cli! I really appreciate all the hard work put in.

As per http://guides.emberjs.com/v1.13.0/templates/writing-helpers/#toc_helper-arguments
this commit updates http://www.ember-cli.com/user-guide/#resolving-handlebars-helpers
to use examples for the `Ember.Helper.helper` over the deprecated
`Ember.Handlebars.registerBoundHelper`

The command `ember generate helper foo-bar` also produces this output.

Stylistically this uses destructuring assignment as in the Ember docs example.

I hope this is helpful.