### PR TITLE
Make options available in all Blueprint hooks as this.options

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -157,6 +157,10 @@ module.exports = Blueprint;
       }
     },
 
+    filesPath: function(options) {
+      return path.join(this.path, 'files');
+    },
+
     beforeInstall: function(options) {},
     afterInstall: function(options) {},
     beforeUninstall: function(options) {},
@@ -173,6 +177,7 @@ module.exports = Blueprint;
   - `locals`
   - `normalizeEntityName`
   - `fileMapTokens`
+  - `filesPath`
   - `beforeInstall`
   - `afterInstall`
   - `beforeUninstall`
@@ -238,6 +243,13 @@ module.exports = Blueprint;
   Tokens are used in the files folder (see `files`), and get replaced with
   values when the `mapFile` method is called.
 
+  ### filesPath
+
+  Use `filesPath` to define where the blueprint files to install are located.
+  This can be used to customize which set of files to install based on options
+  or environmental variables. It defaults to the `files` directory within the
+  blueprint's folder.
+
   ### beforeInstall & beforeUninstall
 
   Called before any of the template files are processed and receives
@@ -280,10 +292,11 @@ Blueprint.prototype.availableOptions = [];
 Blueprint.prototype.anonymousOptions = ['name'];
 
 /**
-  Used to determine the path to where files will be stored. By default
-  this is `path.join(this.path, 'files)`.
+  Hook to specify the path to the blueprint's files. By default this is
+  `path.join(this.path, 'files)`.
 
   @method filesPath
+  @param {Object} options
   @return {String} Path to the blueprints files directory.
 */
 
