### PR TITLE
Wrapped error prone require in try/catch block

### DIFF
--- a/lib/utilities/find-build-file.js
+++ b/lib/utilities/find-build-file.js
@@ -16,7 +16,12 @@ module.exports = function(file) {
 
   process.chdir(baseDir);
 
-  var buildFile = require(buildFilePath);
-
+  try {
+    var buildFile = require(buildFilePath);	
+  }
+  catch(err){
+	  throw new Error('Error: Could not require "'+file+'": '+err.message);
+  }
+  
   return buildFile;
 };

--- a/lib/utilities/find-build-file.js
+++ b/lib/utilities/find-build-file.js
@@ -20,7 +20,7 @@ module.exports = function(file) {
     var buildFile = require(buildFilePath);	
   }
   catch(err){
-	  throw new Error('Error: Could not require "'+file+'": '+err.message);
+	  throw new Error(err.name+': Could not require "'+file+'": '+err.message);
   }
   
   return buildFile;

--- a/lib/utilities/find-build-file.js
+++ b/lib/utilities/find-build-file.js
@@ -16,11 +16,13 @@ module.exports = function(file) {
 
   process.chdir(baseDir);
 
+  var buildFile = null;
   try {
-    var buildFile = require(buildFilePath);	
+    buildFile = require(buildFilePath);	
   }
   catch(err){
-	  throw new Error(err.name+': Could not require "'+file+'": '+err.message);
+	err.message = 'Could not require \''+file+'\': '+err.message;
+    throw err;
   }
   
   return buildFile;

--- a/tests/unit/utilities/find-build-file-test.js
+++ b/tests/unit/utilities/find-build-file-test.js
@@ -3,7 +3,6 @@
 var expect = require('chai').expect;
 var fs = require('fs-extra');
 var tmp = require('../../helpers/tmp');
-var fileUtils = require('../../helpers/file-utils');
 var findBuildFile = require('../../../lib/utilities/find-build-file');
 
 describe('find-build-file', function() {
@@ -28,7 +27,7 @@ describe('find-build-file', function() {
   });
   
   it('does not throws an error when the file is valid syntax', function() {
-  	fs.writeFileSync(tmpFilename, "module.exports = function(){return {'a': 'A', 'b': 'B'};}", { encoding: 'utf8' });
+  	fs.writeFileSync(tmpFilename, 'module.exports = function(){return {\'a\': \'A\', \'b\': \'B\'};}', { encoding: 'utf8' });
 	
 	expect(function() {
       findBuildFile(tmpFilename);
@@ -36,10 +35,10 @@ describe('find-build-file', function() {
   });
 
   it('throws an SyntaxError if the file contains a syntax mistake', function(){  
-	fs.writeFileSync(tmpFilename, "module.exports = function(){return {'a': 'A' 'b': 'B'};}", { encoding: 'utf8' });
+	fs.writeFileSync(tmpFilename, 'module.exports = function(){return {\'a\': \'A\' \'b\': \'B\'};}', { encoding: 'utf8' });
 	
     expect(function() {  
       findBuildFile(tmpFilename);
-    }).to.throw('SyntaxError: Could not require "'+tmpFilename+'": Unexpected string');
+    }).to.throw(SyntaxError, /Could not require '.*':/);
   });
 });

--- a/tests/unit/utilities/find-build-file-test.js
+++ b/tests/unit/utilities/find-build-file-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var expect = require('chai').expect;
+var fs = require('fs-extra');
+var tmp = require('../../helpers/tmp');
+var fileUtils = require('../../helpers/file-utils');
+var findBuildFile = require('../../../lib/utilities/find-build-file');
+
+describe('find-build-file', function() {
+  var tmpPath, tmpFilename, tmpFilePath;
+  var currentWorkingDir = process.cwd();
+	
+  beforeEach(function() {
+    tmpPath = process.cwd()+'/tmp/';
+	tmpFilename = 'ember-cli-build.js';
+	tmpFilePath = tmpPath + tmpFilename;
+    return tmp.setup(tmpPath)
+	  .then(function(){
+	    process.chdir(tmpPath);
+      });
+  });
+  
+  afterEach(function() {
+	  delete require.cache[require.resolve(tmpFilePath)];
+	  return tmp.teardown(tmpPath).then(function(){
+	  	process.chdir(currentWorkingDir);
+	  });
+  });
+  
+  it('does not throws an error when the file is valid syntax', function() {
+  	fs.writeFileSync(tmpFilename, "module.exports = function(){return {'a': 'A', 'b': 'B'};}", { encoding: 'utf8' });
+	
+	expect(function() {
+      findBuildFile(tmpFilename);
+    }).to.not.throw();
+  });
+
+  it('throws an SyntaxError if the file contains a syntax mistake', function(){  
+	fs.writeFileSync(tmpFilename, "module.exports = function(){return {'a': 'A' 'b': 'B'};}", { encoding: 'utf8' });
+	
+    expect(function() {  
+      findBuildFile(tmpFilename);
+    }).to.throw('SyntaxError: Could not require "'+tmpFilename+'": Unexpected string');
+  });
+});


### PR DESCRIPTION
Because the build file is user editable, it presents the possibility of a user introducing invalid javascript, which causes `require` to throw an error.

I would like the error message to be more descriptive, but I couldn't get any more information from the exception require() threw.

Also I was debating whether to use the full path, `buildFilePath`, or just the file name, `file`.

I encountered this because I forgot a comma, and `ember s` returned this error:
```
Unexpected string
SyntaxError: Unexpected string
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at module.exports (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/utilities/find-build-file.js:20:21)
    at Class.module.exports.Task.extend.setupBroccoliBuilder (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/models/builder.js:49:21)
    at Class.module.exports.Task.extend.init (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/models/builder.js:89:10)
```
Which this makes no sense.

Now the error message will be:
```
SyntaxError: could not require "ember-cli-build.js": Unexpected string
Error: SyntaxError: could not require "ember-cli-build.js": Unexpected string
    at module.exports (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/utilities/find-build-file.js:24:8)
    at Class.module.exports.Task.extend.setupBroccoliBuilder (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/models/builder.js:49:21)
    at Class.module.exports.Task.extend.init (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/models/builder.js:89:10)
    at new Class (/Users/michael/Sites/myemberapp/node_modules/ember-cli/node_modules/core-object/core-object.js:18:12)
    at Class.module.exports.Task.extend.run (/Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/tasks/serve.js:15:19)
    at /Users/michael/Sites/myemberapp/node_modules/ember-cli/lib/commands/serve.js:70:22
    at lib$rsvp$$internal$$tryCatch (/Users/michael/Sites/myemberapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:493:16)
    at lib$rsvp$$internal$$invokeCallback (/Users/michael/Sites/myemberapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:505:17)
    at /Users/michael/Sites/myemberapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1001:13
    at lib$rsvp$asap$$flush (/Users/michael/Sites/myemberapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1198:9)
```

While the stack trace doesn't help the user, at least I know the error is in `ember-cli-build.js`.