### PR TITLE
Ensure prepended app.imports are properly ordered.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -95,9 +95,11 @@ function EmberApp() {
   this._initVendorFiles();
 
   this.legacyFilesToAppend     = [];
+  this.filesToPrepend          = [];
   this.vendorStaticStyles      = [];
   this.otherAssetPaths         = [];
   this.legacyTestFilesToAppend = [];
+  this.testFilesToPrepend      = [];
   this.vendorTestStaticStyles  = [];
 
   this.trees = this.options.trees;
@@ -1110,6 +1112,7 @@ EmberApp.prototype._prunedBabelOptions = function() {
 EmberApp.prototype.javascript = function() {
   var applicationJs       = this.appAndDependencies();
   var legacyFilesToAppend = this.legacyFilesToAppend;
+  var filesToPrepend      = this.filesToPrepend;
   var appOutputPath       = this.options.outputPaths.app.js;
   var appJs = applicationJs;
 
@@ -1147,6 +1150,7 @@ EmberApp.prototype.javascript = function() {
   });
 
   var inputFiles = ['vendor/ember-cli/vendor-prefix.js']
+    .concat(filesToPrepend)
     .concat(legacyFilesToAppend)
     .concat('vendor/addons.js')
     .concat('vendor/ember-cli/vendor-suffix.js');
@@ -1257,6 +1261,7 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
 
   var headerFiles = [].concat(
     'vendor/ember-cli/test-support-prefix.js',
+    this.testFilesToPrepend,
     this.legacyTestFilesToAppend
   );
 
@@ -1408,13 +1413,13 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if (options.type === 'vendor') {
       if (options.prepend) {
-        this.legacyFilesToAppend.unshift(assetPath);
+        this.filesToPrepend.push(assetPath);
       } else {
         this.legacyFilesToAppend.push(assetPath);
       }
     } else if (options.type === 'test' ) {
       if (options.prepend) {
-        this.legacyTestFilesToAppend.unshift(assetPath);
+        this.testFilesToPrepend.push(assetPath);
       } else {
         this.legacyTestFilesToAppend.push(assetPath);
       }

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -684,11 +684,14 @@ describe('broccoli/ember-app', function() {
       emberApp.import('vendor/moment.js', {type: 'vendor'});
       expect(emberApp.legacyFilesToAppend.indexOf('vendor/moment.js')).to.equal(emberApp.legacyFilesToAppend.length - 1);
     });
-    it('prepends dependencies', function() {
+    it('prepends dependencies in order imported', function() {
       emberApp = new EmberApp({
       });
-      emberApp.import('vendor/es5-shim.js', {type: 'vendor', prepend: true});
-      expect(emberApp.legacyFilesToAppend.indexOf('vendor/es5-shim.js')).to.equal(0);
+
+      emberApp.import('vendor/first.js', {type: 'vendor', prepend: true});
+      emberApp.import('vendor/second.js', {type: 'vendor', prepend: true});
+
+      expect(emberApp.filesToPrepend).to.eql(['vendor/first.js', 'vendor/second.js']);
     });
     it('defaults to development if production is not set', function() {
       process.env.EMBER_ENV = 'production';


### PR DESCRIPTION
Prior to this change given the following:

```js
app.import('foo/bar/one.js', { prepend: true });
app.import('foo/bar/two.js', { prepend: true });
```

The resulting output would include `two.js` *BEFORE* `one.js` (because the last prepend was being `unshift`'ed onto the same array).

After this change, the list of prepended assets is managed separately and in order of `app.import`.  This means that given the snippet above, `one.js` is before `two.js` (and sanity is restored to the world).

---

This is supporting the changes discussed in https://github.com/ember-cli/ember-cli/pull/5379#issuecomment-173765481.

/cc @nathanhammond