### PR TITLE
[ENHANCEMENT] Use absolute import paths for tests -> app imports

### DIFF
--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,12 +1,14 @@
 /*jshint node:true*/
 
-var testInfo = require('ember-cli-test-info');
+var testInfo     = require('ember-cli-test-info');
+var stringUtils  = require('ember-cli-string-utils');
 
 module.exports = {
   description: 'Generates a util unit test.',
   locals: function(options) {
     return {
-      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Utility")
+      friendlyTestName: testInfo.name(options.entity.name, "Unit", "Utility"),
+      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
     };
   }
 };

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -792,7 +792,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from '../../../utils/foo-bar';"
+          "import fooBar from 'dummy/utils/foo-bar';"
         ]
       });
     });
@@ -812,7 +812,7 @@ describe('Acceptance: ember generate in-addon', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from '../../../utils/foo/bar-baz';"
+          "import fooBarBaz from 'dummy/utils/foo/bar-baz';"
         ]
       });
     });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -914,7 +914,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from '../../../utils/foo-bar';"
+          "import fooBar from 'my-app/utils/foo-bar';"
         ]
       });
     });
@@ -929,7 +929,7 @@ describe('Acceptance: ember generate', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from '../../../utils/foo/bar-baz';"
+          "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
         ]
       });
     });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -775,7 +775,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from '../../../utils/foo-bar';"
+          "import fooBar from 'my-app/utils/foo-bar';"
         ]
       });
     });
@@ -795,7 +795,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from '../../../utils/foo/bar-baz';"
+          "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
         ]
       });
     });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1559,7 +1559,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/utils/foo-bar-test.js', {
         contains: [
-          "import fooBar from '../../../utils/foo-bar';"
+          "import fooBar from 'my-app/utils/foo-bar';"
         ]
       });
     });
@@ -1574,7 +1574,7 @@ describe('Acceptance: ember generate pod', function() {
       });
       assertFile('tests/unit/utils/foo/bar-baz-test.js', {
         contains: [
-          "import fooBarBaz from '../../../utils/foo/bar-baz';"
+          "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
         ]
       });
     });


### PR DESCRIPTION
As per @stefanpenner 's [comment](https://github.com/ember-cli/ember-cli/issues/5194#issuecomment-163792064).

I used `dasherizedModulePrefix` instead of `dasherizedPackageName` to preserve existing behavior - app namespace for apps, and dummy for addons.

If this looks good I can update other blueprints
 - `helper-test`
 - `initializer-test`
 - `instance-initializer-test`
 - `mixin-test`