### PR TITLE
Testem v1.0.0 & detect global errors

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -21,10 +21,10 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <script src="testem.js" integrity=""></script>
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/<%= name %>.js"></script>
-    <script src="testem.js" integrity=""></script>
     <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1293,9 +1293,9 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
   });
 
   var sourceTrees = [
+    testemTree,
     testJs,
-    testLoader,
-    testemTree
+    testLoader
   ];
 
   if (this.vendorTestStaticStyles.length > 0) {

--- a/lib/broccoli/test-support-suffix.js
+++ b/lib/broccoli/test-support-suffix.js
@@ -2,6 +2,10 @@
 
 runningTests = true;
 
+if (window.Testem) {
+  window.Testem.hookIntoTestFramework();
+}
+
 {{content-for 'test-support-suffix'}}
 
 /* jshint ignore:end */

--- a/lib/broccoli/testem.js
+++ b/lib/broccoli/testem.js
@@ -7,7 +7,7 @@
  * the test build of index.html, which requires a
  * snippet to load the testem.js file:
  *   <script src="/testem.js"></script>
- * This has to go after the qunit framework and app
+ * This has to go before the qunit framework and app
  * tests are loaded.
  *
  * Testem internally supplies this file. However, if you

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.3",
-    "testem": "0.9.11",
+    "testem": "^1.0.0-rc.1",
     "through": "^2.3.6",
     "tiny-lr": "0.2.1",
     "walk-sync": "^0.2.6",


### PR DESCRIPTION
Testem can now instrument the window, before the test framework is
loaded and manually hooked into the framework later. This allows
catching syntax and other global errors.

Fixes: https://github.com/ember-cli/ember-cli/issues/5175

The current master includes some bigger changes and requires some testing time. I would love to merge this after the next stable is shipped. Do you have any rough estimate when the next ember-cli stable might be cut?