### PR TITLE
ESLint: Use recommended rules preset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  extends: 'eslint:recommended',
   env: {
     browser: false,
     node: true,
@@ -89,5 +90,8 @@ module.exports = {
 
     // JSHint "eqnull"
     'no-eq-null': 2,
+
+    'no-console': 0,
+    'comma-dangle': 0,
   },
 };

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -285,7 +285,7 @@ EmberApp.prototype._initVendorFiles = function() {
     ]
   }, this.options.vendorFiles), isNull);
 
-  if (!!this.registry.availablePlugins['ember-resolver']) {
+  if (this.registry.availablePlugins['ember-resolver']) {
     // if the project is using `ember-resolver` as an addon
     // remove it from `vendorFiles` (the NPM version properly works
     // without `app.import`s)

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -49,17 +49,17 @@ module.exports = Blueprint;
   ```
   blueprints/controller
   ├── files
-  │   ├── app
-  │   │   └── __path__
-  │   │       └── __name__.js
+  │   ├── app
+  │   │   └── __path__
+  │   │       └── __name__.js
   └── index.js
 
   blueprints/controller-test
   ├── files
-  │   └── tests
-  │       └── unit
-  │           └── controllers
-  │               └── __test__.js
+  │   └── tests
+  │       └── unit
+  │           └── controllers
+  │               └── __test__.js
   └── index.js
   ```
 

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -4,7 +4,6 @@ var Promise    = require('../../lib/ext/promise');
 var path       = require('path');
 var fs         = require('fs-extra');
 var remove     = Promise.denodeify(fs.remove);
-var expect     = require('chai').expect;
 var addonName  = 'some-cool-addon';
 var spawn      = require('child_process').spawn;
 var chalk      = require('chalk');

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -17,7 +17,6 @@ var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
-var existsSync          = require('exists-sync');
 
 var appName  = 'some-cool-app';
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -7,7 +7,6 @@ var Addon   = require('../../../lib/models/addon');
 var Promise = require('../../../lib/ext/promise');
 var expect  = require('chai').expect;
 var remove  = Promise.denodeify(fs.remove);
-var path    = require('path');
 var findWhere = require('lodash/find');
 var MockUI = require('../../helpers/mock-ui');
 var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -7,7 +7,6 @@ var proxyquire        = require('proxyquire');
 var commandOptions    = require('../../factories/command-options');
 var stub              = require('../../helpers/stub').stub;
 var processHelpString = require('../../helpers/process-help-string');
-var Command           = require('../../../lib/models/command');
 var assign            = require('lodash/assign');
 var Yam               = require('yam');
 var EOL               = require('os').EOL;


### PR DESCRIPTION
This PR adds the `eslint:recommended` rules preset to `.eslintrc.js` and fixes the few issues that came up.

- `no-console` is disabled because we obviously do need to use the console in a CLI.
- `comma-dangle` is disabled because the code in the project is inconsistent about this and I wasn't sure what the desired style is and whether we want to enforce it.