### PR TITLE
Remove unnecessary configuration for ember-cli-qunit.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -169,9 +169,6 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     sourcemaps: {},
     trees: {},
     jshintrc: {},
-    'ember-cli-qunit': {
-      disableContainerStyles: false
-    },
     addons: {}
   };
 


### PR DESCRIPTION
As a consequence of ember-cli/ember-cli-qunit#82 we can remove configuration from the default `EmberApp` that is relevant only to `ember-cli-qunit`. We now expect you to explicitly declare a setting as `false` or `true` in order to opt in or out of certain behaviors. `undefined` will be treated as the default behavior for that setting.

This is blocked by releasing a new version of ember-cli-qunit.