### PR TITLE
app blueprint: Update jQuery version

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -4,8 +4,7 @@
     "ember": "2.3.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "jquery": "1.11.3"
+    "ember-qunit-notifications": "0.1.0"
   },
   "resolutions": {
     "ember": "2.3.0"


### PR DESCRIPTION
This is what Ember’s jQuery version requirements were updated to in emberjs/ember.js#12958 although I can update to just point at ^2.2.0 if so desired.