### PR TITLE
Allow addon trees to be watched automatically with watchman ^3.7.0.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -196,7 +196,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     templates: existsSync('app/templates') ? unwatchedTree('app/templates') : null,
 
     // do not watch vendor/ or bower's default directory by default
-    bower: this.project._usingWatchman ? this.bowerDirectory : unwatchedTree(this.bowerDirectory),
+    bower: this.project._watchmanInfo.enabled ? this.bowerDirectory : unwatchedTree(this.bowerDirectory),
     vendor: existsSync('vendor') ? unwatchedTree('vendor') : null,
 
     public: existsSync('public') ? 'public' : null

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -263,7 +263,7 @@ Addon.prototype.eachAddonInvoke = function eachAddonInvoke(methodName, args) {
 */
 Addon.prototype.treeGenerator = function(dir) {
   var tree;
-  if (this.isDevelopingAddon()) {
+  if (this.project._watchmanInfo.canNestRoots || this.isDevelopingAddon()) {
     tree = dir;
   } else {
     tree = this._unwatchedTreeGenerator(dir);

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -143,9 +143,10 @@ Command.prototype.validateAndRun = function(args) {
   }
 
   return Watcher.detectWatcher(this.ui, commandOptions.options).then(function(options) {
-    if (options.watcher === 'watchman') {
-      this.project._usingWatchman = true;
+    if (options._watchmanInfo) {
+      this.project._watchmanInfo = options._watchmanInfo;
     }
+
     return this.run(options, commandOptions.args);
   }.bind(this));
 };

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -46,7 +46,11 @@ function Project(root, pkg, ui, cli) {
   this.setupNodeModulesPath();
   this.addonDiscovery = new AddonDiscovery(this.ui);
   this.addonsFactory = new AddonsFactory(this, this);
-  this._usingWatchman = false;
+  this._watchmanInfo = {
+    enabled: false,
+    version: null,
+    canNestRoots: false
+  };
 }
 
 /**
@@ -56,9 +60,11 @@ function Project(root, pkg, ui, cli) {
   For example, this information is used in the broccoli build pipeline to know
   if we can watch additional directories (like bower_components) "cheaply".
 
+  Contains `enabled` and `version`.
+
   @private
-  @property _usingWatchman
-  @returns {Boolean}
+  @property _watchmanInfo
+  @returns {Object}
   @default false
 */
 

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -104,9 +104,15 @@ Watcher.detectWatcher = function(ui, _options) {
       }
       debug('detected watchman: %s', version);
 
-      if (require('semver').satisfies(version, '^3.0.0')) {
+      var semver = require('semver');
+      if (semver.satisfies(version, '^3.0.0')) {
         debug('watchman %s does satisfy: %s', version, '^3.0.0');
         options.watcher = 'watchman';
+        options._watchmanInfo = {
+          enabled: true,
+          version: version,
+          canNestRoots: semver.satisfies(version, '^3.7.0')
+        };
       } else {
         debug('watchman %s does NOT satisfy: %s', version, '^3.0.0');
         ui.writeLine('Invalid watchman found, version: [' + version + '] did not satisfy [^3.0.0], falling back to NodeWatcher.');


### PR DESCRIPTION
`watchman` has added the ability to nest roots properly in version 3.7.0, this changes the `treeGenerator` to automatically allow trees to be watched if using `watchman` `^3.7.0`.