### PR TITLE
Update ember-try version in addon blueprint

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -36,7 +36,7 @@ module.exports = {
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.0.0';
 
     // add `ember-try` to addons by default
-    contents.devDependencies['ember-try'] = '0.0.6';
+    contents.devDependencies['ember-try'] = '~0.0.8';
     contents.scripts.test = "ember try:testall";
 
     contents['ember-addon'] = contents['ember-addon'] || {};


### PR DESCRIPTION
 to 0.0.8

Diff: https://github.com/kategengler/ember-try/compare/v0.0.6...v0.0.8

Notable improvements:
* Support for bower devDependencies
* bower is run in non-interactive mode

cc @kategengler - author and maintainer of this wonderful addon