### PR TITLE
[BUGFIX #4814] Add Node.js 4.0 as valid platform version

### DIFF
--- a/lib/utilities/valid-platform-version.js
+++ b/lib/utilities/valid-platform-version.js
@@ -8,5 +8,6 @@ module.exports = function(version) {
          semver.satisfies(version, '^2.0.0')  || // io.js 2.x.y
          semver.satisfies(version, '^3.0.0')  || // io.js (dev)
          semver.satisfies(version, '^0.12.0') || // node 0.12.x
-         semver.satisfies(version, '^0.13.0');   // node 0.13.x
+         semver.satisfies(version, '^0.13.0') || // node 0.13.x
+         semver.satisfies(version, '^4.0.0');    // node 4.x.x
 };

--- a/lib/utilities/valid-platform-version.js
+++ b/lib/utilities/valid-platform-version.js
@@ -4,10 +4,5 @@ var semver = require('semver');
 
 module.exports = function(version) {
 
-  return semver.satisfies(version, '^1.0.0')  || // io.js 1.x.y
-         semver.satisfies(version, '^2.0.0')  || // io.js 2.x.y
-         semver.satisfies(version, '^3.0.0')  || // io.js (dev)
-         semver.satisfies(version, '^0.12.0') || // node 0.12.x
-         semver.satisfies(version, '^0.13.0') || // node 0.13.x
-         semver.satisfies(version, '^4.0.0');    // node 4.x.x
+  return semver.satisfies(version, '>=0.12.0');
 };

--- a/tests/unit/utilities/valid-platform-version-test.js
+++ b/tests/unit/utilities/valid-platform-version-test.js
@@ -32,4 +32,12 @@ describe('platform-version-check', function() {
     expect(checkValidPlatform('v0.13.15')).to.be.equal(true);
     expect(checkValidPlatform('v0.13.30')).to.be.equal(true);
   });
+
+  it('should return true if running on node v4.0', function() {
+    expect(checkValidPlatform('v4.0.0')).to.be.equal(true);
+    expect(checkValidPlatform('v4.0.15')).to.be.equal(true);
+    expect(checkValidPlatform('v4.0.30')).to.be.equal(true);
+    expect(checkValidPlatform('v4.1.0')).to.be.equal(true);
+    expect(checkValidPlatform('v4.2.0')).to.be.equal(true);
+  });
 });


### PR DESCRIPTION
Connected Issue: https://github.com/ember-cli/ember-cli/issues/4814

![image](https://cloud.githubusercontent.com/assets/1009783/9749477/49dc55c4-56e1-11e5-8e45-bcd269bb8996.png)