### PR TITLE
Add ability to specify a build path for running tests

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var Command = require('../models/command');
-var Watcher = require('../models/watcher');
-var Builder = require('../models/builder');
-var fs      = require('fs');
-var path    = require('path');
-var win     = require('../utilities/windows-admin');
+var Command     = require('../models/command');
+var Watcher     = require('../models/watcher');
+var Builder     = require('../models/builder');
+var SilentError = require('silent-error');
+var fs          = require('fs');
+var path        = require('path');
+var win         = require('../utilities/windows-admin');
+var existsSync  = require('exists-sync');
 
 var defaultPort = 7357;
 
@@ -25,7 +27,8 @@ module.exports = Command.extend({
     { name: 'watcher',     type: String,  default: 'events',        aliases: ['w'] },
     { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
     { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit]' },
-    { name: 'test-page',   type: String,                                             description: 'Test page to invoke' }
+    { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
+    { name: 'path',        type: String,                                             description: 'Path to a build to run tests against.' }
   ],
 
   init: function() {
@@ -90,7 +93,19 @@ module.exports = Command.extend({
   },
 
   run: function(commandOptions) {
-    var outputPath  = this.tmp();
+    var hasBuild = !!commandOptions.path;
+    var outputPath;
+
+    if (hasBuild) {
+      outputPath = path.resolve(commandOptions.path);
+
+      if (!existsSync(outputPath)) {
+        throw new SilentError('The path ' + commandOptions.path + ' does not exist. Please specify a valid build directory to test.');
+      }
+    } else {
+      outputPath = this.tmp();
+    }
+
     process.env['EMBER_CLI_TEST_OUTPUT'] = outputPath;
     var testOptions = this.assign({}, commandOptions, {
       outputPath: outputPath,
@@ -106,6 +121,10 @@ module.exports = Command.extend({
     };
 
     if (commandOptions.server) {
+      if (hasBuild) {
+        throw new SilentError('Specifying a build is not allowed with the `--server` option.');
+      }
+
       options.builder = new this.Builder(testOptions);
 
       var TestServerTask = this.tasks.TestServer;
@@ -120,9 +139,15 @@ module.exports = Command.extend({
         .finally(this.rmTmp.bind(this));
     } else {
       var TestTask  = this.tasks.Test;
-      var BuildTask = this.tasks.Build;
-
       var test  = new TestTask(options);
+
+      if (hasBuild) {
+        return win.checkWindowsElevation(this.ui).then(function() {
+          return test.run(testOptions).finally(this.rmTmp.bind(this));
+        }.bind(this));
+      }
+
+      var BuildTask = this.tasks.Build;
       var build = new BuildTask(options);
 
       return win.checkWindowsElevation(this.ui).then(function() {

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -189,6 +189,7 @@ ember test \u001b[36m<options...>\u001b[39m' + EOL + '\
   \u001b[36m--reporter\u001b[39m \u001b[36m(String)\u001b[39m Test reporter to use [tap|dot|xunit]' + EOL + '\
     \u001b[90maliases: -r <value>\u001b[39m' + EOL + '\
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke' + EOL + '\
+  \u001b[36m--path\u001b[39m \u001b[36m(String)\u001b[39m Path to a build to run tests against.' + EOL + '\
 ' + EOL + '\
 ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
   outputs ember-cli version' + EOL + '\
@@ -1082,6 +1083,12 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
                 name: 'test-page',
                 description: 'Test page to invoke',
                 key: 'testPage',
+                required: false
+              },
+              {
+                name: 'path',
+                description: 'Path to a build to run tests against.',
+                key: 'path',
                 required: false
               }
             ],

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -134,6 +134,27 @@ describe('test command', function() {
         expect(testOptions.reporter).to.equal('xunit');
       });
     });
+
+    it('has the correct options when called with a build path and does not run a build task', function() {
+      return command.validateAndRun(['--path=tests']).then(function() {
+        expect(buildRun.called).to.equal(0, 'build task not called');
+        expect(testRun.called).to.equal(1, 'test task called once');
+
+        var testOptions = testRun.calledWith[0][0];
+
+        expect(testOptions.outputPath).to.equal(path.resolve('tests'), 'has outputPath');
+        expect(testOptions.configFile).to.equal('./testem.json', 'has config file');
+        expect(testOptions.port).to.equal(7357, 'has config file');
+      });
+    });
+
+    it('throws an error if the build path does not exist', function() {
+      return command.validateAndRun(['--path=bad/path/to/build']).then(function() {
+        expect(false, 'should have rejected the build path');
+      }).catch(function(error) {
+        expect(error.message).to.equal('The path bad/path/to/build does not exist. Please specify a valid build directory to test.');
+      });
+    });
   });
 
   describe('--server option', function() {
@@ -157,6 +178,14 @@ describe('test command', function() {
         var testOptions = testServerRun.calledWith[0][0];
 
         expect(testOptions.watcher.options.watcher).to.equal('polling');
+      });
+    });
+
+    it('throws an error if using a build path', function() {
+      return command.validateAndRun(['--server', '--path=tests']).then(function() {
+        expect(false, 'should have rejected using a build path with the server');
+      }).catch(function(error) {
+        expect(error.message).to.equal('Specifying a build is not allowed with the `--server` option.');
       });
     });
   });


### PR DESCRIPTION
Addresses #4872. Adds the `--path` option to allow you to run the tests from a previous build of the application.