### PR TITLE
Split config module from app-boot.

### DIFF
--- a/lib/broccoli/app-boot.js
+++ b/lib/broccoli/app-boot.js
@@ -1,9 +1,3 @@
 /* jshint ignore:start */
-
-define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
-  {{content-for 'config-module'}}
-});
-
 {{content-for 'app-boot'}}
-
 /* jshint ignore:end */

--- a/lib/broccoli/app-config.js
+++ b/lib/broccoli/app-config.js
@@ -1,0 +1,7 @@
+/* jshint ignore:start */
+
+define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
+  {{content-for 'config-module'}}
+});
+
+/* jshint ignore:end */

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -960,6 +960,7 @@ EmberApp.prototype._processedEmberCLITree = function() {
     'vendor-suffix.js',
     'app-prefix.js',
     'app-suffix.js',
+    'app-config.js',
     'app-boot.js',
     'test-support-prefix.js',
     'test-support-suffix.js',
@@ -1140,6 +1141,7 @@ EmberApp.prototype.javascript = function() {
     ],
     footerFiles: [
       'vendor/ember-cli/app-suffix.js',
+      'vendor/ember-cli/app-config.js',
       'vendor/ember-cli/app-boot.js'
     ],
     outputFile: appOutputPath,


### PR DESCRIPTION
`EmberApp` creates a config module which can be included at any point in the output code and is not order dependent. However, since `app-boot` *is* order dependent, and included as part of the same config file it forces the entire chunk of code to be order dependent.

This decouples the two, reducing the amount of specific ordering required in the code. No functional changes.

Related to #5242.