### PR TITLE
Add --reset-namespace option to route generator

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -18,6 +18,10 @@ module.exports = {
       name: 'skip-router',
       type: Boolean,
       default: false
+    },
+    {
+      name: 'reset-namespace',
+      type: Boolean
     }
   ],
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -393,6 +393,30 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
+  it('route foo with --reset-namespace', function() {
+    return generate(['route', 'foo', '--reset-namespace']).then(function() {
+      assertFile('app/router.js', {
+        contains: [
+          'this.route(\'foo\', {',
+          'resetNamespace: true',
+          '});'
+        ]
+      });
+    });
+  });
+
+  it('route foo with --reset-namespace=false', function() {
+    return generate(['route', 'foo', '--reset-namespace=false']).then(function() {
+      assertFile('app/router.js', {
+        contains: [
+          'this.route(\'foo\', {',
+          'resetNamespace: false',
+          '});'
+        ]
+      });
+    });
+  });
+
   it('route index', function() {
     return generate(['route', 'index']).then(function() {
       assertFile('app/router.js', {
@@ -515,6 +539,30 @@ describe('Acceptance: ember generate', function() {
         contains: [
           'this.route(\'foos\', {',
           'path: \'app/foos\'',
+          '});'
+        ]
+      });
+    });
+  });
+
+  it('resource foos with --reset-namespace', function() {
+    return generate(['resource', 'foos', '--reset-namespace']).then(function() {
+      assertFile('app/router.js', {
+        contains: [
+          'this.route(\'foos\', {',
+          'resetNamespace: true',
+          '});'
+        ]
+      });
+    });
+  });
+
+  it('resource foos with --reset-namespace=false', function() {
+    return generate(['resource', 'foos', '--reset-namespace=false']).then(function() {
+      assertFile('app/router.js', {
+        contains: [
+          'this.route(\'foos\', {',
+          'resetNamespace: false',
           '});'
         ]
       });

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -656,6 +656,12 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
                       default: false,
                       key: 'skipRouter',
                       required: false
+                    },
+                    {
+                      name: 'reset-namespace',
+                      type: 'Boolean',
+                      key: 'resetNamespace',
+                      required: false
                     }
                   ],
                   anonymousOptions: ['name'],
@@ -1206,6 +1212,7 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a route and a template, and registers the route with the router.\u001b[39m' + EOL + '\
         \u001b[36m--path\u001b[39m \u001b[36m(Default: )\u001b[39m' + EOL + '\
         \u001b[36m--skip-router\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
+        \u001b[36m--reset-namespace\u001b[39m' + EOL + '\
       route-addon \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates import wrappers for a route and its template.\u001b[39m' + EOL + '\
       route-test \u001b[33m<name>\u001b[39m' + EOL + '\

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -883,6 +883,31 @@ describe('Acceptance: ember generate pod', function() {
     });
   });
 
+  it('route foo --pod with --reset-namespace', function() {
+    return generate(['route', 'foo', '--pod', '--reset-namespace'])
+      .then(function() {
+        assertFile('app/router.js', {
+          contains: [
+            'this.route(\'foo\', {',
+            'resetNamespace: true',
+            '});'
+          ]
+        });
+      });
+  });
+
+  it('route foo --pod with --reset-namespace=false', function() {
+    return generate(['route', 'foo', '--pod', '--reset-namespace=false'])
+      .then(function() {
+        assertFile('app/router.js', {
+          contains: [
+            'this.route(\'foo\', {',
+            'resetNamespace: false',
+            '});'
+          ]
+        });
+      });
+  });
 
   it('route foo --pod podModulePrefix', function() {
     return generateWithPrefix(['route', 'foo', '--pod']).then(function() {
@@ -1063,6 +1088,32 @@ describe('Acceptance: ember generate pod', function() {
           contains: [
             'this.route(\'foos\', {',
             'path: \'app/foos\'',
+            '});'
+          ]
+        });
+      });
+  });
+
+  it('resource foos --pod with --reset-namespace', function() {
+    return generate(['resource', 'foos', '--pod', '--reset-namespace'])
+      .then(function() {
+        assertFile('app/router.js', {
+          contains: [
+            'this.route(\'foos\', {',
+            'resetNamespace: true',
+            '});'
+          ]
+        });
+      });
+  });
+
+  it('resource foos --pod with --reset-namespace=false', function() {
+    return generate(['resource', 'foos', '--pod', '--reset-namespace=false'])
+      .then(function() {
+        assertFile('app/router.js', {
+          contains: [
+            'this.route(\'foos\', {',
+            'resetNamespace: false',
             '});'
           ]
         });


### PR DESCRIPTION
This option was added to ember-router-generator and with this PR can be used in the route blueprint.