### PR TITLE
Remove wasted work in app.import.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -96,7 +96,6 @@ function EmberApp() {
   this.legacyFilesToAppend     = [];
   this.vendorStaticStyles      = [];
   this.otherAssetPaths         = [];
-  this._importTrees            = [];
   this.legacyTestFilesToAppend = [];
   this.vendorTestStaticStyles  = [];
 
@@ -197,7 +196,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     templates: existsSync('app/templates') ? unwatchedTree('app/templates') : null,
 
     // do not watch vendor/ or bower's default directory by default
-    bower: unwatchedTree(this.bowerDirectory),
+    bower: this.project._usingWatchman ? this.bowerDirectory : unwatchedTree(this.bowerDirectory),
     vendor: existsSync('vendor') ? unwatchedTree('vendor') : null,
 
     public: existsSync('public') ? 'public' : null
@@ -773,8 +772,7 @@ EmberApp.prototype._processedVendorTree = function() {
     return this._cachedVendorTree;
   }
 
-  var trees = this._importTrees.slice();
-  trees = trees.concat(this._addonTree());
+  var trees = this._addonTree();
   trees = trees.concat(this.addonTreesFor('vendor'));
 
   if (this.trees.vendor) {
@@ -1213,8 +1211,6 @@ EmberApp.prototype.import = function(asset, options) {
     throw new Error('You must pass a file to `app.import`. For directories specify them to the constructor under the `trees` option.');
   }
 
-  this._importAssetTree(directory, subdirectory);
-
   this._import(
     assetPath,
     options,
@@ -1264,23 +1260,6 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
       file: basename,
       dest: destDir || subdirectory
     });
-  }
-};
-
-/**
-  @private
-  @method _importAssetTree
-  @param {String} directory
-  @param {String} subdirectory
- */
-EmberApp.prototype._importAssetTree = function(directory, subdirectory) {
-  if (existsSync(directory) && this._importTrees.indexOf(directory) === -1) {
-    var assetTree = new Funnel(directory, {
-      srcDir: '/',
-      destDir: subdirectory
-    });
-
-    this._importTrees.push(assetTree);
   }
 };
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -143,6 +143,9 @@ Command.prototype.validateAndRun = function(args) {
   }
 
   return Watcher.detectWatcher(this.ui, commandOptions.options).then(function(options) {
+    if (options.watcher === 'watchman') {
+      this.project._usingWatchman = true;
+    }
     return this.run(options, commandOptions.args);
   }.bind(this));
 };

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -46,7 +46,21 @@ function Project(root, pkg, ui, cli) {
   this.setupNodeModulesPath();
   this.addonDiscovery = new AddonDiscovery(this.ui);
   this.addonsFactory = new AddonsFactory(this, this);
+  this._usingWatchman = false;
 }
+
+/**
+  Set when the `Watcher.detectWatchman` helper method finishes running,
+  so that other areas of the system can be aware that watchman is being used.
+
+  For example, this information is used in the broccoli build pipeline to know
+  if we can watch additional directories (like bower_components) "cheaply".
+
+  @private
+  @property _usingWatchman
+  @returns {Boolean}
+  @default false
+*/
 
 /**
   Sets the name of the bower directory for this project


### PR DESCRIPTION
In the early days of ember-cli the watcher was very expensive and we did not want to watch all of `bower_components`, but we have always intended to allow `app.import`ing a file from a given directory to allow that directory to be watched.

The way that we selectively watched these subdirectories in `bower_components` was by creating a tree for each file `app.import`'ed and then merging those together but not using any of their output!! This basically meant that for every `app.import` we created an extra ultimatley unused `Funnel` instance that we merged with the rest of the system resulting in merging some subdirectories of `bower_components` with themselves AND the rest of `bower_components` multiple times over again in each build.

This change removes all that crazy shenanigans and if `watchman` is present, just watches all of `bower_components`.