### PR TITLE
[BUGFIX] close #5014 move git init to before npm and bower install

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -46,6 +46,15 @@ module.exports = Command.extend({
       project: this.project
     });
 
+    // needs an explicit check in case it's just 'undefined'
+    // due to passing of options from 'new' and 'addon'
+    if (commandOptions.skipGit === false) {
+      var gitInit = new this.tasks.GitInit({
+        ui: this.ui,
+        project: this.project
+      });
+    }
+
     if (!commandOptions.skipNpm) {
       var npmInstall = new this.tasks.NpmInstall({
         ui: this.ui,
@@ -91,6 +100,11 @@ module.exports = Command.extend({
     return installBlueprint.run(blueprintOpts)
       .then(function() {
         debug('after:installblueprint');
+        if (commandOptions.skipGit === false) {
+          return gitInit.run(commandOptions, rawArgs);
+        }
+      })
+      .then(function() {
         if (!commandOptions.skipNpm) {
           return npmInstall.run({
               verbose: commandOptions.verbose,

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -68,11 +68,6 @@ module.exports = Command.extend({
     });
     var InitCommand = this.commands.Init;
 
-    var gitInit = new this.tasks.GitInit({
-      ui: this.ui,
-      project: this.project
-    });
-
     var initCommand = new InitCommand({
       ui: this.ui,
       analytics: this.analytics,
@@ -85,7 +80,6 @@ module.exports = Command.extend({
         directoryName: commandOptions.directory,
         dryRun: commandOptions.dryRun
       })
-      .then(initCommand.run.bind(initCommand, commandOptions, rawArgs))
-      .then(gitInit.run.bind(gitInit, commandOptions, rawArgs));
+      .then(initCommand.run.bind(initCommand, commandOptions, rawArgs));
   }
 });

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -1,21 +1,22 @@
 'use strict';
 
-var ember     = require('../helpers/ember');
-var expect    = require('chai').expect;
-var walkSync  = require('walk-sync');
-var glob      = require('glob');
-var Blueprint = require('../../lib/models/blueprint');
-var path      = require('path');
-var tmp       = require('../helpers/tmp');
-var root      = process.cwd();
-var util      = require('util');
-var conf      = require('../helpers/conf');
-var minimatch = require('minimatch');
-var intersect = require('lodash/array/intersection');
-var remove    = require('lodash/array/remove');
-var forEach   = require('lodash/collection/forEach');
-var any       = require('lodash/collection/some');
-var EOL       = require('os').EOL;
+var ember      = require('../helpers/ember');
+var expect     = require('chai').expect;
+var walkSync   = require('walk-sync');
+var existsSync = require('exists-sync');
+var glob       = require('glob');
+var Blueprint  = require('../../lib/models/blueprint');
+var path       = require('path');
+var tmp        = require('../helpers/tmp');
+var root       = process.cwd();
+var util       = require('util');
+var conf       = require('../helpers/conf');
+var minimatch  = require('minimatch');
+var intersect  = require('lodash/array/intersection');
+var remove     = require('lodash/array/remove');
+var forEach    = require('lodash/collection/forEach');
+var any        = require('lodash/collection/some');
+var EOL        = require('os').EOL;
 
 var defaultIgnoredFiles = Blueprint.ignoredFiles;
 
@@ -221,6 +222,17 @@ describe('Acceptance: ember init', function() {
       ]);
     })
     .then(confirmBlueprinted);
+  });
+
+  it('should not create .git folder', function() {
+    return ember([
+      'init',
+      '--skip-npm',
+      '--skip-bower'
+    ])
+    .then(function() {
+      expect(!existsSync('.git'));
+    });
   });
 
 });


### PR DESCRIPTION
Moves the git setup to the 'init' command process

Includes a check for the skipGit flag to be explicitly false, so that if it is 'undefined' it doesn't run.