### PR TITLE
Use ember-load-initializers as addon

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Resolver from './resolver';
-import loadInitializers from 'ember/load-initializers';
+import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,7 +4,6 @@
     "ember": "2.3.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-load-initializers": "0.1.7",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "1.11.3"
   },

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -35,6 +35,7 @@
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.0"
   }

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -278,13 +278,6 @@ EmberApp.prototype._initVendorFiles = function() {
           'ember/resolver': ['default']
         }
       }
-    ],
-    'ember-load-initializers.js': [
-      this.bowerDirectory + '/ember-load-initializers/ember-load-initializers.js', {
-        exports: {
-          'ember/load-initializers': ['default']
-        }
-      }
     ]
   }, this.options.vendorFiles), isNull);
 

--- a/tests/fixtures/addon/simple/bower.json
+++ b/tests/fixtures/addon/simple/bower.json
@@ -5,8 +5,7 @@
     "ember": "1.7.0",
     "ember-data": "1.0.0-beta.10",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2"
+    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4"
   },
   "devDependencies": {
     "ember-qunit": "0.1.8",

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/app/app.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Resolver from 'ember-resolver';
-import loadInitializers from 'ember/load-initializers';
+import loadInitializers from 'ember-load-initializers';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/tests/fixtures/brocfile-tests/query/app/app.js
+++ b/tests/fixtures/brocfile-tests/query/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Resolver from 'ember-resolver';
-import loadInitializers from 'ember/load-initializers';
+import loadInitializers from 'ember-load-initializers';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/tests/fixtures/project-with-handlebars/bower.json
+++ b/tests/fixtures/project-with-handlebars/bower.json
@@ -6,8 +6,7 @@
     "ember": "1.7.0",
     "ember-data": "1.0.0-beta.10",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2"
+    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4"
   },
   "devDependencies": {
     "ember-qunit": "0.1.8",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -717,7 +717,7 @@ describe('broccoli/ember-app', function() {
   describe('vendorFiles', function() {
     var defaultVendorFiles = [
       'jquery.js', 'ember.js',
-      'app-shims.js', 'ember-resolver.js', 'ember-load-initializers.js'
+      'app-shims.js', 'ember-resolver.js'
     ];
 
     describe('handlebars.js', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -178,7 +178,6 @@ describe('models/project.js', function() {
         'ember-data': '1.0.0-beta.10',
         'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3',
         'ember-cli-test-loader': 'rwjblue/ember-cli-test-loader#0.0.4',
-        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2',
         'ember-qunit': '0.1.8',
         'ember-qunit-notifications': '0.0.4',
         'qunit': '~1.15.0'


### PR DESCRIPTION
Removes one more bower dependency. Depends on ember-cli/ember-load-initializers#23 and having it published to npm.

Not sure if I forgot to change something, please send me feedbacks so I can fix it.