### PR TITLE
[ENHANCEMENT] Upgrade dependencies for app/addon blueprints

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,18 +1,18 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember": "2.0.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
-    "ember-data": "2.0.0",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
-    "ember-qunit": "0.4.10",
+    "ember": "2.1.0",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-data": "2.1.0",
+    "ember-load-initializers": "0.1.7",
+    "ember-qunit": "0.4.13",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.3.0",
+    "loader.js": "3.3.0",
     "qunit": "~1.19.0"
   },
   "resolutions": {
-    "ember": "2.0.0"
+    "ember": "2.1.0"
   }
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,23 +19,23 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.1.2",
-    "ember-ajax": "0.6.2",
+    "broccoli-asset-rev": "^2.2.0",
+    "ember-ajax": "0.6.3",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.3",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
-    "ember-cli-htmlbars": "^1.0.0",
+    "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.1",
-    "ember-cli-release": "0.2.3",
-    "ember-cli-sri": "^1.0.3",
+    "ember-cli-qunit": "^1.0.3",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "2.0.0",
-    "ember-disable-proxy-controllers": "^1.0.0",
+    "ember-data": "2.1.0",
+    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-resolver": "^2.0.2"
+    "ember-resolver": "^2.0.3"
   }
 }


### PR DESCRIPTION
1) Bumped Ember & Ember-Data to the latest stable versions (2.1.0/2.1.0, respectively)
2) Removed github tags for `ember-cli-shims`, `ember-cli-test-loader`, `ember-load-initializers`, and `loader.js`, since these are all registered with bower and redirect to the correct repositories
3) Upgraded `ember-cli-release`, `ember-qunit` & `ember-cli-shims` to latest patch versions
4) Upgraded versions for several npm dependencies that were using `^`, which should make no difference in installation other than having the current version listed now.