### PR TITLE
Update initializer blueprints for Ember 2.1.

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -2,13 +2,12 @@ import Ember from 'ember';
 import { initialize } from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-var registry, application;
+var application;
 
 module('<%= friendlyTestName %>', {
   beforeEach: function() {
     Ember.run(function() {
       application = Ember.Application.create();
-      registry = application.registry;
       application.deferReadiness();
     });
   }
@@ -16,7 +15,7 @@ module('<%= friendlyTestName %>', {
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  initialize(registry, application);
+  initialize(application);
 
   // you would normally confirm the results of the initializer here
   assert.ok(true);

--- a/blueprints/initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/initializer/files/__root__/initializers/__name__.js
@@ -1,4 +1,4 @@
-export function initialize(/* container, application */) {
+export function initialize(/* application */) {
   // application.inject('route', 'foo', 'service:foo');
 }
 

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -345,7 +345,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
   it('dummy initializer foo', function() {
     return generateInAddon(['initializer', 'foo', '--dummy']).then(function() {
       assertFile('tests/dummy/app/initializers/foo.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
@@ -362,7 +362,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
   it('dummy initializer foo/bar', function() {
     return generateInAddon(['initializer', 'foo/bar', '--dummy']).then(function() {
       assertFile('tests/dummy/app/initializers/foo/bar.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -495,7 +495,7 @@ describe('Acceptance: ember generate in-addon', function() {
   it('in-addon initializer foo', function() {
     return generateInAddon(['initializer', 'foo']).then(function() {
       assertFile('addon/initializers/foo.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
@@ -516,7 +516,7 @@ describe('Acceptance: ember generate in-addon', function() {
   it('in-addon initializer foo/bar', function() {
     return generateInAddon(['initializer', 'foo/bar']).then(function() {
       assertFile('addon/initializers/foo/bar.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -524,7 +524,7 @@ describe('Acceptance: ember generate', function() {
   it('initializer foo', function() {
     return generate(['initializer', 'foo']).then(function() {
       assertFile('app/initializers/foo.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
@@ -546,9 +546,8 @@ describe('Acceptance: ember generate', function() {
         contains: [
           "import { initialize } from '../../../initializers/foo';",
           "module('Unit | Initializer | foo'",
-          "var registry, application;",
-          "registry = application.registry;",
-          "initialize(registry, application);"
+          "var application;",
+          "initialize(application);"
         ]
       });
     });
@@ -557,7 +556,7 @@ describe('Acceptance: ember generate', function() {
   it('initializer foo/bar', function() {
     return generate(['initializer', 'foo/bar']).then(function() {
       assertFile('app/initializers/foo/bar.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -159,7 +159,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
     });
   });
-  
+
   it('in-repo-addon component-test x-foo --unit', function() {
     return generateInRepoAddon(['component-test', 'x-foo', '--in-repo-addon=my-addon', '--unit']).then(function() {
       assertFile('tests/unit/components/x-foo-test.js', {
@@ -468,7 +468,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
   it('in-repo-addon initializer foo', function() {
     return generateInRepoAddon(['initializer', 'foo', '--in-repo-addon=my-addon']).then(function() {
       assertFile('lib/my-addon/addon/initializers/foo.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
@@ -489,7 +489,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
   it('in-repo-addon initializer foo/bar', function() {
     return generateInRepoAddon(['initializer', 'foo/bar', '--in-repo-addon=my-addon']).then(function() {
       assertFile('lib/my-addon/addon/initializers/foo/bar.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1095,7 +1095,7 @@ describe('Acceptance: ember generate pod', function() {
   it('initializer foo --pod', function() {
     return generate(['initializer', 'foo', '--pod']).then(function() {
       assertFile('app/initializers/foo.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
@@ -1110,7 +1110,7 @@ describe('Acceptance: ember generate pod', function() {
   it('initializer foo/bar --pod', function() {
     return generate(['initializer', 'foo/bar', '--pod']).then(function() {
       assertFile('app/initializers/foo/bar.js', {
-        contains: "export function initialize(/* container, application */) {" + EOL +
+        contains: "export function initialize(/* application */) {" + EOL +
                   "  // application.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+


### PR DESCRIPTION
Expecting `registry` as an initial argument is now deprecated.