### PR TITLE
adds travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
+language: node_js
 sudo: false
-env:
-  - NODE_VERSION=0.10
-  - NODE_VERSION=0.12
-  - NODE_VERSION=iojs
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs-v2"
+  - "iojs-v3"
+  - "4"
 
 os:
   - linux
 script: npm run-script test-all:cover
 before_install:
-  - test $TRAVIS_OS_NAME = "osx" && brew update && brew install nvm && source $(brew --prefix nvm)/nvm.sh && brew install phantomjs || test $TRAVIS_OS_NAME = "linux"
-  - nvm install $NODE_VERSION
   - npm config set spin false
 install:
-  - node --version
-  - npm --version
   - git --version
   - npm install --no-optional
 


### PR DESCRIPTION
Changes `travis.yml` to use the [node](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Choosing-Node-versions-to-test-against) [build matrix](http://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix).
This removes the manual nvm, npm and node installation. In addition the manual version logging is removed because travis does that automatically in a `node_js` language config ([example](https://travis-ci.org/lovell/sharp/jobs/79881738#L41)).

The change also includes node 4, iojs-v2 and iojs-v3 as node test version.

The updated `.travis.yml` will still fail to build because there exiting test errors.
