### PR TITLE
Move MODEL_FACTORY_INJECTIONS flag to environment.js

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -3,11 +3,7 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-var App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+var App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(environment) {
     baseURL: '/',
     locationType: 'auto',
     EmberENV: {
+      MODEL_FACTORY_INJECTIONS: true,
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true


### PR DESCRIPTION
emberjs/ember.js#3271 made it possible to set this flag on `EmberENV` instead of `Ember` itself.

In my opinion, it would be nice to have it out of app.js and kept with the rest of the config flags.