### PR TITLE
[ENHANCEMENT] Cleans up generated application directory if `ember new` errors

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -5,6 +5,8 @@ var Command            = require('../models/command');
 var Promise            = require('../ext/promise');
 var Project            = require('../models/project');
 var SilentError        = require('silent-error');
+var rimraf             = require('rimraf');
+var rmdir              = Promise.denodeify(rimraf);
 var validProjectName   = require('../utilities/valid-project-name');
 var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 
@@ -80,6 +82,18 @@ module.exports = Command.extend({
         directoryName: commandOptions.directory,
         dryRun: commandOptions.dryRun
       })
-      .then(initCommand.run.bind(initCommand, commandOptions, rawArgs));
+      .then(function(opts){
+        return initCommand
+          .run(commandOptions, rawArgs)
+          .catch(function(err){
+            console.log(arguments)
+            var dirName = commandOptions.directory;
+            process.chdir(opts.initialDirectory);
+            return rmdir(dirName).then(function(){
+              console.log(chalk.red('Error creating new application. Removing generated directory `./' + dirName + '`'));
+              throw err;
+            });
+          });
+        });
   }
 });

--- a/lib/tasks/create-and-step-into-directory.js
+++ b/lib/tasks/create-and-step-into-directory.js
@@ -38,7 +38,9 @@ module.exports = Task.extend({
         }
       }.bind(this))
       .then(function() {
+        var cwd = process.cwd();
         process.chdir(directoryName);
+        return { initialDirectory: cwd };
       });
   }
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -182,6 +182,27 @@ describe('Acceptance: ember new', function() {
     });
   });
 
+  it('ember new cleans up after itself on error', function() {
+    return tmp.setup('./tmp/my_blueprint')
+      .then(function() {
+        fs.writeFileSync('./tmp/my_blueprint/index.js', 'throw("this will break");');
+        process.chdir('./tmp');
+
+        return ember([
+          'new',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+          '--blueprint=./my_blueprint'
+        ]);
+      })
+      .then(function(){
+        var cwd = process.cwd();
+        expect(!existsSync(path.join(cwd, 'foo')), 'the generated directory is removed');
+      });
+  });
+
   it('ember new with --dry-run does not create new directory', function(){
     return ember([
       'new',


### PR DESCRIPTION
If `ember new` errors, removes the partially generated project instead of leaving behind in a partially generated state.  Useful if generating from a blueprint and the blueprint is broken.