### PR TITLE
Update bower-config dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.2",
     "bower": "^1.3.12",
-    "bower-config": "0.6.1",
+    "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
     "broccoli": "0.16.9",
     "broccoli-babel-transpiler": "^5.4.5",


### PR DESCRIPTION
Currently bower-config is at `0.6.1`, which pulls in `graceful-fs 2.0.3`. This displays a scary warning about `graceful-fs` not working on older node versions. This MR bumps the version up to 1.3.0, which uses `graceful-fs` version 4.