### PR TITLE
Update bower deps.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -3,14 +3,14 @@
   "dependencies": {
     "ember": "2.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
     "ember-data": "2.0.0",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
+    "loader.js": "ember-cli/loader.js#3.3.0",
+    "qunit": "~1.19.0"
   },
   "resolutions": {
     "ember": "2.0.0"


### PR DESCRIPTION
* Update ember-cli-test-loader to incorporate include/exclude patterns
  for test module loading, and "unsee" test modules after they are
  evaluated.
* Update ember-load-initializers to prevent errors from ocurring in
  Ember < 1.12 when an addon includes an `instance-initializer`.
* Update loader.js to include `require.unsee` to allow required modules
  to be cleared.
* Update qunit to 1.19 to get various bugfixes and improvements.

---

Replaces the version bumps in #4809, but does not change to allow loose versioning yet.