### PR TITLE
Bump ember-qunit-notification version.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -7,7 +7,7 @@
     "ember-data": "2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.10",
-    "ember-qunit-notifications": "0.0.7",
+    "ember-qunit-notifications": "0.1.0",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.3.0",
     "qunit": "~1.19.0"


### PR DESCRIPTION
Dependent upon:
https://github.com/dockyard/ember-qunit-notifications/pull/6 (And a 0.1.0 tag of that project.)

Which was dependent upon
https://github.com/dockyard/qunit-notifications/pull/24

Just cascading the changes through the ecosystem.