### PR TITLE
Revert "Do not pack ember-cli-build.js"

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -10,6 +10,5 @@ dist/
 .npmignore
 **/.gitkeep
 bower.json
-ember-cli-build.js
 Brocfile.js
 testem.json


### PR DESCRIPTION
Reverts ember-cli/ember-cli#4348

@stefanpenner and I think there's no value in npm-ignoring this, only potential :cry: for addon developers who are hacking in their `node_modules` folder