### PR TITLE
output-file import

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1097,6 +1097,10 @@ EmberApp.prototype.javascript = function() {
   var appOutputPath       = this.options.outputPaths.app.js;
   var appJs = applicationJs;
 
+  this.import('vendor/ember-cli/vendor-prefix.js', {prepend: true});
+  this.import('vendor/addons.js');
+  this.import('vendor/ember-cli/vendor-suffix.js');
+
   // Note: If ember-cli-babel is installed we have already performed the transpilation at this point
   if (!this._addonInstalled('ember-cli-babel')) {
     appJs = new Babel(
@@ -1131,25 +1135,15 @@ EmberApp.prototype.javascript = function() {
   });
 
   var vendorFiles = [];
-  for (var outputFileName in this.legacyFilesToAppend) {
-    var inputFiles = this.legacyFilesToAppend[outputFileName],
-      outputFile = outputFileName;
-
-    if (outputFileName === 'vendor') {
-      inputFiles = ['vendor/ember-cli/vendor-prefix.js']
-        .concat(inputFiles)
-        .concat('vendor/addons.js')
-        .concat('vendor/ember-cli/vendor-suffix.js');
-
-      outputFile = this.options.outputPaths.vendor.js;
-    }
+  for (var outputFile in this.legacyFilesToAppend) {
+    var inputFiles = this.legacyFilesToAppend[outputFile];
 
     vendorFiles.push(
       this.concatFiles(applicationJs, {
         inputFiles: inputFiles,
         outputFile: outputFile,
         separator: EOL + ';',
-        annotation: 'Concat: Vendor ' + outputFileName
+        annotation: 'Concat: Vendor ' + outputFile
       })
     );
   }
@@ -1158,7 +1152,6 @@ EmberApp.prototype.javascript = function() {
     annotation: 'TreeMerger (vendor & appJS)'
   });
 };
-
 
 /**
   Returns the tree for styles
@@ -1175,6 +1168,8 @@ EmberApp.prototype.styles = function() {
   if (existsSync('app/styles/' + this.name + '.css')) {
     throw new SilentError('Style file cannot have the name of the application - ' + this.name);
   }
+
+  this.import('vendor/addons.css');
 
   var addonTrees = this.addonTreesFor('styles');
   var external = this._processedExternalTree();
@@ -1198,14 +1193,8 @@ EmberApp.prototype.styles = function() {
   var preprocessedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
 
   var vendorStyles = [];
-  for (var outputFileName in this.vendorStaticStyles) {
-    var inputFiles = this.vendorStaticStyles[outputFileName],
-      outputFile = outputFileName;
-
-    if (outputFileName === 'vendor') {
-      inputFiles.push('vendor/addons.css');
-      outputFile = this.options.outputPaths.vendor.css;
-    }
+  for (var outputFile in this.vendorStaticStyles) {
+    var inputFiles = this.vendorStaticStyles[outputFile];
 
     vendorStyles.push(this.concatFiles(stylesAndVendor, {
       inputFiles: inputFiles,
@@ -1413,20 +1402,11 @@ EmberApp.prototype.import = function(asset, options) {
  */
 EmberApp.prototype._import = function(assetPath, options, directory, subdirectory, extension) {
   var basename = path.basename(assetPath);
-  var outputFileName = options.outputFile || options.type;
 
-  // @todo: any reason not to use extension argument here?
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if (options.type === 'vendor') {
-      if (!this.legacyFilesToAppend[outputFileName]) {
-        this.legacyFilesToAppend[outputFileName] = [];
-      }
-
-      if (options.prepend) {
-        this.legacyFilesToAppend[outputFileName].unshift(assetPath);
-      } else {
-        this.legacyFilesToAppend[outputFileName].push(assetPath);
-      }
+      options.outputFile = options.outputFile || this.options.outputPaths.vendor.js;
+      addOutputFile(this.legacyFilesToAppend, assetPath, options);
     } else if (options.type === 'test' ) {
       if (options.prepend) {
         this.legacyTestFilesToAppend.unshift(assetPath);
@@ -1438,11 +1418,8 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
     }
   } else if (extension === '.css') {
     if (options.type === 'vendor') {
-      if (!this.vendorStaticStyles[outputFileName]) {
-        this.vendorStaticStyles[outputFileName] = [];
-      }
-
-      this.vendorStaticStyles[outputFileName].push(assetPath);
+      options.outputFile = options.outputFile || this.options.outputPaths.vendor.css;
+      addOutputFile(this.vendorStaticStyles, assetPath, options);
     } else {
       this.vendorTestStaticStyles.push(assetPath);
     }
@@ -1672,3 +1649,22 @@ function calculateAppConfig(config) {
 function calculateModulePrefix(config) {
   return config.modulePrefix;
 }
+
+function addOutputFile(container, assetPath, options) {
+  var outputFile = options.outputFile;
+
+  if (!outputFile) {
+    throw new Error('outputFile is not specified');
+  }
+
+  if (!container[outputFile]) {
+    container[outputFile] = [];
+  }
+
+  if (options.prepend) {
+    container[outputFile].unshift(assetPath);
+  } else {
+    container[outputFile].push(assetPath);
+  }
+}
+

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -93,8 +93,9 @@ function EmberApp() {
   this._initOptions(options, isProduction);
   this._initVendorFiles();
 
-  this.legacyFilesToAppend     = [];
-  this.vendorStaticStyles      = [];
+  this.legacyFilesToAppend     = {};
+  this.vendorStaticStyles      = {};
+
   this.otherAssetPaths         = [];
   this.legacyTestFilesToAppend = [];
   this.vendorTestStaticStyles  = [];
@@ -1093,7 +1094,6 @@ EmberApp.prototype._prunedBabelOptions = function() {
 */
 EmberApp.prototype.javascript = function() {
   var applicationJs       = this.appAndDependencies();
-  var legacyFilesToAppend = this.legacyFilesToAppend;
   var appOutputPath       = this.options.outputPaths.app.js;
   var appJs = applicationJs;
 
@@ -1130,22 +1130,31 @@ EmberApp.prototype.javascript = function() {
     annotation: 'Concat: App'
   });
 
-  var inputFiles = ['vendor/ember-cli/vendor-prefix.js']
-    .concat(legacyFilesToAppend)
-    .concat('vendor/addons.js')
-    .concat('vendor/ember-cli/vendor-suffix.js');
+  var vendorFiles = [];
+  for (var outputFileName in this.legacyFilesToAppend) {
+    var inputFiles = this.legacyFilesToAppend[outputFileName],
+      outputFile = outputFileName;
 
-  var vendor = this.concatFiles(applicationJs, {
-    inputFiles: inputFiles,
-    outputFile: this.options.outputPaths.vendor.js,
-    separator: EOL + ';',
-    annotation: 'Concat: Vendor'
-  });
+    if (outputFileName === 'vendor') {
+      inputFiles = ['vendor/ember-cli/vendor-prefix.js']
+        .concat(inputFiles)
+        .concat('vendor/addons.js')
+        .concat('vendor/ember-cli/vendor-suffix.js');
 
-  return mergeTrees([
-    vendor,
-    appJs
-  ], {
+      outputFile = this.options.outputPaths.vendor.js;
+    }
+
+    vendorFiles.push(
+      this.concatFiles(applicationJs, {
+        inputFiles: inputFiles,
+        outputFile: outputFile,
+        separator: EOL + ';',
+        annotation: 'Concat: Vendor ' + outputFileName
+      })
+    );
+  }
+
+  return mergeTrees(vendorFiles.concat(appJs), {
     annotation: 'TreeMerger (vendor & appJS)'
   });
 };
@@ -1178,20 +1187,36 @@ EmberApp.prototype.styles = function() {
   var trees = [external].concat(addonTrees);
   trees.push(styles);
 
+  var options = { outputPaths: this.options.outputPaths.app.css };
+  options.registry = this.registry;
+
   var stylesAndVendor = this.addonPreprocessTree('css', mergeTrees(trees, {
     annotation: 'TreeMerger (stylesAndVendor)',
     overwrite: true
   }));
 
-  var options = { outputPaths: this.options.outputPaths.app.css };
-  options.registry = this.registry;
   var preprocessedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
 
+  var vendorStyles = [];
+  for (var outputFileName in this.vendorStaticStyles) {
+    var inputFiles = this.vendorStaticStyles[outputFileName],
+      outputFile = outputFileName;
 
-  var vendorStyles = this.addonPreprocessTree('css', this.concatFiles(stylesAndVendor, {
-    inputFiles: this.vendorStaticStyles.concat(['vendor/addons.css']),
-    outputFile: this.options.outputPaths.vendor.css,
-    annotation: 'Concat: Vendor Styles'
+    if (outputFileName === 'vendor') {
+      inputFiles.push('vendor/addons.css');
+      outputFile = this.options.outputPaths.vendor.css;
+    }
+
+    vendorStyles.push(this.concatFiles(stylesAndVendor, {
+      inputFiles: inputFiles,
+      outputFile: outputFile,
+      annotation: 'Concat: Vendor Styles' + outputFile
+    }));
+  }
+
+  vendorStyles = this.addonPreprocessTree('css', mergeTrees(vendorStyles, {
+    annotation: 'TreeMerger (vendorStyles)',
+    overwrite: true
   }));
 
   if (this.options.minifyCSS.enabled === true) {
@@ -1388,13 +1413,19 @@ EmberApp.prototype.import = function(asset, options) {
  */
 EmberApp.prototype._import = function(assetPath, options, directory, subdirectory, extension) {
   var basename = path.basename(assetPath);
+  var outputFileName = options.outputFile || options.type;
 
+  // @todo: any reason not to use extension argument here?
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if (options.type === 'vendor') {
+      if (!this.legacyFilesToAppend[outputFileName]) {
+        this.legacyFilesToAppend[outputFileName] = [];
+      }
+
       if (options.prepend) {
-        this.legacyFilesToAppend.unshift(assetPath);
+        this.legacyFilesToAppend[outputFileName].unshift(assetPath);
       } else {
-        this.legacyFilesToAppend.push(assetPath);
+        this.legacyFilesToAppend[outputFileName].push(assetPath);
       }
     } else if (options.type === 'test' ) {
       if (options.prepend) {
@@ -1407,7 +1438,11 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
     }
   } else if (extension === '.css') {
     if (options.type === 'vendor') {
-      this.vendorStaticStyles.push(assetPath);
+      if (!this.vendorStaticStyles[outputFileName]) {
+        this.vendorStaticStyles[outputFileName] = [];
+      }
+
+      this.vendorStaticStyles[outputFileName].push(assetPath);
     } else {
       this.vendorTestStaticStyles.push(assetPath);
     }

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -336,6 +336,26 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('specifying outputFile results in a explicitly generated assets', function() {
+    return copyFixtureFiles('brocfile-tests/app-import-output-file')
+      .then(function () {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .then(function() {
+        var files = [
+          '/assets/output-file.js',
+          '/assets/output-file.css',
+          '/assets/vendor.css',
+          '/assets/vendor.js'
+        ];
+
+        var basePath = path.join('.', 'dist');
+        files.forEach(function(file) {
+          expect(existsSync(path.join(basePath, file))).to.be.true;
+        });
+      });
+  });
+
   it('specifying partial `outputPaths` hash deep merges options correctly', function() {
     return copyFixtureFiles('brocfile-tests/custom-output-paths')
       .then(function () {

--- a/tests/fixtures/brocfile-tests/app-import-output-file/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-output-file/ember-cli-build.js
@@ -1,0 +1,13 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  var app = new EmberApp(defaults, {});
+
+  app.import('vendor/custom-output-file.js', {outputFile: '/assets/output-file.js'});
+  app.import('vendor/custom-output-file.css', {outputFile: '/assets/output-file.css'});
+
+  return app.toTree();
+};
+

--- a/tests/fixtures/brocfile-tests/app-import-output-file/vendor/custom-output-file.css
+++ b/tests/fixtures/brocfile-tests/app-import-output-file/vendor/custom-output-file.css
@@ -1,0 +1,3 @@
+body:after {
+  content: "hello from css custom output file"
+}

--- a/tests/fixtures/brocfile-tests/app-import-output-file/vendor/custom-output-file.js
+++ b/tests/fixtures/brocfile-tests/app-import-output-file/vendor/custom-output-file.js
@@ -1,0 +1,1 @@
+console.log("hello from js custom output file");

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -713,20 +713,61 @@ describe('broccoli/ember-app', function() {
   });
 
   describe('import', function() {
+    it('appends dependencies to vendor by default', function() {
+      emberApp = new EmberApp({
+        project: project
+      });
+      emberApp.import('vendor/moment.js');
+      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+
+      expect(outputFile).to.be.instanceof(Array);
+      expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
+    });
     it('appends dependencies', function() {
       emberApp = new EmberApp({
         project: project
       });
       emberApp.import('vendor/moment.js', {type: 'vendor'});
-      expect(emberApp.legacyFilesToAppend.indexOf('vendor/moment.js')).to.equal(emberApp.legacyFilesToAppend.length - 1);
+
+      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+
+      expect(outputFile).to.be.instanceof(Array);
+      expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
     });
     it('prepends dependencies', function() {
       emberApp = new EmberApp({
         project: project
       });
       emberApp.import('vendor/es5-shim.js', {type: 'vendor', prepend: true});
-      expect(emberApp.legacyFilesToAppend.indexOf('vendor/es5-shim.js')).to.equal(0);
+
+      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+
+      expect(outputFile).to.be.instanceof(Array);
+      expect(outputFile.indexOf('vendor/es5-shim.js')).to.equal(0);
     });
+    it('prepends dependencies to outputFile', function() {
+      emberApp = new EmberApp({
+        project: project
+      });
+      emberApp.import('vendor/moment.js', {outputFile: 'moment.js', prepend: true});
+
+      var outputFile = emberApp.legacyFilesToAppend['moment.js'];
+
+      expect(outputFile).to.be.instanceof(Array);
+      expect(outputFile.indexOf('vendor/moment.js')).to.equal(0);
+    });
+    it('appends dependencies to outputFile', function() {
+      emberApp = new EmberApp({
+        project: project
+      });
+      emberApp.import('vendor/moment.js', {outputFile: 'moment.js'});
+
+      var outputFile = emberApp.legacyFilesToAppend['moment.js'];
+
+      expect(outputFile).to.be.instanceof(Array);
+      expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
+    });
+
     it('defaults to development if production is not set', function() {
       process.env.EMBER_ENV = 'production';
       emberApp = new EmberApp({
@@ -735,9 +776,9 @@ describe('broccoli/ember-app', function() {
       emberApp.import({
         'development': 'vendor/jquery.js'
       });
-      expect(emberApp.legacyFilesToAppend.indexOf('vendor/jquery.js')).to.equal(emberApp.legacyFilesToAppend.length -1);
+      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+      expect(outputFile.indexOf('vendor/jquery.js')).to.equal(outputFile.length -1);
       process.env.EMBER_ENV = undefined;
-
     });
     it('honors explicitly set to null in environment', function() {
       process.env.EMBER_ENV = 'production';
@@ -748,7 +789,7 @@ describe('broccoli/ember-app', function() {
         'development': 'vendor/jquery.js',
         'production':  null
       });
-      expect(emberApp.legacyFilesToAppend.indexOf('vendor/jquery.js')).to.equal(-1);
+      expect(emberApp.legacyFilesToAppend['/assets/vendor.js'].indexOf('vendor/jquery.js')).to.equal(-1);
       process.env.EMBER_ENV = undefined;
     });
   });
@@ -871,4 +912,6 @@ describe('broccoli/ember-app', function() {
       expect(emberFiles.development).to.equal('vendor/ember.debug.js');
     });
   });
+
 });
+


### PR DESCRIPTION
Resolves https://github.com/ember-cli/ember-cli/issues/5308

Here we have an ability to import file to a custom output file:
```javascript
app.import('vendor/important-file.js', {outputFile: '/assets/very-important.js'})
```

It also works for css files:
```javascript
app.import('vendor/important-file.css', {outputFile: '/assets/very-important.css'})
```

The side effect of the current implementation is that `prepend` option is now applies for css files(not sure if it's ok).