### PR TITLE
[ENHANCEMENT] On Windows, check for elevation, warn if missing

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -2,6 +2,7 @@
 
 var path    = require('path');
 var Command = require('../models/command');
+var win     = require('../utilities/windows-admin');
 
 module.exports = Command.extend({
   name: 'build',
@@ -22,7 +23,10 @@ module.exports = Command.extend({
       analytics: this.analytics,
       project: this.project
     });
-    return buildTask.run(commandOptions);
+
+    return win.checkWindowsElevation(this.ui).then(function() {
+      return buildTask.run(commandOptions);
+    });
   },
 
   taskFor: function(options) {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,7 +5,8 @@ var path        = require('path');
 var Command     = require('../models/command');
 var Promise     = require('../ext/promise');
 var SilentError = require('silent-error');
-var PortFinder = require('portfinder');
+var PortFinder  = require('portfinder');
+var win         = require('../utilities/windows-admin');
 
 PortFinder.basePort = 49152;
 
@@ -59,7 +60,9 @@ module.exports = Command.extend({
         project: this.project
       });
 
-      return serve.run(commandOptions);
+      return win.checkWindowsElevation(this.ui).then(function() {
+        return serve.run(commandOptions);
+      });
     }.bind(this));
   },
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -6,6 +6,7 @@ var Builder   = require('../models/builder');
 
 var fs = require('fs');
 var path = require('path');
+var win = require('../utilities/windows-admin');
 
 var defaultPortNumber = 7357;
 
@@ -126,7 +127,8 @@ module.exports = Command.extend({
       var test  = new TestTask(options);
       var build = new BuildTask(options);
 
-      return build.run({
+      return win.checkWindowsElevation(this.ui).then(function() {
+        return build.run({
           environment: commandOptions.environment,
           outputPath: outputPath
         })
@@ -134,6 +136,7 @@ module.exports = Command.extend({
           return test.run(testOptions);
         })
         .finally(this.rmTmp.bind(this));
+      }.bind(this));
     }
   }
 });

--- a/lib/utilities/windows-admin.js
+++ b/lib/utilities/windows-admin.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var Promise = require('../ext/promise');
+var chalk   = require('chalk');
+var exec    = require('child_process').exec;
+
+module.exports = {
+  /**
+   * Uses the eon-old command NET SESSION to determine whether or not the
+   * current user has elevated rights (think sudo, but Windows).
+   *
+   * @method checkWindowsElevation
+   * @param  {Object} ui - ui object used to call writeLine();
+   * @return {Object} Object describing whether we're on windows and if admin rights exist
+   */
+  checkWindowsElevation: function (ui) {
+    return new Promise(function (resolve) {
+      if (/^win/.test(process.platform)) {
+        exec('NET SESSION', function (error, stdout, stderr) {
+          var elevated = (!stderr || stderr.length === 0);
+
+          if (!elevated && ui && ui.writeLine) {
+            ui.writeLine(chalk.yellow('\nRunning without elevated rights. ' +
+              'Running Ember Cli "as Administrator" increases performance significantly.'));
+            ui.writeLine('See ember-cli.com/#windows for details.\n');
+          }
+
+          resolve({
+            windows: true,
+            elevated: elevated
+          });
+        });
+      } else {
+        resolve({
+          windows: false,
+          elevated: null
+        });
+      }
+    });
+  }
+};

--- a/tests/unit/utilities/windows-admin-test.js
+++ b/tests/unit/utilities/windows-admin-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var win = require('../../../lib/utilities/windows-admin');
+var expect = require('chai').expect;
+var MockUI = require('../../helpers/mock-ui');
+
+describe('windows-admin', function() {
+  before(function() {
+    this.originalPlatform = process.platform;
+  });
+
+  after(function () {
+    Object.defineProperty(process, 'platform', {  
+      value: this.originalPlatform
+    });
+  });
+
+  it('attempts to determine admin rights if Windows', function(done) {
+    Object.defineProperty(process, 'platform', {  
+      value: 'win'
+    });
+
+    win.checkWindowsElevation(new MockUI()).then(function (result) {
+      expect(result).to.be.ok;
+      expect(result.windows).to.be.true;
+      done();
+    });
+  });
+
+  it('does not attempt to determine admin rights if not on Windows', function(done) {
+    Object.defineProperty(process, 'platform', {  
+      value: 'MockOS'
+    });
+
+    win.checkWindowsElevation(new MockUI()).then(function (result) {
+      expect(result).to.be.ok;
+      expect(result.windows).to.be.false;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
- Added a small utility that checks if we’re running on Windows, and if
so, checks if ember cli is currently running with elevated rights
(think sudo, but windows)
- If no elevation is detected, we log a small warning, informing about
the performance impact
- Elevation check uses `NET SESSION`, which works on Windows versions
20+ years old
- Test included