### PR TITLE
[INTERNAL] Replace tiny-lr with mini-lr fork

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -9,7 +9,7 @@ var SilentError = require('silent-error');
 function createServer(options) {
   var instance;
 
-  var Server = (require('tiny-lr')).Server;
+  var Server = (require('mini-lr')).Server;
   Server.prototype.error = function() {
     instance.error.apply(instance, arguments);
   };

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "readline2",
     "resolve",
     "testem",
-    "through",
-    "tiny-lr"
+    "through"
   ],
   "dependencies": {
     "amd-name-resolver": "0.0.2",
@@ -118,6 +117,7 @@
     "markdown-it": "4.3.0",
     "markdown-it-terminal": "0.0.2",
     "merge-defaults": "^0.2.1",
+    "mini-lr": "0.1.7",
     "minimatch": "^2.0.4",
     "morgan": "^1.5.2",
     "node-modules-path": "^1.0.0",
@@ -138,7 +138,6 @@
     "temp": "0.8.1",
     "testem": "0.9.5",
     "through": "^2.3.6",
-    "tiny-lr": "0.1.5",
     "walk-sync": "0.1.3",
     "yam": "0.0.18"
   },


### PR DESCRIPTION
Fixes #4896 via https://github.com/mklabs/tiny-lr/issues/91
mini-lr fork was created due to tiny-lr project abandonment blocking npm v3 usage of the livereload server