### PR TITLE
Configure Hound to lint with JSCS

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+jscs:
+  enabled: true
+  config_file: .jscsrc

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,77 @@
+{
+  "esnext": true,
+  "verbose": true,
+
+  "disallowEmptyBlocks": true,
+  "disallowKeywordsOnNewLine": ["else"],
+  "disallowMultipleLineBreaks": true,
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "disallowNewlineBeforeBlockStatements": true,
+  "disallowOperatorBeforeLineBreak": ["."],
+  "disallowSpaceAfterObjectKeys": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowSpaceBeforePostfixUnaryOperators": true,
+  "disallowSpaceBeforeSemicolon": true,
+  "disallowSpacesInFunction": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideParentheses": true,
+  "disallowSpacesInCallExpression": true,
+  "disallowTrailingComma": true,
+  "disallowTrailingWhitespace": true,
+  "requireBlocksOnNewline": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "requireCapitalizedConstructors": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch",
+    "switch"
+  ],
+  "requireDotNotation": true,
+  "requireLineBreakAfterVariableAssignment": true,
+  "requireParenthesesAroundArrowParam": true,
+  "requireSemicolons": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof"
+  ],
+  "requireSpaceAfterLineComment": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceBeforeObjectValues": true,
+  "requireSpaceBetweenArguments": true,
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInForStatement": true,
+  "requireSpacesInsideObjectBrackets": "all",
+  "validateIndentation": 2,
+  "validateParameterSeparator": ", ",
+  "validateQuoteMarks": {
+    "mark": "'",
+    "escape": true
+  }
+}


### PR DESCRIPTION
[Hound] is a [continuous integration service][site] designed to comment
during Code Review on Pull Requests with [style guide
infractions][why-does-style-matter] in their diffs.

We're currently linting our JavaScript with [CodeClimate] (which seems
to use JSHint), but unfortunately those infractions are separate from
the typical Code Review workflow that occurs in GitHub, and are instead
buried deep within the CodeClimate website.

Alternatively, we could introduce JSCS linting into the build process,
the way `emberjs/ember.js` and `emberjs/data` do.

This approach would add additional tests to an already lengthy test
suite. Local style infractions would slow down the development feedback
loop, and could introduce terminal noise, which would distract the
developer from the task at hand.

Dealing with style guide infractions are the Code Review / Pull Request
delays the checks until the task at hand is complete and ready for CI.

Maintaining a consistent style would help [make collaboration
easier][collaboration], as well as make the codebase more approachable
for new contributors.

[Hound]: https://robots.thoughtbot.com/introducing-hound
[site]: https://houndci.com
[why-does-style-matter]: https://robots.thoughtbot.com/why-does-style-matter
[collaboration]: https://robots.thoughtbot.com/collaboration-is-other-people
[CodeClimate]: https://codeclimate.com/github/ember-cli/ember-cli/issues/categories/style

# NOTE

The `.jscsrc` file is intentionally left blank, since I don't personally have a sense of the project's currently de facto styleguide / rules.

I encourage someone in-the-know to help me generate a good baseline configuration.