### PR TITLE
Make the ExpressServer object re-emit listening.

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -34,6 +34,10 @@ module.exports = Task.extend({
     this.emitter.off.apply(this.emitter, arguments);
   },
 
+  emit: function() {
+    this.emitter.emit.apply(this.emitter, arguments);
+  },
+
   displayHost: function(specifiedHost) {
     return specifiedHost || 'localhost';
   },
@@ -77,9 +81,12 @@ module.exports = Task.extend({
     var server = this.httpServer;
     return new Promise(function(resolve, reject) {
       server.listen(port, host);
-      server.on('listening', resolve);
+      server.on('listening', function() {
+        resolve();
+        this.emit('listening');
+      }.bind(this));
       server.on('error', reject);
-    });
+    }.bind(this));
   },
 
   processAddonMiddlewares: function(options) {
@@ -143,7 +150,7 @@ module.exports = Task.extend({
             return this.startHttpServer();
           }.bind(this))
           .then(function () {
-            this.emitter.emit('restart');
+            this.emit('restart');
             this.ui.writeLine('');
             this.ui.writeLine(chalk.green('Server restarted.'));
             this.ui.writeLine('');


### PR DESCRIPTION
It's presently impossible to attach events to the express-server that is generated, though you can get a reference to our wrapper of it. Have our wrapper re-emit the `listening` event from the server.