### PR TITLE
Remove deprecated 'registry' in instance initializer template.

### DIFF
--- a/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
+++ b/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
@@ -1,5 +1,5 @@
 export function initialize(/* appInstance */) {
-  // appInstance.registry.injection('route', 'foo', 'service:foo');
+  // appInstance.inject('route', 'foo', 'service:foo');
 }
 
 export default {

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -626,7 +626,7 @@ describe('Acceptance: ember generate', function() {
     return generate(['instance-initializer', 'foo']).then(function() {
       assertFile('app/instance-initializers/foo.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +
@@ -645,7 +645,7 @@ describe('Acceptance: ember generate', function() {
     return generate(['instance-initializer', 'foo/bar']).then(function() {
       assertFile('app/instance-initializers/foo/bar.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -511,7 +511,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
     return generateInRepoAddon(['instance-initializer', 'foo', '--in-repo-addon=my-addon']).then(function() {
       assertFile('lib/my-addon/addon/instance-initializers/foo.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +
@@ -532,7 +532,7 @@ describe('Acceptance: ember generate in-repo-addon', function() {
     return generateInRepoAddon(['instance-initializer', 'foo/bar', '--in-repo-addon=my-addon']).then(function() {
       assertFile('lib/my-addon/addon/instance-initializers/foo/bar.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1180,7 +1180,7 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['instance-initializer', 'foo', '--pod']).then(function() {
       assertFile('app/instance-initializers/foo.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +
@@ -1195,7 +1195,7 @@ describe('Acceptance: ember generate pod', function() {
     return generate(['instance-initializer', 'foo/bar', '--pod']).then(function() {
       assertFile('app/instance-initializers/foo/bar.js', {
         contains: "export function initialize(/* appInstance */) {" + EOL +
-                  "  // appInstance.registry.injection('route', 'foo', 'service:foo');" + EOL +
+                  "  // appInstance.inject('route', 'foo', 'service:foo');" + EOL +
                   "}" + EOL +
                   "" + EOL+
                   "export default {" + EOL +


### PR DESCRIPTION
Updates the instance initializer template in line with the [deprecation][depr] introduced in 2.1.

[depr]: http://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry