### PR TITLE
[BUGFIX] Update generate resource documentation

### DIFF
--- a/blueprints/resource/index.js
+++ b/blueprints/resource/index.js
@@ -6,7 +6,7 @@ var merge      = require('lodash/object/merge');
 var inflection = require('inflection');
 
 module.exports = {
-  description: 'Generates a model and route.',
+  description: 'Generates a model, template, route, and registers the route with the router.',
 
   install: function(options) {
     return this._process('install', options);

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -657,7 +657,7 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
                 },
                 {
                   name: 'resource',
-                  description: 'Generates a model and route.',
+                  description: 'Generates a model, template, route, and registers the route with the router.',
                   availableOptions: [],
                   anonymousOptions: ['name'],
                   overridden: false
@@ -1243,7 +1243,7 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
       model-test \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a model unit test.\u001b[39m' + EOL + '\
       resource \u001b[33m<name>\u001b[39m' + EOL + '\
-        \u001b[90mGenerates a model and route.\u001b[39m' + EOL + '\
+        \u001b[90mGenerates a model, template, route, and registers the route with the router.\u001b[39m' + EOL + '\
       route \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a route and a template, and registers the route with the router.\u001b[39m' + EOL + '\
         \u001b[36m--path\u001b[39m \u001b[36m(Default: )\u001b[39m' + EOL + '\


### PR DESCRIPTION
Currently the `$ ember generate resource -h` docs give insufficient information.
Judging by the cli's help docs, it specifies that only a model
and route are generated.

I've updated the cli help to document the current behavior. However,
if the behavior should be changed to what the help docs state,
let me know.

```
  $ ember g resource -h
    version: 1.13.13
    Requested ember-cli commands:

    ember generate <blueprint> <options...>
      Generates new code from blueprints.
      aliases: g
      --dry-run (Boolean) (Default: false)
        aliases: -d
      --verbose (Boolean) (Default: false)
        aliases: -v
      --pod (Boolean) (Default: false)
        aliases: -p
      --classic (Boolean) (Default: false)
        aliases: -c
      --dummy (Boolean) (Default: false)
        aliases: -dum, -id
      --in-repo-addon (String) (Default: null)
        aliases: -in-repo <value>, -ir <value>

          resource <name>
            Generates a model and route.
```

However, a template is also generated

```
  $ ember g resource foo
    version: 1.13.13
    installing model
      create app/models/foo.js
    installing model-test
      create tests/unit/models/foo-test.js
    installing route
      create app/routes/foo.js
      create app/templates/foo.hbs
    updating router
      add route foo
    installing route-test
      create tests/unit/routes/foo-test.js
```

So, the template is now added to the cli docs

```
  $ ember g resource -h

    Missing symlinked npm packages:
    Package: ember-cli
      * Specified: 1.13.13
      * Symlinked: 2.2.0-beta.1

    version: 2.2.0-beta.1-update-cli-help-docs-e803ac7fa6
    Requested ember-cli commands:

    ember generate <blueprint> <options...>
      Generates new code from blueprints.
      aliases: g
      --dry-run (Boolean) (Default: false)
        aliases: -d
      --verbose (Boolean) (Default: false)
        aliases: -v
      --pod (Boolean) (Default: false)
        aliases: -p
      --classic (Boolean) (Default: false)
        aliases: -c
      --dummy (Boolean) (Default: false)
        aliases: -dum, -id
      --in-repo-addon (String) (Default: null)
        aliases: -in-repo <value>, -ir <value>

          resource <name>
            Generates a model, template, and route.
```

***

Related #4952