### PR TITLE
[1.X] Deprecate vendor-prefix and vendor-suffix.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -34,7 +34,7 @@ module.exports = {
     }
 
     // add `ember-disable-prototype-extensions` to addons by default
-    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.0.0';
+    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.0';
 
     // add `ember-try` to addons by default
     contents.devDependencies['ember-try'] = '~0.0.8';

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1440,7 +1440,7 @@ EmberApp.prototype.toTree = function(additionalTrees) {
  */
 EmberApp.prototype.contentFor = function(config, match, type) {
   var content = [];
-  var deprecatedHooks = ['app-prefix', 'app-suffix'];
+  var deprecatedHooks = ['app-prefix', 'app-suffix', 'vendor-prefix', 'vendor-suffix'];
   var deprecateUI = deprecate.deprecateUI(this.project.ui);
 
   switch (type) {


### PR DESCRIPTION
These hooks make it easy to do bad things inside of ember-cli. Deprecating them to make the world a better place.

Don't merge yet, need to come up with a solution for https://github.com/rwjblue/ember-disable-prototype-extensions first.