### PR TITLE
[INTERNAL release] proxy require for unit tests

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -27,11 +27,10 @@ var preprocessMinifyCss = p.preprocessMinifyCss;
 var ES6Modules  = require('broccoli-es6modules');
 var concatFilesWithSourcemaps = require('broccoli-sourcemap-concat');
 
-var configLoader        = require('./broccoli-config-loader');
-var configReplace       = require('./broccoli-config-replace');
-var upstreamMergeTrees  = require('broccoli-merge-trees');
-
-var unwatchedTree    = require('broccoli-unwatched-tree');
+var configLoader  = require('./broccoli-config-loader');
+var configReplace = require('./broccoli-config-replace');
+var mergeTrees    = require('./merge-trees');
+var unwatchedTree = require('broccoli-unwatched-tree');
 
 var defaults      = require('merge-defaults');
 var merge         = require('lodash/object/merge');
@@ -39,16 +38,6 @@ var omit          = require('lodash/object/omit');
 var path          = require('path');
 var ES3SafeFilter = require('broccoli-es3-safe-recast');
 var Funnel        = require('broccoli-funnel');
-
-function mergeTrees(inputTree, options) {
-  options = options || {};
-  options.description = options.annotation;
-  var tree = upstreamMergeTrees(inputTree, options);
-
-  tree.description = options && options.description;
-
-  return tree;
-}
 
 module.exports = EmberApp;
 
