### PR TITLE
add unit test for blueprint overriding

### DIFF
--- a/tests/helpers/stub.js
+++ b/tests/helpers/stub.js
@@ -1,13 +1,13 @@
 'use strict';
 
 module.exports = {
-  stub: function stub(obj, name, value) {
+  stub: function stub(obj, name, value, shouldInvoke) {
     var original = obj[name];
 
     obj[name] = function() {
       obj[name].called++;
       obj[name].calledWith.push(arguments);
-      return value;
+      return shouldInvoke ? value.apply(this, arguments) : value;
     };
 
     obj[name].restore = function() {


### PR DESCRIPTION
There was no unit test for blueprint overriding. I also modified the `stub` helper so you can work with instances instead of singletons if you want.