### PR TITLE
Update ember-cli-qunit to 1.1.0.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -6,7 +6,6 @@
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "2.1.0",
     "ember-load-initializers": "0.1.7",
-    "ember-qunit": "0.4.17",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "^1.11.3",
     "loader.js": "^3.5.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-qunit": "^1.1.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
Removes need for bower deps on `qunit` and `ember-qunit` (by obtaining them from NPM instead).