### PR TITLE
Test blueprints to use const instead of var

### DIFF
--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
@@ -7,6 +7,6 @@ moduleFor('adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var adapter = this.subject();
+  let adapter = this.subject();
   assert.ok(adapter);
 });

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -25,7 +25,7 @@ test('it renders', function(assert) {
 
   assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>
   // Creates the component instance
-  /*var component =*/ this.subject();
+  /*let component =*/ this.subject();
   // Renders the component to the page
   this.render();
   assert.equal(this.$().text().trim(), '');<% } %>

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.js
@@ -7,6 +7,6 @@ moduleFor('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var controller = this.subject();
+  let controller = this.subject();
   assert.ok(controller);
 });

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -5,6 +5,6 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = <%= camelizedModuleName %>(42);
+  let result = <%= camelizedModuleName %>(42);
   assert.ok(result);
 });

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import <%= classifiedModuleName %>Initializer from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-var application;
+let application;
 
 module('<%= friendlyTestName %>', {
   beforeEach: function() {

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -6,7 +6,7 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
-  var subject = <%= classifiedModuleName %>Object.create();
+  let <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
+  let subject = <%= classifiedModuleName %>Object.create();
   assert.ok(subject);
 });

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -6,7 +6,7 @@ moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyDescription %>', {
 });
 
 test('it exists', function(assert) {
-  var model = this.subject();
-  // var store = this.store();
+  let model = this.subject();
+  // let store = this.store();
   assert.ok(!!model);
 });

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -6,6 +6,6 @@ moduleFor('route:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it exists', function(assert) {
-  var route = this.subject();
+  let route = this.subject();
   assert.ok(route);
 });

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -7,9 +7,9 @@ moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', 
 
 // Replace this with your real tests.
 test('it serializes records', function(assert) {
-  var record = this.subject();
+  let record = this.subject();
 
-  var serializedRecord = record.serialize();
+  let serializedRecord = record.serialize();
 
   assert.ok(serializedRecord);
 });

--- a/blueprints/service-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/service-test/files/tests/unit/__path__/__test__.js
@@ -7,6 +7,6 @@ moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var service = this.subject();
+  let service = this.subject();
   assert.ok(service);
 });

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.js
@@ -7,6 +7,6 @@ moduleFor('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription 
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var transform = this.subject();
+  let transform = this.subject();
   assert.ok(transform);
 });

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -5,6 +5,6 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = <%= camelizedModuleName %>();
+  let result = <%= camelizedModuleName %>();
   assert.ok(result);
 });

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.js
@@ -4,6 +4,6 @@ moduleFor('view:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>');
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var view = this.subject();
+  let view = this.subject();
   assert.ok(view);
 });


### PR DESCRIPTION
App and source blueprints use `const` / `let` but the test blueprints don't. This change fixes that across test blueprints. 

This is the first thing I change in any newly generated test file so felt it should be in the cli blueprint.