### PR TITLE
bump testem to latest to compensate for breakage in xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.3",
-    "testem": "^1.0.0-rc.4",
+    "testem": "^1.0.0-rc.7",
     "through": "^2.3.6",
     "tiny-lr": "0.2.1",
     "walk-sync": "^0.2.6",


### PR DESCRIPTION
Our CI which uses the xunit reporter was reporting the following:

```js
/home/bamboo/node_modules/ember-cli/node_modules/testem/node_modules/xmldom/dom.js:906
        node.serializeToString(attributeSorter);
```

The fix for this was addressed in
https://github.com/testem/testem/pull/730
and a new release was deployed as v1.0.0-rc.7