### PR TITLE
Add `UI.errorStream`

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -26,7 +26,8 @@ resolve('ember-cli', {
   cli({
     cliArgs: process.argv.slice(2),
     inputStream: process.stdin,
-    outputStream: process.stdout
+    outputStream: process.stdout,
+    errorStream: process.stderr
   }).then(function(result) {
     var exitCode = typeof result === 'object' ? result.exitCode : result;
     exit(exitCode);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41,6 +41,7 @@ module.exports = function(options) {
   var ui = new UI({
     inputStream:  options.inputStream,
     outputStream: options.outputStream,
+    errorStream:  options.errorStream || process.stderr,
     ci:           process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
     writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
   });

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -44,8 +44,8 @@ function UI(options) {
   this.outputStream.setMaxListeners(0);
   this.outputStream.pipe(this.actualOuputStream);
 
-  // Input stream
   this.inputStream = options.inputStream;
+  this.errorStream = options.errorStream;
 
   this.writeLevel = options.writeLevel || 'INFO';
   this.ci = !!options.ci;
@@ -61,7 +61,9 @@ function UI(options) {
   @param {Number} writeLevel
 */
 UI.prototype.write = function(data, writeLevel) {
-  if (this.writeLevelVisible(writeLevel)) {
+  if (writeLevel === 'ERROR') {
+    this.errorStream.write(data);
+  } else if (this.writeLevelVisible(writeLevel)) {
     this.outputStream.write(data);
   }
 };
@@ -76,9 +78,7 @@ UI.prototype.write = function(data, writeLevel) {
   @param {Number} writeLevel
 */
 UI.prototype.writeLine = function(data, writeLevel) {
-  if (this.writeLevelVisible(writeLevel)) {
-    this.write(data + EOL);
-  }
+  this.write(data + EOL, writeLevel);
 };
 
 /**

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -7,11 +7,15 @@ var Promise = require('../../lib/ext/promise');
 module.exports = MockUI;
 function MockUI() {
   this.output = '';
+  this.errors = '';
 
   UI.call(this, {
     inputStream: through(),
     outputStream: through(function(data) {
       this.output += data;
+    }.bind(this)),
+    errorStream: through(function(data) {
+      this.errors += data;
     }.bind(this))
   });
 }
@@ -20,6 +24,7 @@ MockUI.prototype = Object.create(UI.prototype);
 MockUI.prototype.constructor = MockUI;
 MockUI.prototype.clear = function(){
   this.output = '';
+  this.errors = '';
 };
 
 MockUI.prototype.waitForPrompt = function() {

--- a/tests/unit/ui/write-error-test.js
+++ b/tests/unit/ui/write-error-test.js
@@ -16,6 +16,9 @@ describe('writeError', function() {
 
   it('no error', function() {
     writeError(ui);
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal('');
   });
 
   it('error with message', function() {
@@ -23,7 +26,8 @@ describe('writeError', function() {
       message: 'build error'
     }));
 
-    expect(ui.output).to.equal(chalk.red('build error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('build error') + EOL);
   });
 
   it('error with stack', function() {
@@ -31,7 +35,8 @@ describe('writeError', function() {
       stack: 'the stack'
     }));
 
-    expect(ui.output).to.equal(chalk.red('Error') + EOL + 'the stack' + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Error') + EOL + 'the stack' + EOL);
   });
 
   it('error with file', function() {
@@ -39,7 +44,8 @@ describe('writeError', function() {
       file: 'the file'
     }));
 
-    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with filename (as from Uglify)', function() {
@@ -47,7 +53,8 @@ describe('writeError', function() {
       filename: 'the file'
     }));
 
-    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line', function() {
@@ -56,7 +63,8 @@ describe('writeError', function() {
       line: 'the line'
     }));
 
-    expect(ui.output).to.equal(chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + col', function() {
@@ -65,7 +73,8 @@ describe('writeError', function() {
       col: 'the col'
     }));
 
-    expect(ui.output).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
   });
 
   it('error with file + line + col', function() {
@@ -75,6 +84,7 @@ describe('writeError', function() {
       col:  'the col'
     }));
 
-    expect(ui.output).to.equal(chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
   });
 });


### PR DESCRIPTION
If `ui.writeLine(error, 'ERROR')` is invoked, write to the
`ui.errorStream`, which defaults to `process.stderr`.

Closes [#5038].

[#5038]: https://github.com/ember-cli/ember-cli/issues/5038