### PR TITLE
[WIP][BUGFIX] Not overwrite the custom css configuration 

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -286,7 +286,9 @@ EmberApp.prototype._initVendorFiles = function() {
         }
       }
     ]
-  }, this.options.vendorFiles), isNull);
+  }, this.options.vendorFiles), function(value) {
+    return value === null;
+  });
 
   if (!!this.registry.availablePlugins['ember-resolver']) {
     // if the project is using `ember-resolver` as an addon

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -97,6 +97,31 @@ describe('broccoli/ember-app', function() {
       });
     });
 
+    it('should not override custom css config if it was configured', function() {
+      var app = new EmberApp({
+        project: project
+      });
+
+      // testing the current behavior
+      expect(app.options.outputPaths.app.css).to.deep.equal({app: '/assets/test-project.css'});
+
+      var customCssConfig = {
+        'theme-one': '/assets/theme-one.css',
+        'theme-two': '/assets/theme-two.css',
+      };
+
+      app = new EmberApp({
+        outputPaths: {
+          app: {
+            css: customCssConfig
+          }
+        }
+      });
+
+      expect(app.options.outputPaths.app.css).to.not.have.property('app');
+      expect(app.options.outputPaths.app.css).to.deep.equal(customCssConfig);
+    });
+
     it('should do the right thing when merging default object options', function() {
       var app = new EmberApp({
         project: project,


### PR DESCRIPTION
Today the `defaults` merge is overwrite the css `outputPath` configured always adding the app config.
This pull request fix https://github.com/ember-cli/ember-cli/issues/4948 and is related with https://github.com/aexmachina/ember-cli-sass/issues/81 


See the problem, given the follow config
```
var app = new EmberApp({
  outputPaths: {
    app: {
      css: {
        'theme-orange': '/assets/theme-orange.css',
        'theme-purple': '/assets/theme-purple.css'
      }
    }
  }
});
```
With this config today it's expected a app.css but the user explicitly overwrote the css config. In the other hand the guides teach the user put the app file when he is overwrite the css outputPath

```
var app = new EmberApp({
  outputPaths: {
    app: {
      css: {
        'app': '/assets/application-name.css',
        'themes/alpha': '/assets/themes/alpha.css'
      }
    }
  }
});
```

A alternative and easy fix is tell to users always have a app.css because the ember will always send to addon the `outputPaths` with `app`


ps: Maybe I need fix some acceptance tests