### PR TITLE
[FEATURE] Allow addon commands to override core command if marked explicitly

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -38,6 +38,13 @@ module.exports = function(commands, commandName, commandArgs, optionHash) {
   }
 
   if (command && addonCommand) {
+    if (addonCommand.overrideCore) {
+      ui.writeLine(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
+              command.prototype.name + '". The addon command will be used as the overridding was explicit.'));
+
+      return addonCommand;
+    }
+
     ui.writeLine(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
                             command.prototype.name + '". The core command will be used.'));
     return command;

--- a/tests/fixtures/addon/commands/addon-override-intentional.js
+++ b/tests/fixtures/addon/commands/addon-override-intentional.js
@@ -1,0 +1,20 @@
+var Command = require('../../../../lib/models/command');
+
+function Addon() {
+  this.name = "Other Ember CLI Addon Command To Test Intentional Core Command Override"
+  return this;
+}
+
+Addon.prototype.includedCommands = function() {
+  var cmd = Command.extend({
+    name: 'serve',
+    description: 'this intentionally overrides the core command'
+  });
+  cmd.overrideCore = true
+
+  return {
+    'InitOverrideIntentional': cmd
+  };
+}
+
+module.exports = Addon;

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -9,6 +9,7 @@ var MockUI        = require('../../helpers/mock-ui');
 var AddonCommand  = require('../../fixtures/addon/commands/addon-command');
 var OtherCommand  = require('../../fixtures/addon/commands/other-addon-command');
 var ClassCommand  = require('../../fixtures/addon/commands/addon-command-class');
+var OverrideCommand  = require('../../fixtures/addon/commands/addon-override-intentional');
 
 var commands = {
   serve: Command.extend({
@@ -133,7 +134,25 @@ describe('cli/lookup-command.js', function() {
       ui: ui
     });
 
-    expect(ui.output).to.match(/warning: An ember-addon has attempted to override the core command "serve".*/);
+    expect(ui.output).to.match(/warning: An ember-addon has attempted to override the core command "serve"\. The core command will be used.*/);
+  });
+
+  it('lookupCommand() should write out a warning when overriding a core command and allow it if intentional', function() {
+    project = {
+      isEmberCLIProject: function(){ return true; },
+      initializeAddons: function() {
+        this.addons = [new OverrideCommand()];
+      },
+      addonCommands: Project.prototype.addonCommands,
+      eachAddonCommand: Project.prototype.eachAddonCommand
+    };
+
+    lookupCommand(commands, 'serve', [], {
+      project: project,
+      ui: ui
+    });
+
+    expect(ui.output).to.match(/warning: An ember-addon has attempted to override the core command "serve"\. The addon command will be used as the overridding was explicit.*/);
   });
 
   it('lookupCommand() should return UnknownCommand object when command name is not present.', function() {


### PR DESCRIPTION
Sometimes it's useful for addons to be able to override a core command, at least I know I'm using it.
This permits it via a flag on a command called `overrideCore` that can be set to true.

I wasn't sure where's the best place to add docs to this, since it's a "static" property of the command.

We can move it to be a flag on the command instances, and it would align better with other options, but then we couldn't know if an addon command is intended to overwrite a core command unless we instantiate it which doesn't feel ideal.

If anybody has any thoughts on that last issue, please let me know :)