### PR TITLE
[BUGFIX] Set `ember serve --host` default to `undefined`.

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -19,7 +19,7 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'port', type: Number, default: process.env.PORT || 4200, aliases: ['p'] },
-    { name: 'host', type: String, default: '0.0.0.0', aliases: ['H'] },
+    { name: 'host', type: String, description: 'Listens on all interfaces by default', aliases: ['H'] },
     { name: 'proxy',  type: String, aliases: ['pr','pxy'] },
     { name: 'insecure-proxy', type: Boolean, default: false, description: 'Set false to proxy self-signed SSL certificates', aliases: ['inspr'] },
     { name: 'watcher',  type: String, default: 'events', aliases: ['w'] },

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -35,7 +35,7 @@ module.exports = Task.extend({
   },
 
   displayHost: function(specifiedHost) {
-    return specifiedHost === '0.0.0.0' ? 'localhost' : specifiedHost;
+    return specifiedHost || 'localhost';
   },
 
   setupHttpServer: function() {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -68,7 +68,7 @@ module.exports = Task.extend({
   },
 
   displayHost: function(specifiedHost) {
-    return specifiedHost === '0.0.0.0' ? 'localhost' : specifiedHost;
+    return specifiedHost || 'localhost';
   },
 
   writeBanner: function(url) {

--- a/tests/acceptance/help/help-serve-json-test.js
+++ b/tests/acceptance/help/help-serve-json-test.js
@@ -47,7 +47,7 @@ describe('Acceptance: ember help --json serve', function() {
           },
           {
             name: 'host',
-            default: '0.0.0.0',
+            description: 'Listens on all interfaces by default',
             aliases: ['H'],
             key: 'host',
             required: false

--- a/tests/acceptance/help/help-serve-test.js
+++ b/tests/acceptance/help/help-serve-test.js
@@ -39,7 +39,7 @@ ember serve \u001b[36m<options...>\u001b[39m' + EOL + '\
   \u001b[90maliases: server, s\u001b[39m' + EOL + '\
   \u001b[36m--port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 4200)\u001b[39m' + EOL + '\
     \u001b[90maliases: -p <value>\u001b[39m' + EOL + '\
-  \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: 0.0.0.0)\u001b[39m' + EOL + '\
+  \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m Listens on all interfaces by default' + EOL + '\
     \u001b[90maliases: -H <value>\u001b[39m' + EOL + '\
   \u001b[36m--proxy\u001b[39m \u001b[36m(String)\u001b[39m' + EOL + '\
     \u001b[90maliases: -pr <value>, -pxy <value>\u001b[39m' + EOL + '\

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -46,15 +46,11 @@ describe('server command', function() {
     ]).then(function() {
       var serveRun = tasks.Serve.prototype.run;
       var runOps = serveRun.calledWith[0][0];
-      var getPortOps = ServeCommand.prototype._getPort.calledWith[0][0];
-
-      expect(getPortOps.host).to.equal('0.0.0.0', 'a livereload port is found using the default host');
 
       expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
       expect(runOps.port).to.equal(4000,            'has correct port');
       expect(runOps.liveReloadPort).to.be.within(49152, 65535, 'has correct liveReload port');
-      expect(runOps.liveReloadHost).to.equal('0.0.0.0', 'has correct liveReload host');
     });
   });
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -48,12 +48,12 @@ describe('express-server', function() {
   });
 
   describe('displayHost', function() {
-    it('should use the specified host if not 0.0.0.0', function() {
+    it('should use the specified host if specified', function() {
       expect(subject.displayHost('1.2.3.4')).to.equal('1.2.3.4');
     });
 
-    it('should use the use localhost if specified host is 0.0.0.0', function() {
-      expect(subject.displayHost('0.0.0.0')).to.equal('localhost');
+    it('should use the use localhost if host is not specified', function() {
+      expect(subject.displayHost(undefined)).to.equal('localhost');
     });
   });
 
@@ -86,7 +86,7 @@ describe('express-server', function() {
 
     it('with ssl', function() {
       return subject.start({
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         ssl: true,
         sslCert: 'tests/fixtures/ssl/server.crt',
@@ -101,7 +101,7 @@ describe('express-server', function() {
     it('with proxy', function() {
       return subject.start({
         proxy: 'http://localhost:3001/',
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         baseURL: '/'
       }).then(function() {
@@ -114,7 +114,7 @@ describe('express-server', function() {
 
     it('without proxy', function() {
       return subject.start({
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         baseURL: '/'
       }).then(function() {
@@ -126,7 +126,7 @@ describe('express-server', function() {
 
     it('with baseURL', function() {
       return subject.start({
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         baseURL: '/foo'
       }).then(function() {
@@ -141,7 +141,7 @@ describe('express-server', function() {
       preexistingServer.listen(1337);
 
       return subject.start({
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337'
       })
         .then(function() {
@@ -160,7 +160,7 @@ describe('express-server', function() {
     it('starts with ssl if ssl option is passed', function() {
 
       return subject.start({
-        host:  'localhost',
+        host: 'localhost',
         port: '1337',
         ssl: true,
         sslCert: 'tests/fixtures/ssl/server.crt',
@@ -194,7 +194,7 @@ describe('express-server', function() {
 
       subject.start({
         proxy: 'http://localhost:3001/',
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         baseURL: '/'
       })
@@ -227,7 +227,7 @@ describe('express-server', function() {
 
       subject.start({
         proxy: 'http://localhost:3001/',
-        host:  '0.0.0.0',
+        host: undefined,
         port: '1337',
         baseURL: '/'
       })
@@ -251,7 +251,7 @@ describe('express-server', function() {
       beforeEach(function() {
         return subject.start({
           proxy: 'http://localhost:3001/',
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337',
           baseURL: '/'
         });
@@ -333,7 +333,7 @@ describe('express-server', function() {
 
         return subject.start({
           proxy: 'http://api.lvh.me',
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337',
           baseURL: '/'
         });
@@ -446,7 +446,7 @@ describe('express-server', function() {
     describe('without proxy', function() {
       function startServer(baseURL) {
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337',
           baseURL: baseURL || '/'
         });
@@ -660,7 +660,7 @@ describe('express-server', function() {
 
       it('calls processAddonMiddlewares upon start', function() {
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           expect(calls).to.equal(1);
@@ -692,7 +692,7 @@ describe('express-server', function() {
 
       it('calls serverMiddleware on the addons on start', function() {
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           expect(firstCalls).to.equal(1);
@@ -702,7 +702,7 @@ describe('express-server', function() {
 
       it('calls serverMiddleware on the addons on restart', function() {
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           subject.changedFiles = ['bar.js'];
@@ -743,7 +743,7 @@ describe('express-server', function() {
 
       it('waits for async middleware to complete before the next middleware', function(){
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           expect(order[0]).to.equal('first');
@@ -765,7 +765,7 @@ describe('express-server', function() {
       });
       it('up to server start', function(){
         return subject.start({
-          host: '0.0.0.0',
+          host: undefined,
           port: '1337'
         })
           .catch(function(reason){
@@ -790,7 +790,7 @@ describe('express-server', function() {
 
       it('calls processAppMiddlewares upon start', function() {
         var realOptions = {
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         };
 
@@ -802,7 +802,7 @@ describe('express-server', function() {
 
       it('calls processAppMiddlewares upon restart', function() {
         var realOptions = {
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         };
 
@@ -830,7 +830,7 @@ describe('express-server', function() {
         };
 
         var realOptions = {
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         };
 
@@ -848,7 +848,7 @@ describe('express-server', function() {
         };
 
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
@@ -863,7 +863,7 @@ describe('express-server', function() {
         };
 
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           subject.serverWatcher.emit('change', 'foo.txt');
@@ -898,7 +898,7 @@ describe('express-server', function() {
         var originalHttpServer;
         var originalApp;
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           ui.output = '';
@@ -919,7 +919,7 @@ describe('express-server', function() {
         var originalHttpServer;
         var originalApp;
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           originalHttpServer = subject.httpServer;
@@ -946,7 +946,7 @@ describe('express-server', function() {
           calls++;
         });
         return subject.start({
-          host:  '0.0.0.0',
+          host: undefined,
           port: '1337'
         }).then(function() {
           subject.changedFiles = ['bar.js'];


### PR DESCRIPTION
Fixes #4775.

I adapted the test cases where appropriate and removed obsolete tests. The following test cases were removed, because they are no longer applicable:

- server command has correct options
  - [a livereload port is found using the default host](https://github.com/ember-cli/ember-cli/compare/master...buschtoens:fix-4775-default-host?expand=1#diff-6b87c9728965f1ddffe252463882d03cL51) (removed)
  - [has correct liveReload host](https://github.com/ember-cli/ember-cli/compare/master...buschtoens:fix-4775-default-host?expand=1#diff-6b87c9728965f1ddffe252463882d03cL57) (removed)

All other relevant tests have been updated accordingly.

```
$ ember help serve
version: 1.13.8
Requested ember-cli commands:

ember serve <options...>
  Builds and serves your app, rebuilding on file changes.
  aliases: server, s
  --port (Number) (Default: 4200)
    aliases: -p <value>
  --host (String) Listens on all interfaces by default
    aliases: -H <value>
  ...
```
