### PR TITLE
Remove app-prefix and app-suffix hooks.

### DIFF
--- a/lib/broccoli/app-prefix.js
+++ b/lib/broccoli/app-prefix.js
@@ -1,4 +1,1 @@
 "use strict";
-/* jshint ignore:start */
-{{content-for 'app-prefix'}}
-/* jshint ignore:end */

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,3 +1,0 @@
-/* jshint ignore:start */
-{{content-for 'app-suffix'}}
-/* jshint ignore:end */

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -959,7 +959,6 @@ EmberApp.prototype._processedEmberCLITree = function() {
     'vendor-prefix.js',
     'vendor-suffix.js',
     'app-prefix.js',
-    'app-suffix.js',
     'app-config.js',
     'app-boot.js',
     'test-support-prefix.js',
@@ -1140,7 +1139,6 @@ EmberApp.prototype.javascript = function() {
       'vendor/ember-cli/app-prefix.js'
     ],
     footerFiles: [
-      'vendor/ember-cli/app-suffix.js',
       'vendor/ember-cli/app-config.js',
       'vendor/ember-cli/app-boot.js'
     ],


### PR DESCRIPTION
This removes the `app-prefix` and `app-suffix` hooks in 2.X. Part of closing #5240.