### PR TITLE
[FEATURE] addAddonsToProject for blueprints

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -855,7 +855,7 @@ Blueprint.prototype._locals = function(options) {
 };
 
 /**
-  Used to add a package to the projects `package.json`.
+  Used to add a package to the project's `package.json`.
 
   Generally, this would be done from the `afterInstall` hook, to
   ensure that a package that is required by a given blueprint is
@@ -877,7 +877,7 @@ Blueprint.prototype.addPackageToProject = function(packageName, target) {
 };
 
 /**
-  Used to add multiple packages to the projects `package.json`.
+  Used to add multiple packages to the project's `package.json`.
 
   Generally, this would be done from the `afterInstall` hook, to
   ensure that a package that is required by a given blueprint is
@@ -891,8 +891,8 @@ Blueprint.prototype.addPackageToProject = function(packageName, target) {
   @return {Promise}
 */
 Blueprint.prototype.addPackagesToProject = function(packages) {
-  var task         = this.taskFor('npm-install');
-  var install      = (packages.length > 1) ? 'install packages' : 'install package';
+  var task = this.taskFor('npm-install');
+  var installText = (packages.length > 1) ? 'install packages' : 'install package';
   var packageNames = [];
   var packageArray = [];
 
@@ -908,7 +908,7 @@ Blueprint.prototype.addPackagesToProject = function(packages) {
     packageArray.push(packageNameAndVersion);
   }
 
-  this._writeStatusToUI(chalk.green, install, packageNames.join(', '));
+  this._writeStatusToUI(chalk.green, installText, packageNames.join(', '));
 
   return task.run({
     'save-dev': true,
@@ -918,7 +918,7 @@ Blueprint.prototype.addPackagesToProject = function(packages) {
 };
 
 /**
-  Used to remove a package from the projects `package.json`.
+  Used to remove a package from the project's `package.json`.
 
   Generally, this would be done from the `afterInstall` hook, to
   ensure that any package conflicts can be resolved before the
@@ -935,7 +935,7 @@ Blueprint.prototype.removePackageFromProject = function(packageName) {
 };
 
 /**
-  Used to remove multiple packages from the projects `package.json`.
+  Used to remove multiple packages from the project's `package.json`.
 
   Generally, this would be done from the `afterInstall` hook, to
   ensure that any package conflicts can be resolved before the
@@ -948,8 +948,8 @@ Blueprint.prototype.removePackageFromProject = function(packageName) {
   @return {Promise}
 */
 Blueprint.prototype.removePackagesFromProject = function(packages) {
-  var task         = this.taskFor('npm-uninstall');
-  var install      = (packages.length > 1) ? 'uninstall packages' : 'uninstall package';
+  var task = this.taskFor('npm-uninstall');
+  var installText = (packages.length > 1) ? 'uninstall packages' : 'uninstall package';
   var packageNames = [];
   var packageArray = [];
 
@@ -961,7 +961,7 @@ Blueprint.prototype.removePackagesFromProject = function(packages) {
     packageArray.push(packageNameAndVersion);
   }
 
-  this._writeStatusToUI(chalk.green, install, packageNames.join(', '));
+  this._writeStatusToUI(chalk.green, installText, packageNames.join(', '));
 
   return task.run({
     'save-dev': true,
@@ -1031,12 +1031,15 @@ Blueprint.prototype.addBowerPackageToProject = function(localPackageName, target
 */
 Blueprint.prototype.addBowerPackagesToProject = function(packages, installOptions) {
   var task = this.taskFor('bower-install');
-  var packageNamesAndVersions = packages
-    .map(function(pkg) {
-      pkg.source = pkg.source || pkg.name;
-      return pkg;
-    })
-    .map(bowEpParser.compose);
+  var installText = (packages.length > 1) ? 'install bower packages' : 'install bower package';
+  var packageNames = [];
+  var packageNamesAndVersions = packages.map(function (pkg) {
+    pkg.source = pkg.source || pkg.name;
+    packageNames.push(pkg.name);
+    return pkg;
+  }).map(bowEpParser.compose);
+
+  this._writeStatusToUI(chalk.green, installText, packageNames.join(', '));
 
   return task.run({
     verbose: true,
@@ -1046,7 +1049,7 @@ Blueprint.prototype.addBowerPackagesToProject = function(packages, installOption
 };
 
 /**
-  Used to add an addon to the projects `package.json` and run it's
+  Used to add an addon to the project's `package.json` and run it's
   `defaultBlueprint` if it provides one.
 
   Generally, this would be done from the `afterInstall` hook, to
@@ -1058,29 +1061,57 @@ Blueprint.prototype.addBowerPackagesToProject = function(packages, installOption
   @return {Promise}
 */
 Blueprint.prototype.addAddonToProject = function(options) {
-  var taskOptions = {};
+  return this.addAddonsToProject({
+    packages: [options],
+    extraArgs: options.extraArgs || {},
+    blueprintOptions: options.blueprintOptions || {}
+  });
+};
 
-  if (typeof options === 'string') {
-    taskOptions['packages'] = [options];
+/**
+  Used to add multiple addons to the project's `package.json` and run their
+  `defaultBlueprint` if they provide one.
+
+  Generally, this would be done from the `afterInstall` hook, to
+  ensure that a package that is required by a given blueprint is
+  available.
+
+  @method addAddonsToProject
+  @param {Object} options
+  @return {Promise}
+*/
+Blueprint.prototype.addAddonsToProject = function (options) {
+  var taskOptions = {
+    packages: [],
+    extraArgs: options.extraArgs || [],
+    blueprintOptions: options.blueprintOptions || {}
+  };
+
+  var packages = options.packages;
+  if (packages && packages.length) {
+    taskOptions.packages = packages.map(function (pkg) {
+      if (typeof pkg === 'string') {
+        return pkg;
+      }
+
+      if (!pkg.name) {
+        throw new SilentError('You must provide a package `name` to addAddonsToProject');
+      }
+
+      if (pkg.target) {
+        pkg.name += '@' + pkg.target;
+      }
+
+      return pkg.name;
+    });
   } else {
-    if (!options.name) {
-      throw new SilentError('You must provide a `name` to addAddonToProject');
-    }
-
-    if (options.target) {
-      options.name += '@' + options.target;
-    }
-
-    taskOptions['packages']      = [options.name];
-    taskOptions.extraArgs        = options.extraArgs || [];
-    taskOptions.blueprintOptions = options.blueprintOptions || {};
+    throw new SilentError('You must provide package to addAddonsToProject');
   }
 
-  var task = this.taskFor('addon-install');
+  var installText = (packages.length > 1) ? 'install addons' : 'install addon';
+  this._writeStatusToUI(chalk.green, installText, taskOptions['packages'].join(', '));
 
-  this._writeStatusToUI(chalk.green, 'install addon', taskOptions['packages']);
-
-  return task.run(taskOptions);
+  return this.taskFor('addon-install').run(taskOptions);
 };
 
 /**


### PR DESCRIPTION
This adds the `addAddonsToProject` method to mirror the same aggregate functionality provided by `addPackagesToProject` and `addBowerPackagesToProject`
Additionally, refactors `addAddonToProject` to leverage the new method
Also adds `_writeStatusToUI` to `addBowerPackagesToProject` to bring it to parity with the npm/addon versions

Here's an example blueprint you can use to test `addAddonsToProject`:

```
module.exports = {
  description: 'Set up additional packages for Ember apps',
  normalizeEntityName: function() {}, // no-op since we're just adding dependencies

  afterInstall: function(options) {
    return this.addAddonsToProject({
      packages: [
        'ember-cli-blanket',
        'ember-cli-sass-pods',
        'ember-cpm',
        'ember-feature-flags',
        'ember-metrics',
        'ember-moment'
      ]
    });
  }
};
```

I chose several common addons that have various blueprint actions in their afterInstall so that it's clear each blueprint is being executed as expected. Additionally, you may pass objects in the `packages` array to indicate version compatibility or include it in the string itself.

```
module.exports = {
  description: 'Set up additional packages for Ember apps',
  normalizeEntityName: function() {}, // no-op since we're just adding dependencies

  afterInstall: function(options) {
    return this.addAddonsToProject({
      packages: [
        'ember-cli-blanket',
        'ember-cli-sass-pods',
        'ember-cpm',
        { name: 'ember-feature-flags', target: '1.1.0' },
        'ember-metrics',
        'ember-moment@3.4.0'
      ]
    });
  }
};
```