### PR TITLE
Fix linting error in nested developing addons

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -637,9 +637,13 @@ Addon.prototype.jshintAddonTree = function() {
   }
 
   var addonJs = this.addonJsFiles(addonPath);
-  var jshintedAddon = this.app.addonLintTree('addon', addonJs);
+  var lintTrees = this.eachAddonInvoke('lintTree', [addonJs]);
+  var lintedAddon = mergeTrees(lintTrees, {
+    overwrite: true,
+    annotation: 'TreeMerger (addon-lint)'
+  });
 
-  return new Funnel(jshintedAddon, {
+  return new Funnel(lintedAddon, {
     srcDir: '/',
     destDir: this.name + '/tests/'
   });

--- a/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
+++ b/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import layout from '../templates/components/simple-component';
+
+export default Ember.Component.extend({
+  layout
+});

--- a/tests/fixtures/addon/developing-addon/addon/templates/components/simple-component.hbs
+++ b/tests/fixtures/addon/developing-addon/addon/templates/components/simple-component.hbs
@@ -1,0 +1,1 @@
+<p>This is a simple component</p>

--- a/tests/fixtures/addon/developing-addon/app/components/simple-component.js
+++ b/tests/fixtures/addon/developing-addon/app/components/simple-component.js
@@ -1,0 +1,1 @@
+export { default } from 'developing-addon/components/simple-component';

--- a/tests/fixtures/addon/developing-addon/index.js
+++ b/tests/fixtures/addon/developing-addon/index.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+module.exports = {
+  name: 'developing-addon',
+
+  isDevelopingAddon: function() {
+    return true;
+  }
+};

--- a/tests/fixtures/addon/developing-addon/package.json
+++ b/tests/fixtures/addon/developing-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "developing-addon",
+  "version": "0.0.1",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "latest"
+  }
+}


### PR DESCRIPTION
Addresses #4918, the root cause is that `app` wasn't being set for nested addons, so then when it later tried to call `addonLintTree` it would fail. The solution proposed here is to pass `app` to all addons in the dependency tree after initializing the addons.