### PR TITLE
Remove Component Test Blueprint `assert.expect`s

### DIFF
--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -8,8 +8,7 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-  <% if (testType === 'integration' ) { %>assert.expect(2);
-
+  <% if (testType === 'integration' ) { %>
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
 
@@ -24,8 +23,7 @@ test('it renders', function(assert) {
     {{/<%= componentPathName %>}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>assert.expect(1);
-
+  assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>
   // Creates the component instance
   /*var component =*/ this.subject();
   // Renders the component to the page


### PR DESCRIPTION
All steps in the generated exercise and assertion phases occur
synchronously. Therefore, the `assert.expect(n)` lines:

* add noise to the generated file
* make the resulting tests brittle
* encourages new Ember developers to unnecessarily add them to future
  tests