### PR TITLE
[ENHANCEMENT] Changes to support `ember-cli-blueprint-test-helpers`

### DIFF
--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -11,17 +11,15 @@ module.exports = {
     return {
       __name__: function(options) {
         if (options.pod && options.hasPathToken) {
-          return options.originBlueprintName;
+          return options.locals.blueprintName;
         }
         return options.dasherizedModuleName;
       },
       __path__: function(options) {
-        var blueprintName = options.originBlueprintName;
-
         if (options.pod && options.hasPathToken) {
           return path.join(options.podPath, options.dasherizedModuleName);
         }
-        return inflector.pluralize(blueprintName);
+        return inflector.pluralize(options.locals.blueprintName);
       },
       __root__: function(options) {
         if (options.inRepoAddon) {
@@ -36,13 +34,20 @@ module.exports = {
     var addonName      = stringUtil.dasherize(addonRawName);
     var fileName       = stringUtil.dasherize(options.entity.name);
     var pathName       = [addonName, inflector.pluralize(options.originBlueprintName), fileName].join('/');
-
+    var blueprintName  = options.originBlueprintName;
+    
+    if (blueprintName.match(/-addon/)) {
+      blueprintName = blueprintName.substr(0,blueprintName.indexOf('-addon'));
+      pathName = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
+    }
+    
     if (options.pod) {
-      pathName = [addonName, fileName, options.originBlueprintName].join('/');
+      pathName = [addonName, fileName, blueprintName].join('/');
     }
 
     return {
-      modulePath: pathName
+      modulePath: pathName,
+      blueprintName: blueprintName
     };
   }
 };

--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -1,11 +1,17 @@
 /*jshint node:true*/
 
-var stringUtil = require('ember-cli-string-utils');
-var path       = require('path');
-var inflector  = require('inflection');
+var stringUtil  = require('ember-cli-string-utils');
+var path        = require('path');
+var inflector   = require('inflection');
+var SilentError = require('silent-error');
 
 module.exports = {
   description: 'Generates an import wrapper.',
+  beforeInstall: function(options) {
+    if(options.originBlueprintName === 'addon-import') {
+      throw new SilentError('You cannot call the addon-import blueprint directly.');
+    }
+  },
 
   fileMapTokens: function() {
     return {
@@ -33,20 +39,20 @@ module.exports = {
     var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
     var addonName      = stringUtil.dasherize(addonRawName);
     var fileName       = stringUtil.dasherize(options.entity.name);
-    var pathName       = [addonName, inflector.pluralize(options.originBlueprintName), fileName].join('/');
+    var modulePath     = [addonName, inflector.pluralize(options.originBlueprintName), fileName].join('/');
     var blueprintName  = options.originBlueprintName;
     
     if (blueprintName.match(/-addon/)) {
       blueprintName = blueprintName.substr(0,blueprintName.indexOf('-addon'));
-      pathName = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
+      modulePath = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
     }
     
     if (options.pod) {
-      pathName = [addonName, fileName, blueprintName].join('/');
+      modulePath = [addonName, fileName, blueprintName].join('/');
     }
 
     return {
-      modulePath: pathName,
+      modulePath: modulePath,
       blueprintName: blueprintName
     };
   }

--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -36,23 +36,23 @@ module.exports = {
     };
   },
   locals: function(options) {
-    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
-    var addonName      = stringUtil.dasherize(addonRawName);
-    var fileName       = stringUtil.dasherize(options.entity.name);
-    var modulePath     = [addonName, inflector.pluralize(options.originBlueprintName), fileName].join('/');
-    var blueprintName  = options.originBlueprintName;
+    var addonRawName       = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    var addonName          = stringUtil.dasherize(addonRawName);
+    var fileName           = stringUtil.dasherize(options.entity.name);
+    var blueprintName      = options.originBlueprintName;
+    var modulePathSegments = [addonName, inflector.pluralize(options.originBlueprintName), fileName];
     
     if (blueprintName.match(/-addon/)) {
       blueprintName = blueprintName.substr(0,blueprintName.indexOf('-addon'));
-      modulePath = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
+      modulePathSegments = [addonName, inflector.pluralize(blueprintName), fileName];
     }
     
     if (options.pod) {
-      modulePath = [addonName, fileName, blueprintName].join('/');
+      modulePathSegments = [addonName, fileName, blueprintName];
     }
 
     return {
-      modulePath: modulePath,
+      modulePath: modulePathSegments.join('/'),
       blueprintName: blueprintName
     };
   }

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -107,15 +107,12 @@ CLI.prototype.run = function(environment) {
       // Possibly this issue: https://github.com/joyent/node/issues/8329
       // Wait to resolve promise when running on windows.
       // This ensures that stdout is flushed so acceptance tests get full output
-      var result = {
-        exitCode: exitCode,
-        ui: this.ui
-      };
+
       return new Promise(function(resolve) {
         if (process.platform === 'win32') {
-          setTimeout(resolve, 250, result);
+          setTimeout(resolve, 250, exitCode);
         } else {
-          resolve(result);
+          resolve(exitCode);
         }
       });
     }.bind(this));
@@ -165,6 +162,7 @@ CLI.prototype.logError = function(error) {
       console.error(error.stack);
     }
   }
+  this.ui.errorLog.push(error);
   this.ui.writeError(error);
   return 1;
 };

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -6,6 +6,7 @@ var versionUtils   = require('../utilities/version-utils');
 var UpdateChecker  = require('../models/update-checker');
 var getOptionArgs  = require('../utilities/get-option-args');
 var debug          = require('debug')('ember-cli:cli');
+var debugTesting   = require('debug')('ember-cli:testing');
 
 var PlatformChecker = require('../utilities/platform-checker');
 var emberCLIVersion      = versionUtils.emberCLIVersion;
@@ -16,6 +17,7 @@ function CLI(options) {
   this.ui = options.ui;
   this.analytics = options.analytics;
   this.testing = options.testing;
+  this.disableDependencyChecker = options.disableDependencyChecker;
   this.root = options.root;
   this.npmPackage = options.npmPackage;
 
@@ -84,6 +86,7 @@ CLI.prototype.run = function(environment) {
     command.beforeRun(commandArgs);
 
     return Promise.resolve(update).then(function() {
+      debugTesting('cli: command.validateAndRun');
       return command.validateAndRun(commandArgs);
     }).then(function(result) {
       // if the help option was passed, call the help command
@@ -99,6 +102,7 @@ CLI.prototype.run = function(environment) {
 
       return result;
     }.bind(this)).then(function(exitCode) {
+      debugTesting('cli: command run complete. exitCode: ' + exitCode);
       // TODO: fix this
       // Possibly this issue: https://github.com/joyent/node/issues/8329
       // Wait to resolve promise when running on windows.
@@ -157,7 +161,9 @@ CLI.prototype.callHelp = function(options) {
 CLI.prototype.logError = function(error) {
   if (this.testing && error){
     console.error(error.message);
-    console.error(error.stack);
+    if (error.stack) {
+      console.error(error.stack);
+    }
   }
   this.ui.writeError(error);
   return 1;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -85,6 +85,7 @@ module.exports = function(options) {
     analytics: leek,
     testing:   options.testing,
     name: options.cli ? options.cli.name : 'ember',
+    disableDependencyChecker: options.disableDependencyChecker,
     root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
     npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli'
   });

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -461,7 +461,6 @@ Blueprint.prototype._checkInRepoAddonExists = function(inRepoAddon) {
 Blueprint.prototype._process = function(options, beforeHook, process, afterHook) {
   var intoDir = options.target;
   var locals  = this._locals(options);
-
   return Promise.resolve()
     .then(beforeHook.bind(this, options, locals))
     .then(process.bind(this, intoDir, locals)).map(this._commit.bind(this))
@@ -742,7 +741,6 @@ function finishProcessingForUninstall(infos) {
 Blueprint.prototype.processFiles = function(intoDir, templateVariables) {
   var files = this._getFilesForInstall(templateVariables.targetFiles);
   var fileInfos = this._getFileInfos(files, intoDir, templateVariables);
-
   this._checkForNoMatch(fileInfos, templateVariables.rawArgs);
 
   this._ignoreUpdateFiles();
@@ -1446,6 +1444,7 @@ Blueprint.defaultLookupPaths = function() {
   @return {Promise}
 */
 function prepareConfirm(info) {
+  
   return info.checkForConflict().then(function(resolution) {
     info.resolution = resolution;
     return info;

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -569,20 +569,35 @@ Project.closest = function(pathName, _ui, _cli) {
  */
 Project.closestSync = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
-
-  try {
-    var directory = findup.sync(pathName, 'package.json');
-    var pkg = require(path.join(directory, 'package.json'));
-
-    if (pkg && pkg.name === 'ember-cli') {
-      return Project.nullProject(_ui, _cli);
+  var directory, pkg;
+  
+  if (_cli && _cli.testing) {
+    directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
+    
+    if (directory) {
+      pkg = require(path.join(directory, 'package.json'));
+    } else {
+      pkg = {name: 'ember-cli'};
     }
-
-    debug('closestSync %s -> %s', pathName, directory);
-    return new Project(directory, pkg, ui, _cli);
-  } catch(reason) {
-    handleFindupError(pathName, reason);
+ 
+  } else {
+    try {
+      directory = findup.sync(pathName, 'package.json');
+      pkg = require(path.join(directory, 'package.json'));
+       
+    } catch(reason) {
+      handleFindupError(pathName, reason);
+    }
   }
+  
+  debug('dir' + directory);
+  debug('pkg: %s', pkg);
+  if (pkg && pkg.name === 'ember-cli') {
+    return Project.nullProject(_ui, _cli);
+  }
+
+  debug('closestSync %s -> %s', pathName, directory);
+  return new Project(directory, pkg, ui, _cli);
 };
 
 /**

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -571,15 +571,25 @@ Project.closestSync = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
   var directory, pkg;
   
+  // special lookup rules only when testing
   if (_cli && _cli.testing) {
-    directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
-    
-    if (directory) {
-      pkg = require(path.join(directory, 'package.json'));
-    } else {
-      pkg = {name: 'ember-cli'};
-    }
- 
+      directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
+      
+      if (directory) {
+        pkg = require(path.join(directory, 'package.json'));
+      // if we're anywhere inside the app, use findup
+      } else if (pathName.indexOf('/app') > -1){
+        try {
+          directory = findup.sync(pathName, 'package.json');
+          pkg = require(path.join(directory, 'package.json'));
+           
+        } catch(reason) {
+          handleFindupError(pathName, reason);
+        }
+      } else {
+        pkg = {name: 'ember-cli'};
+      }
+      
   } else {
     try {
       directory = findup.sync(pathName, 'package.json');

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -571,35 +571,22 @@ Project.closestSync = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
   var directory, pkg;
   
-  // special lookup rules only when testing
   if (_cli && _cli.testing) {
-      directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
-      
-      if (directory) {
-        pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
-      // if we're anywhere inside the app, use findup
-      } else if (pathName.indexOf('/app') > -1){
-        try {
-          directory = findup.sync(pathName, 'package.json');
-          pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
-           
-        } catch(reason) {
-          handleFindupError(pathName, reason);
-        }
+    directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
+    if (!directory) {
+      if (pathName.indexOf('/app') > -1){
+        directory = findupPath(pathName);
       } else {
         pkg = {name: 'ember-cli'};
       }
-      
-  } else {
-    try {
-      directory = findup.sync(pathName, 'package.json');
-      pkg = require(path.join(directory, 'package.json'));
-       
-    } catch(reason) {
-      handleFindupError(pathName, reason);
     }
+  } else {
+    directory = findupPath(pathName);
   }
-  
+  if (!pkg) {
+    pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
+  }
+
   debug('dir' + directory);
   debug('pkg: %s', pkg);
   if (pkg && pkg.name === 'ember-cli') {
@@ -696,6 +683,14 @@ function closestPackageJSON(pathName) {
         pkg: require(path.join(directory, 'package.json'))
       });
     });
+}
+
+function findupPath(pathName) {
+  try {
+    return findup.sync(pathName, 'package.json');       
+  } catch(reason) {
+    handleFindupError(pathName, reason);
+  }
 }
 
 function isFindupError(reason) {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -576,12 +576,12 @@ Project.closestSync = function(pathName, _ui, _cli) {
       directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
       
       if (directory) {
-        pkg = require(path.join(directory, 'package.json'));
+        pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
       // if we're anywhere inside the app, use findup
       } else if (pathName.indexOf('/app') > -1){
         try {
           directory = findup.sync(pathName, 'package.json');
-          pkg = require(path.join(directory, 'package.json'));
+          pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
            
         } catch(reason) {
           handleFindupError(pathName, reason);

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -14,7 +14,7 @@ module.exports = Task.extend({
   run: function(options) {
     var self = this;
     var name = options.args[0];
-    var noAddonBlueprint = ['mixin'];
+    var noAddonBlueprint = ['mixin', 'blueprint-test'];
 
     var mainBlueprint  = this.lookupBlueprint(name, options.ignoreMissingMain);
     var testBlueprint  = this.lookupBlueprint(name + '-test', true);

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -72,7 +72,7 @@ module.exports = Task.extend({
         return testBlueprint[self.blueprintFunction](testBlueprintOptions);
       })
       .then(function() {
-        if (!addonBlueprint) { return; }
+        if (!addonBlueprint || name.match(/-addon/)) { return; }
         if (!this.project.isEmberCLIAddon() && blueprintOptions.inRepoAddon === null) { return; }
 
         if (addonBlueprint.locals === Blueprint.prototype.locals) {

--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -36,7 +36,10 @@ module.exports = Task.extend({
         .then(function(){
           ui.writeLine(chalk.green('Successfully initialized git.'));
         });
-      }).catch(function(/*error*/){
+      }).catch(function(error){
+        if (commandOptions.logErrors) {
+          ui.writeError(error);
+        }
         // if git is not found or an error was thrown during the `git`
         // init process just swallow any errors here
     });

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -50,6 +50,7 @@ function UI(options) {
   this.inputStream = options.inputStream;
   this.errorStream = options.errorStream;
 
+  this.errorLog = options.errorLog || [];
   this.writeLevel = options.writeLevel || DEFAULT_WRITE_LEVEL;
   this.ci = !!options.ci;
 }

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -874,6 +874,22 @@ describe('Acceptance: ember generate in-addon', function() {
       assertFileToNotExist('app/service-test/foo.js');
     });
   });
+  
+  it('in-addon addon-import cannot be called directly', function() {
+    return generateInAddon(['addon-import', 'foo']).catch(function(error) {
+      expect(error.message).to.include('You cannot call the addon-import blueprint directly.');
+    });
+  });
+  
+  it('in-addon addon-import component-addon works', function() {
+    return generateInAddon(['component-addon', 'foo-bar', '--pod']).then(function() {
+      assertFile('app/components/foo-bar/component.js', {
+        contains: [
+          "export { default } from 'my-addon/components/foo-bar/component';"
+        ]
+      });
+    });
+  });
 
   it('in-addon blueprint foo', function() {
     return generateInAddon(['blueprint', 'foo']).then(function() {

--- a/tests/acceptance/install-test-slow.js
+++ b/tests/acceptance/install-test-slow.js
@@ -68,7 +68,7 @@ describe('Acceptance: ember install', function() {
         ]
       });
 
-      expect(result.ui.output).not.to.include('The `ember generate` command '+
+      expect(result.outputStream.join()).not.to.include('The `ember generate` command '+
                                               'requires an entity name to be specified. For more details, use `ember help`.');
     });
   });

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -669,7 +669,7 @@ describe('Acceptance: ember destroy pod', function() {
   // Skip until podModulePrefix is deprecated
   it.skip('podModulePrefix deprecation warning', function() {
     return destroyAfterGenerate(['controller', 'foo', '--pod']).then(function(result) {
-      expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
+      expect(result.outputStream.join()).to.include("`podModulePrefix` is deprecated and will be"+
       " removed from future versions of ember-cli. Please move existing pods from"+
       " 'app/pods/' to 'app/'.");
     });
@@ -677,7 +677,7 @@ describe('Acceptance: ember destroy pod', function() {
 
   it('usePodsByDefault deprecation warning', function() {
     return destroyAfterGenerateWithPodsByDefault(['controller', 'foo', '--pod']).then(function(result) {
-      expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+
+      expect(result.outputStream.join()).to.include('`usePodsByDefault` is no longer supported in'+
         ' \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.');
     });
   });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -2037,7 +2037,7 @@ describe('Acceptance: ember generate pod', function() {
   // Skip until podModulePrefix is deprecated
   it.skip('podModulePrefix deprecation warning', function() {
     return generateWithPrefix(['controller', 'foo', '--pod']).then(function(result) {
-      expect(result.ui.output).to.include("`podModulePrefix` is deprecated and will be"+
+      expect(result.outputStream.join()).to.include("`podModulePrefix` is deprecated and will be"+
       " removed from future versions of ember-cli. Please move existing pods from"+
       " 'app/pods/' to 'app/'.");
     });
@@ -2045,7 +2045,7 @@ describe('Acceptance: ember generate pod', function() {
 
   it('usePodsByDefault deprecation warning', function() {
     return generateWithUsePodsDeprecated(['controller', 'foo', '--pod']).then(function(result) {
-      expect(result.ui.output).to.include('`usePodsByDefault` is no longer supported in'+
+      expect(result.outputStream.join()).to.include('`usePodsByDefault` is no longer supported in'+
         ' \'config/environment.js\', use `usePods` in \'.ember-cli\' instead.');
     });
   });

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -179,7 +179,7 @@ describe('Acceptance: smoke-test', function() {
         process.stdout.write = originalWrite;
       })
       .then(function(result) {
-        expect(result.statusCode).to.equal(0, 'exit code should be 0 for passing tests');
+        expect(result.exitCode).to.equal(0, 'exit code should be 0 for passing tests');
 
         output = output.join(EOL);
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -179,7 +179,7 @@ describe('Acceptance: smoke-test', function() {
         process.stdout.write = originalWrite;
       })
       .then(function(result) {
-        expect(result.exitCode).to.equal(0, 'exit code should be 0 for passing tests');
+        expect(result.statusCode).to.equal(0, 'exit code should be 0 for passing tests');
 
         output = output.join(EOL);
 

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -3,6 +3,7 @@
 var MockUI        = require('./mock-ui');
 var MockAnalytics = require('./mock-analytics');
 var cli           = require('../../lib/cli');
+var path          = require('path');
 
 /*
   Accepts a single array argument, that contains the
@@ -37,18 +38,29 @@ var cli           = require('../../lib/cli');
     a `MockUI` instance), this can be used to inspect the commands output.
 
 */
-module.exports = function ember(args) {
+module.exports = function ember(args, options) {
   var cliInstance;
+  var ui = options && options.UI || MockUI;
+  var pkg = options && options.package || path.resolve(__dirname, '..', '..');
+  var disableDependencyChecker = options && options.disableDependencyChecker || true;
 
   args.push('--disable-analytics');
   args.push('--watcher=node');
+  args.push('--skipGit');
   cliInstance = cli({
     inputStream:  [],
     outputStream: [],
     cliArgs:      args,
     Leek: MockAnalytics,
-    UI: MockUI,
-    testing: true
+    UI: ui,
+    testing: true,
+    disableDependencyChecker: disableDependencyChecker,
+    cli: {
+      // This prevents ember-cli from detecting any other package.json files
+      // forcing ember-cli to act as the globally installed package
+      npmPackage: 'ember-cli',
+      root: pkg 
+    }
   });
 
   return cliInstance;

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -4,6 +4,7 @@ var MockUI        = require('./mock-ui');
 var MockAnalytics = require('./mock-analytics');
 var cli           = require('../../lib/cli');
 var path          = require('path');
+var Promise       = require('../../lib/ext/promise');
 
 /*
   Accepts a single array argument, that contains the
@@ -43,16 +44,22 @@ module.exports = function ember(args, options) {
   var ui = options && options.UI || MockUI;
   var pkg = options && options.package || path.resolve(__dirname, '..', '..');
   var disableDependencyChecker = options && options.disableDependencyChecker || true;
+  var inputStream  = [];
+  var outputStream = [];
+  var errorStream  = [];
+  var errorLog     = [];
 
   args.push('--disable-analytics');
   args.push('--watcher=node');
   args.push('--skipGit');
   cliInstance = cli({
-    inputStream:  [],
-    outputStream: [],
+    inputStream:  inputStream,
+    outputStream: outputStream,
+    errorStream:  errorStream,
+    errorLog:     errorLog,
     cliArgs:      args,
     Leek: MockAnalytics,
-    UI: ui,
+    UI: MockUI,
     testing: true,
     disableDependencyChecker: disableDependencyChecker,
     cli: {
@@ -62,6 +69,17 @@ module.exports = function ember(args, options) {
       root: pkg 
     }
   });
+  function returnTestState(statusCode) {
+     return {
+        statusCode: statusCode,
+        inputStream: inputStream,
+        outputStream: outputStream,
+        errorStream: errorStream,
+        errorLog: errorLog
+     };
+   }
 
-  return cliInstance;
+  return cliInstance.then(returnTestState, function(statusCode) {
+     return Promise.reject(returnTestState(statusCode));
+  });
 };

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -71,6 +71,7 @@ module.exports = function ember(args, options) {
   });
   function returnTestState(statusCode) {
      return {
+        exitCode: statusCode,
         statusCode: statusCode,
         inputStream: inputStream,
         outputStream: outputStream,

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -59,7 +59,7 @@ module.exports = function ember(args, options) {
     errorLog:     errorLog,
     cliArgs:      args,
     Leek: MockAnalytics,
-    UI: MockUI,
+    UI: ui,
     testing: true,
     disableDependencyChecker: disableDependencyChecker,
     cli: {

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -46,7 +46,6 @@ module.exports = function ember(args, options) {
   var disableDependencyChecker = options && options.disableDependencyChecker || true;
   var inputStream  = [];
   var outputStream = [];
-  var errorStream  = [];
   var errorLog     = [];
 
   args.push('--disable-analytics');
@@ -55,7 +54,6 @@ module.exports = function ember(args, options) {
   cliInstance = cli({
     inputStream:  inputStream,
     outputStream: outputStream,
-    errorStream:  errorStream,
     errorLog:     errorLog,
     cliArgs:      args,
     Leek: MockAnalytics,
@@ -75,7 +73,6 @@ module.exports = function ember(args, options) {
         statusCode: statusCode,
         inputStream: inputStream,
         outputStream: outputStream,
-        errorStream: errorStream,
         errorLog: errorLog
      };
    }

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -5,16 +5,23 @@ var through = require('through');
 var Promise = require('../../lib/ext/promise');
 
 module.exports = MockUI;
-function MockUI() {
+function MockUI(options) {
   this.output = '';
   this.errors = '';
+  this.errorLog = options && options.errorLog || [];
 
   UI.call(this, {
     inputStream: through(),
     outputStream: through(function(data) {
+      if (options && options.outputStream) {
+        options.outputStream.push(data);
+      }
       this.output += data;
     }.bind(this)),
     errorStream: through(function(data) {
+      if (options && options.errorStream) {
+        options.errorStream.push(data);
+      }
       this.errors += data;
     }.bind(this))
   });
@@ -25,6 +32,7 @@ MockUI.prototype.constructor = MockUI;
 MockUI.prototype.clear = function(){
   this.output = '';
   this.errors = '';
+  this.errorLog = [];
 };
 
 MockUI.prototype.waitForPrompt = function() {

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -19,9 +19,6 @@ function MockUI(options) {
       this.output += data;
     }.bind(this)),
     errorStream: through(function(data) {
-      if (options && options.errorStream) {
-        options.errorStream.push(data);
-      }
       this.errors += data;
     }.bind(this))
   });

--- a/tests/unit/blueprints/addon-import-test.js
+++ b/tests/unit/blueprints/addon-import-test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var Blueprint = require('../../../lib/models/blueprint');
+var expect    = require('chai').expect;
+
+describe('blueprint - addon-import', function(){
+  describe('fileMapTokens', function(){
+    it('generates proper tokens with *-addon blueprints', function(){
+      var blueprint = Blueprint.lookup('addon-import');
+      var options = {
+        inRepoAddon: false,
+        project: {
+          name: function(){
+            return 'my-addon';
+          },
+          config: function() {
+            return {};
+          },
+          isEmberCLIAddon: function() {
+            return true;
+          }
+        },
+        entity: {
+          name: 'foo-bar'
+        },
+        originBlueprintName: 'component-addon',
+        pod: false,
+        podPath: '', 
+        dasherizedModuleName: 'foo-bar',
+        hasPathToken: true
+        
+      };
+      var locals, podLocals, fileMapTokens, fileMapTokensPods;
+      locals = blueprint.locals(options);
+      fileMapTokens = blueprint.fileMapTokens(locals);
+      
+      options.locals = locals;
+      
+      expect(fileMapTokens.__name__(options)).to.equal('foo-bar');
+      expect(fileMapTokens.__path__(options)).to.equal('components');
+      expect(fileMapTokens.__root__(options)).to.equal('app');
+      
+      options.pod = true;
+      podLocals = blueprint.locals(options);
+      fileMapTokensPods = blueprint.fileMapTokens(podLocals);
+      
+      expect(fileMapTokens.__name__(options)).to.equal('component');
+      expect(fileMapTokens.__path__(options)).to.equal('foo-bar');
+      expect(fileMapTokens.__root__(options)).to.equal('app');
+      
+    });
+  });
+});

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -99,7 +99,52 @@ describe('Unit: CLI', function() {
       expect(output.length).to.equal(1, 'expected no extra output');
     });
   });
-
+/*  
+  it('logError', function() {
+    var cli = new CLI({
+      ui: ui,
+      analytics: analytics,
+      testing: true
+    });
+    var error = new Error('Error message!');
+    var expected = {exitCode: 1, ui: ui, error: error};
+    expect(cli.logError(error)).to.eql(expected, 'expected error object');
+  });
+*/
+  it('callHelp', function() {
+    var cli = new CLI({
+      ui: ui,
+      analytics: analytics,
+      testing: true
+    });
+    var init = stubValidateAndRun('init');
+    var help = stubValidateAndRun('help');
+    var helpOptions = {
+      environment: {
+        tasks:    {},
+        commands: commands,
+        cliArgs: [],
+        settings: {},
+        project: {
+          isEmberCLIProject: function() {  // similate being inside or outside of a project
+            return isWithinProject;
+          },
+          hasDependencies: function() {
+            return true;
+          },
+          blueprintLookupPaths: function() {
+            return [];
+          }
+        }
+      },
+      commandName: 'init',
+      commandArgs: []
+    };
+    cli.callHelp(helpOptions);
+    expect(help.called).to.equal(1, 'expected help to be called once');
+    expect(init.called).to.equal(0, 'expected init not to be called');
+  });
+  
   describe('help', function(){
     ['--help', '-h'].forEach(function(command){
       it('ember ' + command, function() {

--- a/tests/unit/tasks/git-init-test.js
+++ b/tests/unit/tasks/git-init-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var fs          = require('fs-extra');
+var expect      = require('chai').expect;
+var MockUI      = require('../../helpers/mock-ui');
+var GitInitTask = require('../../../lib/tasks/git-init');
+var MockProject = require('../../helpers/mock-project');
+var Promise     = require('../../../lib/ext/promise');
+var remove      = Promise.denodeify(fs.remove);
+var path        = require('path');
+var root        = process.cwd();
+var tmp         = require('tmp-sync');
+var tmproot     = path.join(root, 'tmp');
+
+describe('git-init', function() {
+  var subject, ui;
+  var tmpdir;
+
+  beforeEach(function() {
+    tmpdir  = tmp.in(tmproot);
+    ui      = new MockUI();
+    subject = new GitInitTask({
+      ui: ui,
+      project: new MockProject()
+    });
+    process.chdir(tmpdir);
+  });
+  
+  afterEach(function() {
+    process.chdir(root);
+    return remove(tmproot);
+  });
+  
+/** 
+* TODO: git commit not working with this test setup, it errors out.
+* We need to be able to
+*/  
+  it('skipGit properly skips git-init', function() {
+    return subject.run({skipGit:true}).then(function() {
+      expect(ui.output).to.not.include('Successfully initialized git.');
+    });
+  });
+  
+  it('errors are logged with logErrors', function() {
+    return subject.run({skipGit: false, logErrors: true}).then(function() {
+      expect(ui.output).to.equal('');
+      expect(ui.errors).to.not.equal('');
+    });
+  });
+});

--- a/tests/unit/tasks/git-init-test.js
+++ b/tests/unit/tasks/git-init-test.js
@@ -9,21 +9,23 @@ var Promise     = require('../../../lib/ext/promise');
 var remove      = Promise.denodeify(fs.remove);
 var path        = require('path');
 var root        = process.cwd();
-var tmp         = require('tmp-sync');
+var mkTmpDirIn  = require('../../../lib/utilities/mk-tmp-dir-in');
 var tmproot     = path.join(root, 'tmp');
 
 describe('git-init', function() {
-  var subject, ui;
-  var tmpdir;
+  var subject, ui, tmpdir;
 
   beforeEach(function() {
-    tmpdir  = tmp.in(tmproot);
-    ui      = new MockUI();
-    subject = new GitInitTask({
-      ui: ui,
-      project: new MockProject()
+    return mkTmpDirIn(tmproot).then(function(dir){
+      tmpdir  = dir;
+      ui      = new MockUI();
+      subject = new GitInitTask({
+        ui: ui,
+        project: new MockProject()
+      });
+      process.chdir(tmpdir);  
     });
-    process.chdir(tmpdir);
+
   });
   
   afterEach(function() {


### PR DESCRIPTION
This PR contains changes to support `ember-cli-blueprint-test-helpers`. The primary changes are for the `tests/helpers/ember` test helper, adding the following:

* the ability to capture and return UI output, including input, output, errors, and the statusCode, so errors can be asserted.
* add the ability to disable the `ember-cli-dependency-checker` through the `disableDependencyChecker` option. Will require [this PR](https://github.com/quaertym/ember-cli-dependency-checker/pull/49) to be merged, and a new version to be cut.
* allow the `package.json` path to be passed in, allowing the ember-cli commands to be run in different project structures (`app` vs `addon`). Some modifications to the `project` model were necessary for it to allow the passed in `package.json` to be discovered.

It was also necessary to modify the `addon-import` blueprint for some of the changes done in extracting the blueprints to `ember-cli-legacy-blueprints`.

This is not ready for merge yet, it still has a couple tweaks needed, as well as some general cleanup. It should hopefully be ready later tonight.