### PR TITLE
Update ember-qunit to 0.4.17.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "2.1.0",
     "ember-load-initializers": "0.1.7",
-    "ember-qunit": "0.4.16",
+    "ember-qunit": "0.4.17",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "^1.11.3",
     "loader.js": "^3.5.0",


### PR DESCRIPTION
This update provides support for Ember 2.3+