### PR TITLE
[BUGFIX] Remove npm version from `ember --version` output.

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -14,10 +14,9 @@ module.exports = Command.extend({
 
   run: function(options) {
     var versions = process.versions;
-    versions['npm'] = require('npm').version;
     versions['os'] = process.platform + ' ' + process.arch;
 
-    var alwaysPrint = ['node', 'npm', 'os'];
+    var alwaysPrint = ['node', 'os'];
 
     for (var module in versions) {
       if (options.verbose || alwaysPrint.indexOf(module) > -1) {

--- a/tests/unit/commands/version-test.js
+++ b/tests/unit/commands/version-test.js
@@ -24,7 +24,6 @@ describe('version command', function() {
     return command.validateAndRun().then(function() {
       var lines = options.ui.output.split(EOL);
       expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
-      expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
       expect(someLineStartsWith(lines, 'os:'), 'contains the version of os');
     });
   });
@@ -33,7 +32,6 @@ describe('version command', function() {
     return command.validateAndRun(['--verbose']).then(function() {
       var lines = options.ui.output.split(EOL);
       expect(someLineStartsWith(lines, 'node:'), 'contains the version of node');
-      expect(someLineStartsWith(lines, 'npm:'), 'contains the version of npm');
       expect(someLineStartsWith(lines, 'os:'), 'contains the version of os');
       expect(someLineStartsWith(lines, 'v8:'), 'contains the version of v8');
     });


### PR DESCRIPTION
Fixes #5447.

  - Add a utility to check the global npm version by spawning
    `npm --version` and retrieving its result.
  - Use the new utility to set a global npm version.
  - Print both local and global npm versions in the Version command.