### PR TITLE
[WIP][ENHANCEMENT] Hot reload styles

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -5,6 +5,10 @@ var path        = require('path');
 var Task        = require('../../models/task');
 var SilentError = require('../../errors/silent');
 
+// default reload css extensions
+var styleExtensions = ['css', 'scss', 'sass', 'less', 'styl'];
+var reloadCssPattern = new RegExp('\.(' + styleExtensions.join('|') + ')$');
+
 function createServer() {
   var instance;
   var Server = (require('tiny-lr')).Server;
@@ -62,6 +66,15 @@ module.exports = Task.extend({
 
   didChange: function(results) {
     var filePath = path.relative(this.project.root, results.filePath || '');
+    var appStyleResource = this.project.pkg.name + '.css';
+
+    var reloadPaths = function() {
+      if (reloadCssPattern.test(filePath)) {
+        return [appStyleResource];
+      } else {
+        return ['LiveReload files'];
+      }
+    };
 
     var canTrigger = this.project.liveReloadFilterPatterns.reduce(function(bool, pattern) {
       bool = bool && !filePath.match(pattern);
@@ -71,7 +84,7 @@ module.exports = Task.extend({
     if (canTrigger) {
       this.liveReloadServer().changed({
         body: {
-          files: ['LiveReload files']
+          files: reloadPaths()
         }
       });
 

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -185,7 +185,7 @@ describe('livereload-server', function() {
       liveReloadServer = subject.liveReloadServer();
       liveReloadServer.changed = function(options) {
         reloadFile = options.body.files[0];
-      }
+      };
       subject.analytics.track = function() {};
     });
 

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -27,7 +27,8 @@ describe('livereload-server', function() {
       analytics: { trackError: function() { } },
       project: {
         liveReloadFilterPatterns: [],
-        root: '/home/user/my-project'
+        root: '/home/user/my-project',
+        pkg: { name: 'my-project' }
       }
     });
   });
@@ -173,6 +174,79 @@ describe('livereload-server', function() {
         expect(changedCount).to.equal(0);
         expect(trackCount).to.equal(0);
       });
+    });
+  });
+
+  describe('hot reload css', function() {
+    var liveReloadServer;
+    var reloadFile;
+
+    beforeEach(function() {
+      liveReloadServer = subject.liveReloadServer();
+      liveReloadServer.changed = function(options) {
+        reloadFile = options.body.files[0];
+      }
+      subject.analytics.track = function() {};
+    });
+
+    afterEach(function() {
+      reloadFile = undefined;
+    });
+
+    it('injects newly genrated css without a full reload', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.css'
+      });
+      expect(reloadFile).to.equal('my-project.css');
+    });
+
+    it('injects newly genrated css from stylus without a full reload', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.styl'
+      });
+      expect(reloadFile).to.equal('my-project.css');
+    });
+
+    it('injects newly genrated css from sass without a full reload', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.sass'
+      });
+      expect(reloadFile).to.equal('my-project.css');
+    });
+
+    it('injects newly genrated css from scss without a full reload', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.scss'
+      });
+      expect(reloadFile).to.equal('my-project.css');
+    });
+
+    it('injects newly genrated css from less without a full reload', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.less'
+      });
+      expect(reloadFile).to.equal('my-project.css');
+    });
+
+    it('does a full reload when a hbs file changes', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.hbs'
+      });
+      expect(reloadFile).to.equal('LiveReload files');
+    });
+
+    it('does a full reload when a js file changes', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.js'
+      });
+      expect(reloadFile).to.equal('LiveReload files');
+    });
+
+    it('does a full reload when a html file changes', function() {
+      subject.didChange({
+        filePath: '/home/user/my-project/test/fixtures/proxy/file-a.html'
+      });
+      expect(reloadFile).to.equal('LiveReload files');
     });
   });
 });


### PR DESCRIPTION
This PR adds support for "hot reloading" styles. That means that instead of doing a full page reload when you save a `css`, `sass`, `scss`, `less` or `styl` file the live reload server will just inject the compiled `project-name.css` into the browser.

This is my first PR to this repo. I would love feedback and suggestions on how to clean it up and getting it merge.

When I initially suggested this enhancement in the ember-cli channel on Slack @rwjblue referred me to the great [ember-cli-styles-reloader](https://github.com/xomaczar/ember-cli-styles-reloader) addon. After reading the source of the addon I ended up taking a lot it and including it in this PR. Thanks to @xomaczar.