### PR TITLE
Allow content to be mutated in contentFor.

### DIFF
--- a/ADDON_HOOKS.md
+++ b/ADDON_HOOKS.md
@@ -373,6 +373,7 @@ Allow addons to implement contentFor method to add string output into the associ
 
 - type
 - config
+- content
 
 **Source:** [lib/broccoli/ember-app.js:1167](https://github.com/ember-cli/ember-cli/blob/v0.1.15/lib/broccoli/ember-app.js#L1167)
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1438,7 +1438,7 @@ EmberApp.prototype.contentFor = function(config, match, type) {
   }
 
   content = this.project.addons.reduce(function(content, addon) {
-    var addonContent = addon.contentFor ? addon.contentFor(type, config) : null;
+    var addonContent = addon.contentFor ? addon.contentFor(type, config, content) : null;
     if (addonContent) {
       return content.concat(addonContent);
     }

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -167,6 +167,35 @@ describe('broccoli/ember-app', function() {
 
         expect(actual).to.equal('blammo\nblahzorz');
       });
+
+      it('allows later addons to inspect previous content', function() {
+        var calledContent;
+
+        project.addons.push({
+          contentFor: function() {
+            return 'zero';
+          }
+        });
+
+        project.addons.push({
+          contentFor: function() {
+            return 'one';
+          }
+        });
+
+        project.addons.push({
+          contentFor: function(type, config, content) {
+            calledContent = content.slice();
+            content.pop();
+            return 'two';
+          }
+        });
+
+        var actual = emberApp.contentFor(config, defaultMatch, 'foo');
+
+        expect(calledContent).to.deep.equal(['zero', 'one']);
+        expect(actual).to.equal('zero\ntwo');
+      });
     });
 
     describe('contentFor("head")', function() {


### PR DESCRIPTION
This allows me to register my addon as `after` another addon and to modify the output generated by any previous addon. Results in coupling, but keeps it pretty loose. Current use-case is modifying the output of `ember-cli-qunit` in my addon to not include any of the `test-body` content.

```javascript
{
  contentFor: function(type, config, content) {
    if (type !== 'test-body') { return; }

    for (var i = 0; i < content.length; i++) {
      if (~content[i].toString().indexOf('ember-testing-container')) {
        content = content.splice(i,1);
      }
    }
  }
}
```

(You're probably noticing a theme in my PRs...)