### PR TITLE
[BUGFIX] rethrow exceptions after logging

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -163,6 +163,7 @@ CLI.prototype.logError = function(error) {
     if (error.stack) {
       console.error(error.stack);
     }
+    throw error;
   }
   this.ui.errorLog.push(error);
   this.ui.writeError(error);

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -134,7 +134,7 @@ Command.prototype.validateAndRun = function(args) {
 
   if (this.works === 'outsideProject' && this.isWithinProject) {
     return Promise.reject(new SilentError(
-      'You cannot use the ' +  chalk.green(this.name) + ' command inside an ember-cli project.'
+      'You cannot use the ' + chalk.green(this.name) + ' command inside an ember-cli project.'
     ));
   }
 
@@ -232,7 +232,7 @@ Command.prototype.assignOption = function(option, parsedOptions, commandOptions)
     }
   } else {
     this.ui.writeLine('The specified command ' + chalk.green(this.name) +
-                     ' requires the option ' + chalk.green(option.name) + '.');
+                      ' requires the option ' + chalk.green(option.name) + '.');
   }
   return isValid;
 };

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -875,7 +875,8 @@ describe('Acceptance: ember generate in-addon', function() {
 
   it('in-addon addon-import cannot be called directly', function() {
     return generateInAddon(['addon-import', 'foo']).catch(function(error) {
-      expect(error.errorLog[0].message).to.contain('You cannot call the addon-import blueprint directly.');
+      expect(error.name).to.equal('SilentError');
+      expect(error.message).to.equal('You cannot call the addon-import blueprint directly.');
     });
   });
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -520,11 +520,12 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
-  it('resource without entity name does not throw exception', function() {
+  it('resource without entity name does throw a warning', function() {
     return generate(['resource']).then(function() {
       expect(false).to.be.ok;
     }, function(err) {
-      expect(err.errorLog[0].message).to.equal('The `ember generate <entity-name>` command requires an entity name to be specified. For more details, use `ember help`.');
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.equal('The `ember generate <entity-name>` command requires an entity name to be specified. For more details, use `ember help`.');
     });
   });
 
@@ -755,7 +756,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'application', '--base-class=application']).then(function() {
       expect(false).to.be.ok;
     }, function(err) {
-      expect(err.errorLog[0]).to.match(/Adapters cannot extend from themself/);
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.match(/Adapters cannot extend from themself/);
     });
   });
 
@@ -763,7 +765,8 @@ describe('Acceptance: ember generate', function() {
     return generate(['adapter', 'foo', '--base-class=foo']).then(function() {
       expect(false).to.be.ok;
     }, function(err) {
-      expect(err.errorLog[0]).to.match(/Adapters cannot extend from themself/);
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.match(/Adapters cannot extend from themself/);
     });
   });
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -14,6 +14,7 @@ var util       = require('util');
 var conf       = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var EOL        = require('os').EOL;
 var assertFile = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
+var chalk      = require('chalk');
 
 describe('Acceptance: ember new', function() {
   this.timeout(10000);
@@ -71,8 +72,9 @@ describe('Acceptance: ember new', function() {
       ''
     ]).then(function() {
       throw new Error('this promise should be rejected');
-    }, function(result) {
-      expect(result.errorLog[0].message).to.contain('The `ember new` command requires a name to be specified.');
+    }, function(err) {
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
     });
   });
 
@@ -81,8 +83,9 @@ describe('Acceptance: ember new', function() {
       'new'
     ]).then(function() {
       throw new Error('this promise should be rejected');
-    }, function(result) {
-      expect(result.errorLog[0].message).to.contain('The `ember new` command requires a name to be specified.');
+    }, function(err) {
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
     });
   });
 
@@ -117,9 +120,10 @@ describe('Acceptance: ember new', function() {
         '--skip-git'
       ]).then(function() {
         throw new Error('this promise should be rejected');
-      }, function(result) {
-        expect(result.errorLog[0].message).to.match(/You cannot use the .*new.* command inside an ember-cli project./);
+      }).catch(function(error) {
         expect(existsSync('foo')).to.be.false;
+        expect(error.name).to.equal('SilentError');
+        expect(error.message).to.equal('You cannot use the ' + chalk.green('new') + ' command inside an ember-cli project.');
       });
     }).then(confirmBlueprinted);
   });
@@ -167,7 +171,7 @@ describe('Acceptance: ember new', function() {
   });
 
 
