### PR TITLE
Remove Ember Data from the addon blueprints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"
 sudo: false
-env:
-  - NODE_VERSION=0.10
-  - NODE_VERSION=0.12
-  - NODE_VERSION=iojs
 
 os:
   - linux

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -36,6 +36,9 @@ module.exports = {
     // add `ember-disable-prototype-extensions` to addons by default
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.0.0';
 
+    // remove ember-data from devDepenencies
+    delete contents.devDependencies['ember-data'];
+
     // add `ember-try` to addons by default
     contents.devDependencies['ember-try'] = '~0.0.8';
     contents.scripts.test = "ember try:testall";
@@ -51,6 +54,9 @@ module.exports = {
     var contents  = JSON.parse(fs.readFileSync(bowerPath, { encoding: 'utf8' }));
 
     contents.name = this.project.name();
+
+    // remove ember-data from devDepenencies
+    delete contents.dependencies['ember-data'];
 
     fs.writeFileSync(path.join(this.path, 'files', 'bower.json'), JSON.stringify(contents, null, 2));
   },

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -18,7 +18,6 @@ var assertDirEmpty      = require('../helpers/assert-dir-empty');
 var acceptance          = require('../helpers/acceptance');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
-var cleanupDependencies = acceptance.cleanupDependencies;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
 
@@ -26,19 +25,17 @@ describe('Acceptance: addon-smoke-test', function() {
   this.timeout(450000);
 
   before(function() {
-    cleanupDependencies();
-    return createTestTargets(addonName, {
+    return createTestTargets(addonName, 'addon', {
       command: 'addon'
     });
   });
 
   after(function() {
-    cleanupDependencies();
     return teardownTestTargets();
   });
 
   beforeEach(function() {
-    return linkDependencies(addonName);
+    return linkDependencies(addonName, 'addon');
   });
 
   afterEach(function() {

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -18,6 +18,7 @@ var assertDirEmpty      = require('../helpers/assert-dir-empty');
 var acceptance          = require('../helpers/acceptance');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
+var cleanupDependencies = acceptance.cleanupDependencies;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
 
@@ -25,12 +26,14 @@ describe('Acceptance: addon-smoke-test', function() {
   this.timeout(450000);
 
   before(function() {
+    cleanupDependencies();
     return createTestTargets(addonName, {
       command: 'addon'
     });
   });
 
   after(function() {
+    cleanupDependencies();
     return teardownTestTargets();
   });
 

--- a/tests/fixtures/addon/simple/bower.json
+++ b/tests/fixtures/addon/simple/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.7.0",
-    "ember-data": "1.0.0-beta.10",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -26,14 +26,14 @@ function handleResult(result) {
   throw result;
 }
 
-function downloaded(item) {
+function downloaded(item, type) {
   var exists = false;
   switch (item) {
     case 'node_modules':
-      exists = existsSync(path.join(root, '.node_modules-tmp'));
+      exists = existsSync(path.join(root, '.node_modules-' +  type + '-tmp'));
       break;
     case 'bower_components':
-      exists = existsSync(path.join(root, '.bower_components-tmp'));
+      exists = existsSync(path.join(root, '.bower_components-' +  type + '-tmp'));
       break;
   }
 
@@ -83,24 +83,29 @@ function createTmp(command) {
  * @property {String} options.command The command you want to run
  * @return {Promise}  The result of the running the command
  */
-function createTestTargets(projectName, options) {
+function createTestTargets(projectName, type, options) {
   var command;
+  if (arguments.length === 2) {
+    options = type;
+    type= 'app';
+  }
   options = options || {};
   options.command = options.command || 'new';
 
-  var noNodeModules = !downloaded('node_modules');
+  var hasNodeModules = downloaded('node_modules', type);
+  var hasBowerComponents = downloaded('bower_components', type);
   // Fresh install
-  if (noNodeModules && !downloaded('bower_components')) {
+  if (!hasNodeModules && !hasBowerComponents) {
     command = function() {
       return applyCommand(options.command, projectName);
     };
     // bower_components but no node_modules
-  } else if (noNodeModules && downloaded('bower_components')) {
+  } else if (!hasNodeModules && hasBowerComponents) {
     command = function() {
       return applyCommand(options.command, projectName, '--skip-bower');
     };
     // node_modules but no bower_components
-  } else if (!downloaded('bower_components') && downloaded('node_modules')) {
+  } else if (!hasBowerComponents && hasNodeModules) {
     command = function() {
       return applyCommand(options.command, projectName, '--skip-npm');
     };
@@ -115,7 +120,7 @@ function createTestTargets(projectName, options) {
     return command().
       catch(handleResult).
       then(function(value) {
-        if (noNodeModules) {
+        if (!hasNodeModules) {
           return exec('npm install ember-disable-prototype-extensions').then(function() {
             return value;
           });
@@ -150,24 +155,26 @@ function cleanupDependencies() {
  * @param  {String} projectName The name of the project under test
  * @return {Promise}
  */
-function linkDependencies(projectName) {
+function linkDependencies(projectName, type) {
+  type = type || 'app';
   var targetPath = './tmp/' + projectName;
   return tmp.setup('./tmp').then(function() {
     return copy('./common-tmp/' + projectName, targetPath);
   }).then(function() {
     var nodeModulesPath = targetPath + '/node_modules/';
     var bowerComponentsPath = targetPath + '/bower_components/';
+    var cacheNodeModules = '.node_modules-' +  type + '-tmp';
+    var cacheBowerComponents = '.bower_components-' +  type + '-tmp';
 
-    mvRm(nodeModulesPath, '.node_modules-tmp');
-    mvRm(bowerComponentsPath, '.bower_components-tmp');
-
+    mvRm(nodeModulesPath, cacheNodeModules);
+    mvRm(bowerComponentsPath, cacheBowerComponents);
 
     if (!existsSync(nodeModulesPath)) {
-      symLinkDir(targetPath, '.node_modules-tmp', 'node_modules');
+      symLinkDir(targetPath, cacheNodeModules, 'node_modules');
     }
 
     if (!existsSync(bowerComponentsPath)) {
-      symLinkDir(targetPath, '.bower_components-tmp', 'bower_components');
+      symLinkDir(targetPath, cacheBowerComponents, 'bower_components');
     }
 
     process.chdir('./tmp');

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -137,6 +137,13 @@ function teardownTestTargets() {
   });
 }
 
+function cleanupDependencies() {
+  var npmDir    = path.resolve(path.join(root, '.node_modules-tmp'));
+  var bowerDir  = path.resolve(path.join(root, '.bower_components-tmp'));
+  fs.removeSync(npmDir);
+  fs.removeSync(bowerDir);
+}
+
 /**
  * Creates symbolic links from the dependency temp directories
  * to the project that is under test.
@@ -188,5 +195,6 @@ module.exports = {
   createTestTargets: createTestTargets,
   linkDependencies: linkDependencies,
   teardownTestTargets: teardownTestTargets,
-  cleanupRun: cleanupRun
+  cleanupRun: cleanupRun,
+  cleanupDependencies: cleanupDependencies
 };

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -142,13 +142,6 @@ function teardownTestTargets() {
   });
 }
 
-function cleanupDependencies() {
-  var npmDir    = path.resolve(path.join(root, '.node_modules-tmp'));
-  var bowerDir  = path.resolve(path.join(root, '.bower_components-tmp'));
-  fs.removeSync(npmDir);
-  fs.removeSync(bowerDir);
-}
-
 /**
  * Creates symbolic links from the dependency temp directories
  * to the project that is under test.
@@ -202,6 +195,5 @@ module.exports = {
   createTestTargets: createTestTargets,
   linkDependencies: linkDependencies,
   teardownTestTargets: teardownTestTargets,
-  cleanupRun: cleanupRun,
-  cleanupDependencies: cleanupDependencies
+  cleanupRun: cleanupRun
 };

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -175,7 +175,6 @@ describe('models/project.js', function() {
       var expected = {
         'jquery': '^1.11.1',
         'ember': '1.7.0',
-        'ember-data': '1.0.0-beta.10',
         'loader.js': 'ember-cli/loader.js#1.0.1',
         'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3',
         'ember-cli-test-loader': 'rwjblue/ember-cli-test-loader#0.0.4',


### PR DESCRIPTION
Following up on https://github.com/ember-cli/ember-cli/issues/4633,
this PR offers to remove Ember Data from the addon blueprints.