### PR TITLE
[BUGFIX] fixes resource generator when invoked without entity name

### DIFF
--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -48,9 +48,11 @@ module.exports = {
   },
 
   _process: function(type, options) {
+    var entityName = options.entity.name;
+
     var modelOptions = merge({}, options, {
       entity: {
-        name: inflection.singularize(options.entity.name)
+        name: entityName ? inflection.singularize(entityName) : ''
       }
     });
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -18,6 +18,7 @@ var tmproot          = path.join(root, 'tmp');
 var EOL              = require('os').EOL;
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 var expect           = require('chai').expect;
+var MockUI             = require('../helpers/mock-ui');
 
 describe('Acceptance: ember generate', function() {
   this.timeout(10000);
@@ -483,6 +484,19 @@ describe('Acceptance: ember generate', function() {
         contains: "moduleFor('route:foos'"
       });
     });
+  });
+
+  it('resource without entity name does not throw exception', function() {
+
+    var restoreWriteError = MockUI.prototype.writeError;
+    MockUI.prototype.writeError = function(error) {
+      expect(error.message).to.equal('The `ember generate` command requires an entity name to be specified. For more details, use `ember help`.');
+    };
+
+    return generate(['resource']).then(function() {
+      MockUI.prototype.writeError = restoreWriteError;
+    });
+
   });
 
   it('resource foos with --path', function() {


### PR DESCRIPTION
addresses #4665 

Currently, when running `ember generate resource` without specifying an entity name, the user does not get the nice `SilentError` message but a stack trace because at some point it tries to inflect `undefined`.

This PR fixes that bug and also adds a regression test