### PR TITLE
Update ember-cli-sri minimum version to 1.2.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -31,7 +31,7 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^1.1.0",
+    "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
Fixes issues with rebuilds during tests getting invalid integrity values.

Fixes #5110.