### PR TITLE
Ensure that Testem can use `testem.js` by default.

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -17,7 +17,7 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'environment', type: String,  default: 'test',          aliases: ['e'] },
-    { name: 'config-file', type: String,  default: './testem.json', aliases: ['c', 'cf'] },
+    { name: 'config-file', type: String,                            aliases: ['c', 'cf']},
     { name: 'server',      type: Boolean, default: false,           aliases: ['s'] },
     { name: 'host',        type: String,                            aliases: ['H'] },
     { name: 'test-port',   type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running with --server.' },

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -180,7 +180,7 @@ ember test \u001b[36m<options...>\u001b[39m' + EOL + '\
   \u001b[90maliases: t\u001b[39m' + EOL + '\
   \u001b[36m--environment\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: test)\u001b[39m' + EOL + '\
     \u001b[90maliases: -e <value>\u001b[39m' + EOL + '\
-  \u001b[36m--config-file\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: ./testem.json)\u001b[39m' + EOL + '\
+  \u001b[36m--config-file\u001b[39m \u001b[36m(String)\u001b[39m' + EOL + '\
     \u001b[90maliases: -c <value>, -cf <value>\u001b[39m' + EOL + '\
   \u001b[36m--server\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m' + EOL + '\
     \u001b[90maliases: -s\u001b[39m' + EOL + '\
@@ -1068,7 +1068,6 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
             },
             {
               name: 'config-file',
-              default: './testem.json',
               aliases: ['c', 'cf'],
               key: 'configFile',
               required: false

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -34,6 +34,8 @@ describe('Acceptance: smoke-test', function() {
   });
 
   afterEach(function() {
+    delete process.env._TESTEM_CONFIG_JS_RAN;
+
     return cleanupRun().then(function() {
       assertDirEmpty('tmp');
     });
@@ -99,7 +101,13 @@ describe('Acceptance: smoke-test', function() {
   it('ember test still runs when only a JavaScript testem config exists', function() {
     return copyFixtureFiles('smoke-tests/js-testem-config')
       .then(function() {
+        // testem.json "wins" over testem.js by default so we need to delete
+        // it from the default blueprint first
+        fs.unlinkSync('testem.json');
         return ember(['test']);
+      })
+      .then(function() {
+        expect(!!process.env._TESTEM_CONFIG_JS_RAN).to.equal(true);
       });
   });
 

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -1,3 +1,5 @@
+process.env._TESTEM_CONFIG_JS_RAN = true;
+
 module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -63,7 +63,7 @@ describe('test command', function() {
 
         expect(buildOptions.environment).to.equal('test', 'has correct env');
         expect(buildOptions.outputPath, 'has outputPath');
-        expect(testOptions.configFile).to.equal('./testem.json', 'has config file');
+        expect(testOptions.configFile).to.equal(undefined, 'does not supply config file when not specified');
         expect(testOptions.port).to.equal(7357, 'has config file');
       });
     });
@@ -140,8 +140,8 @@ describe('test command', function() {
         var testOptions = testRun.calledWith[0][0];
 
         expect(testOptions.outputPath).to.equal(path.resolve('tests'), 'has outputPath');
-        expect(testOptions.configFile).to.equal('./testem.json', 'has config file');
-        expect(testOptions.port).to.equal(7357, 'has config file');
+        expect(testOptions.configFile).to.equal(undefined, 'does not include configFile when not specified in options');
+        expect(testOptions.port).to.equal(7357, 'has port');
       });
     });
 


### PR DESCRIPTION
Support was added to allow folks to use `testem.js` instead of `testem.json` (in #4912), but that PR accidentally forgot to pass through the `--config-file` option to the created Testem instance.

Shortly after that #5089 landed and passed the `--config-file` option through to Testem.  Unfortunately, #5089 broke the ability for Testem to automatically choose its own config because the `--config-file` option was always defaulted to `./testem.json`.

The tests added in #4912 happened to continue to pass because the options supplied to Testem are actually enough to ensure that it runs the tests (but it was not actually invoking `testem.js` at all).

I tweaked the fixture and test to ensure that the file is actually ran, and removed the default (Testem internally will still default things properly).

/cc @cspanring @asakusuma