### PR TITLE
[ENHANCEMENT] Support custom blueprint options in new and init commands

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var Command     = require('../models/command');
-var Promise     = require('../ext/promise');
-var Blueprint   = require('../models/blueprint');
-var merge       = require('lodash/merge');
-var SilentError = require('silent-error');
+var Command               = require('../models/command');
+var Promise               = require('../ext/promise');
+var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+var merge                 = require('lodash/merge');
+var SilentError           = require('silent-error');
 
 module.exports = Command.extend({
   name: 'destroy',
@@ -25,17 +25,7 @@ module.exports = Command.extend({
     '<blueprint>'
   ],
 
-  beforeRun: function(rawArgs) {
-    if (!rawArgs.length) {
-      return;
-    }
-    try {
-      // merge in blueprint availableOptions
-      this.registerOptions(this.lookupBlueprint(rawArgs[0]));
-    } catch(e) {
-      SilentError.debugOrThrow('ember-cli/commands/destroy', e);
-    }
-  },
+  beforeRun: mergeBlueprintOptions,
 
   run: function(commandOptions, rawArgs) {
     var blueprintName = rawArgs[0];
@@ -76,12 +66,6 @@ module.exports = Command.extend({
     }
 
     return task.run(taskOptions);
-  },
-
-  lookupBlueprint: function(name) {
-    return Blueprint.lookup(name, {
-      paths: this.project.blueprintLookupPaths()
-    });
   },
 
   printDetailedHelp: function() {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var chalk       = require('chalk');
-var Command     = require('../models/command');
-var Promise     = require('../ext/promise');
-var Blueprint   = require('../models/blueprint');
-var merge       = require('lodash/merge');
-var reject      = require('lodash/reject');
-var EOL         = require('os').EOL;
-var SilentError = require('silent-error');
+var chalk                 = require('chalk');
+var Command               = require('../models/command');
+var Promise               = require('../ext/promise');
+var Blueprint             = require('../models/blueprint');
+var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+var merge                 = require('lodash/merge');
+var reject                = require('lodash/reject');
+var EOL                   = require('os').EOL;
+var SilentError           = require('silent-error');
 
 module.exports = Command.extend({
   name: 'generate',
@@ -28,20 +29,7 @@ module.exports = Command.extend({
     '<blueprint>'
   ],
 
-  beforeRun: function(rawArgs) {
-    if (!rawArgs.length) {
-      return;
-    }
-    // merge in blueprint availableOptions
-    var blueprint;
-    try{
-      blueprint = this.lookupBlueprint(rawArgs[0]);
-      this.registerOptions(blueprint);
-    }
-    catch(e) {
-      SilentError.debugOrThrow('ember-cli/commands/generate', e);
-    }
-  },
+  beforeRun: mergeBlueprintOptions,
 
   run: function(commandOptions, rawArgs) {
     var blueprintName = rawArgs[0];
@@ -75,12 +63,6 @@ module.exports = Command.extend({
     }
 
     return task.run(taskOptions);
-  },
-
-  lookupBlueprint: function(name) {
-    return Blueprint.lookup(name, {
-      paths: this.project.blueprintLookupPaths()
-    });
   },
 
   printDetailedHelp: function(options) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var copy               = require('lodash/lang/clone');
+var merge              = require('lodash/object/merge');
+var Blueprint          = require('../models/blueprint');
 var Command            = require('../models/command');
 var Promise            = require('../ext/promise');
 var SilentError        = require('silent-error');
@@ -32,6 +35,27 @@ module.exports = Command.extend({
     } else {
       return 'app';
     }
+  },
+
+  beforeRun: function(rawArgs) {
+    if (!rawArgs.length) {
+      return;
+    }
+    // merge in blueprint availableOptions
+    var blueprint;
+    try{
+      blueprint = this.lookupBlueprint(rawArgs[0]);
+      this.registerOptions(blueprint);
+    }
+    catch(e) {
+      SilentError.debugOrThrow('ember-cli/commands/init', e);
+    }
+  },
+
+  lookupBlueprint: function(name) {
+    return Blueprint.lookup(name, {
+      paths: this.project.blueprintLookupPaths()
+    });
   },
 
   run: function(commandOptions, rawArgs) {
@@ -82,19 +106,18 @@ module.exports = Command.extend({
       return Promise.reject(new SilentError(message));
     }
 
-    var blueprintOpts = {
-      dryRun: commandOptions.dryRun,
-      blueprint: commandOptions.blueprint || this._defaultBlueprint(),
+    var blueprintOpts = copy(commandOptions);
+    merge(blueprintOpts, {
       rawName: packageName,
       targetFiles: rawArgs || '',
       rawArgs: rawArgs.toString()
-    };
+    });
 
     if (!validProjectName(packageName)) {
       return Promise.reject(new SilentError('We currently do not support a name of `' + packageName + '`.'));
     }
 
-    blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint);
+    blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint());
 
     debug('before:installblueprint');
     return installBlueprint.run(blueprintOpts)

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var copy               = require('lodash/lang/clone');
-var merge              = require('lodash/object/merge');
-var Blueprint          = require('../models/blueprint');
-var Command            = require('../models/command');
-var Promise            = require('../ext/promise');
-var SilentError        = require('silent-error');
-var validProjectName   = require('../utilities/valid-project-name');
-var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
-var debug              = require('debug')('ember-cli:command:init');
+var copy                  = require('lodash/lang/clone');
+var merge                 = require('lodash/object/merge');
+var Command               = require('../models/command');
+var Promise               = require('../ext/promise');
+var SilentError           = require('silent-error');
+var validProjectName      = require('../utilities/valid-project-name');
+var normalizeBlueprint    = require('../utilities/normalize-blueprint-option');
+var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+var debug                 = require('debug')('ember-cli:command:init');
 
 module.exports = Command.extend({
   name: 'init',
@@ -37,26 +37,7 @@ module.exports = Command.extend({
     }
   },
 
-  beforeRun: function(rawArgs) {
-    if (!rawArgs.length) {
-      return;
-    }
-    // merge in blueprint availableOptions
-    var blueprint;
-    try{
-      blueprint = this.lookupBlueprint(rawArgs[0]);
-      this.registerOptions(blueprint);
-    }
-    catch(e) {
-      SilentError.debugOrThrow('ember-cli/commands/init', e);
-    }
-  },
-
-  lookupBlueprint: function(name) {
-    return Blueprint.lookup(name, {
-      paths: this.project.blueprintLookupPaths()
-    });
-  },
+  beforeRun: mergeBlueprintOptions,
 
   run: function(commandOptions, rawArgs) {
     if (commandOptions.dryRun) {
@@ -110,14 +91,13 @@ module.exports = Command.extend({
     merge(blueprintOpts, {
       rawName: packageName,
       targetFiles: rawArgs || '',
-      rawArgs: rawArgs.toString()
+      rawArgs: rawArgs.toString(),
+      blueprint: normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint())
     });
 
     if (!validProjectName(packageName)) {
       return Promise.reject(new SilentError('We currently do not support a name of `' + packageName + '`.'));
     }
-
-    blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint());
 
     debug('before:installblueprint');
     return installBlueprint.run(blueprintOpts)

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var copy                  = require('lodash/lang/clone');
-var merge                 = require('lodash/object/merge');
+var clone                 = require('lodash/clone');
+var merge                 = require('lodash/merge');
 var Command               = require('../models/command');
 var Promise               = require('../ext/promise');
 var SilentError           = require('silent-error');
@@ -87,7 +87,7 @@ module.exports = Command.extend({
       return Promise.reject(new SilentError(message));
     }
 
-    var blueprintOpts = copy(commandOptions);
+    var blueprintOpts = clone(commandOptions);
     merge(blueprintOpts, {
       rawName: packageName,
       targetFiles: rawArgs || '',

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var chalk              = require('chalk');
-var Blueprint          = require('../models/blueprint');
-var Command            = require('../models/command');
-var Promise            = require('../ext/promise');
-var Project            = require('../models/project');
-var SilentError        = require('silent-error');
-var rimraf             = require('rimraf');
-var rmdir              = Promise.denodeify(rimraf);
-var validProjectName   = require('../utilities/valid-project-name');
-var normalizeBlueprint = require('../utilities/normalize-blueprint-option');
+var chalk                 = require('chalk');
+var Command               = require('../models/command');
+var Promise               = require('../ext/promise');
+var Project               = require('../models/project');
+var SilentError           = require('silent-error');
+var rimraf                = require('rimraf');
+var rmdir                 = Promise.denodeify(rimraf);
+var validProjectName      = require('../utilities/valid-project-name');
+var normalizeBlueprint    = require('../utilities/normalize-blueprint-option');
+var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 
 module.exports = Command.extend({
   name: 'new',
@@ -30,26 +30,7 @@ module.exports = Command.extend({
     '<app-name>'
   ],
 
-  beforeRun: function(rawArgs) {
-    if (!rawArgs.length) {
-      return;
-    }
-    // merge in blueprint availableOptions
-    var blueprint;
-    try{
-      blueprint = this.lookupBlueprint(rawArgs[0]);
-      this.registerOptions(blueprint);
-    }
-    catch(e) {
-      SilentError.debugOrThrow('ember-cli/commands/init', e);
-    }
-  },
-
-  lookupBlueprint: function(name) {
-    return Blueprint.lookup(name, {
-      paths: this.project.blueprintLookupPaths()
-    });
-  },
+  beforeRun: mergeBlueprintOptions,
 
   run: function(commandOptions, rawArgs) {
     var packageName = rawArgs[0],

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chalk              = require('chalk');
+var Blueprint          = require('../models/blueprint');
 var Command            = require('../models/command');
 var Promise            = require('../ext/promise');
 var Project            = require('../models/project');
@@ -28,6 +29,27 @@ module.exports = Command.extend({
   anonymousOptions: [
     '<app-name>'
   ],
+
+  beforeRun: function(rawArgs) {
+    if (!rawArgs.length) {
+      return;
+    }
+    // merge in blueprint availableOptions
+    var blueprint;
+    try{
+      blueprint = this.lookupBlueprint(rawArgs[0]);
+      this.registerOptions(blueprint);
+    }
+    catch(e) {
+      SilentError.debugOrThrow('ember-cli/commands/init', e);
+    }
+  },
+
+  lookupBlueprint: function(name) {
+    return Blueprint.lookup(name, {
+      paths: this.project.blueprintLookupPaths()
+    });
+  },
 
   run: function(commandOptions, rawArgs) {
     var packageName = rawArgs[0],

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -7,6 +7,7 @@ var isGitRepo     = require('is-git-url');
 var temp          = require('temp');
 var childProcess  = require('child_process');
 var path          = require('path');
+var merge         = require('lodash/object/merge');
 
 // Automatically track and cleanup temp files at exit
 temp.track();
@@ -34,6 +35,8 @@ module.exports = Task.extend({
       targetFiles: options.targetFiles,
       rawArgs: options.rawArgs
     };
+
+    installOptions = merge(installOptions, options || {});
 
     if (isGitRepo(blueprintOption)) {
       return mkdir('ember-cli').then(function(pathName){

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -7,7 +7,7 @@ var isGitRepo     = require('is-git-url');
 var temp          = require('temp');
 var childProcess  = require('child_process');
 var path          = require('path');
-var merge         = require('lodash/object/merge');
+var merge         = require('lodash/merge');
 
 // Automatically track and cleanup temp files at exit
 temp.track();

--- a/lib/utilities/merge-blueprint-options.js
+++ b/lib/utilities/merge-blueprint-options.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var SilentError = require('silent-error');
+var Blueprint   = require('../models/blueprint');
+
+/*
+ * Helper for commands that use a blueprint to merge the blueprint's options
+ * into the command's options so they can be passed in. Needs to be invoked
+ * with `this` pointing to the command object, e.g.
+ *
+ * var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+ *
+ * Command.extend({
+ *   beforeRun: mergeBlueprintOptions
+ * })
+ */
+module.exports = function(rawArgs) {
+  if (rawArgs.length === 0) {
+    return;
+  }
+  // merge in blueprint availableOptions
+  var blueprint;
+  try {
+    blueprint = Blueprint.lookup(rawArgs[0], {
+      paths: this.project.blueprintLookupPaths()
+    });
+    this.registerOptions(blueprint);
+  } catch(e) {
+    SilentError.debugOrThrow('ember-cli/commands/' + this.name, e);
+  }
+};

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -30,6 +30,10 @@ describe('init command', function() {
     };
   });
 
+  afterEach(function() {
+    safeRestore(Blueprint, 'lookup');
+  });
+
   function buildCommand(projectOpts) {
     var options = {
       ui: ui,
@@ -217,14 +221,10 @@ describe('init command', function() {
       };
     }, true);
 
-    try {
-      buildCommand();
+    buildCommand();
 
-      command.beforeRun(['app']);
-      expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
-    } finally {
-      safeRestore(Blueprint, 'lookup');
-    }
+    command.beforeRun(['app']);
+    expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
   });
 
   it('Passes command options through to the install blueprint task', function() {

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -239,6 +239,9 @@ describe('init command', function() {
     buildCommand();
 
     return command.validateAndRun(['--custom-option=customValue'])
+      .then(function() {
+        expect(false, 'promise should have rejected');
+      })
       .catch(function(reason) {
         expect(reason).to.equal('Called run');
       });

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -4,7 +4,7 @@ var fs            = require('fs');
 var os            = require('os');
 var path          = require('path');
 var expect        = require('chai').expect;
-var pluck         = require('lodash/collection/pluck');
+var map           = require('lodash/map');
 var MockUI        = require('../../helpers/mock-ui');
 var MockAnalytics = require('../../helpers/mock-analytics');
 var stub          = require('../../helpers/stub');
@@ -224,7 +224,7 @@ describe('init command', function() {
     buildCommand();
 
     command.beforeRun(['app']);
-    expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
+    expect(map(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
   });
 
   it('Passes command options through to the install blueprint task', function() {

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -31,6 +31,10 @@ describe('new command', function() {
     command = new NewCommand(options);
   });
 
+  afterEach(function() {
+    safeRestore(Blueprint, 'lookup');
+  });
+
   it('doesn\'t allow to create an application named `test`', function() {
     return command.validateAndRun(['test']).then(function() {
       expect(false, 'should have rejected with an application name of test');
@@ -113,12 +117,8 @@ describe('new command', function() {
       };
     }, true);
 
-    try {
-      command.beforeRun(['app']);
-      expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
-    } finally {
-      safeRestore(Blueprint, 'lookup');
-    }
+    command.beforeRun(['app']);
+    expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
   });
 
   it('passes command options through to init command', function() {
@@ -147,8 +147,6 @@ describe('new command', function() {
 
     return command.validateAndRun(['foo', '--custom-option=customValue']).then(function(reason) {
       expect(reason).to.equal('Called run');
-    }).finally(function() {
-      safeRestore(Blueprint, 'lookup');
     });
   });
 });

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect         = require('chai').expect;
-var pluck          = require('lodash/collection/pluck');
+var map          = require('lodash/map');
 var commandOptions = require('../../factories/command-options');
 var stub           = require('../../helpers/stub');
 var NewCommand     = require('../../../lib/commands/new');
@@ -118,7 +118,7 @@ describe('new command', function() {
     }, true);
 
     command.beforeRun(['app']);
-    expect(pluck(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
+    expect(map(command.availableOptions, 'name')).to.contain('custom-blueprint-option');
   });
 
   it('passes command options through to init command', function() {

--- a/tests/unit/utilities/merge-blueprint-options-test-disabled.js
+++ b/tests/unit/utilities/merge-blueprint-options-test-disabled.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var expect                = require('chai').expect;
+var map                   = require('lodash/map');
+var stub                  = require('../../helpers/stub');
+var Blueprint             = require('../../../lib/models/blueprint');
+var Project               = require('../../../lib/models/project');
+var Command               = require('../../../lib/models/command');
+var mergeBlueprintOptions = require('../../../lib/utilities/merge-blueprint-options');
+
+var safeRestore = stub.safeRestore;
+stub = stub.stub;
+
+describe('merge-blueprint-options', function() {
+  var TestCommand = Command.extend({
+    name: 'test-command',
+    description: 'Runs a test command.',
+    aliases: ['t'],
+    works: 'everywhere',
+
+    availableOptions: [
+      { name: 'verbose',    type: Boolean, default: false, aliases: ['v'] }
+    ],
+
+    beforeRun: mergeBlueprintOptions
+  });
+
+  afterEach(function() {
+    safeRestore(Blueprint, 'lookup');
+  });
+
+  function buildCommand() {
+    return new TestCommand({
+      project: new Project(process.cwd(), { name: 'some-random-name' })
+    });
+  }
+
+  it('it works as a command\'s beforeRun()', function() {
+    var command, availableOptions;
+
+    stub(Blueprint, 'lookup', function(name) {
+      expect(name).to.equal('test-blueprint');
+      return {
+        availableOptions: [
+          { name: 'custom-blueprint-option', type: String }
+        ]
+      };
+    }, true);
+
+    command = buildCommand();
+    command.beforeRun(['test-blueprint']);
+
+    availableOptions = map(command.availableOptions, 'name');
+    expect(availableOptions).to.contain('verbose');
+    expect(availableOptions).to.contain('custom-blueprint-option');
+  });
+});


### PR DESCRIPTION
The new and init commands can be given a custom blueprint to use. This modifies those commands to be aware of blueprint-specific options and pass them through, like the generate command.

This is handy in the near-term for custom app/addon blueprints that accept options, and could pave the way to add options to the built-in blueprints if that ever seems valuable. A few examples I can think of immediately are the server port and the root URL.

I didn't make any changes to the help output because the default blueprints don't support any custom options and ```ember help new appName --blueprint=./my-blueprint``` seems like a weird use case.