### PR TITLE
skips version banner in --json mode

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -67,7 +67,10 @@ CLI.prototype.run = function(environment) {
       }
     }
 
-    this.ui.writeLine('version: ' + emberCLIVersion());
+    var skipVersionBanner = commandArgs.indexOf('--json') !== -1;
+    if (!skipVersionBanner) {
+      this.ui.writeLine('version: ' + emberCLIVersion());
+    }
     debug('command: %s', commandName);
 
     if (commandName !== 'update' && !this.testing) {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -6,6 +6,9 @@ var lookupCommand   = require('../cli/lookup-command');
 var string          = require('../utilities/string');
 var assign          = require('lodash/assign');
 var GenerateCommand = require('./generate');
+var versionUtils    = require('../utilities/version-utils');
+
+var emberCLIVersion      = versionUtils.emberCLIVersion;
 
 var RootCommand = Command.extend({
   isRoot: true,
@@ -43,6 +46,7 @@ module.exports = Command.extend({
     });
     if (commandOptions.json) {
       json = rootCommand.getJson(commandOptions);
+      json.version = emberCLIVersion();
       json.commands = [];
       json.addons = [];
     }

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -13,6 +13,9 @@ var HelpCommand       = require('../../lib/commands/help');
 var requireAsHash     = require('../../lib/utilities/require-as-hash');
 var Command           = require('../../lib/models/command');
 var commands          = requireAsHash('../../lib/commands/*.js', Command);
+var versionUtils      = require('../../lib/utilities/version-utils');
+
+var emberCLIVersion      = versionUtils.emberCLIVersion;
 
 chai.use(chaiString);
 
@@ -225,6 +228,7 @@ ember version \u001b[36m<options...>\u001b[39m' + EOL + '\
       works: 'insideProject',
       availableOptions: [],
       anonymousOptions: ['<command (Default: help)>'],
+      version: emberCLIVersion(),
       commands: [
         {
           name: 'addon',


### PR DESCRIPTION
Currently ember-cli will always print the version banner (i.e. `version: 2.2.0-beta.6`). 
In combination with the `--json` flag that results in invalid json stdout.

I'm not sure if it's currently possible to add a test for this change because https://github.com/ember-cli/ember-cli/blob/master/tests/acceptance/help-test.js#L219 isn't including the previous ui stdout.