### PR TITLE
Added a new outputReady builder hook

### DIFF
--- a/ADDON_HOOKS.md
+++ b/ADDON_HOOKS.md
@@ -6,6 +6,7 @@ Table of Contents:
 - [serverMiddleware](#servermiddleware)
 - [postBuild](#postbuild)
 - [preBuild](#prebuild)
+- [outputReady](#outputready)
 - [buildError](#builderror)
 - [included](#included)
 - [setupPreprocessorRegistry](#setuppreprocessorregistry)
@@ -171,7 +172,6 @@ Gives access to the result of the tree, and the location of the output.
 
 - Slow tree listing
 - May be used to manipulate your project after build has happened
-- Opportunity to symlink or copy files elsewhere.
 
 **Examples:**
 
@@ -191,17 +191,27 @@ Hook called before build takes place.
 
 **Uses:**
 
+<a name='outputready'></a>
+## outputReady
+
+Hook called after the build has been processed and the files have been copied to the output directory
+
+**Received arguments:**
+
+- Result object from broccoli build
+  - `result.directory` - final output path
+
+**Default implementation:** None
+
 **Examples:**
 
-- [ember-cli-rails-addon](https://github.com/rondale-sc/ember-cli-rails-addon/blob/v0.0.11/index.js#L41)
-  - In this case we are using this in tandem with a rails middleware to create a lock file.
-  *[See postBuild]*
+- Opportunity to symlink or copy files elsewhere.
 
 <a name='builderror'></a>
 ## buildError
 
 buildError hook will be called on when an error occurs during the
-preBuild or postBuild hooks for addons, or when builder#build
+preBuild, postBuild or outputReady hooks for addons, or when builder#build
 fails
 
 **Received arguments:**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -54,6 +54,7 @@ function mergeTrees(inputTree, options) {
   - {{#crossLink "Addon/includedCommands:method"}}includedCommands{{/crossLink}}
   - {{#crossLink "Addon/serverMiddleware:method"}}serverMiddleware{{/crossLink}}
   - {{#crossLink "Addon/postBuild:method"}}postBuild{{/crossLink}}
+  - {{#crossLink "Addon/outputReady:method"}}outputReady{{/crossLink}}
   - {{#crossLink "Addon/preBuild:method"}}preBuild{{/crossLink}}
   - {{#crossLink "Addon/buildError:method"}}buildError{{/crossLink}}
   - {{#crossLink "Addon/included:method"}}included{{/crossLink}}
@@ -821,7 +822,18 @@ Addon.lookup = function(addon) {
 */
 
 /**
-  This hook is called when an error occurs during the preBuild or postBuild hooks
+  This hook is called after the build files have been copied to the output directory
+
+  It's passed an `result` object which contains:
+  - `directory` Path to build output
+
+  @public
+  @method outputReady
+  @param {Object} result Build result object
+*/
+
+/**
+  This hook is called when an error occurs during the preBuild, postBuild or outputReady hooks
   for addons, or when the build fails
 
   @public

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -193,8 +193,8 @@ module.exports = Task.extend({
       })
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
       .then(this.processBuildResult.bind(this))
+      .then(this.processAddonBuildSteps.bind(this, 'outputReady'))
       .catch(function(error) {
-
         this.processAddonBuildSteps('buildError', error);
         throw error;
       }.bind(this));


### PR DESCRIPTION
In ember-cli/ember-cli#4027 the `postBuild` hook was re-ordered to appear before the `processBuildResult` step. This allowed you to do some work on the final tree before it was output to `dist`. This also meant there was no longer a hook which fired to do work after everything was copied to `dist`, which is something we're trying to do.

This PR re-adds the old hook, fired after `processBuildResult`, but with a new name `postResult` (name was suggested in #4247). I'm open to changing the hook name if there are any better ideas.

This should also resolve #4247 