### PR TITLE
[FEATURE] Add clean script to package.json in app blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "ember build",
+    "clean": "npm cache clean && bower cache clean && rimraf node_modules bower_components dist tmp",
     "start": "ember server",
     "test": "ember test"
   },


### PR DESCRIPTION
Adds a clean script the default app blueprint, allowing users to run the following command:

`npm run clean`

which will clean the npm/bower caches and remove node_modules/bower_components/dist/tmp

As outlined [here](http://jhawk.co/upgrading-ember-i).