### PR TITLE
Add ember-truth-helpers to project blueprint

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -24,6 +24,9 @@ module.exports = {
     contents.keywords = contents.keywords || [];
     contents.dependencies = contents.dependencies || {};
 
+    // only include `ember-truth-helpers` for project blueprints, not addons
+    delete contents.devDependencies['ember-truth-helpers'];
+
     // npm doesn't like it when we have something in both deps and devDeps
     // and dummy app still uses it when in deps
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -36,6 +36,7 @@
     "ember-data": "2.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.4",
-    "ember-resolver": "^2.0.2"
+    "ember-resolver": "^2.0.2",
+    "ember-truth-helpers": "~1.1.0"
   }
 }


### PR DESCRIPTION
ember-truth-helpers is now a "highly recommended" addon according to the Ember Core team, as referenced here: http://emberjs.com/blog/2015/10/04/ember-2-1-released.html#toc_code-get-code-helper

As such, it makes sense to include it in the default blueprint provided by ember-cli