@@ -301,7 +314,7 @@ Blueprint.prototype.filesPath = function() {
 Blueprint.prototype.files = function() {
   if (this._files) { return this._files; }
 
-  var filesPath = this.filesPath();
+  var filesPath = this.filesPath(this.options);
   if (existsSync(filesPath)) {
     this._files = walkSync(filesPath);
   } else {
@@ -317,7 +330,7 @@ Blueprint.prototype.files = function() {
   @return {String} Resolved path to the file
 */
 Blueprint.prototype.srcPath = function(file) {
-  return path.resolve(this.filesPath(), file);
+  return path.resolve(this.filesPath(this.options), file);
 };
 
 /**
@@ -477,6 +490,7 @@ Blueprint.prototype.install = function(options) {
   var dryRun   = this.dryRun = options.dryRun;
   this.project = options.project;
   this.pod     = options.pod;
+  this.options = options;
   this.hasPathToken = hasPathToken(this.files());
 
   podDeprecations(this.project.config(), ui);
@@ -513,6 +527,7 @@ Blueprint.prototype.uninstall = function(options) {
   var dryRun   = this.dryRun = options.dryRun;
   this.project = options.project;
   this.pod     = options.pod;
+  this.options = options;
   this.hasPathToken = hasPathToken(this.files());
 
   podDeprecations(this.project.config(), ui);
@@ -1444,7 +1459,6 @@ Blueprint.defaultLookupPaths = function() {
   @return {Promise}
 */
 function prepareConfirm(info) {
-  
   return info.checkForConflict().then(function(resolution) {
     info.resolution = resolution;
     return info;

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -751,6 +751,77 @@ help in detail');
       options.entity = { name: 'bar' };
       blueprint.install(options);
     });
+
+    it('calls appropriate hooks with correct arguments', function() {
+      var localsCalled = false;
+      blueprint.locals = function(opts) {
+        localsCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.locals.apply(this, arguments);
+      };
+
+      var normalizeEntityNameCalled = false;
+      blueprint.normalizeEntityName = function(name) {
+        normalizeEntityNameCalled = true;
+        expect(name).to.equal('foo');
+        return this._super.normalizeEntityName.apply(this, arguments);
+      };
+
+      var fileMapTokensCalled = false;
+      blueprint.fileMapTokens = function() {
+        fileMapTokensCalled = true;
+        return this._super.fileMapTokens.apply(this, arguments);
+      };
+
+      var filesPathCalled = false;
+      blueprint.filesPath = function(opts) {
+        filesPathCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.filesPath.apply(this, arguments);
+      };
+
+      var beforeInstallCalled = false;
+      var originalBeforeInstall = blueprint.beforeInstall;
+      blueprint.beforeInstall = function(opts) {
+        beforeInstallCalled = true;
+        expect(opts).to.deep.equal(options);
+        return originalBeforeInstall.apply(this, arguments);
+      };
+
+      var afterInstallCalled = false;
+      blueprint.afterInstall = function(opts) {
+        afterInstallCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.afterInstall.apply(this, arguments);
+      };
+
+      var beforeUninstallCalled = false;
+      blueprint.beforeUninstall = function() {
+        beforeUninstallCalled = true;
+        return this._super.beforeUninstall.apply(this, arguments);
+      };
+
+      var afterUninstallCalled = false;
+      blueprint.afterUninstall = function() {
+        afterUninstallCalled = true;
+        return this._super.afterUninstall.apply(this, arguments);
+      };
+
+      options.entity = { name: 'foo' };
+
+      return blueprint.install(options)
+        .then(function() {
+            expect(localsCalled).to.be.true;
+            expect(normalizeEntityNameCalled).to.be.true;
+            expect(fileMapTokensCalled).to.be.true;
+            expect(filesPathCalled).to.be.true;
+            expect(beforeInstallCalled).to.be.true;
+            expect(afterInstallCalled).to.be.true;
+
+            expect(beforeUninstallCalled).to.be.false;
+            expect(afterUninstallCalled).to.be.false;
+        });
+    });
   });
 
   describe('basic blueprint uninstallation', function() {
@@ -806,6 +877,76 @@ help in detail');
             function(exists) {
               expect(exists).to.be.false;
             });
+        });
+    });
+
+    it('calls appropriate hooks with correct arguments', function() {
+      var localsCalled = false;
+      blueprint.locals = function(opts) {
+        localsCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.locals.apply(this, arguments);
+      };
+
+      var normalizeEntityNameCalled = false;
+      blueprint.normalizeEntityName = function(name) {
+        normalizeEntityNameCalled = true;
+        expect(name).to.equal('foo');
+        return this._super.normalizeEntityName.apply(this, arguments);
+      };
+
+      var fileMapTokensCalled = false;
+      blueprint.fileMapTokens = function() {
+        fileMapTokensCalled = true;
+        return this._super.fileMapTokens.apply(this, arguments);
+      };
+
+      var filesPathCalled = false;
+      blueprint.filesPath = function(opts) {
+        filesPathCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.filesPath.apply(this, arguments);
+      };
+
+      var beforeInstallCalled = false;
+      blueprint.beforeInstall = function() {
+        beforeInstallCalled = true;
+        return this._super.beforeInstall.apply(this, arguments);
+      };
+
+      var afterInstallCalled = false;
+      blueprint.afterInstall = function() {
+        afterInstallCalled = true;
+        return this._super.afterInstall.apply(this, arguments);
+      };
+
+      var beforeUninstallCalled = false;
+      blueprint.beforeUninstall = function(opts) {
+        beforeUninstallCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.beforeUninstall.apply(this, arguments);
+      };
+
+      var afterUninstallCalled = false;
+      blueprint.afterUninstall = function(opts) {
+        afterUninstallCalled = true;
+        expect(opts).to.deep.equal(options);
+        return this._super.afterUninstall.apply(this, arguments);
+      };
+
+      options.entity = { name: 'foo' };
+
+      return blueprint.uninstall(options)
+        .then(function() {
+            expect(localsCalled).to.be.true;
+            expect(normalizeEntityNameCalled).to.be.true;
+            expect(fileMapTokensCalled).to.be.true;
+            expect(filesPathCalled).to.be.true;
+            expect(beforeUninstallCalled).to.be.true;
+            expect(afterUninstallCalled).to.be.true;
+
+            expect(beforeInstallCalled).to.be.false;
+            expect(afterInstallCalled).to.be.false;
         });
     });
   });


### PR DESCRIPTION
Currently, not all the available Blueprint hooks receive the `options` hash (e.g., `filesPath` and `normalizeEntityName`). This is a simple change to ensure that all hooks can access the options via `this.options`.

cc @rwjblue 