### PR TITLE
Update ember-cli-shims to prevent errors on Ember < 1.13.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -2,7 +2,7 @@
   "name": "<%= name %>",
   "dependencies": {
     "ember": "2.0.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.4",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",


### PR DESCRIPTION
ember-cli-shims@0.0.4 threw errors when used with Ember < 1.13 (due to `Ember.Helper.helper` being `undefined`). This updates the default to fix that parse error.