### PR TITLE
Workaround for babel includePolyfill exception

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1021,6 +1021,7 @@ EmberApp.prototype._addonInstalled = function(addonName) {
 EmberApp.prototype._prunedBabelOptions = function() {
   var babelOptions = merge({}, this.options.babel);
   delete babelOptions.compileModules;
+  delete babelOptions.includePolyfill;
   return babelOptions;
 };
 


### PR DESCRIPTION
This is a workaround related to #5103. It should ease upgrade pain for anybody who was already using the `includePolyfill` option to ember-cli-babel.