### PR TITLE
fix failing tests

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1169,12 +1169,6 @@ EmberApp.prototype.testFiles = function() {
     annotation: 'Concat: Test Support Suffix'
   });
 
-  var testCss = this.concatFiles(external, {
-    inputFiles: this.vendorTestStaticStyles,
-    outputFile: this.options.outputPaths.testSupport.css,
-    annotation: 'Concat: Test Support CSS'
-  });
-
   var testemPath = path.join(__dirname, 'testem');
   testemPath = path.dirname(testemPath);
 
@@ -1198,10 +1192,19 @@ EmberApp.prototype.testFiles = function() {
 
   var sourceTrees = [
     testJs,
-    testCss,
     testLoader,
     testemTree
   ];
+
+  if (this.vendorTestStaticStyles.length > 0) {
+    sourceTrees.push(
+      this.concatFiles(external, {
+        inputFiles: this.vendorTestStaticStyles,
+        outputFile: this.options.outputPaths.testSupport.css,
+        annotation: 'Concat: Test Support CSS'
+      })
+    );
+  }
 
   return mergeTrees(sourceTrees, {
       overwrite: true,

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -63,17 +63,19 @@ module.exports = Task.extend({
 
     var builder = this;
 
-    this.builder.on('start', function() {
-      builder.monitor = new FSMonitor();
-    });
+    if (process.env.BROCCOLI_VIZ) {
+      this.builder.on('start', function() {
+        builder.monitor = new FSMonitor();
+      });
 
-    this.builder.on('nodeStart', function(node) {
-      builder.monitor.push(node);
-    });
+      this.builder.on('nodeStart', function(node) {
+        builder.monitor.push(node);
+      });
 
-    this.builder.on('nodeEnd', function() {
-      builder.monitor.pop();
-    });
+      this.builder.on('nodeEnd', function() {
+        builder.monitor.pop();
+      });
+    }
   },
 
   trapSignals: function() {

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -691,8 +691,18 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                     "    res.status(204).end();" + EOL +
                     "  });" + EOL +
                     EOL +
+                    "  // The POST and PUT call will not contain a request body" + EOL +
+                    "  // because the body-parser is not included by default." + EOL +
+                    "  // To use req.body, run:" + EOL +
+                    EOL +
+                    "  //    npm install --save-dev body-parser" + EOL +
+                    EOL +
+                    "  // After installing, you need to `use` the body-parser for" + EOL +
+                    "  // this mock uncommenting the following line:" + EOL +
+                    "  //" + EOL +
+                    "  //app.use('/api/foo', require('body-parser'));" + EOL +
                     "  app.use('/api/foo', fooRouter);" + EOL +
-                    "};"
+                    "};" + EOL
         });
         assertFile('server/.jshintrc', {
           contains: '{' + EOL + '  "node": true' + EOL + '}'
@@ -740,8 +750,18 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                     "    res.status(204).end();" + EOL +
                     "  });" + EOL +
                     EOL +
+                    "  // The POST and PUT call will not contain a request body" + EOL +
+                    "  // because the body-parser is not included by default." + EOL +
+                    "  // To use req.body, run:" + EOL +
+                    EOL +
+                    "  //    npm install --save-dev body-parser" + EOL +
+                    EOL +
+                    "  // After installing, you need to `use` the body-parser for" + EOL +
+                    "  // this mock uncommenting the following line:" + EOL +
+                    "  //" + EOL +
+                    "  //app.use('/api/foo-bar', require('body-parser'));" + EOL +
                     "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
-                    "};"
+                    "};" + EOL
         });
         assertFile('server/.jshintrc', {
           contains: '{' + EOL + '  "node": true' + EOL + '}'

--- a/tests/helpers/assert-file.js
+++ b/tests/helpers/assert-file.js
@@ -58,10 +58,15 @@ module.exports = function assertFile(file, options) {
         pass = contains(actual, expected);
       }
 
-      expect(pass).to.equal(true, EOL + EOL + 'expected ' + file + ':' + EOL + EOL +
-                                  actual +
-                                  EOL + 'to contain:' + EOL + EOL +
-                                  expected + EOL);
+      var message =  'expected: `' + file + '`';
+      if (pass) {
+        expect(true).to.equal(true, EOL + EOL + 'expected ' + file + ':' + EOL + EOL +
+                                    actual +
+                                    EOL + 'to contain:' + EOL + EOL +
+                                    expected + EOL);
+      } else {
+        throw new EqualityError(message, actual, expected);
+      }
     });
   }
 
@@ -82,3 +87,15 @@ module.exports = function assertFile(file, options) {
     });
   }
 };
+
+function EqualityError(message, actual, expected) {
+  this.message = message;
+  this.actual = actual;
+  this.expected = expected;
+  this.showDiff = true;
+  Error.captureStackTrace(this, module.exports);
+}
+
+EqualityError.prototype = Object.create(Error.prototype);
+EqualityError.prototype.name = 'EqualityError';
+EqualityError.prototype.constructor = EqualityError;


### PR DESCRIPTION
this.vendorTestStaticStyles can be empty, lets not bother concatting if it is empty.

- [x] simpleconcat is more strict
- [x] fix test failure introduced by "green" build, being out-of-sync with master when merged
- [x] assertFile now gives a useful diff output.
- [x] fix upstream DEP causing everything to be emo.

new diff output example:

<img width="472" alt="screen shot 2015-09-13 at 6 41 48 pm" src="https://cloud.githubusercontent.com/assets/1377/9840451/29845650-5a47-11e5-89f0-11a8eca82ba4.png">
