### PR TITLE
Remove Travis allowed failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ install:
   - npm --version
   - git --version
   - npm install --no-optional
-matrix:
-  allow_failures:
-    - node_js: "5"
-    - node_js: "node"
 
 after_script:
   - cat coverage/lcov.info | codeclimate

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2"
+  - "4"
   - "5"
   - node
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -52,7 +52,7 @@ module.exports = EmberApp;
     - storeConfigInMeta, defaults to `true`,
     - autoRun, defaults to `true`,
     - outputPaths, defaults to `{}`,
-    - minifyCSS, defaults to `{enabled: !!isProduction,options: { relativeTo: 'app/styles' }},
+    - minifyCSS, defaults to `{enabled: !!isProduction,options: { relativeTo: 'assets' }},
     - minifyJS, defaults to `{enabled: !!isProduction},
     - sourcemaps, defaults to `{}`,
     - trees, defaults to `{},`
@@ -160,7 +160,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     outputPaths: {},
     minifyCSS: {
       enabled: !!isProduction,
-      options: { relativeTo: 'app/styles' }
+      options: { relativeTo: 'assets' }
     },
     minifyJS: {
       enabled: !!isProduction

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",
-    "ember-cli-preprocess-registry": "^1.0.3",
+    "ember-cli-preprocess-registry": "^2.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-router-generator": "^1.0.0",


### PR DESCRIPTION
The original issue with both of these (npm 3.3.10 - 3.3.12 was the default and is completely busted) is no longer an issue (now that "5" resolves to 5.6.0).

---

There are two remaining failures, both of which will be fixed by https://github.com/ember-cli/ember-cli-preprocessor-registry/issues/6.