### PR TITLE
New logo fixes for small mobile phones

### DIFF
--- a/assets/styles/ecli.css
+++ b/assets/styles/ecli.css
@@ -304,6 +304,11 @@ body {
   .content-section .guide-content .edit-page {
     margin-top: 5px; } }
 @media (max-width: 500px) {
+  #showcase .content .brand {
+    height: 78px;
+    width: 290px;
+    margin-top: 30px; }
+
   #showcase .primary-nav {
     margin-top: 2em; }
 

--- a/assets/styles/ecli.scss
+++ b/assets/styles/ecli.scss
@@ -320,6 +320,12 @@ body {
 }
 
 @media (max-width:500px) {
+  #showcase .content .brand {
+    height: 78px;
+    width: 290px;
+    margin-top: 30px;
+  }
+
   #showcase .primary-nav {
     margin-top:2em;
   }


### PR DESCRIPTION
In PR #4853 I tested the mobile version on a big screen, it breaks on small ones such as iPhone 5s.


<img width="319" alt="screen shot 2015-09-15 at 1 13 11 pm" src="https://cloud.githubusercontent.com/assets/230476/9889025/43dd556c-5bad-11e5-8a1a-f5e1763b1602.png">

<img width="375" alt="screen shot 2015-09-15 at 1 14 08 pm" src="https://cloud.githubusercontent.com/assets/230476/9889024/43dce122-5bad-11e5-9506-abf2dc2c1f3a.png">
