### PR TITLE
[Safe for 2.0] Update initializer blueprints.

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { initialize } from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
+import <%= classifiedModuleName %>Initializer from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 var registry, application;
@@ -16,7 +16,7 @@ module('<%= friendlyTestName %>', {
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  initialize(registry, application);
+  <%= classifiedModuleName %>Initializer.initialize(registry, application);
 
   // you would normally confirm the results of the initializer here
   assert.ok(true);


### PR DESCRIPTION
The initializer API has changed as of 2.X, the blueprints need to be updated to address those changes. See also: https://github.com/emberjs/ember.js/pull/10179