### PR TITLE
[BUGFIX release] fixes #4330 adding `--classic` flag to destroy and generate commands

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -17,7 +17,10 @@ module.exports = Command.extend({
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'pod', type: Boolean, default: false, aliases: ['p'] },
-    { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir']}
+    { name: 'classic', type: Boolean, default: false, aliases: ['c'] },
+    { name: 'dummy', type: Boolean, default: false, aliases: ['dum','id'] },
+    { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir'] }
+
   ],
 
   anonymousOptions: [
@@ -64,7 +67,7 @@ module.exports = Command.extend({
       args: rawArgs
     };
 
-    if(this.settings && this.settings.usePods) {
+    if(this.settings && this.settings.usePods && !commandOptions.classic) {
       commandOptions.pod = !commandOptions.pod;
     }
 

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -23,8 +23,9 @@ module.exports = Command.extend({
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'pod', type: Boolean, default: false, aliases: ['p'] },
-    { name: 'dummy', type: Boolean, default: false, aliases: ['dum','id']},
-    { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir']}
+    { name: 'classic', type: Boolean, default: false, aliases: ['c'] },
+    { name: 'dummy', type: Boolean, default: false, aliases: ['dum','id'] },
+    { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir'] }
   ],
 
   anonymousOptions: [
@@ -67,7 +68,7 @@ module.exports = Command.extend({
       args: rawArgs
     };
 
-    if (this.settings && this.settings.usePods) {
+    if (this.settings && this.settings.usePods && !commandOptions.classic) {
       commandOptions.pod = !commandOptions.pod;
     }
 

--- a/tests/acceptance/help/help-destroy-test.js
+++ b/tests/acceptance/help/help-destroy-test.js
@@ -43,6 +43,10 @@ ember destroy \u001b[33m<blueprint>\u001b[39m\u001b[36m <options...>\u001b[39m' 
     aliases: -v\u001b[39m' + EOL + '\
 \u001b[36m  --pod\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
     aliases: -p\u001b[39m' + EOL + '\
+\u001b[36m  --classic\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
+    aliases: -c\u001b[39m' + EOL + '\
+\u001b[36m  --dummy\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
+    aliases: -dum, -id\u001b[39m' + EOL + '\
 \u001b[36m  --in-repo-addon\u001b[39m\u001b[36m (String)\u001b[39m\u001b[36m (Default: null)\u001b[39m\u001b[90m' + EOL + '\
     aliases: -in-repo <value>, -ir <value>\u001b[39m' + EOL + '\
 ' + EOL + '\

--- a/tests/acceptance/help/help-generate-test.js
+++ b/tests/acceptance/help/help-generate-test.js
@@ -43,6 +43,8 @@ ember generate \u001b[33m<blueprint>\u001b[39m\u001b[36m <options...>\u001b[39m'
     aliases: -v\u001b[39m' + EOL + '\
 \u001b[36m  --pod\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
     aliases: -p\u001b[39m' + EOL + '\
+\u001b[36m  --classic\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
+    aliases: -c\u001b[39m' + EOL + '\
 \u001b[36m  --dummy\u001b[39m\u001b[36m (Boolean)\u001b[39m\u001b[36m (Default: false)\u001b[39m\u001b[90m' + EOL + '\
     aliases: -dum, -id\u001b[39m' + EOL + '\
 \u001b[36m  --in-repo-addon\u001b[39m\u001b[36m (String)\u001b[39m\u001b[36m (Default: null)\u001b[39m\u001b[90m' + EOL + '\

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -213,8 +213,8 @@ describe('Acceptance: ember destroy pod', function() {
     return assertDestroyAfterGenerateWithUsePods(commandArgs, files);
   });
 
-  it('.ember-cli usePods setting destroys in basic structure with --pod flag', function() {
-    var commandArgs = ['controller', 'foo', '--pod'];
+  it('.ember-cli usePods setting destroys in classic structure with --classic flag', function() {
+    var commandArgs = ['controller', 'foo', '--classic'];
     var files       = [
       'app/controllers/foo.js',
       'tests/unit/controllers/foo-test.js'

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -150,8 +150,8 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
-  it('.ember-cli usePods setting generates in basic structure with --pod flag', function() {
-    return generateWithUsePods(['controller', 'foo', '--pod']).then(function() {
+  it('.ember-cli usePods setting generates in classic structure with --classic flag', function() {
+    return generateWithUsePods(['controller', 'foo', '--classic']).then(function() {
       assertFile('app/controllers/foo.js', {
         contains: [
           "import Ember from 'ember';",


### PR DESCRIPTION
The behavior of the `--pod` flag when the `usePods` setting is true has proven confusing to a lot of users. This PR adds a `--classic` flag (alias `-c`) that will generate a blueprint in classic structure. It is only effective when `usePods` is true, and does not have precedence over the `--pod` flag.

When a user generates or destroys with the `--pod` flag with `usePods` true, the blueprint will now be generated or destroyed in pod structure as would be expected.

so for example with `usePods` true in your project:
```
ember g component foo-bar --classic
// generates
app/components/foo-bar.js
app/templates/components/foo-bar.hbs
```