### PR TITLE
only hide folders at root in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /node_modules
 npm-debug.log
-tmp*
-common-tmp
+/tmp
+/common-tmp
 *.tgz
 /docs/build
 .node_modules-tmp


### PR DESCRIPTION
I noticed this while making the .npmignore. `tmp*` had the side-effect of hiding `/tests/helpers/tmp.js`. I remember @tomdale was burned by this in the past, since npm used .gitignore to exclude files.