### PR TITLE
[2.X] Deprecate vendor-prefix and vendor-suffix.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     // add `ember-disable-prototype-extensions` to addons by default
-    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.0.0';
+    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.0';
 
     // add `ember-try` to addons by default
     contents.devDependencies['ember-try'] = '~0.0.8';

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1542,7 +1542,7 @@ EmberApp.prototype.toTree = function(additionalTrees) {
  */
 EmberApp.prototype.contentFor = function(config, match, type) {
   var content = [];
-  var deprecatedHooks = ['app-prefix', 'app-suffix'];
+  var deprecatedHooks = ['app-prefix', 'app-suffix', 'vendor-prefix', 'vendor-suffix'];
   var deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
 
   switch (type) {

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -127,7 +127,7 @@ describe('blueprint - addon', function() {
   ],\n\
   "dependencies": {},\n\
   "devDependencies": {\n\
-    "ember-disable-prototype-extensions": "^1.0.0",\n\
+    "ember-disable-prototype-extensions": "^1.1.0",\n\
     "ember-try": "~0.0.8"\n\
   },\n\
   "ember-addon": {\n\
@@ -224,7 +224,7 @@ describe('blueprint - addon', function() {
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
-        expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.0.0');
+        expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.0');
       });
 
       it('overwrites any version of `ember-try`', function() {


### PR DESCRIPTION
These hooks make it easy to do bad things inside of ember-cli. Deprecating them to make the world a better place.

Don't merge yet, need to come up with a solution for https://github.com/rwjblue/ember-disable-prototype-extensions first.