### PR TITLE
Expose a project.generateTestFile() method to be overwritten by test framework addons

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -530,6 +530,30 @@ Project.prototype.findAddonByName = function(name) {
 };
 
 /**
+  Generate test file contents.
+
+  This method is supposed to be overwritten by test framework addons
+  like `ember-cli-qunit` and `ember-cli-mocha`.
+
+  @public
+  @method generateTestFile
+  @param {String} moduleName Name of the test module (e.g. `JSHint`)
+  @param {Object[]} tests Array of tests with `name`, `passed` and `errorMessage` properties
+  @return {String} The test file content
+ */
+Project.prototype.generateTestFile = function(/* moduleName, tests */) {
+  var message = 'Please install an Ember.js test framework addon or update your dependencies.';
+
+  if (this.ui) {
+    this.ui.writeDeprecateLine(message)
+  } else {
+    console.warn(message);
+  }
+
+  return '';
+};
+
+/**
   Returns a new project based on the first package.json that is found
   in `pathName`.
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -525,4 +525,16 @@ describe('models/project.js', function() {
       expect(Project.nullProject()).to.equal(Project.nullProject());
     });
   });
+
+  describe('generateTestFile()', function (){
+    it('returns empty file and shows warning', function() {
+      var ui = new MockUI();
+
+      projectPath = path.resolve(__dirname, '../../fixtures/project');
+      project = new Project(projectPath, {}, ui);
+
+      expect(project.generateTestFile()).to.equal('');
+      expect(ui.output).to.contain('Please install an Ember.js test framework addon or update your dependencies.');
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a `generateTestFile()` method to the `Project` model that is supposed to be overwritten by test framework addons like `ember-cli-qunit` and `ember-cli-mocha`. This function can then be used by linter addons like `ember-cli-eslint` or `broccoli-jscs` to generate tests files without knowledge of the actual test framework being used.

/cc @rwjblue 