### PR TITLE
Add `Blueprint.prototype.filesPath`.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -282,6 +282,18 @@ Blueprint.prototype.availableOptions = [];
 Blueprint.prototype.anonymousOptions = ['name'];
 
 /**
+  Used to determine the path to where files will be stored. By default
+  this is `path.join(this.path, 'files)`.
+
+  @method filesPath
+  @return {String} Path to the blueprints files directory.
+*/
+
+Blueprint.prototype.filesPath = function() {
+  return path.join(this.path, 'files');
+};
+
+/**
   Used to retrieve files for blueprint. The `file` param is an
   optional string that is turned into a glob.
 
@@ -291,9 +303,9 @@ Blueprint.prototype.anonymousOptions = ['name'];
 Blueprint.prototype.files = function() {
   if (this._files) { return this._files; }
 
-  var filesPath = path.join(this.path, 'files');
+  var filesPath = this.filesPath();
   if (existsSync(filesPath)) {
-    this._files = walkSync(path.join(this.path, 'files'));
+    this._files = walkSync(filesPath);
   } else {
     this._files = [];
   }
@@ -307,7 +319,7 @@ Blueprint.prototype.files = function() {
   @return {String} Resolved path to the file
 */
 Blueprint.prototype.srcPath = function(file) {
-  return path.resolve(this.path, 'files', file);
+  return path.resolve(this.filesPath(), file);
 };
 
 /**
@@ -1187,7 +1199,7 @@ Blueprint.prototype._getDetailedHelpPath = function() {
   if (!this.path) {
     return null;
   }
-  
+
   return path.join(this.path, './HELP.md');
 };
 

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -197,6 +197,14 @@ describe('Blueprint', function() {
     expect(blueprint.name).to.equal('basic');
   });
 
+  describe('filesPath', function() {
+    it('returns the blueprints default files path', function() {
+      var blueprint = new Blueprint(basicBlueprint);
+
+      expect(blueprint.filesPath()).to.equal(path.join(basicBlueprint, 'files'));
+    });
+  });
+
   describe('basic blueprint installation', function() {
     var BasicBlueprintClass = require(basicBlueprint);
     var blueprint;


### PR DESCRIPTION
By default this returns `path.join(this.path, 'files')`, but it can easily be overridden by blueprints.

One common example is to provide blueprints for both `mocha` and `qunit`. Before these changes you would have to override both `files` and `srcPath` methods (because `path.join(this.path, 'files')` was hard coded in both).

Now, you could add the following to support `mocha` and `qunit` style tests in a test blueprint:

```javascript
var path = require('path');

module.exports = function() {
  description: 'Generate a test for XXXX',
  filesPath() {
    if (this._filesPath) { return this._filesPath; }

    var type;
    if ('ember-cli-mocha' in this.project.addonPackages) {
      type = 'mocha';
    } else if ('ember-cli-qunit' in this.project.addonPackages) {
      type = 'qunit';
    }

    return path.join(this.path, type + '-files');
  }
}
```