### PR TITLE
Testem 0.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.1",
-    "testem": "0.9.10",
+    "testem": "0.9.11",
     "through": "^2.3.6",
     "tiny-lr": "0.2.0",
     "walk-sync": "0.1.3",


### PR DESCRIPTION
Fixed Microsoft Edge detection. I would also propose to unlock testem again as patching its deps is no longer required, but thats your call.