### PR TITLE
Use a repo that is in the org for testing Github blueprints

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -164,7 +164,7 @@ describe('Acceptance: ember new', function() {
       '--skip-npm',
       '--skip-bower',
       '--skip-git',
-      '--blueprint=https://github.com/trek/app-blueprint-test.git'
+      '--blueprint=https://github.com/ember-cli/app-blueprint-test.git'
     ]).then(function() {
       expect(existsSync('.ember-cli'));
     });


### PR DESCRIPTION
This will keep Trek from accidentally deleting important things. Already forked that repo into the org: https://github.com/ember-cli/app-blueprint-test