### PR TITLE
Update ember-cli-sri minimum version to 2.0.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.1.0",
     "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^1.2.0",
+    "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.2.1",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
To enable SRI when unicode is present in the file as Chrome is now fixed meaning the paranoia check can be removed.