### PR TITLE
Fix test failures from moving loader.js to an addon.

### DIFF
--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -194,7 +194,7 @@ describe('models/project.js', function() {
         'proxy-server-middleware', 'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon',
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
-        'ember-devDeps-addon', 'ember-addon-with-dependencies', 'ember-super-button'
+        'ember-devDeps-addon', 'ember-addon-with-dependencies', 'loader.js', 'ember-super-button'
       ];
       expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
     });
@@ -203,9 +203,9 @@ describe('models/project.js', function() {
       var addons = project.addons;
 
       expect(addons[5].name).to.equal('Ember Non Root Addon');
-      expect(addons[11].name).to.equal('Ember Super Button');
-      expect(addons[11].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[11].addons[1].name).to.equal('Ember Ng');
+      expect(addons[12].name).to.equal('Ember Super Button');
+      expect(addons[12].addons[0].name).to.equal('Ember Yagni');
+      expect(addons[12].addons[1].name).to.equal('Ember Ng');
     });
 
     it('addons get passed the project instance', function() {


### PR DESCRIPTION
These tests fail for me on current master (bfd6e63273cce881b865986fd4f52e0fe42abdcc) due to `loader.js` being pulled from `npm` as an addon now.

---

It is possible that this is some sort of local caching issue, and doesn't affect others (Travis seems to be passing properly without these changes).