### PR TITLE
[BUGFIX release] pin jQuery version.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
   }


### PR DESCRIPTION
* hard coded check in ember exists, causing grief with the recent jQuery release
* a fix is in ember, but it cannot be released quite yet.
* this allows new apps to work in the interim, and users upgrading will also benefit