### PR TITLE
Break out tests into separate file

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -18,13 +18,14 @@
     {{content-for 'test-head-footer'}}
   </head>
   <body>
-
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/<%= name %>.js"></script>
     <script src="testem.js" integrity=""></script>
+    <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -183,6 +183,9 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
       },
       js: '/assets/' + this.name + '.js'
     },
+    tests: {
+      js: '/assets/tests.js'
+    },
     vendor: {
       css: '/assets/vendor.css',
       js: '/assets/vendor.js'
@@ -882,7 +885,8 @@ EmberApp.prototype._processedEmberCLITree = function() {
     'app-suffix.js',
     'app-boot.js',
     'test-support-prefix.js',
-    'test-support-suffix.js'
+    'test-support-suffix.js',
+    'tests-suffix.js'
   ];
   var emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
@@ -933,8 +937,6 @@ EmberApp.prototype.appAndDependencies = function() {
     registry: this.registry
   });
 
-  this._addAppTests(sourceTrees);
-
   var postprocessedApp = this.addonPostprocessTree('js', preprocessedApp);
   sourceTrees = sourceTrees.concat([
     external,
@@ -954,17 +956,16 @@ EmberApp.prototype.appAndDependencies = function() {
 
 /**
   @private
-  @method _addAppTests
-  @param {Array} sourceTrees
+  @method appTests
 */
-EmberApp.prototype._addAppTests = function(sourceTrees) {
-  if (this.tests) {
+EmberApp.prototype.appTests = function() {
+    var appTestTrees = [];
     var tests = this.addonPreprocessTree('test', this._processedTestsTree());
     var preprocessedTests = preprocessJs(tests, '/tests', this.name, {
       registry: this.registry
     });
 
-    sourceTrees.push(this.addonPostprocessTree('test', preprocessedTests));
+    appTestTrees.push(this.addonPostprocessTree('test', preprocessedTests));
 
     if (this.hinting) {
       var jshintedApp = this.addonLintTree('app', this._filterAppTree());
@@ -976,17 +977,29 @@ EmberApp.prototype._addAppTests = function(sourceTrees) {
         annotation: 'Funnel (jshint app)'
       }), this._prunedBabelOptions());
 
-
       jshintedTests = new Babel(new Funnel(jshintedTests, {
         srcDir: '/',
         destDir: this.name + '/tests/',
         annotation: 'Funnel (jshint tests)'
       }), this._prunedBabelOptions());
 
-      sourceTrees.push(jshintedApp);
-      sourceTrees.push(jshintedTests);
+      appTestTrees.push(jshintedApp);
+      appTestTrees.push(jshintedTests);
     }
-  }
+
+   appTestTrees.push(this._processedEmberCLITree());
+
+    appTestTrees = mergeTrees(appTestTrees, {
+      overwrite: true,
+      annotation: 'TreeMerger (appTestTrees)'
+    });
+
+    return this.concatFiles(appTestTrees, {
+      inputFiles: [ this.name + '/tests/**/*.js' ],
+      footerFiles: [ 'vendor/ember-cli/tests-suffix.js' ],
+      outputFile: this.options.outputPaths.tests.js,
+      annotation: 'Concat: App Tests'
+    });
 };
 
 /**
@@ -1383,7 +1396,7 @@ EmberApp.prototype.toArray = function() {
   ];
 
   if (this.tests) {
-    sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles());
+    sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles(), this.appTests());
   }
 
   return sourceTrees;
@@ -1486,19 +1499,15 @@ EmberApp.prototype._contentForConfigModule = function(content, config) {
   @param {Object} config
 */
 EmberApp.prototype._contentForAppBoot = function(content, config) {
-  content.push('if (runningTests) {');
-  content.push('  require("' +
-    config.modulePrefix +
-    '/tests/test-helper");');
   if (this.options.autoRun) {
-    content.push('} else {');
+    content.push('if (!runningTests) {');
     content.push('  require("' +
       config.modulePrefix +
       '/app")["default"].create(' +
       calculateAppConfig(config) +
       ');');
+    content.push('}');
   }
-  content.push('}');
 };
 
 /**

--- a/lib/broccoli/tests-suffix.js
+++ b/lib/broccoli/tests-suffix.js
@@ -1,0 +1,5 @@
+/* jshint ignore:start */
+
+require('{{MODULE_PREFIX}}/tests/test-helper');
+
+/* jshint ignore:end */

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -138,7 +138,7 @@ describe('Acceptance: smoke-test', function() {
         var dirPath = path.join('.', 'dist');
         var paths = walkSync(dirPath);
 
-        expect(paths).to.have.length.below(21, 'expected fewer than 21 files in dist, found ' + paths.length);
+        expect(paths).to.have.length.below(23, 'expected fewer than 23 files in dist, found ' + paths.length);
       });
   });
 


### PR DESCRIPTION
Addresses #4862. Moves the test files to be their own file (`/assets/tests.js`), instead of lumped in with `app.js`.