### PR TITLE
[INTERNAL] Revert mini-lr back to tiny-lr

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -9,7 +9,7 @@ var SilentError = require('silent-error');
 function createServer(options) {
   var instance;
 
-  var Server = (require('mini-lr')).Server;
+  var Server = (require('tiny-lr')).Server;
   Server.prototype.error = function() {
     instance.error.apply(instance, arguments);
   };

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "markdown-it": "4.3.0",
     "markdown-it-terminal": "0.0.2",
     "merge-defaults": "^0.2.1",
-    "mini-lr": "0.1.7",
     "minimatch": "^2.0.4",
     "morgan": "^1.5.2",
     "node-modules-path": "^1.0.0",
@@ -138,6 +137,7 @@
     "temp": "0.8.1",
     "testem": "0.9.5",
     "through": "^2.3.6",
+    "tiny-lr": "0.2.0",
     "walk-sync": "0.1.3",
     "yam": "0.0.18"
   },


### PR DESCRIPTION
An npm@3-compatible release was finally cut on the main project, so the fork isn't needed, pending the resolution of discussing the future of tiny-lr here: https://github.com/mklabs/tiny-lr/issues/96

Reference: #4897

Don't need to merge this yet necessarily, depends on how the above issue resolves itself (though this is likely the correct move).