### PR TITLE
Lock down ember-router-generator@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ember-cli-preprocess-registry": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
-    "ember-router-generator": "^1.0.0",
+    "ember-router-generator": "1.0.0",
     "escape-string-regexp": "^1.0.3",
     "exists-sync": "0.0.3",
     "exit": "^0.1.2",


### PR DESCRIPTION
This needs to be locked down because 1.1.0 has a bug that causes all of our route generation tests to fail. A fix is being worked on, but I'd like to get CI back to a passing state.

See https://github.com/ember-cli/ember-router-generator/issues/17.
Fixes https://github.com/ember-cli/ember-cli/issues/4972.