### PR TITLE
[BUGFIX] remove non-dash helper warning

### DIFF
--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -1,6 +1,5 @@
 'use strict';
 /*jshint node:true*/
-var chalk = require('chalk');
 var Blueprint   = require('../../lib/models/blueprint');
 
 module.exports = {
@@ -8,9 +7,6 @@ module.exports = {
   normalizeEntityName: function(entityName) {
     entityName = Blueprint.prototype.normalizeEntityName.apply(this, arguments);
 
-    if (entityName.indexOf('-') === -1) {
-      this.ui.write(chalk.yellow('[WARN]: helpers without a dash will not automatically be resolved \n'));
-    }
     return entityName;
   }
 };


### PR DESCRIPTION
addresses #4499

This PR is removing the warning message for when users generate dash-less template helpers since they __do__ get resolved nowadays.

I felt like this should not get a regression test right? 