### PR TITLE
[INTERNAL release] remove unused/duplicate strip-ansi

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "sane": "^1.1.1",
     "semver": "^4.3.3",
     "silent-error": "^1.0.0",
-    "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
     "testem": "0.9.1",


### PR DESCRIPTION
I noticed the warning
```
npm WARN package.json Dependency 'strip-ansi' exists in both dependencies and devDependencies, using 'strip-ansi@^2.0.1' from dependencies
```
I did a search of the repo and `strip-ansi` is only used the tests.