### PR TITLE
Implement a destroyApp helper.

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '<%= testFolderRoot %>/tests/helpers/start-app';
+import destroyApp from '<%= testFolderRoot %>/tests/helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
   beforeEach: function() {
@@ -8,7 +8,7 @@ module('<%= friendlyTestName %>', {
   },
 
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/blueprints/app/files/tests/helpers/destroy-app.js
+++ b/blueprints/app/files/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function destroyApp(application) {
+  Ember.run(application, 'destroy');
+}

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -128,7 +128,7 @@ describe('Acceptance: smoke-test', function() {
         expect(exitCode).to.equal(0, 'exit code should be 0 for passing tests');
         expect(output).to.match(/JSHint/, 'JSHint should be run on production assets');
         expect(output).to.match(/fail\s+0/, 'no failures');
-        expect(output).to.match(/pass\s+7/, '1 passing');
+        expect(output).to.match(/pass\s+8/, '1 passing');
       });
   });
 

--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
 import { module, test } from 'qunit';
 
 module('Acceptance', {
@@ -7,7 +7,7 @@ module('Acceptance', {
     this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -3,6 +3,7 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
 import { module, test } from 'qunit';
 
 module('default-development - Integration', {
@@ -10,7 +11,7 @@ module('default-development - Integration', {
     this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -3,6 +3,7 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
 import { module, test } from 'qunit';
 
 module('pods based templates', {
@@ -10,7 +11,7 @@ module('pods based templates', {
     this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -3,6 +3,7 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
 import { module, test } from 'qunit';
 
 module('pods based templates', {
@@ -10,7 +11,7 @@ module('pods based templates', {
     this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
+++ b/tests/fixtures/brocfile-tests/wrap-in-eval/tests/integration/wrap-in-eval-test.js
@@ -3,6 +3,7 @@
 
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
 import { module, test } from 'qunit';
 
 module('wrapInEval in-app test', {
@@ -10,7 +11,7 @@ module('wrapInEval in-app test', {
     this.application = startApp();
   },
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'my-app/tests/helpers/start-app';
+import destroyApp from 'my-app/tests/helpers/destroy-app';
 
 module('Acceptance | foo', {
   beforeEach: function() {
@@ -8,7 +8,7 @@ module('Acceptance | foo', {
   },
 
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/generate/addon-acceptance-test-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-expected.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
+import destroyApp from '../../tests/helpers/destroy-app';
 
 module('Acceptance | foo', {
   beforeEach: function() {
@@ -8,7 +8,7 @@ module('Acceptance | foo', {
   },
 
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 

--- a/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../../tests/helpers/start-app';
+import destroyApp from '../../../tests/helpers/destroy-app';
 
 module('Acceptance | foo/bar', {
   beforeEach: function() {
@@ -8,7 +8,7 @@ module('Acceptance | foo/bar', {
   },
 
   afterEach: function() {
-    Ember.run(this.application, 'destroy');
+    destroyApp(this.application);
   }
 });
 


### PR DESCRIPTION
This is similar to startApp, and is very simple for the time being. However, this allows addon authors to hook into when the app is destroyed in a testing environment.