### PR TITLE
add npm run jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "docs": "node bin/generate-docs.js",
+    "jshint": "mocha tests/unit/jshint-test",
     "test": "node tests/runner",
     "test:debug": "node debug tests/runner",
     "test-all": "node tests/runner all",

--- a/tests/unit/jshint-test.js
+++ b/tests/unit/jshint-test.js
@@ -1,9 +1,11 @@
 'use strict';
+
 var glob = require('glob').sync;
 
 var paths = glob('tests/*').filter(function(path) {
   return !/fixtures/.test(path);
 });
+
 // configuration is based on settings found in .jshintrc and .jshintignore
 require('mocha-jshint')({
   paths: paths.concat([


### PR DESCRIPTION
This little `npm run jshint` shortcut helps me when doing PRs and testing with `.only`.