### PR TITLE
consolidating command/blueprint print logic

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1224,6 +1224,8 @@ Blueprint.prototype.insertIntoFile = function(pathRelativeToProjectRoot, content
   }
 };
 
+Blueprint.prototype._printCommand = printCommand;
+
 Blueprint.prototype.printBasicHelp = function(verbose) {
   var initialMargin = '      ';
   var output = initialMargin;
@@ -1232,7 +1234,7 @@ Blueprint.prototype.printBasicHelp = function(verbose) {
   } else {
     output += this.name;
 
-    output += printCommand.call(this, initialMargin, true);
+    output += this._printCommand(initialMargin, true);
 
     if (verbose) {
       output += EOL + this.printDetailedHelp(this.availableOptions);

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -9,6 +9,7 @@ var chalk               = require('chalk');
 var MarkdownColor       = require('../utilities/markdown-color');
 var printableProperties = require('../utilities/printable-properties').blueprint;
 var sequence            = require('../utilities/sequence');
+var printCommand        = require('../utilities/print-command');
 var fs                  = require('fs-extra');
 var existsSync          = require('exists-sync');
 var inflector           = require('inflection');
@@ -1231,76 +1232,19 @@ Blueprint.prototype.printBasicHelp = function(verbose) {
   } else {
     output += this.name;
 
-    var options = this.anonymousOptions;
+    output += printCommand.call(this, initialMargin, true);
 
-    if (options.length > 0) {
-      output += ' ' + chalk.yellow(options.map(function(opt) {
-        return '<' + opt + '>';
-      }).join(' '));
-    }
-
-    options = this.availableOptions;
-
-    if (options.length > 0) {
-      output += ' ' + chalk.cyan('<options...>');
-    }
-
-    if (this.description) {
-      output += EOL + initialMargin + '  ' + chalk.grey(this.description);
-    }
-
-    options.forEach(function(opt) {
-      output += EOL + initialMargin + '  ' + chalk.cyan('--' + opt.name);
-
-      if (opt.values) {
-        output += chalk.cyan('=' + opt.values.join('|'));
-      }
-
-      if (opt.default !== undefined) {
-        output += ' ' + chalk.cyan('(Default: ' + opt.default + ')');
-      }
-
-      if (opt.required) {
-        output += ' ' + chalk.cyan('(Required)');
-      }
-
-      if (opt.aliases && opt.aliases.length) {
-        output += EOL + initialMargin + '    ' + chalk.grey('aliases: ' + opt.aliases.map(function(a) {
-          if (typeof a === 'string') {
-            return '-' + a + (opt.type === Boolean ? '' : ' <value>');
-          } else {
-            var key = Object.keys(a)[0];
-            return '-' + key + ' (--' + opt.name + '=' + a[key] + ')';
-          }
-        }).join(', '));
-      }
-
-      if (opt.description) {
-        output += ' ' + opt.description;
-      }
-    });
-
-    // I don't think we should support nulling out printDetailedHelp
-    if (verbose && this.printDetailedHelp) {
-      output += EOL + this.printDetailedHelp(options);
+    if (verbose) {
+      output += EOL + this.printDetailedHelp(this.availableOptions);
     }
   }
 
   return output;
 };
 
-Blueprint.prototype._getDetailedHelpPath = function() {
-  if (!this.path) {
-    // I don't think it is possible to reach this line.
-    return null;
-  }
-
-  return path.join(this.path, './HELP.md');
-};
-
 Blueprint.prototype.printDetailedHelp = function() {
   var markdownColor = new MarkdownColor();
-  var filePath = this._getDetailedHelpPath();
+  var filePath = getDetailedHelpPath(this.path);
 
   if (existsSync(filePath)) {
     return markdownColor.renderFile(filePath, { indent: '        ' });
@@ -1324,8 +1268,7 @@ Blueprint.prototype.getJson = function(verbose) {
     json[key] = value;
   }, this);
 
-  // I don't think we should support nulling out printDetailedHelp
-  if (verbose && this.printDetailedHelp) {
+  if (verbose) {
     var detailedHelp = this.printDetailedHelp(this.availableOptions);
     if (detailedHelp) {
       json.detailedHelp = detailedHelp;
@@ -1649,7 +1592,6 @@ function isFilePath(fileInfo) {
 
 /**
  @private
-
  @method dir
  @returns {Array} list of files in the given directory or and empty array if no directory exists
 */
@@ -1661,4 +1603,14 @@ function dir(fullPath) {
   } else {
     return [];
   }
+}
+
+/**
+  @private
+  @method getDetailedHelpPath
+  @param {String} thisPath
+  @return {String} help path
+*/
+function getDetailedHelpPath(thisPath) {
+  return path.join(thisPath, './HELP.md');
 }

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -401,6 +401,8 @@ Command.prototype.run = function(commandArgs) {
   throw new Error('command must implement run' + commandArgs.toString());
 };
 
+Command.prototype._printCommand = printCommand;
+
 /*
   Prints basic help for the command.
 
@@ -426,7 +428,7 @@ Command.prototype.printBasicHelp = function() {
     output = 'ember ' + this.name;
   }
 
-  output += printCommand.call(this);
+  output += this._printCommand();
   output += EOL;
 
   this.ui.writeLine(output);

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -7,6 +7,7 @@ var isGitRepo           = require('is-git-url');
 var camelize            = require('../utilities/string').camelize;
 var getCallerFile       = require('../utilities/get-caller-file');
 var printableProperties = require('../utilities/printable-properties').command;
+var printCommand        = require('../utilities/print-command');
 var Promise             = require('../ext/promise');
 var union               = require('lodash/array/union');
 var uniq                = require('lodash/array/uniq');
@@ -425,73 +426,8 @@ Command.prototype.printBasicHelp = function() {
     output = 'ember ' + this.name;
   }
 
-  // <anonymous-option-1> ...
-  if (this.anonymousOptions.length > 0) {
-    var anonymousOptions = this.anonymousOptions;
-
-    if (anonymousOptions.join) {
-      anonymousOptions = anonymousOptions.join(' ');
-    }
-
-    output += ' ' + chalk.yellow(anonymousOptions);
-  }
-
-  // <options...>
-  if (this.availableOptions.length > 0) {
-    output += ' ' + chalk.cyan('<options...>');
-  }
-
+  output += printCommand.call(this);
   output += EOL;
-
-  // Description
-  if (this.description) {
-    output += '  ' + this.description + EOL;
-  }
-
-  // aliases: a b c
-  if (this.aliases.length) {
-    output += '  ' + chalk.grey('aliases: ' + this.aliases.filter(function(a) { return a; }).join(', ')) + EOL;
-  }
-
-  // --available-option (Required) (Default: value)
-  // ...
-  if (this.availableOptions.length > 0) {
-    this.availableOptions.forEach(function(option) {
-      output += '  ' + chalk.cyan('--' + option.name);
-
-      if (option.type) {
-        output += ' ' + chalk.cyan('(' + (Array.isArray(option.type) ? option.type.map(function(a) {
-          return typeof a === 'string' ? a : a.name;
-        }).join(', ') : option.type.name) + ')');
-      }
-
-      if (option.required) {
-        output += ' ' + chalk.cyan('(Required)');
-      }
-
-      if (option.default !== undefined) {
-        output += ' ' + chalk.cyan('(Default: ' + option.default + ')');
-      }
-
-      if (option.description) {
-        output += ' ' + option.description;
-      }
-
-      if (option.aliases) {
-        output += EOL + '    ' + chalk.grey('aliases: ' + option.aliases.map(function(a) {
-          var key;
-          if (typeof a === 'string') {
-            return '-' + a + (option.type === Boolean ? '' : ' <value>');
-          } else {
-            key = Object.keys(a)[0];
-            return  '-' + key + ' (--' + option.name + '=' + a[key] + ')';
-          }
-        }).join(', '));
-      }
-
-      output += EOL;
-    });
-  }
 
   this.ui.writeLine(output);
 };

--- a/lib/utilities/print-command.js
+++ b/lib/utilities/print-command.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var chalk = require('chalk');
+var EOL   = require('os').EOL;
+
+module.exports = function(initialMargin, shouldDescriptionBeGrey) {
+  initialMargin = initialMargin || '';
+
+  var output = '';
+
+  var options = this.anonymousOptions;
+
+  // <anonymous-option-1> ...
+  if (options.length) {
+    output += ' ' + chalk.yellow(options.map(function(option) {
+      // blueprints we insert brackets, commands already have them
+      if (option.indexOf('<') === 0) {
+        return option;
+      } else {
+        return '<' + option + '>';
+      }
+    }).join(' '));
+  }
+
+  options = this.availableOptions;
+
+  // <options...>
+  if (options.length) {
+    output += ' ' + chalk.cyan('<options...>');
+  }
+
+  // Description
+  var description = this.description;
+  if (description) {
+    if (shouldDescriptionBeGrey) {
+      description = chalk.grey(description);
+    }
+    output += EOL + initialMargin + '  ' + description;
+  }
+
+  // aliases: a b c
+  if (this.aliases && this.aliases.length) {
+    output += EOL + initialMargin + '  ' + chalk.grey('aliases: ' + this.aliases.filter(function(a) { return a; }).join(', '));
+  }
+
+  // --available-option (Required) (Default: value)
+  // ...
+  options.forEach(function(option) {
+    output += EOL + initialMargin + '  ' + chalk.cyan('--' + option.name);
+
+    if (option.values) {
+      output += chalk.cyan('=' + option.values.join('|'));
+    }
+
+    if (option.type) {
+      output += ' ' + chalk.cyan('(' + (Array.isArray(option.type) ? option.type.map(function(a) {
+        return typeof a === 'string' ? a : a.name;
+      }).join(', ') : option.type.name) + ')');
+    }
+
+    if (option.required) {
+      output += ' ' + chalk.cyan('(Required)');
+    }
+
+    if (option.default !== undefined) {
+      output += ' ' + chalk.cyan('(Default: ' + option.default + ')');
+    }
+
+    if (option.description) {
+      output += ' ' + option.description;
+    }
+
+    if (option.aliases && option.aliases.length) {
+      output += EOL + initialMargin + '    ' + chalk.grey('aliases: ' + option.aliases.map(function(a) {
+        if (typeof a === 'string') {
+          return '-' + a + (option.type === Boolean ? '' : ' <value>');
+        } else {
+          var key = Object.keys(a)[0];
+          return '-' + key + ' (--' + option.name + '=' + a[key] + ')';
+        }
+      }).join(', '));
+    }
+  });
+
+  return output;
+};

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -1183,7 +1183,7 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates an acceptance test for a feature.\u001b[39m' + EOL + '\
       adapter \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates an ember-data adapter.\u001b[39m' + EOL + '\
-        \u001b[36m--base-class\u001b[39m' + EOL + '\
+        \u001b[36m--base-class\u001b[39m \u001b[36m(String)\u001b[39m' + EOL + '\
       adapter-test \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates an ember-data adapter unit test\u001b[39m' + EOL + '\
       addon \u001b[33m<name>\u001b[39m' + EOL + '\
@@ -1196,13 +1196,13 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a blueprint and definition.\u001b[39m' + EOL + '\
       component \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component. Name must contain a hyphen.\u001b[39m' + EOL + '\
-        \u001b[36m--path\u001b[39m \u001b[36m(Default: components)\u001b[39m' + EOL + '\
+        \u001b[36m--path\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: components)\u001b[39m' + EOL + '\
           \u001b[90maliases: -no-path (--path=)\u001b[39m' + EOL + '\
       component-addon \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component. Name must contain a hyphen.\u001b[39m' + EOL + '\
       component-test \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component integration or unit test.\u001b[39m' + EOL + '\
-        \u001b[36m--test-type\u001b[39m \u001b[36m(Default: integration)\u001b[39m' + EOL + '\
+        \u001b[36m--test-type\u001b[39m \u001b[36m(integration, unit)\u001b[39m \u001b[36m(Default: integration)\u001b[39m' + EOL + '\
           \u001b[90maliases: -i (--test-type=integration), -u (--test-type=unit), -integration (--test-type=integration), -unit (--test-type=unit)\u001b[39m' + EOL + '\
       controller \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a controller.\u001b[39m' + EOL + '\
@@ -1246,9 +1246,9 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a model, template, route, and registers the route with the router.\u001b[39m' + EOL + '\
       route \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a route and a template, and registers the route with the router.\u001b[39m' + EOL + '\
-        \u001b[36m--path\u001b[39m \u001b[36m(Default: )\u001b[39m' + EOL + '\
-        \u001b[36m--skip-router\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
-        \u001b[36m--reset-namespace\u001b[39m' + EOL + '\
+        \u001b[36m--path\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: )\u001b[39m' + EOL + '\
+        \u001b[36m--skip-router\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
+        \u001b[36m--reset-namespace\u001b[39m \u001b[36m(Boolean)\u001b[39m' + EOL + '\
       route-addon \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates import wrappers for a route and its template.\u001b[39m' + EOL + '\
       route-test \u001b[33m<name>\u001b[39m' + EOL + '\

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -30,7 +30,6 @@ stub = stub.stub;
 var existsSyncStub;
 var readdirSyncStub;
 var readFileSyncStub;
-var printCommandStub;
 var Blueprint = proxyquire('../../../lib/models/blueprint', {
   'exists-sync': function() {
     return existsSyncStub.apply(this, arguments);
@@ -42,9 +41,6 @@ var Blueprint = proxyquire('../../../lib/models/blueprint', {
     readFileSync: function() {
       return readFileSyncStub.apply(this, arguments);
     }
-  },
-  '../utilities/print-command': function() {
-    return printCommandStub.apply(this, arguments);
   }
 });
 
@@ -275,16 +271,8 @@ describe('Blueprint', function() {
     });
 
     describe('printBasicHelp', function() {
-      var printCommandStubWasCalled;
-      var printCommandStubArguments;
-
       beforeEach(function() {
-        printCommandStubWasCalled = false;
-        printCommandStub = function() {
-          printCommandStubWasCalled = true;
-          printCommandStubArguments = arguments;
-          return ' command printed';
-        };
+        stub(blueprint, '_printCommand', ' command printed');
         stub(blueprint, 'printDetailedHelp', 'help in detail');
       });
 
@@ -303,7 +291,7 @@ describe('Blueprint', function() {
       \u001b[90m(overridden) my-blueprint\u001b[39m');
 
         expect(output).to.equal(testString);
-        expect(printCommandStubWasCalled).to.be.false;
+        expect(blueprint._printCommand.called).to.equal(0);
       });
 
       it('calls printCommand', function() {
@@ -313,9 +301,9 @@ describe('Blueprint', function() {
       my-blueprint command printed');
 
         expect(output).to.equal(testString);
-        expect(printCommandStubWasCalled).to.be.true;
-        expect(printCommandStubArguments[0]).to.equal('      ');
-        expect(printCommandStubArguments[1]).to.be.true;
+        expect(blueprint._printCommand.called).to.equal(1);
+        expect(blueprint._printCommand.calledWith[0][0]).to.equal('      ');
+        expect(blueprint._printCommand.calledWith[0][1]).to.be.true;
       });
 
       it('prints detailed help if verbose', function() {

--- a/tests/unit/utilities/print-command-test.js
+++ b/tests/unit/utilities/print-command-test.js
@@ -1,0 +1,89 @@
+/*jshint multistr: true */
+
+'use strict';
+
+var printCommand      = require('../../../lib/utilities/print-command');
+var processHelpString = require('../../helpers/process-help-string');
+var expect            = require('chai').expect;
+var EOL               = require('os').EOL;
+
+describe('printCommand', function() {
+  it('handles all possible options', function() {
+    var availableOptions = [
+      {
+        name: 'test-option',
+        values: ['x', 'y'],
+        default: 'my-def-val',
+        required: true,
+        aliases: ['a', { b: 'c', unused: '' }],
+        description: 'option desc'
+      },
+      {
+        name: 'test-type',
+        type: Boolean,
+        aliases: ['a']
+      },
+      {
+        name: 'test-type-array',
+        type: ['a-type', Number]
+      }
+    ];
+
+    var obj = {
+      description: 'a paragraph',
+      availableOptions: availableOptions,
+      anonymousOptions: ['anon-test', '<anon-test>'],
+      aliases: ['ab', 'cd', '', null, undefined]
+    };
+
+    var output = printCommand.call(obj, '  ', true);
+
+    var testString = processHelpString('\
+ \u001b[33m<anon-test> <anon-test>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
+    \u001b[90ma paragraph\u001b[39m' + EOL + '\
+    \u001b[90maliases: ab, cd\u001b[39m' + EOL + '\
+    \u001b[36m--test-option\u001b[39m\u001b[36m=x|y\u001b[39m \u001b[36m(Required)\u001b[39m \u001b[36m(Default: my-def-val)\u001b[39m option desc' + EOL + '\
+      \u001b[90maliases: -a <value>, -b (--test-option=c)\u001b[39m' + EOL + '\
+    \u001b[36m--test-type\u001b[39m \u001b[36m(Boolean)\u001b[39m' + EOL + '\
+      \u001b[90maliases: -a\u001b[39m' + EOL + '\
+    \u001b[36m--test-type-array\u001b[39m \u001b[36m(a-type, Number)\u001b[39m');
+
+    expect(output).to.equal(testString);
+  });
+
+  it('can have no margin or no options', function() {
+    var output = printCommand.call({
+      availableOptions: [],
+      anonymousOptions: []
+    });
+
+    var testString = processHelpString('');
+
+    expect(output).to.equal(testString);
+  });
+
+  it('can have an uncolored description', function() {
+    var output = printCommand.call({
+      description: 'a paragraph',
+      availableOptions: [],
+      anonymousOptions: []
+    });
+
+    var testString = processHelpString(EOL + '\
+  a paragraph');
+
+    expect(output).to.equal(testString);
+  });
+
+  it('does not print with empty aliases', function() {
+    var output = printCommand.call({
+      availableOptions: [],
+      anonymousOptions: [],
+      aliases: []
+    });
+
+    var testString = processHelpString('');
+
+    expect(output).to.equal(testString);
+  });
+});


### PR DESCRIPTION
Part of my quest to clean up code.
Command and blueprint printing were remarkably similar, so I extracted into a print command utility. There were only minor inconsistencies that resulted in "breaking" changes. By breaking I mean the help text changed a little bit, for instance whether "(Required)" came before or after "(Default: value)".