### PR TITLE
[DOCS] Check ver of installed node

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -17,12 +17,12 @@ To do so, either follow the installation instructions on
 as [Homebrew](http://brew.sh/) on OSX) if you have one.
 
 After the installation is complete, verify that Node is set up correctly by
-typing the below commands on the command line. Both should output help
-messages:
+typing the below commands on the command line. Both should output a version
+number:
 
 {% highlight bash %}
-node --help
-npm --help
+node -v
+npm -v
 {% endhighlight %}
 
 #### Ember CLI


### PR DESCRIPTION
Maybe it would help better to check that the newly installed node and npm are available in the user path by using the `-v` switch instead of `--help` so that the user can also check that they have installed the correct version? The downside of this change would be that the user might not discover that the `--help` switch is available.