### PR TITLE
[ENHANCEMENT] allow custom transforms for model generation

### DIFF
--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -6,6 +6,7 @@
   <yellow><attr-name></yellow>:object
   <yellow><attr-name></yellow>:number
   <yellow><attr-name></yellow>:string
+  <yellow><attr-name></yellow>:your-custom-transform
   <yellow><attr-name></yellow>:belongs-to:<yellow><model-name></yellow>
   <yellow><attr-name></yellow>:has-many:<yellow><model-name></yellow>
 

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -48,21 +48,16 @@ module.exports = {
 
 function dsAttr(name, type) {
   switch (type) {
-  case 'array':
-  case 'boolean':
-  case 'date':
-  case 'number':
-  case 'object':
-  case 'string':
-    return 'DS.attr(\'' + type + '\')';
   case 'belongs-to':
     return 'DS.belongsTo(\'' + name + '\')';
   case 'has-many':
     var singularizedName = inflection.singularize(name);
     return 'DS.hasMany(\'' + singularizedName + '\')';
-  default:
+  case '':
     //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
     //http://emberjs.com/guides/models/defining-models/
     return 'DS.attr()';
+  default:
+    return 'DS.attr(\'' + type + '\')';
   }
 }

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -263,6 +263,7 @@ describe('Acceptance: ember generate', function() {
       'barName:has-many',
       'bazName:belongs-to',
       'test-name:belongs-to',
+      'metricData:custom-transform',
       'echoName:hasMany',
       'bravoName:belongs_to'
     ]).then(function() {
@@ -281,6 +282,7 @@ describe('Acceptance: ember generate', function() {
           "barNames: DS.hasMany('bar-name')",
           "bazName: DS.belongsTo('baz-name')",
           "testName: DS.belongsTo('test-name')",
+          "metricData: DS.attr('custom-transform')",
           "echoNames: DS.hasMany('echo-name')",
           "bravoName: DS.belongsTo('bravo-name')"
         ]

--- a/tests/acceptance/help/help-generate-test.js
+++ b/tests/acceptance/help/help-generate-test.js
@@ -204,6 +204,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m\u001b[36m <options...>\u001b[39m'
         \u001b[33m<attr-name>\u001b[39m:object\n\
         \u001b[33m<attr-name>\u001b[39m:number\n\
         \u001b[33m<attr-name>\u001b[39m:string\n\
+        \u001b[33m<attr-name>\u001b[39m:your-custom-transform\n\
         \u001b[33m<attr-name>\u001b[39m:belongs-to:\u001b[33m<model-name>\u001b[39m\n\
         \u001b[33m<attr-name>\u001b[39m:has-many:\u001b[33m<model-name>\u001b[39m');
 


### PR DESCRIPTION
When I have a custom transform, like 'utc' and then generate a model, I should be able to go 
```
  ember g model foo name:string startDate:utc data
```
and it should generate a file containing:
```
  name: DS.attr('string'),
  startDate: DS.attr('utc'),
  data: DS.attr()
```

currently however it is doing
```
  name: DS.attr('string'),
  startDate: DS.attr(),  // <-- narf
  data: DS.attr()
```