### PR TITLE
Only use `temp` dependency, not `tmp-sync`

### DIFF
--- a/lib/utilities/mk-tmp-dir-in.js
+++ b/lib/utilities/mk-tmp-dir-in.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var Promise   = require('../ext/promise');
+var fs        = require('fs-extra');
+var temp      = require('temp');
+var mkdir     = Promise.denodeify(fs.mkdir);
+var mkdirTemp = Promise.denodeify(temp.mkdir);
+
+function mkTmpDirIn(dir) {
+  return mkdir(dir).then(function() {
+    return mkdirTemp({ dir: dir });
+  });
+}
+
+module.exports = mkTmpDirIn;

--- a/lib/utilities/mk-tmp-dir-in.js
+++ b/lib/utilities/mk-tmp-dir-in.js
@@ -15,7 +15,7 @@ function exists(dir) {
 function mkTmpDirIn(dir) {
   return exists(dir).then(function(doesExist) {
     if (!doesExist) {
-      mkdir(dir);
+      return mkdir(dir);
     }
   }).then(function() {
     return mkdirTemp({ dir: dir });

--- a/lib/utilities/mk-tmp-dir-in.js
+++ b/lib/utilities/mk-tmp-dir-in.js
@@ -6,8 +6,18 @@ var temp      = require('temp');
 var mkdir     = Promise.denodeify(fs.mkdir);
 var mkdirTemp = Promise.denodeify(temp.mkdir);
 
+function exists(dir) {
+  return new Promise(function(resolve) {
+    fs.exists(dir, resolve);
+  });
+}
+
 function mkTmpDirIn(dir) {
-  return mkdir(dir).then(function() {
+  return exists(dir).then(function(doesExist) {
+    if (!doesExist) {
+      mkdir(dir);
+    }
+  }).then(function() {
     return mkdirTemp({ dir: dir });
   });
 }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "strip-ansi": "^2.0.0",
     "supertest": "0.15.0",
     "supports-color": "^3.0.0",
-    "tmp-sync": "^1.0.1",
     "yuidocjs": "0.6.0"
   }
 }

--- a/tests/acceptance/addon-destroy-test.js
+++ b/tests/acceptance/addon-destroy-test.js
@@ -12,8 +12,10 @@ var fs         = require('fs-extra');
 var path       = require('path');
 var remove     = Promise.denodeify(fs.remove);
 var root       = process.cwd();
-var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
+var temp       = require('temp');
+var mkdir      = Promise.denodeify(fs.mkdir);
+var mkdirTemp  = Promise.denodeify(temp.mkdir);
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
@@ -33,8 +35,11 @@ describe('Acceptance: ember destroy in-addon', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkdir(tmproot).then(function() {
+      return mkdirTemp({dir: tmproot})
+    }).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/addon-destroy-test.js
+++ b/tests/acceptance/addon-destroy-test.js
@@ -13,9 +13,7 @@ var path       = require('path');
 var remove     = Promise.denodeify(fs.remove);
 var root       = process.cwd();
 var tmproot    = path.join(root, 'tmp');
-var temp       = require('temp');
-var mkdir      = Promise.denodeify(fs.mkdir);
-var mkdirTemp  = Promise.denodeify(temp.mkdir);
+var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
@@ -35,9 +33,7 @@ describe('Acceptance: ember destroy in-addon', function() {
   });
 
   beforeEach(function() {
-    return mkdir(tmproot).then(function() {
-      return mkdirTemp({dir: tmproot})
-    }).then(function(tmpdir) {
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
       process.chdir(tmpdir);
     });
   });

--- a/tests/acceptance/addon-destroy-test.js
+++ b/tests/acceptance/addon-destroy-test.js
@@ -20,8 +20,6 @@ var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 describe('Acceptance: ember destroy in-addon', function() {
   this.timeout(20000);
 
-  var tmpdir;
-
   before(function() {
     BlueprintNpmTask.disableNPM();
     conf.setup();

--- a/tests/acceptance/addon-dummy-destroy-test.js
+++ b/tests/acceptance/addon-dummy-destroy-test.js
@@ -12,15 +12,13 @@ var fs         = require('fs-extra');
 var path       = require('path');
 var remove     = Promise.denodeify(fs.remove);
 var root       = process.cwd();
-var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
+var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
 describe('Acceptance: ember destroy in-addon-dummy', function() {
   this.timeout(20000);
-
-  var tmpdir;
 
   before(function() {
     BlueprintNpmTask.disableNPM();
@@ -33,8 +31,9 @@ describe('Acceptance: ember destroy in-addon-dummy', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -12,15 +12,14 @@ var fs                   = require('fs-extra');
 var path                 = require('path');
 var remove               = Promise.denodeify(fs.remove);
 var root                 = process.cwd();
-var tmp                  = require('tmp-sync');
 var tmproot              = path.join(root, 'tmp');
 var EOL                  = require('os').EOL;
 var BlueprintNpmTask     = require('../helpers/disable-npm-on-blueprint');
 var expect               = require('chai').expect;
+var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
 
 describe('Acceptance: ember generate in-addon-dummy', function() {
   this.timeout(20000);
-  var tmpdir;
 
   before(function() {
     BlueprintNpmTask.disableNPM();
@@ -33,8 +32,9 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -12,15 +12,14 @@ var fs                   = require('fs-extra');
 var path                 = require('path');
 var remove               = Promise.denodeify(fs.remove);
 var root                 = process.cwd();
-var tmp                  = require('tmp-sync');
 var tmproot              = path.join(root, 'tmp');
 var EOL                  = require('os').EOL;
 var BlueprintNpmTask     = require('../helpers/disable-npm-on-blueprint');
 var expect               = require('chai').expect;
+var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
 
 describe('Acceptance: ember generate in-addon', function() {
   this.timeout(20000);
-  var tmpdir;
 
   before(function() {
     BlueprintNpmTask.disableNPM();
@@ -33,8 +32,9 @@ describe('Acceptance: ember generate in-addon', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -13,9 +13,9 @@ var outputFile = Promise.denodeify(fs.outputFile);
 var path       = require('path');
 var remove     = Promise.denodeify(fs.remove);
 var root       = process.cwd();
-var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
 var EOL        = require('os').EOL;
+var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
@@ -33,8 +33,10 @@ describe('Acceptance: ember destroy', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(dir) {
+      tmpdir = dir;
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -13,12 +13,12 @@ var path             = require('path');
 var remove           = Promise.denodeify(fs.remove);
 var replaceFile      = require('../helpers/file-utils').replaceFile;
 var root             = process.cwd();
-var tmp              = require('tmp-sync');
 var tmproot          = path.join(root, 'tmp');
 var EOL              = require('os').EOL;
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 var expect           = require('chai').expect;
 var MockUI             = require('../helpers/mock-ui');
+var mkTmpDirIn       = require('../../lib/utilities/mk-tmp-dir-in');
 
 describe('Acceptance: ember generate', function() {
   this.timeout(10000);
@@ -36,8 +36,10 @@ describe('Acceptance: ember generate', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(dir) {
+      tmpdir = dir;
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/in-repo-addon-destroy-test.js
+++ b/tests/acceptance/in-repo-addon-destroy-test.js
@@ -12,14 +12,13 @@ var fs         = require('fs-extra');
 var path       = require('path');
 var remove     = Promise.denodeify(fs.remove);
 var root       = process.cwd();
-var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
+var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
 describe('Acceptance: ember destroy in-repo-addon', function() {
   this.timeout(20000);
-  var tmpdir;
 
   before(function() {
     BlueprintNpmTask.disableNPM();
@@ -32,8 +31,9 @@ describe('Acceptance: ember destroy in-repo-addon', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -12,15 +12,14 @@ var fs                   = require('fs-extra');
 var path                 = require('path');
 var remove               = Promise.denodeify(fs.remove);
 var root                 = process.cwd();
-var tmp                  = require('tmp-sync');
 var tmproot              = path.join(root, 'tmp');
 var EOL                  = require('os').EOL;
 var BlueprintNpmTask     = require('../helpers/disable-npm-on-blueprint');
 var expect               = require('chai').expect;
+var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
 
 describe('Acceptance: ember generate in-repo-addon', function() {
   this.timeout(20000);
-  var tmpdir;
 
   before(function() {
     BlueprintNpmTask.disableNPM();
@@ -33,8 +32,9 @@ describe('Acceptance: ember generate in-repo-addon', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/install-test-slow.js
+++ b/tests/acceptance/install-test-slow.js
@@ -9,13 +9,12 @@ var ember      = require('../helpers/ember');
 var path       = require('path');
 var remove     = Promise.denodeify(require('fs-extra').remove);
 var root       = process.cwd();
-var tmp        = require('tmp-sync');
 var tmproot    = path.join(root, 'tmp');
 var expect     = require('chai').expect;
+var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 describe('Acceptance: ember install', function() {
   this.timeout(60000);
-  var tmpdir;
 
   before(function() {
     conf.setup();
@@ -26,8 +25,9 @@ describe('Acceptance: ember install', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -14,9 +14,9 @@ var outputFile  = Promise.denodeify(fs.outputFile);
 var path        = require('path');
 var remove      = Promise.denodeify(fs.remove);
 var root        = process.cwd();
-var tmp         = require('tmp-sync');
 var tmproot     = path.join(root, 'tmp');
 var EOL         = require('os').EOL;
+var mkTmpDirIn  = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
@@ -36,8 +36,10 @@ describe('Acceptance: ember destroy pod', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(dir) {
+      tmpdir = dir;
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -13,10 +13,10 @@ var outputFile       = Promise.denodeify(fs.outputFile);
 var path             = require('path');
 var remove           = Promise.denodeify(fs.remove);
 var root             = process.cwd();
-var tmp              = require('tmp-sync');
 var tmproot          = path.join(root, 'tmp');
 var EOL              = require('os').EOL;
 var expect           = require('chai').expect;
+var mkTmpDirIn       = require('../../lib/utilities/mk-tmp-dir-in');
 
 var BlueprintNpmTask = require('../helpers/disable-npm-on-blueprint');
 
@@ -35,8 +35,10 @@ describe('Acceptance: ember generate pod', function() {
   });
 
   beforeEach(function() {
-    tmpdir = tmp.in(tmproot);
-    process.chdir(tmpdir);
+    return mkTmpDirIn(tmproot).then(function(dir) {
+      tmpdir = dir;
+      process.chdir(tmpdir);
+    });
   });
 
   afterEach(function() {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -7,10 +7,10 @@ var Addon   = require('../../../lib/models/addon');
 var Promise = require('../../../lib/ext/promise');
 var expect  = require('chai').expect;
 var remove  = Promise.denodeify(fs.remove);
-var tmp     = require('tmp-sync');
 var path    = require('path');
 var findWhere = require('lodash/collection/find');
 var MockUI = require('../../helpers/mock-ui');
+var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 
 var broccoli  = require('broccoli');
 var walkSync  = require('walk-sync');
@@ -427,9 +427,10 @@ describe('models/addon.js', function() {
       var tmpdir;
 
       beforeEach(function() {
-        tmpdir  = tmp.in(tmproot);
-
-        addon.root = tmpdir;
+        return mkTmpDirIn(tmproot).then(function(dir) {
+          tmpdir = dir;
+          addon.root = tmpdir;
+        });
       });
 
       afterEach(function() {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -181,7 +181,8 @@ describe('models/addon.js', function() {
     before(function() {
       projectPath = path.resolve(fixturePath, 'simple');
       var packageContents = require(path.join(projectPath, 'package.json'));
-      project = new Project(projectPath, packageContents);
+      var ui = new MockUI();
+      project = new Project(projectPath, packageContents, ui);
       project.initializeAddons();
     });
 

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -15,7 +15,6 @@ var Promise           = require('../../../lib/ext/promise');
 var remove            = Promise.denodeify(fs.remove);
 var EOL               = require('os').EOL;
 var root              = process.cwd();
-var tmp               = require('tmp-sync');
 var tmproot           = path.join(root, 'tmp');
 var SilentError       = require('silent-error');
 var stub              = require('../../helpers/stub').stub;
@@ -23,6 +22,7 @@ var proxyquire        = require('proxyquire');
 var existsSync        = require('exists-sync');
 var MarkdownColor     = require('../../../lib/utilities/markdown-color');
 var assign            = require('lodash/object/assign');
+var mkTmpDirIn        = require('../../../lib/utilities/mk-tmp-dir-in');
 
 var existsSyncStub;
 var readdirSyncStub;
@@ -526,15 +526,17 @@ some details');
     var tmpdir;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new BasicBlueprintClass(basicBlueprint);
-      ui        = new MockUI();
-      project   = new MockProject();
-      options   = {
-        ui: ui,
-        project: project,
-        target: tmpdir
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new BasicBlueprintClass(basicBlueprint);
+        ui        = new MockUI();
+        project   = new MockProject();
+        options   = {
+          ui: ui,
+          project: project,
+          target: tmpdir
+        };
+      });
     });
 
     afterEach(function() {
@@ -817,17 +819,17 @@ some details');
     }
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new BasicBlueprintClass(basicBlueprint);
-      project   = new MockProject();
-      options   = {
-        project: project,
-        target: tmpdir
-      };
-
-      refreshUI();
-      return blueprint.install(options)
-        .then(refreshUI);
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new BasicBlueprintClass(basicBlueprint);
+        project   = new MockProject();
+        options   = {
+          project: project,
+          target: tmpdir
+        };
+        refreshUI();
+        return blueprint.install(options);
+      }).then(refreshUI);
     });
 
     afterEach(function() {
@@ -866,9 +868,11 @@ some details');
     var tmpdir;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+      });
     });
 
     afterEach(function() {
@@ -900,15 +904,15 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new NpmInstallTask();
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new NpmInstallTask();
+        };
+      });
     });
 
     afterEach(function() {
@@ -1039,15 +1043,15 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new NpmUninstallTask();
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new NpmUninstallTask();
+        };
+      });
     });
 
     afterEach(function() {
@@ -1074,15 +1078,15 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new NpmUninstallTask();
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new NpmUninstallTask();
+        };
+      });
     });
 
     afterEach(function() {
@@ -1196,15 +1200,16 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-      blueprint.ui = ui;
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new BowerInstallTask();
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.ui = ui;
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new BowerInstallTask();
+        };
+      });
     });
 
     afterEach(function() {
@@ -1261,15 +1266,15 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new BowerInstallTask();
-      };
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new BowerInstallTask();
+        };
+      });
     });
 
     afterEach(function() {
@@ -1368,9 +1373,11 @@ some details');
     var tmpdir;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+      });
     });
 
     afterEach(function() {
@@ -1402,15 +1409,16 @@ some details');
     var taskNameLookedUp;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        blueprint.taskFor = function(name) {
+          taskNameLookedUp = name;
+          return new AddonInstallTask();
+        };
+      });
 
-      blueprint.taskFor = function(name) {
-        taskNameLookedUp = name;
-
-        return new AddonInstallTask();
-      };
     });
 
     afterEach(function() {
@@ -1540,16 +1548,17 @@ some details');
     var filename;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-      project   = new MockProject();
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        project   = new MockProject();
+        // normally provided by `install`, but mocked here for testing
+        project.root = tmpdir;
+        blueprint.project = project;
+        filename = 'foo-bar-baz.txt';
+      });
 
-      // normally provided by `install`, but mocked here for testing
-      project.root = tmpdir;
-      blueprint.project = project;
-
-      filename = 'foo-bar-baz.txt';
     });
 
     afterEach(function() {
@@ -1745,19 +1754,19 @@ some details');
     var filename;
 
     beforeEach(function() {
-      tmpdir    = tmp.in(tmproot);
-      blueprint = new Blueprint(basicBlueprint);
-      ui        = new MockUI();
-      project   = new MockProject();
-
-      // normally provided by `install`, but mocked here for testing
-      project.root = tmpdir;
-      blueprint.project = project;
-      project.blueprintLookupPaths = function() {
-        return [fixtureBlueprints];
-      };
-
-      filename = 'foo-bar-baz.txt';
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        blueprint = new Blueprint(basicBlueprint);
+        ui        = new MockUI();
+        project   = new MockProject();
+        // normally provided by `install`, but mocked here for testing
+        project.root = tmpdir;
+        blueprint.project = project;
+        project.blueprintLookupPaths = function() {
+          return [fixtureBlueprints];
+        };
+        filename = 'foo-bar-baz.txt';
+      });
     });
 
     afterEach(function() {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -12,7 +12,7 @@ var Promise         = require('../../../lib/ext/promise');
 var stub            = require('../../helpers/stub').stub;
 var MockProject     = require('../../helpers/mock-project');
 var remove          = Promise.denodeify(fs.remove);
-var tmp             = require('tmp-sync');
+var mkTmpDirIn      = require('../../../lib/utilities/mk-tmp-dir-in');
 
 var root            = process.cwd();
 var tmproot         = path.join(root, 'tmp');
@@ -22,13 +22,14 @@ describe('models/builder.js', function() {
 
   describe('copyToOutputPath', function() {
     beforeEach(function() {
-      tmpdir  = tmp.in(tmproot);
-
-      builder = new Builder({
-        setupBroccoliBuilder: function() { },
-        trapSignals: function() { },
-        cleanupOnExit: function() { },
-        project: new MockProject()
+      return mkTmpDirIn(tmproot).then(function(dir) {
+        tmpdir = dir;
+        builder = new Builder({
+          setupBroccoliBuilder: function() { },
+          trapSignals: function() { },
+          cleanupOnExit: function() { },
+          project: new MockProject()
+        });
       });
     });
 

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -10,9 +10,8 @@ var Promise   = require('../../../lib/ext/promise');
 var writeFile = Promise.denodeify(fs.writeFile);
 var root       = process.cwd();
 var tmproot    = path.join(root, 'tmp');
-var tmp        = require('tmp-sync');
 var assign     = require('lodash/object/assign');
-var tmpdir;
+var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 var testOutputPath;
 
 describe('Unit - FileInfo', function(){
@@ -20,19 +19,19 @@ describe('Unit - FileInfo', function(){
   var validOptions, ui;
 
   beforeEach(function(){
-    tmpdir = tmp.in(tmproot);
-    testOutputPath = path.join(tmpdir, 'outputfile');
-
-    ui = new MockUI();
-    validOptions = {
-      action: 'write',
-      outputPath: testOutputPath,
-      displayPath: '/pretty-output-path',
-      inputPath: path.resolve(__dirname,
-        '../../fixtures/blueprints/with-templating/files/foo.txt'),
-      templateVariables: {},
-      ui: ui
-    };
+    return mkTmpDirIn(tmproot).then(function(tmpdir) {
+      testOutputPath = path.join(tmpdir, 'outputfile');
+      ui = new MockUI();
+      validOptions = {
+        action: 'write',
+        outputPath: testOutputPath,
+        displayPath: '/pretty-output-path',
+        inputPath: path.resolve(__dirname,
+                                '../../fixtures/blueprints/with-templating/files/foo.txt'),
+        templateVariables: {},
+        ui: ui
+      };
+    });
   });
 
   afterEach(function(done){

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -13,7 +13,7 @@ var versionUtils = require('../../../lib/utilities/version-utils');
 var emberCLIVersion = versionUtils.emberCLIVersion;
 
 describe('models/project.js', function() {
-  var project, projectPath;
+  var project, projectPath, tmpPath;
 
   afterEach(function() {
     if (project) { project = null; }
@@ -23,7 +23,8 @@ describe('models/project.js', function() {
     var called;
 
     beforeEach(function() {
-      projectPath = process.cwd() + '/tmp/test-app';
+      tmpPath = path.join(process.cwd(), 'tmp');
+      projectPath = path.join(tmpPath, 'test-app');
       called = false;
       return tmp.setup(projectPath)
         .then(function() {
@@ -41,7 +42,7 @@ describe('models/project.js', function() {
 
     afterEach(function() {
       called = null;
-      return tmp.teardown(projectPath);
+      return tmp.teardown(tmpPath);
     });
 
     it('config() finds and requires config/environment', function() {
@@ -79,15 +80,12 @@ describe('models/project.js', function() {
         foo: 'bar'
       };
 
-      return tmp.setup(projectPath) // ensure no config/environment.js is present
-        .then(function() {
-          project.getAddonsConfig = function() {
-            return expected;
-          };
+      project.getAddonsConfig = function() {
+        return expected;
+      };
 
-          var actual = project.config('development');
-          expect(actual).to.deep.equal(expected);
-        });
+      var actual = project.config('development');
+      expect(actual).to.deep.equal(expected);
     });
 
     describe('merges getAddonsConfig result with app config', function() {
@@ -526,13 +524,18 @@ describe('models/project.js', function() {
     var loaderBowerJSONPath;
 
     beforeEach(function() {
-      projectPath = process.cwd() + '/tmp/test-app';
+      tmpPath = path.join(process.cwd(), 'tmp');
+      projectPath =  path.join(tmpPath, 'test-app');
       loaderBowerJSONPath = projectPath + '/bower_components/loader.js/.bower.json';
 
       return tmp.setup(projectPath)
         .then(function() {
           project = new Project(projectPath, { }, new MockUI());
         });
+    });
+
+    afterEach(function() {
+      return tmp.teardown(tmpPath);
     });
 
     it('returns false when `loader.js` is not a dependency', function(){


### PR DESCRIPTION
Don't use `tmp-sync` dependency which eventually depends on a deprecated `lodash` version.
Instead, use promise-wrapped functions from `temp`