### PR TITLE
Replace \n with native EOL in processed templates

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -97,7 +97,11 @@ FileInfo.prototype.render = function() {
           return content;
         } else {
           try {
-            return processTemplate(content.toString(), context);
+            var result = processTemplate(content.toString(), context);
+            if (EOL !== '\n') {
+              result = result.replace(/\n/g, EOL);
+            }
+            return result;
           } catch (err) {
             err.message += ' (Error in blueprint template: ' + path + ')';
             throw err;

--- a/tests/helpers/assert-file-equals.js
+++ b/tests/helpers/assert-file-equals.js
@@ -2,6 +2,7 @@
 
 var expect = require('chai').expect;
 var fs     = require('fs');
+var EOL    = require('os').EOL;
 
 /*
   Assert that a given file matches another.
@@ -13,6 +14,10 @@ var fs     = require('fs');
 module.exports = function assertFileEquals(pathToActual, pathToExpected) {
   var actual = fs.readFileSync(pathToActual, { encoding: 'utf-8' });
   var expected = fs.readFileSync(pathToExpected, { encoding: 'utf-8' });
+
+  if (EOL !== '\n') {
+    expected = expected.replace(/\n/g, '\r\n');
+  }
 
   expect(actual).to.equal(expected);
 };


### PR DESCRIPTION
This PR fixes most of the line ending issues introduced by the `.gitattributes` file. Once the blueprint template is processed it will (if necessary) replace any `\n` characters with native EOLs.

This should fix some of the AppVeyor issues. Some issues remain, because the fixture files that are used for `assertFileEquals()` obviously use `\n` but the generated files on Windows will now have `\r\n` again. `assertFileEquals()` will most likely need to be modified to support a line ending option for the fixture file.

**Update:** Fixture files are read with native EOLs now too