### PR TITLE
[DOCS] Bump recommended node ver to 4.0.x

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -10,7 +10,7 @@ github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2014-04-
 
 #### Node
 
-First, install the latest stable version of Node (version 0.12.x).
+First, install the latest stable version of Node (version 4.0.x).
 
 To do so, either follow the installation instructions on
 [nodejs.org](http://nodejs.org/), or use your preferred package manager (such


### PR DESCRIPTION
In the Overview section "Currently, Ember CLI supports Node (4.0 recommended) and npm (2.x).". So specify the same node ver at the Prerequisites section also.