### PR TITLE
Added ability to specify 'availableOptions' as a function in command

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -60,6 +60,9 @@ function Command() {
   }
 
   // Options properties
+  if (typeof this.availableOptions === 'function') {
+    this.availableOptions = this.availableOptions();
+  }
   this.availableOptions = this.availableOptions || [];
   this.anonymousOptions = this.anonymousOptions || [];
   this.registerOptions();

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -42,6 +42,17 @@ var OutsideProjectCommand = Command.extend({
   run: function() {}
 });
 
+var OptionFunctionCommand = Command.extend({
+  name: 'options-function',
+  availableOptions: function() {
+    return [{
+      name: 'taco',
+      type: String,
+      default: 'traditional'
+    }];
+  }
+});
+
 var OptionsAliasCommand = Command.extend({
   name: 'options-alias',
   availableOptions: [{
@@ -161,6 +172,15 @@ describe('models/command.js', function() {
   it('validateAndRun() should print a message if inside a project and command is not valid there.', function() {
     return new OutsideProjectCommand(options).validateAndRun([]).catch(function(reason) {
       expect(reason.message).to.match(/You cannot use.*inside an ember-cli project/);
+    });
+  });
+
+  it('availableOptions as a funciton should work.', function() {
+    expect(new OptionFunctionCommand(options).parseArgs(['-taco', 'chalupa'])).to.deep.equal({
+      options: {
+        taco: 'chalupa'
+      },
+      args: []
     });
   });
 


### PR DESCRIPTION
This is related to #4891/#4958 which prevents [ember-cli-release](https://github.com/lytics/ember-cli-release) from being updated.

The addon has a default set of options that is augmented with options specified in a configuration file. This is important so that the user can tailor the behavior of running `ember release` to individual repositories without having to remember what options to specify (which are often not the defaults). This presents a challenge because there's no initialization hook in commands in which to read the config file and override options. This PR provides the ability to specify the `availableOptions` property as a function that is invoked a single time in the constructor.

The upside to this approach is its simplicity and straightforwardness for most cases. The downside is that overwriting the `availableOptions` property with the results of the function invocation is weird, and might catch someone off guard who expects to be able to invoke the function internally later.

Alternatives:

- Create a `buildAvailableOptions` hook that is a no-op by default and is called in the same place in the constructor.
- Create a generic `init` hook that is called from the constructor to perform initialization tasks.

cc @rwjblue 