### PR TITLE
Update bower dependencies and use tilde.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -2,14 +2,14 @@
   "name": "<%= name %>",
   "dependencies": {
     "ember": "2.0.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-shims": "~0.0.5",
+    "ember-cli-test-loader": "~0.2.0",
     "ember-data": "2.0.0",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-load-initializers": "~0.1.6",
     "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
+    "loader.js": "~3.3.0",
     "qunit": "~1.18.0"
   },
   "resolutions": {


### PR DESCRIPTION
After starting a new project working off `ember-cli#master`, I had to update the packages in the PR to get things working (also I'm using Ember and Ember-Data beta) 

`ember-cli-shims` and `ember-load-initializers` were not registered in bower, I just did that so this should work. I know we want to get off-bower but while we do we should make the process as easy as possible for newcomers.
