### PR TITLE
Update Bower resolution to match Ember version

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -10,6 +10,6 @@
     "loader.js": "^3.5.0"
   },
   "resolutions": {
-    "ember": "2.2.0"
+    "ember": "2.3.0"
   }
 }


### PR DESCRIPTION
It looks like the 2.3.0-beta.1 release updated the Ember version, but not the matching resolution in `bower.json`