### PR TITLE
[Safe for 2.1] Update initializer blueprint.

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { initialize } from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
+import <%= classifiedModuleName %>Initializer from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 var application;
@@ -15,7 +15,7 @@ module('<%= friendlyTestName %>', {
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  initialize(application);
+  <%= classifiedModuleName %>Initializer.initialize(application);
 
   // you would normally confirm the results of the initializer here
   assert.ok(true);

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -535,7 +535,7 @@ describe('Acceptance: ember generate', function() {
       });
 
       assertFile('tests/unit/initializers/foo-test.js', {
-        contains: "import { initialize } from '../../../initializers/foo';"
+        contains: "import FooInitializer from '../../../initializers/foo';"
       });
     });
   });
@@ -544,10 +544,10 @@ describe('Acceptance: ember generate', function() {
     return generate(['initializer-test', 'foo']).then(function() {
       assertFile('tests/unit/initializers/foo-test.js', {
         contains: [
-          "import { initialize } from '../../../initializers/foo';",
+          "import FooInitializer from '../../../initializers/foo';",
           "module('Unit | Initializer | foo'",
           "var application;",
-          "initialize(application);"
+          "FooInitializer.initialize(application);"
         ]
       });
     });
@@ -567,7 +567,7 @@ describe('Acceptance: ember generate', function() {
       });
 
       assertFile('tests/unit/initializers/foo/bar-test.js', {
-        contains: "import { initialize } from '../../../../initializers/foo/bar';"
+        contains: "import FooBarInitializer from '../../../../initializers/foo/bar';"
       });
     });
   });


### PR DESCRIPTION
Fixes the test blueprint to invoke the initializer in a way such that `this` is set. See: https://github.com/emberjs/ember.js/pull/10179