### PR TITLE
[ENHANCEMENT] Update Readme with correct npm support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Ember.js command line utility.
 
-Supports node 0.12.x and npm 2.6.x.
+Supports node 0.12.x and npm 2.7.x and 3.x.
 
 ## Community
 * irc: #ember-cli on freenode


### PR DESCRIPTION
This might be the tiniest PR, but correct npm support information is tremendously important for all of us that work with npm and Ember Cli on extremely low-powered systems or Windows, where npm@3 is literally the best thing ever.

- npm@2 version support taken from `package.json`
- npm@3 version support as discussed with @stefanpenner 