### PR TITLE
Replace broccoli-unwatched-tree with broccoli-source

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -30,7 +30,8 @@ var concatFilesWithSourcemaps = require('broccoli-sourcemap-concat');
 var configLoader  = require('./broccoli-config-loader');
 var configReplace = require('./broccoli-config-replace');
 var mergeTrees    = require('./merge-trees');
-var unwatchedTree = require('broccoli-unwatched-tree');
+var WatchedDir    = require('broccoli-source').WatchedDir;
+var UnwatchedDir  = require('broccoli-source').UnwatchedDir;
 
 var defaults      = require('merge-defaults');
 var merge         = require('lodash/object/merge');
@@ -187,18 +188,19 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
   }, defaults);
 
   this.options.trees = merge(this.options.trees, {
-    app:       'app',
-    tests:     'tests',
+    app:       new WatchedDir('app'),
+    tests:     new WatchedDir('tests'),
 
     // these are contained within app/ no need to watch again
-    styles:    unwatchedTree('app/styles'),
-    templates: existsSync('app/templates') ? unwatchedTree('app/templates') : null,
+    // (we should probably have the builder or the watcher dedup though)
+    styles:    new UnwatchedDir('app/styles'),
+    templates: existsSync('app/templates') ? new UnwatchedDir('app/templates') : null,
 
     // do not watch vendor/ or bower's default directory by default
-    bower: this.project._watchmanInfo.enabled ? this.bowerDirectory : unwatchedTree(this.bowerDirectory),
-    vendor: existsSync('vendor') ? unwatchedTree('vendor') : null,
+    bower: this.project._watchmanInfo.enabled ? this.bowerDirectory : new UnwatchedDir(this.bowerDirectory),
+    vendor: existsSync('vendor') ? new UnwatchedDir('vendor') : null,
 
-    public: existsSync('public') ? 'public' : null
+    public: existsSync('public') ? new WatchedDir('public') : null
   }, defaults);
 
   this.options.jshintrc = merge(this.options.jshintrc, {
@@ -858,7 +860,7 @@ EmberApp.prototype._processedEmberCLITree = function() {
     'test-support-prefix.js',
     'test-support-suffix.js'
   ];
-  var emberCLITree = configReplace(unwatchedTree(__dirname), this._configTree(), {
+  var emberCLITree = configReplace(new UnwatchedDir(__dirname), this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: files,
 
@@ -1117,7 +1119,7 @@ EmberApp.prototype.testFiles = function() {
   var testemPath = path.join(__dirname, 'testem');
   testemPath = path.dirname(testemPath);
 
-  var testemTree = new Funnel(unwatchedTree(testemPath), {
+  var testemTree = new Funnel(new UnwatchedDir(testemPath), {
       files: ['testem.js'],
       srcDir: '/',
       destDir: '/'

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -28,6 +28,9 @@ var upstreamMergeTrees = require('broccoli-merge-trees');
 var Funnel     = require('broccoli-funnel');
 var walkSync   = require('walk-sync');
 
+var WatchedDir   = require('broccoli-source').WatchedDir;
+var UnwatchedDir = require('broccoli-source').UnwatchedDir;
+
 function mergeTrees(inputTree, options) {
   options = options || {};
   options.description = options.annotation;
@@ -178,21 +181,6 @@ Addon.prototype.concatFiles = function(tree, options) {
 };
 
 /**
-  Generate an unwatched tree.
-
-  @private
-  @method _unwatchedTreeGenerator
-  @param {Tree} dir Tree
-  @return {Tree} Unwatched tree
-*/
-Addon.prototype._unwatchedTreeGenerator = function unwatchedTree(dir) {
-  return {
-    read:    function() { return dir; },
-    cleanup: function() { }
-  };
-};
-
-/**
   Returns whether or not this addon is running in development
 
   @private
@@ -264,9 +252,9 @@ Addon.prototype.eachAddonInvoke = function eachAddonInvoke(methodName, args) {
 Addon.prototype.treeGenerator = function(dir) {
   var tree;
   if (this.project._watchmanInfo.canNestRoots || this.isDevelopingAddon()) {
-    tree = dir;
+    tree = new WatchedDir(dir);
   } else {
-    tree = this._unwatchedTreeGenerator(dir);
+    tree = new UnwatchedDir(dir);
   }
 
   return tree;

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "broccoli-merge-trees": "0.2.3",
     "broccoli-sane-watcher": "^1.1.1",
     "broccoli-sourcemap-concat": "^1.0.0",
-    "broccoli-unwatched-tree": "0.1.1",
+    "broccoli-source": "^1.1.0",
     "broccoli-writer": "0.1.1",
     "chalk": "1.1.0",
     "clean-base-url": "^1.0.0",

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -407,7 +407,7 @@ describe('models/addon.js', function() {
 
         var tree = addon.treeGenerator('foo/bar');
 
-        expect(tree).to.equal('foo/bar');
+        expect(tree.__broccoliGetInfo__()).to.have.property('watched', true);
       });
 
       it('uses unwatchedTree when not developing the addon itself', function() {
@@ -415,7 +415,7 @@ describe('models/addon.js', function() {
 
         var tree = addon.treeGenerator('foo/bar');
 
-        expect(tree.read()).to.equal('foo/bar');
+        expect(tree.__broccoliGetInfo__()).to.have.property('watched', false);
       });
     });
 


### PR DESCRIPTION
Also start using `WatchedDir` in a few places. There are surely many more
plain-string trees (nodes) left. We'll want to replace them as we go.

broccoli-source supports the [new API](https://github.com/ember-cli/ember-cli/issues/4562).