### PR TITLE
[BUGFIX] Updates base adapter class for Ember Data 2.0

### DIFF
--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
   locals: function(options) {
     var adapterName     = options.entity.name;
-    var baseClass       = 'DS.RESTAdapter';
+    var baseClass       = 'DS.JSONAPIAdapter';
     var importStatement = 'import DS from \'ember-data\';';
     var isAddon         = options.inRepoAddon || options.project.isEmberCLIAddon();
     var relativePath    = pathUtil.getRelativePath(options.entity.name);


### PR DESCRIPTION
As of Ember Data 2.0 the default adapter should be JSONAPIAdapter. This changes the blueprint accordingly.

Aside, should this generator be moved to the ember-data addon?