### PR TITLE
Merging of hash properties in EmberApp#initOptions fails.

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -5,7 +5,6 @@
 @module ember-cli
 */
 var defaults = require('merge-defaults');
-var merge    = require('lodash/object/merge');
 var Funnel   = require('broccoli-funnel');
 var EmberApp = require('./ember-app');
 
@@ -36,7 +35,7 @@ function EmberAddon() {
 
   process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';
 
-  this.appConstructor(merge(options, {
+  this.appConstructor(defaults(options, {
     name: 'dummy',
     configPath: './tests/dummy/config/environment',
     trees: {
@@ -52,7 +51,7 @@ function EmberAddon() {
       tests: './tests',
       app: './tests/dummy'
     },
-  }, defaults));
+  }));
 }
 
 EmberAddon.prototype = Object.create(EmberApp.prototype);

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -153,7 +153,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     };
   }
 
-  this.options = merge(options, {
+  var config = {
     es3Safe: true,
     storeConfigInMeta: true,
     autoRun: true,
@@ -172,10 +172,12 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     'ember-cli-qunit': {
       disableContainerStyles: false
     }
-  }, babelOptions, defaults);
+  };
+
+  this.options = defaults(options, config, babelOptions);
 
   // needs a deeper merge than is provided above
-  this.options.outputPaths = merge(this.options.outputPaths, {
+  this.options.outputPaths = defaults(this.options.outputPaths, {
     app: {
       html: 'index.html',
       css: {
@@ -197,18 +199,18 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
         testLoader: '/assets/test-loader.js'
       }
     }
-  }, defaults);
+  });
 
-  this.options.sourcemaps = merge(this.options.sourcemaps, {
+  this.options.sourcemaps = defaults(this.options.sourcemaps, {
     enabled: !isProduction,
     extensions: ['js']
-  }, defaults);
+  });
 
   // For now we must disable Babel sourcemaps due to unforseen
   // performance regressions.
   this.options.babel.sourceMaps = false;
 
-  this.options.trees = merge(this.options.trees, {
+  this.options.trees = defaults(this.options.trees, {
     app:       new WatchedDir('app'),
     tests:     new WatchedDir('tests'),
 
@@ -222,12 +224,12 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     vendor: existsSync('vendor') ? new UnwatchedDir('vendor') : null,
 
     public: existsSync('public') ? new WatchedDir('public') : null
-  }, defaults);
+  });
 
-  this.options.jshintrc = merge(this.options.jshintrc, {
+  this.options.jshintrc = defaults(this.options.jshintrc, {
     app: this.project.root,
     tests: path.join(this.project.root, 'tests'),
-  }, defaults);
+  });
 };
 
 /**

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -95,6 +95,18 @@ describe('broccoli/ember-app', function() {
       });
     });
 
+    it('should do the right thing when merging default object options', function() {
+      var app = new EmberApp({
+        project: project,
+      }, {
+        'minifyJS': {
+          enabled: 'asdf'
+        }
+      });
+
+      expect(app.options['minifyJS']).to.deep.equal({ enabled: 'asdf' });
+    });
+
     describe('_notifyAddonIncluded', function() {
       beforeEach(function() {
         project.initializeAddons = function() { };


### PR DESCRIPTION
This is a failing unit test for merging properties inside of EmberApp#initOptions. We somehow end up duplicating the entire current object as a property.

Haven't traced for the bug yet.