### PR TITLE
[ENHANCEMENT] Install htmlbars precompiler when generating component integration tests

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -3,6 +3,7 @@
 var path          = require('path');
 var testInfo      = require('ember-cli-test-info');
 var stringUtil    = require('ember-cli-string-utils');
+var isPackageMissing = require('ember-cli-is-package-missing');
 var getPathOption = require('../../lib/utilities/get-component-path-option');
 
 module.exports = {
@@ -55,5 +56,12 @@ module.exports = {
       componentPathName: componentPathName,
       friendlyTestDescription: friendlyTestDescription
     };
+  },
+  afterInstall: function(options) {
+    if (!options.dryRun && options.testType === 'integration' && isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')) {
+      return this.addPackagesToProject([
+        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' }
+      ]);
+    }
   }
 };


### PR DESCRIPTION
A project originally generated with an older version of ember-cli might not have the inline precompiler installed. This means a generated component integration test won't work out of the box.

@rwjblue 