### PR TITLE
Update ember-resolver to 0.1.20.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -8,7 +8,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
+    "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"


### PR DESCRIPTION
* Handles issue with Ember 1.13.0 - 1.13.8 when calling helpers without
  hash or params.
* Removes deprecation in 2.1.0-beta.1+ for using 2 arguments to
  `initialize` function with an initializer.