### PR TITLE
Deprecate app-prefix and app-suffix - master

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1534,6 +1534,8 @@ EmberApp.prototype.toTree = function(additionalTrees) {
  */
 EmberApp.prototype.contentFor = function(config, match, type) {
   var content = [];
+  var deprecatedHooks = ['app-prefix', 'app-suffix'];
+  var deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
 
   switch (type) {
     case 'head':             this._contentForHead(content, config);           break;
@@ -1545,6 +1547,7 @@ EmberApp.prototype.contentFor = function(config, match, type) {
   content = this.project.addons.reduce(function(content, addon) {
     var addonContent = addon.contentFor ? addon.contentFor(type, config, content) : null;
     if (addonContent) {
+      deprecate('The `' + type + '` hook used in ' + addon.name + ' is deprecated. The addon should generate a module and have consumers `require` it.', !~deprecatedHooks.indexOf(type));
       return content.concat(addonContent);
     }
 


### PR DESCRIPTION
Related to #5240 and #5245. Deprecates `app-prefix` and `app-suffix` in the master branch.