### PR TITLE
Copy symlinks without dereference after broccoli build when env is development

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -13,6 +13,7 @@ var attemptNeverIndex = require('../utilities/attempt-never-index');
 var findBuildFile = require('../utilities/find-build-file');
 var viz = require('broccoli-viz');
 var FSMonitor = require('fs-monitor-stack');
+var symlinkOrCopySync = require('symlink-or-copy').sync;
 
 var signalsTrapped = false;
 var buildCount = 0;
@@ -133,13 +134,25 @@ module.exports = Task.extend({
 
   copyToOutputPath: function(inputPath) {
     var outputPath = this.outputPath;
+	var env = this.environment;
 
     return new Promise(function(resolve) {
       if (!existsSync(outputPath)) {
         fs.mkdirsSync(outputPath);
       }
 
-      resolve(cpd.sync(inputPath, outputPath));
+      var syncFunc = cpd.sync;
+
+      if (env == 'development') {
+        syncFunc = function(inputPath, outputPat) {
+          var entries = fs.readdirSync(inputPath).sort()
+          for (var i = 0; i < entries.length; i++) {
+            symlinkOrCopySync(inputPath + path.sep + entries[i], outputPath + path.sep + entries[i])
+          }
+        }
+      }
+
+      resolve(syncFunc(inputPath, outputPath));
     });
   },
 


### PR DESCRIPTION
After the broccoli build we are always copying the files and dereference them.

This leads to high build times in cases where we have big files (my project, for example, includes 90MB of assets which take forever to be copied to the outputPath).

I'm testing directly the env which isn't clearly the best approach here. I believe we should allow the desired behavior (either dereference or not) to be configured somewhere (config\environment.js?) for each environment type.

I was thinking something like the following (I’m just not sure how to test the variable inside the builder).
if (environment === 'development') {
  ENV.dereferenceOnBuild = false;
}

Any thoughts on this?
