### PR TITLE
EmberAddon access to `env`

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -54,6 +54,8 @@ function EmberAddon() {
   }));
 }
 
+EmberAddon.__proto__ = EmberApp;
+
 EmberAddon.prototype = Object.create(EmberApp.prototype);
 EmberAddon.prototype.constructor = EmberAddon;
 EmberAddon.prototype.appConstructor = EmberApp.prototype.constructor;

--- a/tests/unit/broccoli/ember-addon-test.js
+++ b/tests/unit/broccoli/ember-addon-test.js
@@ -3,6 +3,7 @@
 var path       = require('path');
 var Project    = require('../../../lib/models/project');
 var EmberAddon = require('../../../lib/broccoli/ember-addon');
+var EmberApp = require('../../../lib/broccoli/ember-app');
 var expect     = require('chai').expect;
 
 describe('EmberAddon', function() {
@@ -59,5 +60,13 @@ describe('EmberAddon', function() {
         boo: ['custom']
       }
     });
+  });
+
+  it('should contain env', function() {
+    expect(EmberAddon.env).to.be.a('function');
+  });
+
+  it('should contain return the correct environment', function() {
+    expect(EmberAddon.env()).to.eql(EmberApp.env());
   });
 });


### PR DESCRIPTION
This trolled me for a bit when `EmberApp.env` wasn't a function until I realized I was dealing with `ember-cli/lib/broccoli/ember-addon` and not `ember-cli/lib/broccoli/ember-app`

If this fine, I'll write some tests to cover it.