### PR TITLE
Fix beforeEach/afterEach callbacks with moduleForAcceptance.

### DIFF
--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -4,17 +4,19 @@ import destroyApp from '../helpers/destroy-app';
 
 export default function(name, options = {}) {
   module(name, {
-    beforeEach: function() {
+    beforeEach() {
       this.application = startApp();
+
       if (options.beforeEach) {
-        options.beforeEach.call(this, arguments);
+        options.beforeEach.apply(this, arguments);
       }
     },
 
-    afterEach: function() {
+    afterEach() {
       destroyApp(this.application);
+
       if (options.afterEach) {
-        options.afterEach.call(this, arguments);
+        options.afterEach.apply(this, arguments);
       }
     }
   });


### PR DESCRIPTION
These were previously calling the provided `beforeEach`/`afterEach` blocks with a single argument (that is the original arguments object) instead of the correct arguments.

Updated to use `.apply` instead of `.call`.