### PR TITLE
[BUGFIX beta] Replace testem.json with testem.js

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -1,4 +1,5 @@
-{
+/*jshint node:true*/
+module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
@@ -9,4 +10,4 @@
     "PhantomJS",
     "Chrome"
   ]
-}
+};

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -213,7 +213,7 @@ describe('Acceptance: addon-smoke-test', function() {
           '.gitkeep',
           '.travis.yml',
           '.editorconfig',
-          'testem.json',
+          'testem.js',
           '.ember-cli',
           'bower.json',
           '.bowerrc'

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -101,9 +101,6 @@ describe('Acceptance: smoke-test', function() {
   it('ember test still runs when only a JavaScript testem config exists', function() {
     return copyFixtureFiles('smoke-tests/js-testem-config')
       .then(function() {
-        // testem.json "wins" over testem.js by default so we need to delete
-        // it from the default blueprint first
-        fs.unlinkSync('testem.json');
         return ember(['test']);
       })
       .then(function() {


### PR DESCRIPTION
Replace testem.json with testem.js.

JSON syntax is quite limited (no comments, no trailing commas, no single quotes).
Javascript files don't have this limitations and besides give the users access to
more features, like environment variables.

No idea if bugfix beta is the right tag.

Closes #5503