### PR TITLE
Fix body-parser suggested use due to deprecations

### DIFF
--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -42,6 +42,6 @@ module.exports = function(app) {
   // After installing, you need to `use` the body-parser for
   // this mock uncommenting the following line:
   //
-  //app.use('/api/<%= decamelizedModuleName %>', require('body-parser'));
+  //app.use('/api/<%= decamelizedModuleName %>', require('body-parser').json());
   app.use('/api/<%= decamelizedModuleName %>', <%= camelizedModuleName %>Router);
 };

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -700,7 +700,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                     "  // After installing, you need to `use` the body-parser for" + EOL +
                     "  // this mock uncommenting the following line:" + EOL +
                     "  //" + EOL +
-                    "  //app.use('/api/foo', require('body-parser'));" + EOL +
+                    "  //app.use('/api/foo', require('body-parser').json());" + EOL +
                     "  app.use('/api/foo', fooRouter);" + EOL +
                     "};" + EOL
         });
@@ -759,7 +759,7 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                     "  // After installing, you need to `use` the body-parser for" + EOL +
                     "  // this mock uncommenting the following line:" + EOL +
                     "  //" + EOL +
-                    "  //app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());" + EOL +
                     "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                     "};" + EOL
         });

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -966,7 +966,7 @@ describe('Acceptance: ember generate in-addon', function() {
                     "  // After installing, you need to `use` the body-parser for" + EOL +
                     "  // this mock uncommenting the following line:" + EOL +
                     "  //" + EOL +
-                    "  //app.use('/api/foo', require('body-parser'));" + EOL +
+                    "  //app.use('/api/foo', require('body-parser').json());" + EOL +
                     "  app.use('/api/foo', fooRouter);" + EOL +
                     "};"
         });
@@ -1025,7 +1025,7 @@ describe('Acceptance: ember generate in-addon', function() {
                     "  // After installing, you need to `use` the body-parser for" + EOL +
                     "  // this mock uncommenting the following line:" + EOL +
                     "  //" + EOL +
-                    "  //app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());" + EOL +
                     "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                     "};"
         });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1020,7 +1020,7 @@ describe('Acceptance: ember generate', function() {
                   "  // After installing, you need to `use` the body-parser for" + EOL +
                   "  // this mock uncommenting the following line:" + EOL +
                   "  //" + EOL +
-                  "  //app.use('/api/foo', require('body-parser'));" + EOL +
+                  "  //app.use('/api/foo', require('body-parser').json());" + EOL +
                   "  app.use('/api/foo', fooRouter);" + EOL +
                   "};"
       });
@@ -1079,7 +1079,7 @@ describe('Acceptance: ember generate', function() {
                   "  // After installing, you need to `use` the body-parser for" + EOL +
                   "  // this mock uncommenting the following line:" + EOL +
                   "  //" + EOL +
-                  "  //app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                  "  //app.use('/api/foo-bar', require('body-parser').json());" + EOL +
                   "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                   "};"
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1707,7 +1707,7 @@ describe('Acceptance: ember generate pod', function() {
                   "  // After installing, you need to `use` the body-parser for" + EOL +
                   "  // this mock uncommenting the following line:" + EOL +
                   "  //" + EOL +
-                  "  //app.use('/api/foo', require('body-parser'));" + EOL +
+                  "  //app.use('/api/foo', require('body-parser').json());" + EOL +
                   "  app.use('/api/foo', fooRouter);" + EOL +
                   "};"
       });
@@ -1766,7 +1766,7 @@ describe('Acceptance: ember generate pod', function() {
                   "  // After installing, you need to `use` the body-parser for" + EOL +
                   "  // this mock uncommenting the following line:" + EOL +
                   "  //" + EOL +
-                  "  //app.use('/api/foo-bar', require('body-parser'));" + EOL +
+                  "  //app.use('/api/foo-bar', require('body-parser').json());" + EOL +
                   "  app.use('/api/foo-bar', fooBarRouter);" + EOL +
                   "};"
       });


### PR DESCRIPTION
BodyParser has changed how it expects to be called, so this
follows that change to use `.json()` directly.