### PR TITLE
[BUGFIX] Bump quick-temp to 0.1.5, fix jshint error

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -7,6 +7,7 @@ var Project            = require('../models/project');
 var SilentError        = require('silent-error');
 var rimraf             = require('rimraf');
 var rmdir              = Promise.denodeify(rimraf);
+var debug              = require('debug')('ember-cli:new');
 var validProjectName   = require('../utilities/valid-project-name');
 var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 
@@ -86,7 +87,7 @@ module.exports = Command.extend({
         return initCommand
           .run(commandOptions, rawArgs)
           .catch(function(err){
-            console.log(arguments)
+            debug(arguments);
             var dirName = commandOptions.directory;
             process.chdir(opts.initialDirectory);
             return rmdir(dirName).then(function(){

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -165,7 +165,7 @@ function deprecatedAddonFilters(addon, name, insteadUse, fn) {
 
     return fn(tree, options);
   };
-};
+}
 
 /**
   Shorthand method for [broccoli-sourcemap-concat](https://github.com/ef4/broccoli-sourcemap-concat)

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "pleasant-progress": "^1.0.2",
     "portfinder": "^0.4.0",
     "promise-map-series": "^0.2.1",
-    "quick-temp": "0.1.3",
+    "quick-temp": "0.1.5",
     "readline2": "0.1.1",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.17",

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -22,10 +22,10 @@ describe('test', function() {
         expect(testemOptions.cwd).to.equal('blerpy-derpy');
         expect(testemOptions.reporter).to.equal('xunit');
         expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
-        // /* jshint ignore:start */
+        /* jshint ignore:start */
         expect(testemOptions.test_page).to.equal('http://my/test/page');
         expect(testemOptions.config_dir).to.be.an('string');
-        // /* jshint ignore:end*/
+        /* jshint ignore:end*/
         expect(testemOptions.file).to.equal('custom-testem-config.json');
       }
     });


### PR DESCRIPTION
quick-temp `0.1.3` has been causing this [test failure](https://travis-ci.org/ember-cli/ember-cli/jobs/90652801#L2555) for a while now. Bumping to `0.1.5`.

Also fixing a jshint ignore that got commented out accidentally.