### PR TITLE
Fix two spelling errors in ui.js

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -38,14 +38,14 @@ function UI(options) {
   this.readline = require('readline2');
 
   // Output stream
-  this.actualOuputStream = options.outputStream;
+  this.actualOutputStream = options.outputStream;
   this.outputStream      = this.through(function(data) {
     pleasantProgress.stop(true);
     this.emit('data', data);
   });
 
   this.outputStream.setMaxListeners(0);
-  this.outputStream.pipe(this.actualOuputStream);
+  this.outputStream.pipe(this.actualOutputStream);
 
   this.inputStream = options.inputStream;
   this.errorStream = options.errorStream;
@@ -191,8 +191,8 @@ UI.prototype.stopProgress = function(printWithFullStepString) {
 
 UI.prototype.prompt = function(questions, callback) {
   // Pipe it to the output stream but don't forward end event
-  var promtOutputStream = this.through(null, function() {});
-  promtOutputStream.pipe(this.outputStream);
+  var promptOutputStream = this.through(null, function() {});
+  promptOutputStream.pipe(this.outputStream);
 
   var Prompt = require('inquirer').ui.Prompt;
   // Note: Cannot move this outside
@@ -204,7 +204,7 @@ UI.prototype.prompt = function(questions, callback) {
   PromptExt.prototype.constructor = PromptExt;
   PromptExt.prototype.rl = this.readline.createInterface({
     input: this.inputStream,
-    output: promtOutputStream
+    output: promptOutputStream
   });
 
   // If no callback was provided, automatically return a promise


### PR DESCRIPTION
- ember-cli-deploy intends to use ui.actualOutputStream (See https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/blob/55b872daa0df949fa8d22adcf1b75e6b22968b87/index.js#L54-L66)

/cc @ghedamat 