### PR TITLE
bring back the hint for ember-router-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ember-cli-preprocess-registry": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
-    "ember-router-generator": "1.0.0",
+    "ember-router-generator": "^1.0.0",
     "escape-string-regexp": "^1.0.3",
     "exists-sync": "0.0.3",
     "exit": "^0.1.2",


### PR DESCRIPTION
ember-cli/ember-router-generator/pull/18 1.1.1 seems to have fixed our Windows issues