### PR TITLE
[ENHANCEMENT] print double dash for long aliases in availableOptions

### DIFF
--- a/lib/utilities/print-command.js
+++ b/lib/utilities/print-command.js
@@ -73,10 +73,10 @@ module.exports = function(initialMargin, shouldDescriptionBeGrey) {
     if (option.aliases && option.aliases.length) {
       output += EOL + initialMargin + '    ' + chalk.grey('aliases: ' + option.aliases.map(function(a) {
         if (typeof a === 'string') {
-          return '-' + a + (option.type === Boolean ? '' : ' <value>');
+          return (a.length > 4 ? '--': '-') + a + (option.type === Boolean ? '' : ' <value>');
         } else {
           var key = Object.keys(a)[0];
-          return '-' + key + ' (--' + option.name + '=' + a[key] + ')';
+          return (key.length > 4 ? '--': '-') + key + ' (--' + option.name + '=' + a[key] + ')';
         }
       }).join(', '));
     }

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -85,7 +85,7 @@ ember destroy \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m' 
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
     \u001b[90maliases: -dum, -id\u001b[39m' + EOL + '\
   \u001b[36m--in-repo-addon\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: null)\u001b[39m' + EOL + '\
-    \u001b[90maliases: -in-repo <value>, -ir <value>\u001b[39m' + EOL + '\
+    \u001b[90maliases: --in-repo <value>, -ir <value>\u001b[39m' + EOL + '\
 ' + EOL + '\
 ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
   Generates new code from blueprints.' + EOL + '\
@@ -101,7 +101,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m'
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
     \u001b[90maliases: -dum, -id\u001b[39m' + EOL + '\
   \u001b[36m--in-repo-addon\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: null)\u001b[39m' + EOL + '\
-    \u001b[90maliases: -in-repo <value>, -ir <value>\u001b[39m' + EOL + '\
+    \u001b[90maliases: --in-repo <value>, -ir <value>\u001b[39m' + EOL + '\
 ' + EOL + '\
 ember help \u001b[33m<command-name (Default: all)>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
   Outputs the usage instructions for all commands or the provided command' + EOL + '\
@@ -156,7 +156,7 @@ ember serve \u001b[36m<options...>\u001b[39m' + EOL + '\
   \u001b[36m--proxy\u001b[39m \u001b[36m(String)\u001b[39m' + EOL + '\
     \u001b[90maliases: -pr <value>, -pxy <value>\u001b[39m' + EOL + '\
   \u001b[36m--insecure-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Set false to proxy self-signed SSL certificates' + EOL + '\
-    \u001b[90maliases: -inspr\u001b[39m' + EOL + '\
+    \u001b[90maliases: --inspr\u001b[39m' + EOL + '\
   \u001b[36m--watcher\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: events)\u001b[39m' + EOL + '\
     \u001b[90maliases: -w <value>\u001b[39m' + EOL + '\
   \u001b[36m--live-reload\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m' + EOL + '\
@@ -1205,13 +1205,13 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
       component \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component. Name must contain a hyphen.\u001b[39m' + EOL + '\
         \u001b[36m--path\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: components)\u001b[39m' + EOL + '\
-          \u001b[90maliases: -no-path (--path=)\u001b[39m' + EOL + '\
+          \u001b[90maliases: --no-path (--path=)\u001b[39m' + EOL + '\
       component-addon \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component. Name must contain a hyphen.\u001b[39m' + EOL + '\
       component-test \u001b[33m<name>\u001b[39m \u001b[36m<options...>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a component integration or unit test.\u001b[39m' + EOL + '\
         \u001b[36m--test-type\u001b[39m \u001b[36m(integration, unit)\u001b[39m \u001b[36m(Default: integration)\u001b[39m' + EOL + '\
-          \u001b[90maliases: -i (--test-type=integration), -u (--test-type=unit), -integration (--test-type=integration), -unit (--test-type=unit)\u001b[39m' + EOL + '\
+          \u001b[90maliases: -i (--test-type=integration), -u (--test-type=unit), --integration (--test-type=integration), -unit (--test-type=unit)\u001b[39m' + EOL + '\
       controller \u001b[33m<name>\u001b[39m' + EOL + '\
         \u001b[90mGenerates a controller.\u001b[39m' + EOL + '\
       controller-test \u001b[33m<name>\u001b[39m' + EOL + '\

--- a/tests/unit/utilities/print-command-test.js
+++ b/tests/unit/utilities/print-command-test.js
@@ -15,7 +15,7 @@ describe('printCommand', function() {
         values: ['x', 'y'],
         default: 'my-def-val',
         required: true,
-        aliases: ['a', { b: 'c', unused: '' }],
+        aliases: ['a', 'long-a', { b: 'c', unused: '' }, {'long-b': 'c' }],
         description: 'option desc'
       },
       {
@@ -43,7 +43,7 @@ describe('printCommand', function() {
     \u001b[90ma paragraph\u001b[39m' + EOL + '\
     \u001b[90maliases: ab, cd\u001b[39m' + EOL + '\
     \u001b[36m--test-option\u001b[39m\u001b[36m=x|y\u001b[39m \u001b[36m(Required)\u001b[39m \u001b[36m(Default: my-def-val)\u001b[39m option desc' + EOL + '\
-      \u001b[90maliases: -a <value>, -b (--test-option=c)\u001b[39m' + EOL + '\
+      \u001b[90maliases: -a <value>, --long-a <value>, -b (--test-option=c), --long-b (--test-option=c)\u001b[39m' + EOL + '\
     \u001b[36m--test-type\u001b[39m \u001b[36m(Boolean)\u001b[39m' + EOL + '\
       \u001b[90maliases: -a\u001b[39m' + EOL + '\
     \u001b[36m--test-type-array\u001b[39m \u001b[36m(a-type, Number)\u001b[39m');


### PR DESCRIPTION
Presently if one alias for `availableOptions` is a long word the help function for that command will still print the option with a single dash although the `--` version works as well.

i.e.
https://github.com/ember-cli/ember-cli/blob/282641ba662292afb40cb88cdf31557a3e4cc6b7/lib%2Fcommands%2Fbuild.js#L13
will be printed as `-dev` even if also `--dev` is supported.

before this patch:
```
aliases: -a <value>, -long-a <value>, -b (--test-option=c), -long-b (--test-option=c)
```

after:
```
aliases: -a <value>, --long-a <value>, -b (--test-option=c), --long-b (--test-option=c)
```