### PR TITLE
Bump ember-cli package.json version number to 1.13.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "1.13.8",
+  "version": "1.13.13",
   "main": "lib/cli/index.js",
   "description": "Command line tool for developing ambitious ember.js apps",
   "trackingCode": "UA-49225444-1",


### PR DESCRIPTION
I'm presuming this should be in-step with the release number?