### PR TITLE
Replaced "npm cache clear" on "npm cache clean"

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -226,5 +226,5 @@ Adding dependency versions into your package.json fixes the dependency issue:
 
 Clear out old packages and reinstall them with the following:
 {% highlight bash %}
-rm -rf node_modules; npm cache clear; npm install;
+rm -rf node_modules; npm cache clean; npm install;
 {% endhighlight %}


### PR DESCRIPTION
As per NPM docs there is no "clear" option and "clean" should be used. https://docs.npmjs.com/cli/cache