### PR TITLE
Use consistent double quotes in index.html blueprints

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -7,19 +7,19 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for 'head'}}
+    {{content-for "head"}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= name %>.css">
 
-    {{content-for 'head-footer'}}
+    {{content-for "head-footer"}}
   </head>
   <body>
-    {{content-for 'body'}}
+    {{content-for "body"}}
 
     <script src="assets/vendor.js"></script>
     <script src="assets/<%= name %>.js"></script>
 
-    {{content-for 'body-footer'}}
+    {{content-for "body-footer"}}
   </body>
 </html>

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -7,19 +7,19 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for 'head'}}
-    {{content-for 'test-head'}}
+    {{content-for "head"}}
+    {{content-for "test-head"}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= name %>.css">
     <link rel="stylesheet" href="assets/test-support.css">
 
-    {{content-for 'head-footer'}}
-    {{content-for 'test-head-footer'}}
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for 'body'}}
-    {{content-for 'test-body'}}
+    {{content-for "body"}}
+    {{content-for "test-body"}}
 
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
@@ -28,7 +28,7 @@
     <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 
-    {{content-for 'body-footer'}}
-    {{content-for 'test-body-footer'}}
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
   </body>
 </html>


### PR DESCRIPTION
There seems to be a consensus around using double quotes in template/html files, so this PR makes ember-ci's blueprints use double quotes consistently in its `content-for` hooks to match the rest of the file.  

If the use of single quotes was intentional for some reason you can feel free to disregard.