### PR TITLE
[BUGFIX release] addonLintTree copies falsey logic from addonTreesFor

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -116,6 +116,9 @@ function EmberApp() {
   this.populateLegacyFiles();
   p.setupRegistry(this);
   this._notifyAddonIncluded();
+
+  // for test stubbing
+  this._mergeTrees = mergeTrees;
 }
 
 /**
@@ -357,7 +360,7 @@ EmberApp.prototype.addonTreesFor = function(type) {
     if (addon.treeFor) {
       return addon.treeFor(type);
     }
-  }, this).filter(Boolean);
+  }).filter(Boolean);
 };
 
 /**
@@ -462,13 +465,12 @@ EmberApp.prototype.addonPreprocessTree = function(type, tree) {
   @return {Tree}        Processed tree
  */
 EmberApp.prototype.addonLintTree = function(type, tree) {
-  var output = [];
-  this.project.addons.forEach(function(addon) {
+  var output = this.project.addons.map(function(addon) {
     if (addon.lintTree) {
-      output.push(addon.lintTree(type, tree));
+      return addon.lintTree(type, tree);
     }
-  });
-  return mergeTrees(output,{
+  }).filter(Boolean);
+  return this._mergeTrees(output, {
     overwrite: true,
     annotation: 'TreeMerger (lint)'
   });
@@ -600,7 +602,7 @@ EmberApp.prototype.publicTree = function() {
     trees.push(this.trees.public);
   }
 
-  return mergeTrees(trees, {
+  return this._mergeTrees(trees, {
     overwrite: true,
     annotation: 'TreeMerge (public)'
   });
@@ -614,7 +616,7 @@ EmberApp.prototype.publicTree = function() {
 */
 EmberApp.prototype._processedAppTree = function() {
   var addonTrees = this.addonTreesFor('app');
-  var mergedApp  = mergeTrees(addonTrees.concat(this._filterAppTree()), {
+  var mergedApp  = this._mergeTrees(addonTrees.concat(this._filterAppTree()), {
     overwrite: true,
     annotation: 'TreeMerger (app)'
   });
@@ -633,7 +635,7 @@ EmberApp.prototype._processedAppTree = function() {
 EmberApp.prototype._processedTemplatesTree = function() {
   var addonTrees = this.addonTreesFor('templates');
   var mergedTrees = this.trees.templates ? addonTrees.concat(this.trees.templates) : addonTrees;
-  var mergedTemplates = mergeTrees(mergedTrees, {
+  var mergedTemplates = this._mergeTrees(mergedTrees, {
     overwrite: true,
     annotation: 'TreeMerger (templates)'
   });
@@ -650,7 +652,7 @@ EmberApp.prototype._processedTemplatesTree = function() {
     annotation: 'Funnel: Pod Templates'
   });
 
-  var templates = this.addonPreprocessTree('template', mergeTrees([
+  var templates = this.addonPreprocessTree('template', this._mergeTrees([
     standardTemplates,
     podTemplates
   ], { annotation: 'addonPreprocessTree(template)' }));
@@ -679,7 +681,7 @@ EmberApp.prototype._podTemplatePatterns = function() {
 */
 EmberApp.prototype._processedTestsTree = function() {
   var addonTrees  = this.addonTreesFor('test-support');
-  var mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
+  var mergedTests = this._mergeTrees(addonTrees.concat(this.trees.tests), {
     overwrite: true,
     annotation: 'TreeMerger (tests)'
   });
@@ -722,7 +724,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
     return this._cachedAddonTree;
   }
 
-  var addonTrees = mergeTrees(this.addonTreesFor('addon'), {
+  var addonTrees = this._mergeTrees(this.addonTreesFor('addon'), {
     overwrite: true,
     annotation: 'TreeMerger (addons)'
   });
@@ -751,7 +753,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
     }
   });
 
-  var reexportsAndTranspiledAddonTree = mergeTrees([
+  var reexportsAndTranspiledAddonTree = this._mergeTrees([
     transpiledAddonTree,
     addonReexports
   ], {
@@ -793,7 +795,7 @@ EmberApp.prototype._processedVendorTree = function() {
     trees.push(this.trees.vendor);
   }
 
-  var mergedVendor = mergeTrees(trees, {
+  var mergedVendor = this._mergeTrees(trees, {
     overwrite: true,
     annotation: 'TreeMerger (vendor)'
   });
@@ -824,7 +826,7 @@ EmberApp.prototype._processedExternalTree = function() {
     trees.unshift(bower);
   }
 
-  return this._cachedExternalTree = mergeTrees(trees, {
+  return this._cachedExternalTree = this._mergeTrees(trees, {
     annotation: 'TreeMerger (ExternalTree)'
   });
 };
@@ -922,7 +924,7 @@ EmberApp.prototype.appAndDependencies = function() {
 
   sourceTrees.push(emberCLITree);
 
-  return mergeTrees(sourceTrees, {
+  return this._mergeTrees(sourceTrees, {
     overwrite: true,
     description: 'TreeMerger (appAndDependencies)'
   });
@@ -990,7 +992,7 @@ EmberApp.prototype.javascript = function() {
     }
   );
 
-  appJs = mergeTrees([
+  appJs = this._mergeTrees([
     appJs,
     this._processedEmberCLITree()
   ], {
@@ -1022,7 +1024,7 @@ EmberApp.prototype.javascript = function() {
     description: 'Concat: Vendor'
   });
 
-  return mergeTrees([
+  return this._mergeTrees([
       vendor,
       appJs
     ], {
@@ -1057,7 +1059,7 @@ EmberApp.prototype.styles = function() {
   var trees = [external].concat(addonTrees);
   trees.push(styles);
 
-  var stylesAndVendor = this.addonPreprocessTree('css', mergeTrees(trees, {
+  var stylesAndVendor = this.addonPreprocessTree('css', this._mergeTrees(trees, {
     annotation: 'TreeMerger (stylesAndVendor)',
     overwrite: true
   }));
@@ -1080,7 +1082,7 @@ EmberApp.prototype.styles = function() {
     vendorStyles    = preprocessMinifyCss(vendorStyles, options);
   }
 
-  var mergedTrees = mergeTrees([
+  var mergedTrees = this._mergeTrees([
       preprocessedStyles,
       vendorStyles
     ], {
@@ -1113,7 +1115,7 @@ EmberApp.prototype.testFiles = function() {
     description: 'Concat: Test Support JS'
   });
 
-  testJs = this.concatFiles(mergeTrees([testJs, emberCLITree]), {
+  testJs = this.concatFiles(this._mergeTrees([testJs, emberCLITree]), {
     inputFiles: [
       'vendor/ember-cli/test-support-prefix.js',
       testSupportPath.slice(1),
@@ -1155,7 +1157,7 @@ EmberApp.prototype.testFiles = function() {
     testemTree
   ];
 
-  return mergeTrees(sourceTrees, {
+  return this._mergeTrees(sourceTrees, {
       overwrite: true,
       annotation: 'TreeMerger (testFiles)'
     });
@@ -1178,7 +1180,7 @@ EmberApp.prototype.otherAssets = function() {
       destDir: path.dest
     });
   });
-  return mergeTrees(otherAssetTrees, {
+  return this._mergeTrees(otherAssetTrees, {
     annotation: 'TreeMerger (otherAssetTrees)'
   });
 };
@@ -1365,7 +1367,7 @@ EmberApp.prototype.toArray = function() {
   @return {Tree}                  Merged tree for this application
  */
 EmberApp.prototype.toTree = function(additionalTrees) {
-  var tree = mergeTrees(this.toArray().concat(additionalTrees || []), {
+  var tree = this._mergeTrees(this.toArray().concat(additionalTrees || []), {
     overwrite: true,
     description: 'TreeMerger (allTrees)'
   });

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -461,6 +461,71 @@ describe('broccoli/ember-app', function() {
       });
 
     });
+
+    describe('addonLintTree', function() {
+      beforeEach(function() {
+        addon = { };
+
+        project.initializeAddons = function() {
+          this.addons = [ addon ];
+        };
+
+        emberApp = new EmberApp({
+          project: project
+        });
+      });
+
+      it('does not throw an error if lintTree is not defined', function() {
+        emberApp.addonLintTree();
+      });
+
+      it('calls lintTree on the addon', function() {
+        var actualType, actualTree;
+
+        addon.lintTree = function(type, tree) {
+          actualType = type;
+          actualTree = tree;
+
+          return 'blazorz';
+        };
+
+        var assertionsWereRun;
+
+        emberApp._mergeTrees = function(inputTree, options) {
+          expect(inputTree).to.deep.equal(['blazorz']);
+          expect(options).to.deep.equal({
+            overwrite: true,
+            annotation: 'TreeMerger (lint)'
+          });
+
+          assertionsWereRun = true;
+        };
+
+        emberApp.addonLintTree('blah', 'blam');
+
+        expect(actualType).to.equal('blah');
+        expect(actualTree).to.equal('blam');
+        expect(assertionsWereRun).to.be.true;
+      });
+
+      it('filters out tree if lintTree returns falsey', function() {
+        addon.lintTree = function() {
+          return false;
+        };
+
+        var assertionsWereRun;
+
+        emberApp._mergeTrees = function(inputTree) {
+          expect(inputTree.length).to.equal(0);
+
+          assertionsWereRun = true;
+        };
+
+        emberApp.addonLintTree();
+
+        expect(assertionsWereRun).to.be.true;
+      });
+    });
   });
 
   describe('import', function() {


### PR DESCRIPTION
Solution to #4340. Used the filter(Boolean) suggested by @rwjblue.

Added tests for `lintTree`.

Also used `this._mergeTrees` instead of `mergeTrees` in `ember-app.js` for test stubbing.