### PR TITLE
Add notes on args for ember test, -m, -f

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -8,11 +8,13 @@ github: "https://github.com/stefanpenner/ember-cli/blob/gh-pages/_posts/2013-04-
 
 ### Running existing tests
 
-Running your tests is as easy as one of these two commands:
+Running your tests is as easy as one of these commands:
 
 {% highlight bash %}
 ember test            # will run your test-suite in your current shell once
 ember test --server   # will run your tests on every file-change
+ember t -s -m 'Unit | Utility | name' # will run only the unit test module for a utility by `name`, on every change
+ember t -f 'match a phrase in test description(s)' # will run only the tests with a description that matches a phrase
 {% endhighlight %}
 
 Alternatively you can run the tests in your regular browser using the QUnit interface. Run `ember server` and navigate to `http://localhost:4200/tests`. When the app runs in /tests it runs in the development environment, not the test environment.


### PR DESCRIPTION
Adds notes on commands for running specific tests by module name `-m` or by matching a phrase `-f`. 
Includes shortcuts for `ember t` and `ember t -s` as well.