### PR TITLE
Fix the order of  test files to append

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1403,7 +1403,7 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   var basename = path.basename(assetPath);
 
   if (isType(assetPath, 'js', {registry: this.registry})) {
-    if(options.type === 'vendor') {
+    if (options.type === 'vendor') {
       if (options.prepend) {
         this.legacyFilesToAppend.unshift(assetPath);
       } else {
@@ -1419,7 +1419,7 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
       throw new Error('You must pass either `vendor` or `test` for options.type in your call to `app.import` for file: ' + basename);
     }
   } else if (extension === '.css') {
-    if(options.type === 'vendor') {
+    if (options.type === 'vendor') {
       this.vendorStaticStyles.push(assetPath);
     } else {
       this.vendorTestStaticStyles.push(assetPath);

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1025,7 +1025,6 @@ EmberApp.prototype.appAndDependencies = function() {
 };
 
 EmberApp.prototype.test = function() {
-
   var tests = this.addonPreprocessTree('test', this._processedTestsTree());
   var preprocessedTests = preprocessJs(tests, '/tests', this.name, {
     registry: this.registry
@@ -1257,18 +1256,23 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
     annotation: 'Funnel: Addon Test Support'
   });
 
-  var inputFiles = [].concat(
-    this.legacyTestFilesToAppend,
-    'addon-test-support/**/*.js'
+  var headerFiles = [].concat(
+    'vendor/ember-cli/test-support-prefix.js',
+    this.legacyTestFilesToAppend
   );
+
+  var inputFiles = ['addon-test-support/**/*.js'];
+
+  var footerFiles = ['vendor/ember-cli/test-support-suffix.js'];
 
   var baseMergedTree = mergeTrees([emberCLITree, external, coreTestTree, finalAddonTestSupportTree]);
   var testJs = this.concatFiles(baseMergedTree, {
-    headerFiles: [ 'vendor/ember-cli/test-support-prefix.js' ],
+    headerFiles: headerFiles,
     inputFiles: inputFiles,
-    footerFiles: [ 'vendor/ember-cli/test-support-suffix.js' ],
+    footerFiles: footerFiles,
     outputFile: testSupportPath,
-    annotation: 'Concat: Test Support JS'
+    annotation: 'Concat: Test Support JS',
+    allowNone: true
   });
 
   var testemPath = path.join(__dirname, 'testem');

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1410,9 +1410,13 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
         this.legacyFilesToAppend.push(assetPath);
       }
     } else if (options.type === 'test' ) {
-      this.legacyTestFilesToAppend.push(assetPath);
+      if (options.prepend) {
+        this.legacyTestFilesToAppend.unshift(assetPath);
+      } else {
+        this.legacyTestFilesToAppend.push(assetPath);
+      }
     } else {
-      throw new Error( 'You must pass either `vendor` or `test` for options.type in your call to `app.import` for file: '+basename );
+      throw new Error('You must pass either `vendor` or `test` for options.type in your call to `app.import` for file: ' + basename);
     }
   } else if (extension === '.css') {
     if(options.type === 'vendor') {


### PR DESCRIPTION
Hey there,

first of all, many thanks for Ember CLI, happy holidays and a great new year!

Second, this is only a draft for a fix and probably not the final / right solution, @stefanpenner certainly knows a better solution.

The problem: I want to use ember-cli-mocha, but it is currently not working with Ember CLI 2.2, see [ember-cli-mocha #93](https://github.com/switchfly/ember-cli-mocha/issues/93) or [ember-cli-mocha #94](https://github.com/switchfly/ember-cli-mocha/issues/94).

The problem is `ember-mocha` and `ember-mocha-adapter` are included in the compiled `test-support.js` file before Mocha. Ember CLI 2.2 uses a new version of `broccoli-concat` where all files in `inputFiles` gets un-ordered concated and so you have no control over the order.

This fix moves all `legacyTestFilesToAppend` into `headerFiles`, to preserve the order. Additional the `prepend` option can now be used for test files.

Could someone please look over and give me feedback.

Thanks