### PR TITLE
Use ES6 shorthand property for layout in component blueprint

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -64,7 +64,7 @@ module.exports = {
           'templates/components/' + stringUtil.dasherize(options.entity.name);
       }
       importTemplate   = 'import layout from \'' + templatePath + '\';\n';
-      contents         = '\n  layout: layout';
+      contents         = '\n  layout';
     }
 
     return {

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -115,7 +115,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "import Ember from 'ember';",
           "import layout from '../templates/components/x-foo';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });
@@ -176,7 +176,7 @@ describe('Acceptance: ember generate in-addon', function() {
           "import Ember from 'ember';",
           "import layout from '../../templates/components/nested/x-foo';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -120,7 +120,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "import Ember from 'ember';",
           "import layout from '../templates/components/x-foo';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });
@@ -179,7 +179,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
           "import Ember from 'ember';",
           "import layout from '../../templates/components/nested/x-foo';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1843,7 +1843,7 @@ describe('Acceptance: ember generate pod', function() {
           "import Ember from 'ember';",
           "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });
@@ -1872,7 +1872,7 @@ describe('Acceptance: ember generate pod', function() {
           "import Ember from 'ember';",
           "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });
@@ -1901,7 +1901,7 @@ describe('Acceptance: ember generate pod', function() {
           "import Ember from 'ember';",
           "import layout from './template';",
           "export default Ember.Component.extend({",
-          "layout: layout",
+          "layout",
           "});"
         ]
       });


### PR DESCRIPTION
Because my linter (ember-suave) doesn't like non-shorthand properties that should have been shorthanded.