### PR TITLE
[ENHANCEMENT] Allow OS to choose ephemeral port if --test-port=0

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -34,12 +34,15 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions) {
+    var port = commandOptions.port ? Promise.resolve(commandOptions.port) : this._getPort({ host: commandOptions.host });
     var liveReloadHost = commandOptions.liveReloadHost || commandOptions.host;
-    var liveReloadPort = commandOptions.liveReloadPort ? Promise.resolve(commandOptions.liveReloadPort) :
-                                                         this._getPort({ host: liveReloadHost });
+    var liveReloadPort = commandOptions.liveReloadPort ? Promise.resolve(commandOptions.liveReloadPort) : this._getPort({ host: liveReloadHost });
 
-    return liveReloadPort.then(function(liveReloadPort) {
+    return Promise.all([liveReloadPort, port]).then(function(values) {
+      var liveReloadPort = values[0];
+      var port = values[1];
       commandOptions = assign({}, commandOptions, {
+        port: port,
         liveReloadPort: liveReloadPort,
         liveReloadHost: liveReloadHost,
         baseURL: this.project.config(commandOptions.environment).baseURL || '/'

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -73,7 +73,7 @@ module.exports = Command.extend({
   },
 
   _generateTestPortNumber: function(options) {
-    if (options.port && options.testPort !== defaultPortNumber || options.testPort && !options.port) { return options.testPort; }
+    if (options.port && options.testPort !== defaultPortNumber || !isNaN(parseInt(options.testPort)) && !options.port) { return options.testPort; }
     if (options.port) { return parseInt(options.port, 10) + 1; }
   },
 

--- a/tests/unit/commands/server-test.js
+++ b/tests/unit/commands/server-test.js
@@ -49,8 +49,21 @@ describe('server command', function() {
 
       expect(serveRun.called).to.equal(1, 'expected run to be called once');
 
-      expect(runOps.port).to.equal(4000,            'has correct port');
+      expect(runOps.port).to.equal(4000, 'has correct port');
       expect(runOps.liveReloadPort).to.be.within(49152, 65535, 'has correct liveReload port');
+    });
+  });
+
+  it('allows OS to choose port', function() {
+    return new ServeCommand(options).validateAndRun([
+      '--port', '0'
+    ]).then(function() {
+      var serveRun = tasks.Serve.prototype.run;
+      var runOps = serveRun.calledWith[0][0];
+
+      expect(serveRun.called).to.equal(1, 'expected run to be called once');
+
+      expect(runOps.port).to.be.within(49152, 65535, 'has correct port');
     });
   });
 

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -88,6 +88,14 @@ describe('test command', function() {
     });
   });
 
+  it('passes through a custom test port option of 0 to allow OS to chose ephemeral port', function() {
+    return new TestCommand(options).validateAndRun(['--test-port=0']).then(function() {
+      var testOptions  = testRun.calledWith[0][0];
+
+      expect(testOptions.port).to.equal(0);
+    });
+  });
+
   it('only passes through the port option', function() {
     return new TestCommand(options).validateAndRun(['--port=5678']).then(function() {
       var testOptions  = testRun.calledWith[0][0];

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -88,7 +88,7 @@ describe('test command', function() {
     });
   });
 
-  it('passes through a custom test port option of 0 to allow OS to chose ephemeral port', function() {
+  it('passes through a custom test port option of 0 to allow OS to choose open system port', function() {
     return new TestCommand(options).validateAndRun(['--test-port=0']).then(function() {
       var testOptions  = testRun.calledWith[0][0];
 


### PR DESCRIPTION
We ran into this problem on our CI server as we have many ember project build running at the same time and colliding on the default port. We started getting tricky by trying to bind to a port prior to running the tests but then we still ended up with weird race conditions. If we are allowed to pass 0, the OS will choose an open port at the time of test execution. We were unable to set the `--test-port=0` as the check in the `TestCommand` was a simple truthy check that would fail if it was set to `0`. With the modification to check if it is an int, we will be able to pass 0 through.