### PR TITLE
Make ember test helper clearer.

### DIFF
--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -2,14 +2,47 @@
 
 var MockUI        = require('./mock-ui');
 var MockAnalytics = require('./mock-analytics');
-var Cli           = require('../../lib/cli');
+var cli           = require('../../lib/cli');
 
+/*
+  Accepts a single array argument, that contains the
+  `process.argv` style arguments.
+
+  Example:
+
+  ```
+  ember test --no-build --test-port=4567
+  ```
+
+  In this example, `process.argv` would be something similar to:
+
+  ```
+  ['path/to/node', 'path/to/bin/ember', 'test', '--no-build', '--test-port=4567']
+  ```
+
+
+  And this could be emulated by calling:
+
+  ```
+  ember(['test', '--no-build', '--test-port=4567']);
+  ```
+
+  ---
+
+  The return value of this helper is a promise that resolves
+  with an object that contains the following properties:
+
+  * `exitCode` is the normal exit code in standard command invocation
+  * `ui` is the `ui` object that was used for the invocation (which is
+    a `MockUI` instance), this can be used to inspect the commands output.
+
+*/
 module.exports = function ember(args) {
-  var cli;
+  var cliInstance;
 
   args.push('--disable-analytics');
   args.push('--watcher=node');
-  cli = new Cli({
+  cliInstance = cli({
     inputStream:  [],
     outputStream: [],
     cliArgs:      args,
@@ -18,5 +51,5 @@ module.exports = function ember(args) {
     testing: true
   });
 
-  return cli;
+  return cliInstance;
 };


### PR DESCRIPTION
Took me a little bit to figure out that this test helper uses `lib/cli/index.js` (and not `lib/cli/cli.js`). I removed the `new` since `lib/cli/index.js` returns a normal function (and not a constructor).

Return value object is found here: https://github.com/ember-cli/ember-cli/blob/master/lib/cli/cli.js#L103-L106