### PR TITLE
BUGFIX Close #4773 Clarify problem is with starting watchman, not finding it.

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -123,7 +123,7 @@ Watcher.detectWatcher = function(ui, _options) {
       return options;
     }, function(reason) {
       debug('detecting watchman failed %o', reason);
-      ui.writeLine('Could not find watchman, falling back to NodeWatcher for file system events.');
+      ui.writeLine('Could not start watchman; falling back to NodeWatcher for file system events.');
       ui.writeLine(watchmanInfo);
       options.watcher = 'node';
       return options;


### PR DESCRIPTION
#4773 is confusing because the warning message emitted says that watchman couldn't be *found*. In some cases, though this error message is emitted when watchman *was* found, but failed to *start*. This tiny change in the language of the warning should help developers who encounter it investigate why watchman won't start. Maybe the problem is still that watchman couldn't start because it's not installed, or maybe -- as happened to me -- watchman was stuck in a bad state. 

I'd like to also clarify that they should try `watchman watch .` to find out the problem, but I couldn't find where the source for http://www.ember-cli.com/user-guide/#watchman is. Point me there and I'll put up a PR to clarify that too. 