### PR TITLE
remove duplicate in package.json

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
+    "ember-ajax": "0.6.2",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.3",
@@ -35,8 +36,6 @@
     "ember-data": "2.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.4",
-    "ember-resolver": "^2.0.2",
-    "ember-ajax": "0.6.2",
-    "ember-export-application-global": "^1.0.3"
+    "ember-resolver": "^2.0.2"
   }
 }


### PR DESCRIPTION
removes `"ember-export-application-global": "^1.0.3"`, which appears to be a left over.

also sorts the list.