-  it('ember new with git blueprint uses checks out the blueprint and uses it', function() {
+  it('ember new with git blueprint checks out the blueprint and uses it', function() {
     this.timeout(20000); // relies on GH network stuff
 
     return ember([

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1323,7 +1323,8 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'application', '--base-class=application', '--pod']).then(function() {
       expect(false).to.be.ok;
     }, function(err) {
-      expect(err.errorLog[0]).to.match(/Adapters cannot extend from themself/);
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.match(/Adapters cannot extend from themself/);
     });
   });
 
@@ -1331,7 +1332,8 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['adapter', 'foo', '--base-class=foo', '--pod']).then(function() {
       expect(false).to.be.ok;
     }, function(err) {
-      expect(err.errorLog[0]).to.match(/Adapters cannot extend from themself/);
+      expect(err.name).to.equal('SilentError');
+      expect(err.message).to.match(/Adapters cannot extend from themself/);
     });
   });
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -554,10 +554,11 @@ describe('Unit: CLI', function() {
     var help = stubValidateAndRun('help');
 
     return ember(['unknownCommand']).then(function() {
-      var errors = ui.errors.trim().split(EOL);
-      var helpfulMessage = /The specified command .*unknownCommand.* is invalid\. For available options/;
-      expect(errors[0]).to.match(helpfulMessage, 'expected an invalid command message');
+      expect(false).to.be.ok;
+    }).catch(function(error) {
       expect(help.called, 'help command was executed').to.not.be.ok;
+      expect(error.name).to.equal('SilentError');
+      expect(error.message).to.equal('The specified command unknownCommand is invalid. For available options, see `ember help`.');
     });
   });
 
@@ -575,6 +576,39 @@ describe('Unit: CLI', function() {
     });
   });
 
+  describe('logError', function() {
+    it('returns error status code in production', function() {
+      var cli = new CLI({
+        ui: new MockUI(),
+        testing: false
+      });
+
+      expect(cli.logError('foo')).to.equal(1);
+    });
+
+    it('does not throw an error in production', function() {
+      var cli = new CLI({
+        ui: new MockUI(),
+        testing: false
+      });
+
+      var invokeError = cli.logError.bind(cli, new Error('foo'));
+
+      expect(invokeError).to.not.throw();
+    });
+
+    it('throws error in testing', function() {
+      var cli = new CLI({
+        ui: new MockUI(),
+        testing: true
+      });
+
+      var invokeError = cli.logError.bind(cli, new Error('foo'));
+
+      expect(invokeError).to.throw(Error, 'foo');
+    });
+  });
+
   describe('Global command options', function() {
     var verboseCommand = function(args) {
       return ember(['fake-command', '--verbose'].concat(args));
@@ -589,22 +623,34 @@ describe('Unit: CLI', function() {
 
         it('sets process.env.EMBER_VERBOSE_${NAME} for each space delimited option', function() {
           return verboseCommand(['fake_option_1', 'fake_option_2']).then(function() {
+            expect(false).to.be.true;
+          }).catch(function(error) {
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_1).to.be.ok;
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_2).to.be.ok;
+            expect(error.name).to.equal('SilentError');
+            expect(error.message).to.equal('The specified command fake-command is invalid. For available options, see `ember help`.');
           });
         });
 
         it('ignores verbose options after --', function() {
           return verboseCommand(['fake_option_1', '--fake-option', 'fake_option_2']).then(function() {
+            expect(false).to.be.true;
+          }).catch(function(error) {
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_1).to.be.ok;
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_2).to.not.be.ok;
+            expect(error.name).to.equal('SilentError');
+            expect(error.message).to.equal('The specified command fake-command is invalid. For available options, see `ember help`.');
           });
         });
 
         it('ignores verbose options after -', function() {
           return verboseCommand(['fake_option_1', '-f', 'fake_option_2']).then(function() {
+            expect(false).to.be.true;
+          }).catch(function(error) {
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_1).to.be.ok;
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_2).to.not.be.ok;
+            expect(error.name).to.equal('SilentError');
+            expect(error.message).to.equal('The specified command fake-command is invalid. For available options, see `ember help`.');
           });
         });
       });


### PR DESCRIPTION
Currently the `logError` message of the internal `Cli` object is swallowing all exceptions. While I have not discovered any user facing bugs due to this yet, it was a pain to write tests, checking for `SilentError`s and I also found a few tests that where falsely relying on that method not throwing.