### PR TITLE
Pin testem version until testem issue is fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.3",
-    "testem": "^1.1.1",
+    "testem": "1.1.1",
     "through": "^2.3.6",
     "tiny-lr": "0.2.1",
     "tree-sync": "^1.0.0",


### PR DESCRIPTION
The following error started happening once testem had released version [1.1.2](https://github.com/testem/testem/releases/tag/v1.1.2) on 01/26/16

https://github.com/testem/testem/issues/763

Pinning the testem version seems to fix this issue.