### PR TITLE
Serve Task: Prevent Termination Confirmation on Windows

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -81,7 +81,24 @@ module.exports = Task.extend({
       process.on('SIGINT',  this.onSIGINT.bind(this));
       process.on('SIGTERM', this.onSIGTERM.bind(this));
       process.on('message', this.onMessage.bind(this));
+
+      if (/^win/.test(process.platform)) {
+        this.trapWindowsSignals();
+      }
+
       signalsTrapped = true;
+    }
+  },
+  
+  trapWindowsSignals: function () {
+    // This is required to capture Ctrl + C on Windows
+    if (process.stdin && process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+      process.stdin.on('data', function (data) {
+        if (data.length === 1 && data[0] === 0x03) {
+          process.emit('SIGINT');
+        }
+      });
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "glob": "5.0.13",
     "http-proxy": "^1.9.0",
     "inflection": "^1.7.0",
-    "inquirer": "0.5.1",
+    "inquirer": "0.11.1",
     "is-git-url": "^0.2.0",
     "isbinaryfile": "^2.0.3",
     "leek": "0.0.21",

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -72,6 +72,72 @@ describe('models/builder.js', function() {
       });
   });
 
+  describe('Windows CTRL + C Capture', function() {
+    var originalPlatform, called;
+    
+    beforeEach(function () {
+      called = false;
+    });
+    
+    before(function() {
+      originalPlatform = process.platform;
+    });
+    
+    after(function () {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform
+      });
+    });
+
+    it('enables raw capture on Windows', function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'win'
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: {
+          isTTY: true
+        }
+      });
+
+      builder = new Builder({
+        setupBroccoliBuilder: function() { },
+        cleanupOnExit: function() { },
+        trapWindowsSignals: function () {
+          called = true;
+        },
+        project: new MockProject()
+      });
+
+      builder.trapSignals();
+      expect(called).to.equal(true);
+    });
+    
+    it('does not enable raw capture on non-Windows', function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'mockOS'
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: {
+          isTTY: true
+        }
+      });
+
+      builder = new Builder({
+        setupBroccoliBuilder: function() { },
+        cleanupOnExit: function() { },
+        trapWindowsSignals: function () {
+          called = true;
+        },
+        project: new MockProject()
+      });
+
+      builder.trapSignals();
+      expect(called).to.equal(false);
+    });
+  });
+
   describe('Prevent deletion of files for improper outputPath', function() {
     var command;
     var parentPath = '..' + path.sep + '..' + path.sep;


### PR DESCRIPTION
* On Windows, the serve task can't be cancelled with a single Ctrl + C,
because Windows will ask for batch job termination confirmation.
* This commit adds a small windows-only listener for Ctrl + C, handling
process termination inside of Ember Cli.

Closes #5236 