@@ -116,9 +105,6 @@ function EmberApp() {
   this.populateLegacyFiles();
   p.setupRegistry(this);
   this._notifyAddonIncluded();
-
-  // for test stubbing
-  this._mergeTrees = mergeTrees;
 }
 
 /**
@@ -470,7 +456,7 @@ EmberApp.prototype.addonLintTree = function(type, tree) {
       return addon.lintTree(type, tree);
     }
   }).filter(Boolean);
-  return this._mergeTrees(output, {
+  return mergeTrees(output, {
     overwrite: true,
     annotation: 'TreeMerger (lint)'
   });
@@ -602,7 +588,7 @@ EmberApp.prototype.publicTree = function() {
     trees.push(this.trees.public);
   }
 
-  return this._mergeTrees(trees, {
+  return mergeTrees(trees, {
     overwrite: true,
     annotation: 'TreeMerge (public)'
   });
@@ -616,7 +602,7 @@ EmberApp.prototype.publicTree = function() {
 */
 EmberApp.prototype._processedAppTree = function() {
   var addonTrees = this.addonTreesFor('app');
-  var mergedApp  = this._mergeTrees(addonTrees.concat(this._filterAppTree()), {
+  var mergedApp  = mergeTrees(addonTrees.concat(this._filterAppTree()), {
     overwrite: true,
     annotation: 'TreeMerger (app)'
   });
@@ -635,7 +621,7 @@ EmberApp.prototype._processedAppTree = function() {
 EmberApp.prototype._processedTemplatesTree = function() {
   var addonTrees = this.addonTreesFor('templates');
   var mergedTrees = this.trees.templates ? addonTrees.concat(this.trees.templates) : addonTrees;
-  var mergedTemplates = this._mergeTrees(mergedTrees, {
+  var mergedTemplates = mergeTrees(mergedTrees, {
     overwrite: true,
     annotation: 'TreeMerger (templates)'
   });
@@ -652,7 +638,7 @@ EmberApp.prototype._processedTemplatesTree = function() {
     annotation: 'Funnel: Pod Templates'
   });
 
-  var templates = this.addonPreprocessTree('template', this._mergeTrees([
+  var templates = this.addonPreprocessTree('template', mergeTrees([
     standardTemplates,
     podTemplates
   ], { annotation: 'addonPreprocessTree(template)' }));
@@ -681,7 +667,7 @@ EmberApp.prototype._podTemplatePatterns = function() {
 */
 EmberApp.prototype._processedTestsTree = function() {
   var addonTrees  = this.addonTreesFor('test-support');
-  var mergedTests = this._mergeTrees(addonTrees.concat(this.trees.tests), {
+  var mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
     overwrite: true,
     annotation: 'TreeMerger (tests)'
   });
@@ -724,7 +710,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
     return this._cachedAddonTree;
   }
 
-  var addonTrees = this._mergeTrees(this.addonTreesFor('addon'), {
+  var addonTrees = mergeTrees(this.addonTreesFor('addon'), {
     overwrite: true,
     annotation: 'TreeMerger (addons)'
   });
@@ -753,7 +739,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
     }
   });
 
-  var reexportsAndTranspiledAddonTree = this._mergeTrees([
+  var reexportsAndTranspiledAddonTree = mergeTrees([
     transpiledAddonTree,
     addonReexports
   ], {
@@ -795,7 +781,7 @@ EmberApp.prototype._processedVendorTree = function() {
     trees.push(this.trees.vendor);
   }
 
-  var mergedVendor = this._mergeTrees(trees, {
+  var mergedVendor = mergeTrees(trees, {
     overwrite: true,
     annotation: 'TreeMerger (vendor)'
   });
@@ -826,7 +812,7 @@ EmberApp.prototype._processedExternalTree = function() {
     trees.unshift(bower);
   }
 
-  return this._cachedExternalTree = this._mergeTrees(trees, {
+  return this._cachedExternalTree = mergeTrees(trees, {
     annotation: 'TreeMerger (ExternalTree)'
   });
 };
@@ -924,7 +910,7 @@ EmberApp.prototype.appAndDependencies = function() {
 
   sourceTrees.push(emberCLITree);
 
-  return this._mergeTrees(sourceTrees, {
+  return mergeTrees(sourceTrees, {
     overwrite: true,
     description: 'TreeMerger (appAndDependencies)'
   });
@@ -992,7 +978,7 @@ EmberApp.prototype.javascript = function() {
     }
   );
 
-  appJs = this._mergeTrees([
+  appJs = mergeTrees([
     appJs,
     this._processedEmberCLITree()
   ], {
@@ -1024,7 +1010,7 @@ EmberApp.prototype.javascript = function() {
     description: 'Concat: Vendor'
   });
 
-  return this._mergeTrees([
+  return mergeTrees([
       vendor,
       appJs
     ], {
@@ -1059,7 +1045,7 @@ EmberApp.prototype.styles = function() {
   var trees = [external].concat(addonTrees);
   trees.push(styles);
 
-  var stylesAndVendor = this.addonPreprocessTree('css', this._mergeTrees(trees, {
+  var stylesAndVendor = this.addonPreprocessTree('css', mergeTrees(trees, {
     annotation: 'TreeMerger (stylesAndVendor)',
     overwrite: true
   }));
@@ -1082,7 +1068,7 @@ EmberApp.prototype.styles = function() {
     vendorStyles    = preprocessMinifyCss(vendorStyles, options);
   }
 
-  var mergedTrees = this._mergeTrees([
+  var mergedTrees = mergeTrees([
       preprocessedStyles,
       vendorStyles
     ], {
@@ -1115,7 +1101,7 @@ EmberApp.prototype.testFiles = function() {
     description: 'Concat: Test Support JS'
   });
 
-  testJs = this.concatFiles(this._mergeTrees([testJs, emberCLITree]), {
+  testJs = this.concatFiles(mergeTrees([testJs, emberCLITree]), {
     inputFiles: [
       'vendor/ember-cli/test-support-prefix.js',
       testSupportPath.slice(1),
@@ -1157,7 +1143,7 @@ EmberApp.prototype.testFiles = function() {
     testemTree
   ];
 
-  return this._mergeTrees(sourceTrees, {
+  return mergeTrees(sourceTrees, {
       overwrite: true,
       annotation: 'TreeMerger (testFiles)'
     });
@@ -1180,7 +1166,7 @@ EmberApp.prototype.otherAssets = function() {
       destDir: path.dest
     });
   });
-  return this._mergeTrees(otherAssetTrees, {
+  return mergeTrees(otherAssetTrees, {
     annotation: 'TreeMerger (otherAssetTrees)'
   });
 };
@@ -1367,7 +1353,7 @@ EmberApp.prototype.toArray = function() {
   @return {Tree}                  Merged tree for this application
  */
 EmberApp.prototype.toTree = function(additionalTrees) {
-  var tree = this._mergeTrees(this.toArray().concat(additionalTrees || []), {
+  var tree = mergeTrees(this.toArray().concat(additionalTrees || []), {
     overwrite: true,
     description: 'TreeMerger (allTrees)'
   });

--- a/lib/broccoli/merge-trees.js
+++ b/lib/broccoli/merge-trees.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var upstreamMergeTrees = require('broccoli-merge-trees');
+
+module.exports = function(inputTree, options) {
+  options = options || {};
+  options.description = options.annotation;
+  var tree = upstreamMergeTrees(inputTree, options);
+
+  tree.description = options && options.description;
+
+  return tree;
+};

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "multiline": "^1.0.2",
     "nock": "^1.2.1",
     "node-require-timings": "1.0.0",
+    "proxyquire": "^1.6.0",
     "strip-ansi": "^2.0.0",
     "supertest": "0.15.0",
     "supports-color": "^3.0.0",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1,12 +1,20 @@
 /* global escape */
+
 'use strict';
 
-var fs       = require('fs');
-var path     = require('path');
-var Project  = require('../../../lib/models/project');
-var EmberApp = require('../../../lib/broccoli/ember-app');
-var expect   = require('chai').expect;
-var stub     = require('../../helpers/stub').stub;
+var fs         = require('fs');
+var path       = require('path');
+var Project    = require('../../../lib/models/project');
+var expect     = require('chai').expect;
+var stub       = require('../../helpers/stub').stub;
+var proxyquire = require('proxyquire');
+
+var mergeTreesStub;
+var EmberApp = proxyquire('../../../lib/broccoli/ember-app', {
+  './merge-trees': function() {
+    return mergeTreesStub.apply(this, arguments);
+  }
+});
 
 describe('broccoli/ember-app', function() {
   var project, projectPath, emberApp, addonTreesForStub, addon;
@@ -28,6 +36,8 @@ describe('broccoli/ember-app', function() {
   beforeEach(function() {
     projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');
     project = setupProject(projectPath);
+
+    mergeTreesStub = require('../../../lib/broccoli/merge-trees');
   });
 
   describe('constructor', function() {
@@ -491,7 +501,7 @@ describe('broccoli/ember-app', function() {
 
         var assertionsWereRun;
 
-        emberApp._mergeTrees = function(inputTree, options) {
+        mergeTreesStub = function(inputTree, options) {
           expect(inputTree).to.deep.equal(['blazorz']);
           expect(options).to.deep.equal({
             overwrite: true,
@@ -515,7 +525,7 @@ describe('broccoli/ember-app', function() {
 
         var assertionsWereRun;
 
-        emberApp._mergeTrees = function(inputTree) {
+        mergeTreesStub = function(inputTree) {
           expect(inputTree.length).to.equal(0);
 
           assertionsWereRun = true;


### PR DESCRIPTION
I wasn't too happy with how I stubbed out mergeTrees in https://github.com/ember-cli/ember-cli/pull/4685/files#diff-392bb207fea8bcbeb4a084bb445f7cc7R121 and then change everyone from `mergeTrees` to `this._mergeTrees` just for unit testing.

So I experimented and found a `require` proxying library. It allows for me to revert all that noise, for the tradeoff of a little bit more complicated test setup when you want to use it.

Thoughts? Better way? @stefanpenner @rwjblue