### PR TITLE
Bump quick-temp to 0.1.3 (#5057)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "pleasant-progress": "^1.0.2",
     "portfinder": "^0.4.0",
     "promise-map-series": "^0.2.1",
-    "quick-temp": "0.1.2",
+    "quick-temp": "0.1.3",
     "readline2": "0.1.1",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.17",


### PR DESCRIPTION
This seems to fix #5057 for me. Now, the only `npm WARN` line I get is about a lack of `README` in `babel-core`, and `npm shrinkwrap --dev` succeeds.