### PR TITLE
Updating deprecations that use the deprecate utility

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -6,7 +6,6 @@ var versionUtils   = require('../utilities/version-utils');
 var UpdateChecker  = require('../models/update-checker');
 var getOptionArgs  = require('../utilities/get-option-args');
 var debug          = require('debug')('ember-cli:cli');
-var deprecate      = require('../utilities/deprecate');
 
 var PlatformChecker = require('../utilities/platform-checker');
 var emberCLIVersion      = versionUtils.emberCLIVersion;
@@ -56,11 +55,10 @@ CLI.prototype.run = function(environment) {
     var platform = new PlatformChecker(process.version);
     if(!platform.isValid && !this.testing) {
       if (platform.isDeprecated) {
-        this.ui.writeLine(deprecate('Node ' + process.version + ' is no longer supported by Ember CLI. Please update to a more recent version of Node', true));
+        this.ui.writeDeprecateLine('Node ' + process.version + ' is no longer supported by Ember CLI. Please update to a more recent version of Node');
       }
       if (platform.isUntested) {
-        var chalk = require('chalk');
-        this.ui.writeLine(chalk.yellow('WARNING: Node ' + process.version + ' has currently not been tested against Ember CLI and may result in unexpected behaviour.'));
+        this.ui.writeWarnLine('Node ' + process.version + ' has currently not been tested against Ember CLI and may result in unexpected behaviour.');
       }
     }
 

--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var chalk          = require('chalk');
 var UnknownCommand = require('../commands/unknown');
 
 module.exports = function(commands, commandName, commandArgs, optionHash) {
@@ -39,14 +38,14 @@ module.exports = function(commands, commandName, commandArgs, optionHash) {
 
   if (command && addonCommand) {
     if (addonCommand.overrideCore) {
-      ui.writeLine(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
-              command.prototype.name + '". The addon command will be used as the overridding was explicit.'));
+      ui.writeWarnLine('An ember-addon has attempted to override the core command "' +
+              command.prototype.name + '". The addon command will be used as the overridding was explicit.');
 
       return addonCommand;
     }
 
-    ui.writeLine(chalk.cyan('warning: An ember-addon has attempted to override the core command "' +
-                            command.prototype.name + '". The core command will be used.'));
+    ui.writeWarnLine('An ember-addon has attempted to override the core command "' +
+                            command.prototype.name + '". The core command will be used.');
     return command;
   }
 

--- a/lib/commands/install-addon.js
+++ b/lib/commands/install-addon.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var InstallCommand = require('./install');
-var chalk          = require('chalk');
 
 module.exports = InstallCommand.extend({
   name: 'install:addon',
@@ -16,7 +15,7 @@ module.exports = InstallCommand.extend({
   run: function() {
     var warning = 'This command has been deprecated. Please use `ember ';
     warning += 'install <addonName>` instead.';
-    this.ui.writeLine(chalk.red(warning));
+    this.ui.writeDeprecateLine(warning);
     return this._super.run.apply(this, arguments);
   }
 });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -155,10 +155,10 @@ Addon.prototype._requireBuildPackages = function() {
 
 function deprecatedAddonFilters(addon, name, insteadUse, fn) {
   return function(tree, options) {
-    var message = '[Deprecated] ' + name + ' is deprecated, please use ' +
+    var message = name + ' is deprecated, please use ' +
       insteadUse + ' directly instead  [addon: ' + addon.name + ']';
 
-    this.ui && this.ui.writeLine(message);
+    this.ui && this.ui.writeDeprecateLine(message);
 
     if (!this.ui)  {
       console.warn(message);

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -6,7 +6,6 @@
 
 var existsSync   = require('exists-sync');
 var path         = require('path');
-var deprecate    = require('../utilities/deprecate');
 var assign       = require('lodash/object/assign');
 var SilentError  = require('silent-error');
 var Reexporter   = require('../utilities/reexport');
@@ -770,11 +769,13 @@ Addon.prototype.shouldIncludeChildAddon = function() {
   @return {String} Absolute addon path
 */
 Addon.resolvePath = function(addon) {
-  var addonMain;
+  var addonMain = addon.pkg['ember-addon-main'];
 
-  deprecate(addon.pkg.name + ' is using the deprecated ember-addon-main definition. It should be updated to {\'ember-addon\': {\'main\': \'' + addon.pkg['ember-addon-main'] + '\'}}', addon.pkg['ember-addon-main']);
-
-  addonMain = addon.pkg['ember-addon-main'] || (addon.pkg['ember-addon'] && addon.pkg['ember-addon'].main) || addon.pkg['main'] || 'index.js';
+  if (addonMain) {
+    this.ui && this.ui.writeDeprecateLine(addon.pkg.name + ' is using the deprecated ember-addon-main definition. It should be updated to {\'ember-addon\': {\'main\': \'' + addon.pkg['ember-addon-main'] + '\'}}');
+  } else {
+    addonMain = (addon.pkg['ember-addon'] && addon.pkg['ember-addon'].main) || addon.pkg['main'] || 'index.js';
+  }
 
   // Resolve will fail unless it has an extension
   if(!path.extname(addonMain)) {

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -9,7 +9,6 @@ var chalk               = require('chalk');
 var MarkdownColor       = require('../utilities/markdown-color');
 var printableProperties = require('../utilities/printable-properties').blueprint;
 var sequence            = require('../utilities/sequence');
-var deprecateUI         = require('../utilities/deprecate').deprecateUI;
 var fs                  = require('fs-extra');
 var existsSync          = require('exists-sync');
 var inflector           = require('inflection');
@@ -999,13 +998,13 @@ Blueprint.prototype.addBowerPackageToProject = function(localPackageName, target
       var parts = localPackageName.split('#');
       lpn = parts[0];
       tar = parts[1];
-      deprecateUI(this.ui)('passing ' + localPackageName +
+      this.ui.writeDeprecateLine('passing ' + localPackageName +
         ' directly to `addBowerPackageToProject` will soon be unsupported. \n' +
         'You may want to replace this with ' +
-        '`addBowerPackageToProject(\'' + lpn +'\', \'' + tar + '\')`', true);
+        '`addBowerPackageToProject(\'' + lpn +'\', \'' + tar + '\')`');
     } else {
-      deprecateUI(this.ui)('passing ' + localPackageName +
-        ' directly to `addBowerPackageToProject` will soon be unsupported', true);
+      this.ui.writeDeprecateLine('passing ' + localPackageName +
+        ' directly to `addBowerPackageToProject` will soon be unsupported');
     }
   }
   var packageObject = bowEpParser.json2decomposed(lpn, tar);
@@ -1607,8 +1606,10 @@ function podDeprecations(config, ui){
   deprecateUI(ui)('`podModulePrefix` is deprecated and will be removed from future versions of ember-cli.'+
     ' Please move existing pods from \'app/' + podPath + '/\' to \'app/\'.', config.podModulePrefix);
   */
-  deprecateUI(ui)('`usePodsByDefault` is no longer supported in \'config/environment.js\','+
-    ' use `usePods` in \'.ember-cli\' instead.', config.usePodsByDefault);
+  if (config.usePodsByDefault) {
+    ui.writeDeprecateLine('`usePodsByDefault` is no longer supported in \'config/environment.js\','+
+      ' use `usePods` in \'.ember-cli\' instead.');
+  }
 }
 
 /**

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -10,7 +10,6 @@ var SilentError = require('silent-error');
 var chalk       = require('chalk');
 var cpd         = require('ember-cli-copy-dereference');
 var attemptNeverIndex = require('../utilities/attempt-never-index');
-var deprecate   = require('../utilities/deprecate');
 var findBuildFile = require('../utilities/find-build-file');
 var viz = require('broccoli-viz');
 var FSMonitor = require('fs-monitor-stack');
@@ -49,9 +48,8 @@ module.exports = Task.extend({
     var hasBrocfile = existsSync(path.join('.', 'Brocfile.js'));
     var buildFile = findBuildFile('ember-cli-build.js');
 
-    deprecate('Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.', hasBrocfile);
-
     if (hasBrocfile) {
+      this.ui.writeDeprecateLine('Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.');
       this.tree = broccoli.loadBrocfile();
     } else if (buildFile) {
       this.tree = buildFile({ project: this.project });

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -3,7 +3,10 @@
 var PleasantProgress = require('pleasant-progress');
 var Promise          = require('../ext/promise');
 var EOL              = require('os').EOL;
+var chalk            = require('chalk');
 var writeError       = require('./write-error');
+
+var DEFAULT_WRITE_LEVEL = 'INFO';
 
 // Note: You should use `ui.outputStream`, `ui.inputStream` and `ui.write()`
 //       instead of `process.stdout` and `console.log`.
@@ -47,7 +50,7 @@ function UI(options) {
   this.inputStream = options.inputStream;
   this.errorStream = options.errorStream;
 
-  this.writeLevel = options.writeLevel || 'INFO';
+  this.writeLevel = options.writeLevel || DEFAULT_WRITE_LEVEL;
   this.ci = !!options.ci;
 }
 
@@ -71,7 +74,6 @@ UI.prototype.write = function(data, writeLevel) {
 /**
   Unified mechanism to write a string and new line to the console.
   Optionally include a writeLevel, this is used to decide if the specific
-
   logging mechanism should or should not be printed.
   @method writeLine
   @param {String} data
@@ -79,6 +81,69 @@ UI.prototype.write = function(data, writeLevel) {
 */
 UI.prototype.writeLine = function(data, writeLevel) {
   this.write(data + EOL, writeLevel);
+};
+
+/**
+  Helper method to write a string with the DEBUG writeLevel and gray chalk
+  @method writeDebugLine
+  @param {String} data
+*/
+UI.prototype.writeDebugLine = function(data) {
+  this.writeLine(chalk.gray(data), 'DEBUG');
+};
+
+/**
+  Helper method to write a string with the INFO writeLevel and cyan chalk
+  @method writeInfoLine
+  @param {String} data
+*/
+UI.prototype.writeInfoLine = function(data) {
+  this.writeLine(chalk.cyan(data), 'INFO');
+};
+
+/**
+  Helper method to write a string with the WARNING writeLevel and yellow chalk.
+  Optionally include a test. If falsy, the warning will be printed. By default, warnings
+  will be prepended with WARNING text when printed.
+  @method writeWarnLine
+  @param {String} data
+  @param {Boolean} test
+  @param {Boolean} prepend
+*/
+UI.prototype.writeWarnLine = function(data, test, prepend) {
+  if (test) { return; }
+
+  data = this.prependLine('WARNING', data, prepend);
+  this.writeLine(chalk.yellow(data), 'WARNING', test);
+};
+
+/**
+  Helper method to write a string with the WARNING writeLevel and yellow chalk.
+  Optionally include a test. If falsy, the deprecation will be printed. By default deprecations
+  will be prepended with DEPRECATION text when printed.
+  @method writeDeprecateLine
+  @param {String} data
+  @param {Boolean} test
+  @param {Boolean} prepend
+*/
+UI.prototype.writeDeprecateLine = function(data, test, prepend) {
+  data = this.prependLine('DEPRECATION', data, prepend);
+  this.writeWarnLine(data, test, false);
+};
+
+/**
+  Utility method to prepend a line with a flag-like string (i.e., WARNING).
+  @method prependLine
+  @param {String} prependData
+  @param {String} data
+  @param {Boolean} prepend
+*/
+UI.prototype.prependLine = function(prependData, data, prepend) {
+  if (typeof prepend === 'undefined' || prepend) {
+    data = prependData + ': ' + data;
+  }
+
+  return data;
 };
 
 /**
@@ -173,7 +238,7 @@ UI.prototype.WRITE_LEVELS = {
 */
 UI.prototype.writeLevelVisible = function(writeLevel) {
   var levels = this.WRITE_LEVELS;
-  writeLevel = writeLevel || 'INFO';
+  writeLevel = writeLevel || DEFAULT_WRITE_LEVEL;
 
   return levels[writeLevel] >= levels[this.writeLevel];
 };

--- a/lib/utilities/deprecate.js
+++ b/lib/utilities/deprecate.js
@@ -10,8 +10,10 @@ module.exports = function(message, test) {
 
 module.exports.deprecateUI = function(ui){
   return function(message, test) {
-    if(!test) { return; }
+    ui.writeDeprecateLine('The deprecateUI utility has been deprecated in favor of ui.writeDeprecateLine');
 
-    ui.writeLine(chalk.yellow('DEPRECATION: ' + message));
+    test = !test;
+
+    ui.writeDeprecateLine(message, test);
   };
 };

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -134,7 +134,7 @@ describe('cli/lookup-command.js', function() {
       ui: ui
     });
 
-    expect(ui.output).to.match(/warning: An ember-addon has attempted to override the core command "serve"\. The core command will be used.*/);
+    expect(ui.output).to.match(/WARNING: An ember-addon has attempted to override the core command "serve"\. The core command will be used.*/);
   });
 
   it('lookupCommand() should write out a warning when overriding a core command and allow it if intentional', function() {
@@ -152,7 +152,7 @@ describe('cli/lookup-command.js', function() {
       ui: ui
     });
 
-    expect(ui.output).to.match(/warning: An ember-addon has attempted to override the core command "serve"\. The addon command will be used as the overridding was explicit.*/);
+    expect(ui.output).to.match(/WARNING: An ember-addon has attempted to override the core command "serve"\. The addon command will be used as the overridding was explicit.*/);
   });
 
   it('lookupCommand() should return UnknownCommand object when command name is not present.', function() {

--- a/tests/unit/ui/index-test.js
+++ b/tests/unit/ui/index-test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var expect = require('chai').expect;
+var MockUI = require('../../helpers/mock-ui');
+var EOL    = require('os').EOL;
+var chalk  = require('chalk');
+
+describe('UI', function() {
+  var ui;
+
+  beforeEach(function() {
+    ui = new MockUI();
+  });
+
+  describe('writeDebugLine', function() {
+    it('does not write at the default level', function() {
+      ui.writeDebugLine('foo');
+      expect(ui.output).to.equal('');
+    });
+
+    it('writes in the correct chalk', function() {
+      ui.writeLevel = 'DEBUG';
+      ui.writeDebugLine('foo');
+      expect(ui.output).to.equal(chalk.gray('foo') + EOL);
+    });
+  });
+
+  describe('writeInfoLine', function() {
+    it('writes in the correct chalk', function() {
+      ui.writeInfoLine('foo');
+      expect(ui.output).to.equal(chalk.cyan('foo') + EOL);
+    });
+  });
+
+  describe('writeWarningLine', function() {
+    it('does not write when the test is truthy', function() {
+      ui.writeWarnLine('foo', true);
+      expect(ui.output).to.equal('');
+    });
+
+    it('writes a prepended message when the test is falsy', function() {
+      ui.writeWarnLine('foo', false);
+      expect(ui.output).to.equal(chalk.yellow('WARNING: foo') + EOL);
+    });
+
+    it('writes a un-prepended message if prepend is false', function() {
+      ui.writeWarnLine('foo', false, false);
+      expect(ui.output).to.equal(chalk.yellow('foo') + EOL);
+    });
+  });
+
+  describe('writeDeprecateLine', function() {
+    it('does not write when the test is truthy', function() {
+      ui.writeDeprecateLine('foo', true);
+      expect(ui.output).to.equal('');
+    });
+
+    it('writes a prepended message when the test is falsy', function() {
+      ui.writeDeprecateLine('foo', false);
+      expect(ui.output).to.equal(chalk.yellow('DEPRECATION: foo') + EOL);
+    });
+
+    it('writes a un-prepended message if prepend is false', function() {
+      ui.writeDeprecateLine('foo', false, false);
+      expect(ui.output).to.equal(chalk.yellow('foo') + EOL);
+    });
+  });
+
+  describe('prependLine', function() {
+    it('prepends the data when prepend is undefined', function() {
+      var result = ui.prependLine('foo', 'bar');
+      expect(result).to.equal('foo: bar');
+    });
+
+    it('prepends the data when prepend is true', function() {
+      var result = ui.prependLine('foo', 'bar', true);
+      expect(result).to.equal('foo: bar');
+    });
+
+    it('returns the original data when prepend is falsy (but not undefined)', function() {
+      var result = ui.prependLine('foo', 'bar', false);
+      expect(result).to.equal('bar');
+    });
+  });
+});


### PR DESCRIPTION
Updating deprecations that use the deprecate utility to use the `deprecateUI` method instead. Fixes #5176.

This will make deprecation messages obey `--silent` flags in commands.