### PR TITLE
Full testem config file support

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -4,7 +4,6 @@ var Command     = require('../models/command');
 var Watcher     = require('../models/watcher');
 var Builder     = require('../models/builder');
 var SilentError = require('silent-error');
-var fs          = require('fs');
 var path        = require('path');
 var win         = require('../utilities/windows-admin');
 var existsSync  = require('exists-sync');
@@ -52,25 +51,26 @@ module.exports = Command.extend({
     this.quickTemp.remove(this, '-customConfigFile');
   },
 
-  _generateCustomConfigFile: function(options) {
-    if (!options.filter && !options.module && !options.launch && !options['test-page']) { return options.configFile; }
+  _generateCustomConfigs: function(options) {
+    var config = {};
+    if (!options.filter && !options.module && !options.launch && !options['test-page']) { return config; }
 
-    var tmpPath = this.quickTemp.makeOrRemake(this, '-customConfigFile');
-    var customPath = path.join(tmpPath, 'testem.json');
-    var originalContents = JSON.parse(fs.readFileSync(options.configFile, { encoding: 'utf8' }));
-
-    var testPage = options['test-page'] ? options['test-page'] : originalContents['test_page'];
-
-    var containsQueryString = testPage.indexOf('?') > -1;
-    var testPageJoinChar    = containsQueryString ? '&' : '?';
-
-    originalContents['test_page'] = testPage + testPageJoinChar + this.buildTestPageQueryString(options);
-    if (options.launch) {
-      originalContents['launch'] = options.launch;
+    var testPage = options['test-page'];
+    var queryString = this.buildTestPageQueryString(options);
+    if (testPage) {
+      var containsQueryString = testPage.indexOf('?') > -1;
+      var testPageJoinChar    = containsQueryString ? '&' : '?';
+      config.testPage = testPage + testPageJoinChar + queryString;
     }
-    fs.writeFileSync(customPath, JSON.stringify(originalContents));
+    if (queryString) {
+      config.queryString = queryString;
+    }
 
-    return customPath;
+    if (options.launch) {
+      config.launch = options.launch;
+    }
+
+    return config;
   },
 
   _generateTestPortNumber: function(options) {
@@ -110,9 +110,8 @@ module.exports = Command.extend({
     var testOptions = this.assign({}, commandOptions, {
       outputPath: outputPath,
       project: this.project,
-      configFile: this._generateCustomConfigFile(commandOptions),
       port: this._generateTestPortNumber(commandOptions)
-    });
+    }, this._generateCustomConfigs(commandOptions));
 
     var options = {
       ui: this.ui,

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -35,14 +35,21 @@ module.exports = Task.extend({
   },
 
   testemOptions: function(options) {
-    return {
-      file: options.configFile,
+    var testemOptions = {
       host: options.host,
       port: options.port,
       cwd: options.outputPath,
       reporter: options.reporter,
-      middleware: this.addonMiddlewares()
+      middleware: this.addonMiddlewares(),
+      launch: options.launch,
+      /* jshint ignore:start */
+      config_dir: process.cwd(),
+      test_page: options.testPage,
+      query_params: options.queryString
+      /* jshint ignore:end */
     };
+
+    return testemOptions;
   },
 
   run: function(options) {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "0.9.5",
+    "testem": "0.9.7",
     "through": "^2.3.6",
     "tiny-lr": "0.2.0",
     "walk-sync": "0.1.3",

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -15,7 +15,7 @@ var cleanupRun          = acceptance.cleanupRun;
 var appName  = 'some-cool-app';
 
 describe('Acceptance: blueprint smoke tests', function() {
-  this.timeout(400000);
+  this.timeout(500000);
 
   before(function() {
     return createTestTargets(appName);

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -22,7 +22,7 @@ var existsSync          = require('exists-sync');
 var appName  = 'some-cool-app';
 
 describe('Acceptance: brocfile-smoke-test', function() {
-  this.timeout(400000);
+  this.timeout(500000);
 
   before(function() {
     return createTestTargets(appName);

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -20,7 +20,7 @@ var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
 
 describe('Acceptance: smoke-test', function() {
-  this.timeout(400000);
+  this.timeout(500000);
   before(function() {
     return createTestTargets(appName);
   });
@@ -79,6 +79,13 @@ describe('Acceptance: smoke-test', function() {
           .catch(function(result) {
             expect(result.code).to.equal(1);
           });
+      });
+  });
+
+  it('ember test still runs when only a JavaScript testem config exists', function() {
+    return copyFixtureFiles('smoke-tests/js-testem-config')
+      .then(function() {
+        return ember(['test']);
       });
   });
 

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "framework": "qunit",
+  "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
+  "launch_in_ci": [
+    "PhantomJS"
+  ],
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ]
+};

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -21,26 +21,28 @@ describe('test server', function() {
       },
       testem: {
         startDev: function(options) {
-          expect(options.file).to.equal('blahzorz.conf');
           expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
           expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
+          /* jshint ignore:start */
+          expect(options.test_page).to.equal('http://my/test/page');
+          expect(options.config_dir).to.be.an('string');
+          /* jshint ignore:end*/
           done();
         }
       }
     });
 
     subject.run({
-      configFile: 'blahzorz.conf',
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',
       outputPath: 'blerpy-derpy',
-      watcher: watcher
+      watcher: watcher,
+      testPage: 'http://my/test/page'
     });
     watcher.emit('change');
   });
 });
-

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -15,12 +15,15 @@ describe('test', function() {
       },
       testem: {
         startCI: function(options, cb) {
-          expect(options.file).to.equal('blahzorz.conf');
           expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
           expect(options.cwd).to.equal('blerpy-derpy');
           expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
+          /* jshint ignore:start */
+          expect(options.test_page).to.equal('http://my/test/page');
+          expect(options.config_dir).to.be.an('string');
+          /* jshint ignore:end*/
           cb(0);
         },
         app: { reporter: { total: 1 } }
@@ -28,11 +31,11 @@ describe('test', function() {
     });
 
     subject.run({
-      configFile: 'blahzorz.conf',
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',
-      outputPath: 'blerpy-derpy'
+      outputPath: 'blerpy-derpy',
+      testPage: 'http://my/test/page'
     });
   });
 });


### PR DESCRIPTION
Adds support for any kind of testem config, includin `testem.js`

Before, ember-cli assumed `testem.json`. Now, we're letting testem do the config file resolution.

Fixes https://github.com/ember-cli/ember-cli/issues/4908