### PR TITLE
[WIP] Add DOM guard unless `preventDOMGuard` specified on `import`

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -38,6 +38,7 @@ var merge         = require('lodash/object/merge');
 var omit          = require('lodash/object/omit');
 var ES3SafeFilter = require('broccoli-es3-safe-recast');
 var Funnel        = require('broccoli-funnel');
+var stewMap       = require('broccoli-stew').map;
 
 module.exports = EmberApp;
 
@@ -98,6 +99,7 @@ function EmberApp() {
   this.otherAssetPaths         = [];
   this.legacyTestFilesToAppend = [];
   this.vendorTestStaticStyles  = [];
+  this.preventDOMGuard         = {};
 
   this.trees = this.options.trees;
 
@@ -1045,6 +1047,7 @@ EmberApp.prototype.javascript = function() {
   var legacyFilesToAppend = this.legacyFilesToAppend;
   var appOutputPath       = this.options.outputPaths.app.js;
   var appJs = applicationJs;
+  var preventDOMGuard     = this.preventDOMGuard;
 
   // Note: If ember-cli-babel is installed we have already performed the transpilation at this point
   if (!this._addonInstalled('ember-cli-babel')) {
@@ -1083,7 +1086,17 @@ EmberApp.prototype.javascript = function() {
     .concat('vendor/addons.js')
     .concat('vendor/ember-cli/vendor-suffix.js');
 
-  var vendor = this.concatFiles(applicationJs, {
+
+  var vendor = stewMap(applicationJs, function(content, relativePath){
+    if (legacyFilesToAppend.indexOf(relativePath) > -1) {
+      if (!preventDOMGuard[relativePath]) {
+        return "if (document !== 'undefined') {" + content + "}";
+      }
+    }
+    return content;
+  });
+
+  vendor = this.concatFiles(vendor, {
     inputFiles: inputFiles,
     outputFile: this.options.outputPaths.vendor.js,
     separator: EOL + ';',
@@ -1167,8 +1180,10 @@ EmberApp.prototype.styles = function() {
   @return {Tree} Merged tree for test files
  */
 EmberApp.prototype.testFiles = function(coreTestTree) {
+  var preventDOMGuard = this.preventDOMGuard;
   var testSupportPath = this.options.outputPaths.testSupport.js;
   var testLoaderPath = this.options.outputPaths.testSupport.js.testLoader;
+  var legacyTestFilesToAppend = this.legacyTestFilesToAppend;
 
   testSupportPath = testSupportPath.testSupport || testSupportPath;
 
@@ -1176,8 +1191,19 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
 
   var emberCLITree = this._processedEmberCLITree();
 
-  var testJs = this.concatFiles(mergeTrees([external, coreTestTree]), {
-    inputFiles: this.legacyTestFilesToAppend,
+  var coreExt = mergeTrees([external, coreTestTree])
+
+  coreExt = stewMap(coreExt, function(content, relativePath){
+    if (legacyTestFilesToAppend.indexOf(relativePath) > -1) {
+      if (!preventDOMGuard[relativePath]) {
+        return "if (document !== 'undefined') {" + content + "}";
+      }
+    }
+    return content;
+  });
+
+  var testJs = this.concatFiles(coreExt, {
+    inputFiles: legacyTestFilesToAppend,
     outputFile: testSupportPath,
     annotation: 'Concat: Test Support JS'
   });
@@ -1274,6 +1300,7 @@ EmberApp.prototype.dependencies = function(pkg) {
   - type - Either 'vendor' or 'test', defaults to 'vendor'
   - prepend - Whether or not this asset should be prepended, defaults to false
   - destDir - Destination directory, defaults to the name of the directory the asset is in
+  - preventDOMGuard - Whether your import should guard against the non-existence of the document
 
   @public
   @method import
@@ -1298,6 +1325,10 @@ EmberApp.prototype.import = function(asset, options) {
 
   if (!extension) {
     throw new Error('You must pass a file to `app.import`. For directories specify them to the constructor under the `trees` option.');
+  }
+
+  if (options.preventDOMGuard) {
+    this.preventDOMGuard[assetPath] = true;
   }
 
   this._import(

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "broccoli-sane-watcher": "^1.1.1",
     "broccoli-source": "^1.1.0",
     "broccoli-sourcemap-concat": "^1.1.1",
+    "broccoli-stew": "^0.3.6",
     "broccoli-viz": "^2.0.1",
     "chalk": "1.1.0",
     "clean-base-url": "^1.0.0",


### PR DESCRIPTION
The idea here is to make it relatively painless to be fastboot compliant by automatically wrapping imported files in:

```
return "if (document !== 'undefined') {" + content + "}";
```

This can be opted out of by specifying  `preventDOMGuard`.

For example, `app.import(this.bowerDirectory + '/foo/foo.js', { preventDOMGuard: true });` would produce no guard.

I still have some questions about this, so I'm going to mark it as WIP for now. 


❤️