### PR TITLE
Only exclude node_modules at root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-node_modules
+/node_modules
 npm-debug.log
 tmp*
 _posts
 _site
 common-tmp
 *.tgz
-docs/build
+/docs/build
 .node_modules-tmp
 .bower_components-tmp
-coverage
+/coverage


### PR DESCRIPTION
We have some checked-in node_modules (e.g. at
tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules)
that we don't want to ignore.

Also adding slashes to `docs/build` and `coverage` for good measure. (I believe these only ever exist at the root as well, yes?)