### PR TITLE
Add addon-test-support tree.

### DIFF
--- a/ADDON_HOOKS.md
+++ b/ADDON_HOOKS.md
@@ -23,6 +23,7 @@ Table of Contents:
   - [treeForVendor](#treefor-cont)
   - [treeForTestSupport](#treefor-cont)
   - [treeForPublic](#treefor-cont)
+  - [treeForAddonTestSupport](#treefor-cont)
 
 For each hook we'll cover the following (if applicable):
 
@@ -480,6 +481,7 @@ Instead of overriding `treeFor` and acting only if the tree you receive matches 
 - treeForVendor
 - treeForTestSupport
 - treeForPublic
+- treeForAddonTestSupport
 
 When overriding a hook, if you want to preserve it's original functionality, call the same method on `_super` with the function arguments.
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1241,23 +1241,32 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
   testSupportPath = testSupportPath.testSupport || testSupportPath;
 
   var external = this._processedExternalTree();
-
   var emberCLITree = this._processedEmberCLITree();
 
-  var testJs = this.concatFiles(mergeTrees([external, coreTestTree]), {
-    inputFiles: this.legacyTestFilesToAppend,
-    outputFile: testSupportPath,
-    annotation: 'Concat: Test Support JS'
+  var addonTestSupportTree = mergeTrees(this.addonTreesFor('addon-test-support'), {
+    overwrite: true,
+    annotation: 'TreeMerger (addon-test-support)'
+  });
+  var transpiledAddonTestSupportTree = new Babel(addonTestSupportTree, this._prunedBabelOptions());
+
+  var finalAddonTestSupportTree = new Funnel(transpiledAddonTestSupportTree, {
+    allowEmpty: true,
+    destDir: 'addon-test-support',
+    annotation: 'Funnel: Addon Test Support'
   });
 
-  testJs = this.concatFiles(mergeTrees([testJs, emberCLITree]), {
-    inputFiles: [
-      'vendor/ember-cli/test-support-prefix.js',
-      testSupportPath.slice(1),
-      'vendor/ember-cli/test-support-suffix.js'
-    ],
+  var inputFiles = [].concat(
+    this.legacyTestFilesToAppend,
+    'addon-test-support/**/*.js'
+  );
+
+  var baseMergedTree = mergeTrees([emberCLITree, external, coreTestTree, finalAddonTestSupportTree]);
+  var testJs = this.concatFiles(baseMergedTree, {
+    headerFiles: [ 'vendor/ember-cli/test-support-prefix.js' ],
+    inputFiles: inputFiles,
+    footerFiles: [ 'vendor/ember-cli/test-support-suffix.js' ],
     outputFile: testSupportPath,
-    annotation: 'Concat: Test Support Suffix'
+    annotation: 'Concat: Test Support JS'
   });
 
   var testemPath = path.join(__dirname, 'testem');

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -92,6 +92,7 @@ function Addon(parent, project) {
     'addon-templates': 'addon/templates',
     vendor:            'vendor',
     'test-support':    'test-support',
+    'addon-test-support': 'addon-test-support',
     public:            'public'
   };
 
@@ -103,6 +104,7 @@ function Addon(parent, project) {
     addon:             'treeForAddon',
     vendor:            'treeForVendor',
     'test-support':    'treeForTestSupport',
+    'addon-test-support': 'treeForAddonTestSupport',
     public:            'treeForPublic'
   };
 
@@ -470,6 +472,29 @@ Addon.prototype.treeForPublic = function(tree) {
   return new Funnel(tree, {
     srcDir: '/',
     destDir: '/' + this.moduleName()
+  });
+};
+
+/**
+ Returns the tree for all test files namespaced to a given addon.
+
+ @public
+ @method treeForAddonTestSupport
+ @param {Tree} tree
+ @return {Tree}
+ */
+Addon.prototype.treeForAddonTestSupport = function(tree) {
+  if (!tree) {
+    return tree;
+  }
+
+  var processed = this.preprocessJs(tree, '/', this.name, {
+    registry: this.registry
+  });
+
+  return new Funnel(processed, {
+    srcDir: '/',
+    destDir: '/' + this.moduleName() + '/test-support'
   });
 };
 

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -137,6 +137,16 @@ describe('Acceptance: addon-smoke-test', function() {
       });
   });
 
+  it('ember addon with addon-test-support directory', function() {
+    return copyFixtureFiles('addon/with-addon-test-support')
+      .then(function() {
+        return ember(['test']);
+      })
+      .then(function(result) {
+        expect(result.exitCode).to.eql(0);
+      });
+  });
+
   it('ember addon with tests/dummy/public directory', function() {
     return copyFixtureFiles('addon/with-dummy-public')
       .then(function() {

--- a/tests/fixtures/addon/with-addon-test-support/addon-test-support/current-text.js
+++ b/tests/fixtures/addon/with-addon-test-support/addon-test-support/current-text.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const { $ } = Ember;
+
+export default function(application) {
+  let rootElement = application.rootElement;
+
+  return $(rootElement).text();
+}

--- a/tests/fixtures/addon/with-addon-test-support/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/with-addon-test-support/tests/acceptance/main-test.js
@@ -1,0 +1,22 @@
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+import { module, test } from 'qunit';
+import currentText from 'some-cool-addon/test-support/current-text';
+
+module('Acceptance', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+  afterEach: function() {
+    destroyApp(this.application);
+  }
+});
+
+test('can invoke helper', function(assert) {
+  assert.expect(1);
+
+  visit('/')
+    .then(() => {
+      assert.ok(currentText(this.application).indexOf('Stuff Here!') !== -1);
+    });
+});

--- a/tests/fixtures/addon/with-addon-test-support/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/with-addon-test-support/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,1 @@
+Stuff Here!


### PR DESCRIPTION
This commit adds a new tree type to be used during the build processing.  It adds a way for addons to provide testing helpers (in `<addon-name>/test-support` to the consuming app) in the `test-support` file (essentially "vendor" for "tests").

---

- [x] Sanity check
- [x] Add tests
- [x] Perf tests before / after