### PR TITLE
[BUGFIX] disallow `app` as project name

### DIFF
--- a/lib/utilities/valid-project-name.js
+++ b/lib/utilities/valid-project-name.js
@@ -3,7 +3,7 @@
 module.exports = function(name) {
   name = name.toLowerCase();
 
-  if (['test', 'ember', 'ember-cli', 'vendor'].indexOf(name) > -1) { return false; }
+  if (['test', 'ember', 'ember-cli', 'vendor', 'app'].indexOf(name) > -1) { return false; }
   if (name.indexOf('.') > -1) { return false; }
   if (!isNaN(parseInt(name.charAt(0), 10))) { return false; }
 

--- a/tests/unit/utilities/valid-project-name-test.js
+++ b/tests/unit/utilities/valid-project-name-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var validProjectName = require('../../../lib/utilities/valid-project-name');
+var expect             = require('chai').expect;
+
+describe('validate project name', function(){
+  it('invalidates nonconformant project name', function(){
+    var nonConformantName = 'app';
+    var validated = validProjectName(nonConformantName);
+
+    expect(validated).to.not.be.ok;
+  });
+
+
+  it('validates conformant project name', function(){
+    var conformantName = 'my-app';
+    var validated = validProjectName(conformantName);
+
+    expect(validated).to.be.ok;
+  });
+});


### PR DESCRIPTION
addresses #4631

In march, PR #3642 prevented the style sheet name from having the same name as the project (happens to be the case for `ember new app`. So currently you __can__ invoke `ember new app` but get into trouble as soon as you try `ember serve`.

This PR fixes the issue by disallowing `app` as a project name altogether and adds a regression test.
