### PR TITLE
[DOCS] Add `npm test` to Addon README

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -15,6 +15,7 @@ This README outlines the details of collaborating on this Ember addon.
 
 ## Running Tests
 
+* `npm test` (Runs `ember try:testall` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
 


### PR DESCRIPTION
The default blueprint aliases `npm test` to `ember try:testall` rather than `ember test`, yet the README only mentions running `ember test` and `ember test --server` to test the addon.