### PR TITLE
Update jquery

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.1.0",
-    "jquery": "^1.11.3",
+    "jquery": "^2.1.4",
     "loader.js": "ember-cli/loader.js#3.3.0",
     "qunit": "~1.19.0"
   },


### PR DESCRIPTION
Since **IE8** compatibility is being dropped, **jquery 2.x** can be used now.
Related to #4666.