### PR TITLE
reduce number of funnels created to support other asset app.imports

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -37,6 +37,7 @@ var defaults      = require('merge-defaults');
 var merge         = require('lodash/object/merge');
 var omit          = require('lodash/object/omit');
 var Funnel        = require('broccoli-funnel');
+var funnelReducer = require('broccoli-funnel-reducer');
 
 module.exports = EmberApp;
 
@@ -1310,14 +1311,16 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
  */
 EmberApp.prototype.otherAssets = function() {
   var external = this._processedExternalTree();
-  var otherAssetTrees = this.otherAssetPaths.map(function (path) {
-    return new Funnel(external, {
-      srcDir: path.src,
-      files: [path.file],
-      destDir: path.dest,
-      annotation: 'Funnel (otherAssets)'
-    });
+  // combine obviously shared funnels.
+  var otherAssetTrees = funnelReducer(this.otherAssetPaths).map(function(options) {
+    options.annotation = 'Funnel \n  ' +
+      options.srcDir + '\n  ' +
+      options.destDir + '\n include:' +
+      options.include.length;
+
+    return new Funnel(external, options);
   });
+
   return mergeTrees(otherAssetTrees, {
     annotation: 'TreeMerger (otherAssetTrees)'
   });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "broccoli-config-loader": "^1.0.0",
     "broccoli-config-replace": "^1.1.0",
     "broccoli-funnel": "^1.0.0",
+    "broccoli-funnel-reducer": "^1.0.0",
     "broccoli-kitchen-sink-helpers": "^0.2.7",
     "broccoli-merge-trees": "0.2.3",
     "broccoli-plugin": "^1.2.0",


### PR DESCRIPTION
before:

<img width="789" alt="screen shot 2015-11-23 at 5 42 26 pm" src="https://cloud.githubusercontent.com/assets/1377/11355369/9875f15a-9209-11e5-98d4-6e5bd7f365a2.png">

after:

<img width="1527" alt="screen shot 2015-11-23 at 5 41 58 pm" src="https://cloud.githubusercontent.com/assets/1377/11355361/8a28faca-9209-11e5-9542-45c8b2df1fe0.png">


Not really a major cost, but could likely spiral out of control, pretty quickly

@rwjblue r?