### PR TITLE
[ENHANCEMENT] Upgrade testem to 0.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "0.9.7",
+    "testem": "0.9.8",
     "through": "^2.3.6",
     "tiny-lr": "0.2.0",
     "walk-sync": "0.1.3",


### PR DESCRIPTION
Hi there,

I'm one of the few people whose development environment is FreeBSD 10, which makes running ci tests using PhantomJS a little bit of an ordeal. I was able to get a pull request merge into testem that added PhantomJS as a default launcher for FreeBSD, and this merge is included in the 0.9.8 release for testem.

This pull request updates the Ember-CLI testem dependency from 0.9.7 to 0.9.8.

Let me know if anything further is needed from me. Thanks! :)