### PR TITLE
Fix instance-initializer-test blueprint.

### DIFF
--- a/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
 import { initialize } from '<%= dependencyDepth %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
   beforeEach: function() {
-    Ember.run(function() {
+    Ember.run(() => {
       this.application = Ember.Application.create();
-      this.appInstance = application.buildInstance();
+      this.appInstance = this.application.buildInstance();
     });
   },
   afterEach: function() {


### PR DESCRIPTION
* Ensure context is correct when assigning `this.application` and `this.buildInstance`
* Fix invalid reference to `application` (should be `this.application`)
* Import `destroyApp` helper (was being referenced without an import)