### PR TITLE
[INTERNAL] Refactored component-test blueprint to use template conditional instead of string building

### DIFF
--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -1,9 +1,34 @@
-import { moduleForComponent, test } from 'ember-qunit';<%= testImports %>
+import { moduleForComponent, test } from 'ember-qunit';<% if (testType === 'integration') { %>
+import hbs from 'htmlbars-inline-precompile';<% } %>
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
-  <%= testOptions %>
+  <% if (testType === 'integration' ) { %>integration: true<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true<% } %>
 });
 
 test('it renders', function(assert) {
-  <%= testContent %>
+  <% if (testType === 'integration' ) { %>assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{<%= componentPathName %>}}`);
+
+  assert.equal(this.$().text(), '');
+
+  // Template block usage:" + EOL +
+  this.render(hbs`
+    {{#<%= componentPathName %>}}
+      template block text
+    {{/<%= componentPathName %>}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>assert.expect(1);
+
+  // Creates the component instance
+  var component = this.subject();
+  // Renders the component to the page
+  this.render();
+  assert.equal(this.$().text(), '');<% } %>
 });

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -4,7 +4,6 @@ var path          = require('path');
 var testInfo      = require('../../lib/utilities/test-info');
 var stringUtil    = require('../../lib/utilities/string');
 var getPathOption = require('../../lib/utilities/get-component-path-option');
-var EOL           = require('os').EOL;
 
 module.exports = {
   description: 'Generates a component integration or unit test.',
@@ -39,48 +38,21 @@ module.exports = {
   locals: function(options) {
     var dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     var componentPathName = dasherizedModuleName;
-    var testImports = EOL + "import hbs from 'htmlbars-inline-precompile';";
-    var testOptions = "integration: true";
+    var testType = options.testType || "integration";
     var friendlyTestDescription = testInfo.description(options.entity.name, "Integration", "Component");
-    var testContent = "assert.expect(2);" + EOL + EOL +
-      "  // Set any properties with this.set('myProperty', 'value');" + EOL +
-      "  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
-      "  this.render(hbs`{{" + dasherizedModuleName + "}}`);" + EOL + EOL +
-      "  assert.equal(this.$().text().trim(), '');" + EOL + EOL +
-      "  // Template block usage:" + EOL +
-      "  this.render(hbs`" + EOL +
-      "    {{#" + dasherizedModuleName + "}}" + EOL +
-      "      template block text" + EOL +
-      "    {{/" + dasherizedModuleName + "}}" + EOL +
-      "  `);" + EOL + EOL +
-      "  assert.equal(this.$().text().trim(), 'template block text');";
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
 
     if (options.testType === 'unit') {
-      testImports = "";
-      testOptions = "// Specify the other units that are required for this test" +
-        EOL + "  // needs: ['component:foo', 'helper:bar']," + EOL + "  unit: true";
-
-      testContent = "assert.expect(1);" + EOL + EOL +
-        "  // Creates the component instance" + EOL +
-        "  var component = this.subject();" + EOL +
-        "  // Renders the component to the page" + EOL +
-        "  this.render();" + EOL +
-        "  assert.equal(this.$().text().trim(), '');";
-
       friendlyTestDescription = testInfo.description(options.entity.name, "Unit", "Component");
     }
 
     return {
       path: getPathOption(options),
-      testType: options.testType,
-      testImports: testImports,
-      testContent: testContent,
+      testType: testType,
       componentPathName: componentPathName,
-      testOptions: testOptions,
       friendlyTestDescription: friendlyTestDescription
     };
   }

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -132,7 +132,9 @@ describe('Acceptance: ember generate in-addon', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -145,7 +147,9 @@ describe('Acceptance: ember generate in-addon', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
       assertFileToNotExist('app/component-test/x-foo.js');
@@ -189,7 +193,9 @@ describe('Acceptance: ember generate in-addon', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('nested/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{nested/x-foo}}",
+          "{{#nested/x-foo}}"
         ]
       });
     });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -112,7 +112,9 @@ describe('Acceptance: ember generate', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -135,7 +137,9 @@ describe('Acceptance: ember generate', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{foo/x-foo}}",
+          "{{#foo/x-foo}}"
         ]
       });
     });
@@ -158,7 +162,9 @@ describe('Acceptance: ember generate', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -171,12 +177,14 @@ describe('Acceptance: ember generate', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
   });
-  
+
   it('component-test x-foo --unit', function() {
     return generate(['component-test', 'x-foo', '--unit']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -137,7 +137,9 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -150,7 +152,9 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -298,7 +298,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -321,7 +323,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{foo/x-foo}}",
+          "{{#foo/x-foo}}"
         ]
       });
     });
@@ -344,7 +348,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{foo/x-foo}}",
+          "{{#foo/x-foo}}"
         ]
       });
     });
@@ -367,7 +373,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/x-foo}}",
+          "{{#bar/x-foo}}"
         ]
       });
     });
@@ -390,7 +398,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/x-foo}}",
+          "{{#bar/x-foo}}"
         ]
       });
     });
@@ -413,7 +423,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/foo/x-foo}}",
+          "{{#bar/foo/x-foo}}"
         ]
       });
     });
@@ -435,7 +447,9 @@ describe('Acceptance: ember generate pod', function() {
         contains: [
           "import { moduleForComponent, test } from 'ember-qunit';",
           "moduleForComponent('bar/foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/foo/x-foo}}",
+          "{{#bar/foo/x-foo}}"
         ]
       });
     });
@@ -458,7 +472,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/baz/x-foo}}",
+          "{{#bar/baz/x-foo}}"
         ]
       });
     });
@@ -481,7 +497,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/baz/x-foo}}",
+          "{{#bar/baz/x-foo}}"
         ]
       });
     });
@@ -504,7 +522,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/baz/foo/x-foo}}",
+          "{{#bar/baz/foo/x-foo}}"
         ]
       });
     });
@@ -527,7 +547,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('bar/baz/foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{bar/baz/foo/x-foo}}",
+          "{{#bar/baz/foo/x-foo}}"
         ]
       });
     });
@@ -550,7 +572,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -573,7 +597,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{x-foo}}",
+          "{{#x-foo}}"
         ]
       });
     });
@@ -596,7 +622,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{foo/x-foo}}",
+          "{{#foo/x-foo}}"
         ]
       });
     });
@@ -619,7 +647,9 @@ describe('Acceptance: ember generate pod', function() {
           "import { moduleForComponent, test } from 'ember-qunit';",
           "import hbs from 'htmlbars-inline-precompile';",
           "moduleForComponent('foo/x-foo'",
-          "integration: true"
+          "integration: true",
+          "{{foo/x-foo}}",
+          "{{#foo/x-foo}}"
         ]
       });
     });


### PR DESCRIPTION
Previously we were building strings for content in the component-test blueprint. This PR fixes that by using evaluation tokens to conditionally select content:
```
<% if (testType === 'integration') { %>
integration content
<% } else if (testType === 'unit') { %>
unit content
<% } %>
```