### PR TITLE
[BUGFIX] pass updated options to cpr. Fixes #4988

### DIFF
--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -146,7 +146,7 @@ function teardownTestTargets() {
 function linkDependencies(projectName) {
   var targetPath = './tmp/' + projectName;
   return tmp.setup('./tmp').then(function() {
-    return copy('./common-tmp/' + projectName, targetPath);
+    return copy('./common-tmp/' + projectName, targetPath, { overwrite: true });
   }).then(function() {
     var nodeModulesPath = targetPath + '/node_modules/';
     var bowerComponentsPath = targetPath + '/bower_components/';

--- a/tests/helpers/copy-fixture-files.js
+++ b/tests/helpers/copy-fixture-files.js
@@ -8,6 +8,7 @@ var rootPath = process.cwd();
 
 module.exports = function copyFixtureFiles(sourceDir) {
   return copy(path.join(rootPath, 'tests', 'fixtures', sourceDir), '.', {
+    overwrite: true,
     clobber: true,
     stopOnErr: true
   });


### PR DESCRIPTION
This accounts for a regression from cpr 0.4.2 → 0.4.3 discovered in #4988 

(Thank you @kellyselden for [the helpful tool][] that made it a piece of cake to track down the regression)
[the helpful tool]: http://package-hint-historic-resolver.herokuapp.com/?firstDateToCheck=2015-10-08T19%3A43%3A00.000Z&repoDate=2015-10-26T19%3A43%3A00.000Z&repoUrl=https%3A%2F%2Fgithub.com%2Fember-cli%2Fember-cli&secondDateToCheck=2015-10-26T19%3A44%3A00.000Z