### PR TITLE
blueprint unit test fix

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1336,7 +1336,7 @@ Blueprint.list = function(options) {
     }
 
     blueprints = blueprints.map(function(blueprintPath) {
-      var blueprint   = Blueprint.load(blueprintPath);
+      var blueprint = Blueprint.load(blueprintPath);
       var name;
 
       if (blueprint) {

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -162,28 +162,17 @@ describe('Blueprint', function() {
     it('returns a list of blueprints grouped by lookup path', function() {
       var list = Blueprint.list({ paths: [fixtureBlueprints] });
       var actual = list[0];
-      var expected = {
-        source: 'fixtures',
-        blueprints: [{
-          name: 'basic',
-          description: 'A basic blueprint',
-          overridden: false
-        }, {
-          name: 'basic_2',
-          description: 'Another basic blueprint',
-          overridden: false
-        }, {
-          name: 'exporting-object',
-          description: 'A blueprint that exports an object',
-          overridden: false
-        }, {
-          name: 'with-templating',
-          description: 'A blueprint with templating',
-          overridden: false
-        }]
-      };
 
-      expect(actual[0]).to.deep.equal(expected[0]);
+      expect(actual.source).to.equal('fixtures');
+      expect(actual.blueprints.length).to.equal(4);
+      expect(actual.blueprints[0].name).to.equal('basic');
+      expect(actual.blueprints[0].overridden, false);
+      expect(actual.blueprints[1].name).to.equal('basic_2');
+      expect(actual.blueprints[1].overridden, false);
+      expect(actual.blueprints[2].name).to.equal('exporting-object');
+      expect(actual.blueprints[2].overridden, false);
+      expect(actual.blueprints[3].name).to.equal('with-templating');
+      expect(actual.blueprints[3].overridden, false);
     });
   });
 


### PR DESCRIPTION
The original assert was just comparing `undefined` to `undefined` and passing. After taking out the indexer, deep equal wasn't working because the blueprint objects had way more properties than being tested.