### PR TITLE
Increase the test timeout for proxy tests.

### DIFF
--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -248,6 +248,8 @@ describe('express-server', function() {
         });
     });
     describe('with proxy', function() {
+      this.timeout(10000);
+
       beforeEach(function() {
         return subject.start({
           proxy: 'http://localhost:3001/',


### PR DESCRIPTION
These tests seem to consistently fail on node 0.10, this increases the timeout from 5s to 10s to give older node more time...