### PR TITLE
Helper Unit test should pass a params array as first argument

### DIFF
--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -5,6 +5,6 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let result = <%= camelizedModuleName %>(42);
+  let result = <%= camelizedModuleName %>([42]);
   assert.ok(result);
 });


### PR DESCRIPTION
Helper function accepts params as first argument, but helper unit tests currently pass `42`. It should pass `[42]` instead. 

Changed to pass `[42]`.