### PR TITLE
Remove extra input tree filtering.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -519,30 +519,6 @@ EmberApp.prototype.index = function() {
 
 /**
   @private
-  @method _filterAppTree
-  @return tree
-*/
-EmberApp.prototype._filterAppTree = function() {
-  if (this._cachedFilterAppTree) {
-    return this._cachedFilterAppTree;
-  }
-
-  var podPatterns = this._podTemplatePatterns();
-  var excludePatterns = podPatterns.concat([
-    // note: do not use path.sep here Funnel uses
-    // walk-sync which always joins with `/` (not path.sep)
-    'styles/**/*',
-    'templates/**/*',
-  ]);
-
-  return this._cachedFilterAppTree = new Funnel(this.trees.app, {
-    exclude: excludePatterns,
-    description: 'Funnel: Filtered App'
-  });
-};
-
-/**
-  @private
   @method _configReplacePatterns
   @return
 */
@@ -609,7 +585,7 @@ EmberApp.prototype.publicTree = function() {
 */
 EmberApp.prototype._processedAppTree = function() {
   var addonTrees = this.addonTreesFor('app');
-  var mergedApp  = mergeTrees(addonTrees.concat(this._filterAppTree()), {
+  var mergedApp  = mergeTrees(addonTrees.concat(this.trees.app), {
     overwrite: true,
     annotation: 'TreeMerger (app)'
   });
@@ -640,33 +616,15 @@ EmberApp.prototype._processedTemplatesTree = function() {
     annotation: 'ProcessedTemplateTree'
   });
 
-  var podTemplates = new Funnel(this.trees.app, {
-    include: this._podTemplatePatterns(),
-    exclude: [ 'templates/**/*' ],
-    destDir: this.name + '/',
-    annotation: 'Funnel: Pod Templates'
-  });
-
   var templates = this.addonPreprocessTree('template', mergeTrees([
     standardTemplates,
-    podTemplates
+    this.trees.app
   ], { annotation: 'addonPreprocessTree(template)' }));
 
   return this.addonPostprocessTree('template', preprocessTemplates(templates, {
     registry: this.registry,
     description: 'TreeMerger (pod & standard templates)'
   }));
-};
-
-/**
-  @private
-  @method _podTemplatePatterns
-  @returns Array An array of regular expressions.
-*/
-EmberApp.prototype._podTemplatePatterns = function() {
-  return this.registry.extensionsForType('template').map(function(extension) {
-    return '**/*/template.' + extension;
-  });
 };
 
 /**
@@ -940,7 +898,7 @@ EmberApp.prototype._addAppTests = function(sourceTrees) {
     sourceTrees.push(this.addonPostprocessTree('test', preprocessedTests));
 
     if (this.hinting) {
-      var jshintedApp = this.addonLintTree('app', this._filterAppTree());
+      var jshintedApp = this.addonLintTree('app', this.trees.app);
       var jshintedTests = this.addonLintTree('tests', this.trees.tests);
 
       jshintedApp = new Funnel(jshintedApp, {


### PR DESCRIPTION
Tested in Stress App and while there is not a huge performance improvement here, less work/steps is definitely better.

Stress App timings: https://gist.github.com/rwjblue/dd8b0af2c55b5d9cb803