### PR TITLE
Fix proxy tests

### DIFF
--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -287,7 +287,7 @@ describe('express-server', function() {
               return done(err);
             }
 
-            expect(proxy.called, 'proxy receives the request');
+            expect(proxy.called, 'proxy receives the request').to.equal(true);
             expect(proxy.lastReq.method).to.equal(method.toUpperCase());
             expect(proxy.lastReq.url).to.equal(url);
             done();
@@ -314,7 +314,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            expect(proxy.called, 'proxy receives the request');
+            expect(proxy.called, 'proxy receives the request').to.equal(true);
             done();
           });
       });
@@ -344,7 +344,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            expect(nockProxy.called, 'proxy receives the request');
+            expect(nockProxy.called, 'proxy receives the request').to.equal(true);
             expect(nockProxy.method).to.equal(method.toUpperCase());
             expect(nockProxy.url).to.equal(url);
             done();
@@ -434,7 +434,7 @@ describe('express-server', function() {
             if (err) {
               return done(err);
             }
-            expect(nockProxy.called, 'proxy receives the request');
+            expect(nockProxy.called, 'proxy receives the request').to.equal(true);
             done();
           });
       });

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -281,6 +281,7 @@ describe('express-server', function() {
       function apiTest(app, method, url, done) {
         var req = request(app);
         return req[method].call(req, url)
+          .set('content-length', 0)
           .set('accept', 'text/json')
           .end(function(err) {
             if (err) {

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -31,9 +31,6 @@ describe('express-server', function() {
       serverWatcher: new MockServerWatcher(),
       serverRestartDelayTime: 100,
       serverRoot: './server',
-      proxyMiddleware: function() {
-        return proxy.handler.bind(proxy);
-      },
       environment: 'development'
     });
   });


### PR DESCRIPTION
This PR should fix the broken proxy test on node 0.10.42 and also fixes two other issues with that test suite.

see https://github.com/nodejitsu/node-http-proxy/issues/960 and https://github.com/visionmedia/superagent/issues/236 for details.