### PR TITLE
[BUGFIX] Forward `--config-file` test option to testem

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -42,6 +42,7 @@ module.exports = Task.extend({
       reporter: options.reporter,
       middleware: this.addonMiddlewares(),
       launch: options.launch,
+      file: options.configFile,
       /* jshint ignore:start */
       config_dir: process.cwd(),
       test_page: options.testPage,

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -7,26 +7,26 @@ var MockProject = require('../../helpers/mock-project');
 describe('test', function() {
   var subject;
 
-  it('transforms the options and invokes testem properly', function() {
+  it('transforms options for testem configuration', function() {
     subject = new TestTask({
       project: new MockProject(),
       addonMiddlewares: function() {
         return ['middleware1', 'middleware2'];
       },
-      testem: {
-        startCI: function(options, cb) {
-          expect(options.host).to.equal('greatwebsite.com');
-          expect(options.port).to.equal(123324);
-          expect(options.cwd).to.equal('blerpy-derpy');
-          expect(options.reporter).to.equal('xunit');
-          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
-          /* jshint ignore:start */
-          expect(options.test_page).to.equal('http://my/test/page');
-          expect(options.config_dir).to.be.an('string');
-          /* jshint ignore:end*/
-          cb(0);
-        },
-        app: { reporter: { total: 1 } }
+
+      invokeTestem: function(options) {
+        var testemOptions = this.testemOptions(options);
+
+        expect(testemOptions.host).to.equal('greatwebsite.com');
+        expect(testemOptions.port).to.equal(123324);
+        expect(testemOptions.cwd).to.equal('blerpy-derpy');
+        expect(testemOptions.reporter).to.equal('xunit');
+        expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
+        // /* jshint ignore:start */
+        expect(testemOptions.test_page).to.equal('http://my/test/page');
+        expect(testemOptions.config_dir).to.be.an('string');
+        // /* jshint ignore:end*/
+        expect(testemOptions.file).to.equal('custom-testem-config.json');
       }
     });
 
@@ -35,7 +35,8 @@ describe('test', function() {
       port: 123324,
       reporter: 'xunit',
       outputPath: 'blerpy-derpy',
-      testPage: 'http://my/test/page'
+      testPage: 'http://my/test/page',
+      configFile: 'custom-testem-config.json'
     });
   });
 });


### PR DESCRIPTION
Fixes an issue where the `--config-file` test option would not be forwarded to testem and the test runner would use the default config file (`./testem.json`) instead.
