### PR TITLE
Call destroyApp after handling afterEach options

### DIFF
--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -13,11 +13,11 @@ export default function(name, options = {}) {
     },
 
     afterEach() {
-      destroyApp(this.application);
-
       if (options.afterEach) {
         options.afterEach.apply(this, arguments);
       }
+
+      destroyApp(this.application);
     }
   });
 }


### PR DESCRIPTION
As discussed in #5348, `destroyApp(...)` should be
called after `options.afterEach.apply(...)`.