### PR TITLE
[BUGFIX] Lock cpr@0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "compression": "^1.4.4",
     "configstore": "1.2.1",
     "core-object": "0.0.2",
-    "cpr": "^0.4.1",
+    "cpr": "0.4.2",
     "debug": "^2.1.3",
     "diff": "^1.3.1",
     "ember-cli-copy-dereference": "^1.0.0",

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -146,7 +146,7 @@ function teardownTestTargets() {
 function linkDependencies(projectName) {
   var targetPath = './tmp/' + projectName;
   return tmp.setup('./tmp').then(function() {
-    return copy('./common-tmp/' + projectName, targetPath, { overwrite: true });
+    return copy('./common-tmp/' + projectName, targetPath);
   }).then(function() {
     var nodeModulesPath = targetPath + '/node_modules/';
     var bowerComponentsPath = targetPath + '/bower_components/';

--- a/tests/helpers/copy-fixture-files.js
+++ b/tests/helpers/copy-fixture-files.js
@@ -7,9 +7,5 @@ var copy    = Promise.denodeify(require('cpr'));
 var rootPath = process.cwd();
 
 module.exports = function copyFixtureFiles(sourceDir) {
-  return copy(path.join(rootPath, 'tests', 'fixtures', sourceDir), '.', {
-    overwrite: true,
-    clobber: true,
-    stopOnErr: true
-  });
+  return copy(path.join(rootPath, 'tests', 'fixtures', sourceDir), '.');
 };


### PR DESCRIPTION
Fixes #4988... this time without a regression.

It looks like cpr 0.4.3 [introduces an `fs.stat` call][] which [causes an error
with broccoli][]. I'm not sure of the right way to fix this, but for now we
can lock it at v0.4.2 unless someone else has time to debug this.

My suspicion is that broccoli's watcher fires before `cpr` has time to finish, but I haven't time to confirm or fix it right now.

[The cpr diff from 0.4.2 to 0.4.3](https://github.com/davglass/cpr/compare/8ccb044a8c439af86d3065d6ca1cc1086d95fac2...master)
[causes an error with broccoli]: https://travis-ci.org/ember-cli/ember-cli/jobs/87530226#L2053
[introduces an `fs.stat` call]: https://github.com/davglass/cpr/compare/8ccb044a8c439af86d3065d6ca1cc1086d95fac2...master#diff-6d186b954a58d5bb740f73d84fe39073R141