### PR TITLE
[BUGFIX release] pin jQuery version

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -7,7 +7,7 @@
     "ember-data": "^2.2.1",
     "ember-load-initializers": "0.1.7",
     "ember-qunit-notifications": "0.1.0",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "^3.5.0",
     "qunit": "~1.20.0"
   },


### PR DESCRIPTION
* hard coded check in ember exists, causing grief with the recent jQuery release
* a fix is in ember, but it cannot be released quite yet.
* this allows new apps to work in the interim, and users upgrading will also benefit