### PR TITLE
Add `--query` option to test command to allow passing arbitrary query params

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -27,7 +27,8 @@ module.exports = Command.extend({
     { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
     { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit]' },
     { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
-    { name: 'path',        type: String,                                             description: 'Path to a build to run tests against.' }
+    { name: 'path',        type: String,                                             description: 'Path to a build to run tests against.' },
+    { name: 'query',       type: String,                                             description: 'A query string to append to the test page URL.' }
   ],
 
   init: function() {
@@ -53,7 +54,7 @@ module.exports = Command.extend({
 
   _generateCustomConfigs: function(options) {
     var config = {};
-    if (!options.filter && !options.module && !options.launch && !options['test-page']) { return config; }
+    if (!options.filter && !options.module && !options.launch && !options.query && !options['test-page']) { return config; }
 
     var testPage = options['test-page'];
     var queryString = this.buildTestPageQueryString(options);
@@ -87,6 +88,10 @@ module.exports = Command.extend({
 
     if (options.filter) {
       params.push('filter=' + options.filter.toLowerCase());
+    }
+
+    if (options.query) {
+      params.push(options.query);
     }
 
     return params.join('&');

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -197,6 +197,7 @@ ember test \u001b[36m<options...>\u001b[39m' + EOL + '\
     \u001b[90maliases: -r <value>\u001b[39m' + EOL + '\
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke' + EOL + '\
   \u001b[36m--path\u001b[39m \u001b[36m(String)\u001b[39m Path to a build to run tests against.' + EOL + '\
+  \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.' + EOL + '\
 ' + EOL + '\
 ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
   outputs ember-cli version' + EOL + '\
@@ -1094,6 +1095,12 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
               name: 'path',
               description: 'Path to a build to run tests against.',
               key: 'path',
+              required: false
+            },
+            {
+              name: 'query',
+              description: 'A query string to append to the test page URL.',
+              key: 'query',
               required: false
             }
           ],

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -207,6 +207,13 @@ describe('test command', function() {
       expect(result.launcher, 'fooLauncher');
     });
 
+    it('when query option is present, should be reflected in returned config', function() {
+      runOptions.query = 'someQuery=test';
+      var result = command._generateCustomConfigs(runOptions);
+
+      expect(result.queryString).to.equal(runOptions.query);
+    });
+
     it('when provided test-page the new file returned contains the value in test_page', function() {
       runOptions['test-page'] = 'foo/test.html?foo';
       var result = command._generateCustomConfigs(runOptions);
@@ -214,13 +221,41 @@ describe('test command', function() {
       expect(result.testPage).to.be.equal('foo/test.html?foo&');
     });
 
-    it('when provided test-page with filter and module the new file returned contains those values in test_page', function() {
+    it('when provided test-page with filter, module, and query the new file returned contains those values in test_page', function() {
+      runOptions.module = 'fooModule';
+      runOptions.filter = 'bar';
+      runOptions.query = 'someQuery=test';
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var contents = command._generateCustomConfigs(runOptions);
+
+      expect(contents.testPage).to.be.equal('foo/test.html?foo&module=fooModule&filter=bar&someQuery=test');
+    });
+
+    it('when provided test-page with filter and module the new file returned contains both option values in test_page', function() {
       runOptions.module = 'fooModule';
       runOptions.filter = 'bar';
       runOptions['test-page'] = 'foo/test.html?foo';
       var contents = command._generateCustomConfigs(runOptions);
 
       expect(contents.testPage).to.be.equal('foo/test.html?foo&module=fooModule&filter=bar');
+    });
+
+    it('when provided test-page with filter and query the new file returned contains both option values in test_page', function() {
+      runOptions.query = 'someQuery=test';
+      runOptions.filter = 'bar';
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var contents = command._generateCustomConfigs(runOptions);
+
+      expect(contents.testPage).to.be.equal('foo/test.html?foo&filter=bar&someQuery=test');
+    });
+
+    it('when provided test-page with module and query the new file returned contains both option values in test_page', function() {
+      runOptions.module = 'fooModule';
+      runOptions.query = 'someQuery=test';
+      runOptions['test-page'] = 'foo/test.html?foo';
+      var contents = command._generateCustomConfigs(runOptions);
+
+      expect(contents.testPage).to.be.equal('foo/test.html?foo&module=fooModule&someQuery=test');
     });
 
     it('when provided launch the new file returned contains the value in launch', function() {
@@ -274,6 +309,22 @@ describe('test command', function() {
       var contents = command._generateCustomConfigs(runOptions);
 
       expect(contents.testPage).to.be.equal('tests/index.html?module=fooModule');
+    });
+
+    it('new file returned contains the query option value in test_page', function() {
+      runOptions.query = 'someQuery=test';
+      runOptions['test-page'] = 'tests/index.html';
+      var contents = command._generateCustomConfigs(runOptions);
+
+      expect(contents.testPage).to.be.equal('tests/index.html?someQuery=test');
+    });
+
+    it('new file returned contains the query option value with multiple queries in test_page', function() {
+      runOptions.query = 'someQuery=test&something&else=false';
+      runOptions['test-page'] = 'tests/index.html';
+      var contents = command._generateCustomConfigs(runOptions);
+
+      expect(contents.testPage).to.be.equal('tests/index.html?someQuery=test&something&else=false');
     });
   });
 });


### PR DESCRIPTION
As discussed in #4872, this adds an option to the test command to allow user's to pass in arbitrary query parameters to the test page URL.

Example:

```bash
ember test --query='nojshint'
```