### PR TITLE
ESLint: Enable "indent" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,8 @@ module.exports = {
     'strict': [2, 'global'],
 
     // JSHint "indent", disabled due to warnings
-    'indent': [0, 2, {
-      'SwitchCase': 0,
+    'indent': [2, 2, {
+      'SwitchCase': 1,
       'VariableDeclarator': { 'var': 2, 'let': 2, 'const': 3 }
     }],
 

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -63,15 +63,15 @@ module.exports = {
 
 function dsAttr(name, type) {
   switch (type) {
-  case 'belongs-to':
-    return 'DS.belongsTo(\'' + name + '\')';
-  case 'has-many':
-    return 'DS.hasMany(\'' + name + '\')';
-  case '':
-    //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
-    //http://emberjs.com/guides/models/defining-models/
-    return 'DS.attr()';
-  default:
-    return 'DS.attr(\'' + type + '\')';
+    case 'belongs-to':
+      return 'DS.belongsTo(\'' + name + '\')';
+    case 'has-many':
+      return 'DS.hasMany(\'' + name + '\')';
+    case '':
+      //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
+      //http://emberjs.com/guides/models/defining-models/
+      return 'DS.attr()';
+    default:
+      return 'DS.attr(\'' + type + '\')';
   }
 }

--- a/lib/models/update-checker.js
+++ b/lib/models/update-checker.js
@@ -79,11 +79,11 @@ UpdateChecker.prototype.checkNPM = function() {
   var extractVersion = function(data) { return Object.keys(data)[0]; };
 
   return loadNPM({
-      'loglevel': 'silent',
-      'fetch-retries': 1,
-      'cache-min': 1,
-      'cache-max': 0
-    })
+    'loglevel': 'silent',
+    'fetch-retries': 1,
+    'cache-min': 1,
+    'cache-max': 0
+  })
     .then(fetchEmberCliVersion)
     .then(extractVersion)
     .then(this.saveVersionInformation.bind(this))

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -25,12 +25,12 @@ module.exports = Task.extend({
     config.interactive = true;
 
     return new Promise(function(resolve, reject) {
-        bower.commands.install(packages, installOptions, config) // Packages, options, config
-          .on('log', logBowerMessage)
-          .on('prompt', ui.prompt.bind(ui))
-          .on('error', reject)
-          .on('end', resolve);
-      })
+      bower.commands.install(packages, installOptions, config) // Packages, options, config
+        .on('log', logBowerMessage)
+        .on('prompt', ui.prompt.bind(ui))
+        .on('error', reject)
+        .on('end', resolve);
+    })
       .finally(function() { ui.stopProgress(); })
       .then(function() {
         ui.writeLine(chalk.green('Installed browser packages via Bower.'));

--- a/lib/tasks/update.js
+++ b/lib/tasks/update.js
@@ -77,9 +77,9 @@ module.exports = Task.extend({
     }.bind(this));
 
     return loadNPM({
-        loglevel: 'silent',
-        global: true
-      })
+      loglevel: 'silent',
+      global: true
+    })
       .then(npmInstall)
       .then(updateDependencies)
       .catch(reportFailure)

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -625,202 +625,202 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
                   "  //   // Perform extra work here.\n" +
                   "  // }\n" +
                   "};"
-        });
       });
     });
+  });
 
-    it('dummy blueprint foo/bar', function() {
-      return generateInAddon(['blueprint', 'foo/bar', '--dummy']).then(function() {
-        assertFile('blueprints/foo/bar/index.js', {
-          contains: "module.exports = {\n" +
-                    "  description: ''\n" +
-                    "\n" +
-                    "  // locals: function(options) {\n" +
-                    "  //   // Return custom template variables here.\n" +
-                    "  //   return {\n" +
-                    "  //     foo: options.entity.options.foo\n" +
-                    "  //   };\n" +
-                    "  // }\n" +
-                    "\n" +
-                    "  // afterInstall: function(options) {\n" +
-                    "  //   // Perform extra work here.\n" +
-                    "  // }\n" +
-                    "};"
-        });
+  it('dummy blueprint foo/bar', function() {
+    return generateInAddon(['blueprint', 'foo/bar', '--dummy']).then(function() {
+      assertFile('blueprints/foo/bar/index.js', {
+        contains: "module.exports = {\n" +
+                  "  description: ''\n" +
+                  "\n" +
+                  "  // locals: function(options) {\n" +
+                  "  //   // Return custom template variables here.\n" +
+                  "  //   return {\n" +
+                  "  //     foo: options.entity.options.foo\n" +
+                  "  //   };\n" +
+                  "  // }\n" +
+                  "\n" +
+                  "  // afterInstall: function(options) {\n" +
+                  "  //   // Perform extra work here.\n" +
+                  "  // }\n" +
+                  "};"
       });
     });
+  });
 
-    it('dummy http-mock foo', function() {
-      return generateInAddon(['http-mock', 'foo', '--dummy']).then(function() {
-        assertFile('server/index.js', {
-          contains:"mocks.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/mocks/foo.js', {
-          contains: "module.exports = function(app) {\n" +
-                    "  var express = require('express');\n" +
-                    "  var fooRouter = express.Router();\n" +
-                    "\n" +
-                    "  fooRouter.get('/', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': []\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.post('/', function(req, res) {\n" +
-                    "    res.status(201).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.get('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.put('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.delete('/:id', function(req, res) {\n" +
-                    "    res.status(204).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  // The POST and PUT call will not contain a request body\n" +
-                    "  // because the body-parser is not included by default.\n" +
-                    "  // To use req.body, run:\n" +
-                    "\n" +
-                    "  //    npm install --save-dev body-parser\n" +
-                    "\n" +
-                    "  // After installing, you need to `use` the body-parser for\n" +
-                    "  // this mock uncommenting the following line:\n" +
-                    "  //\n" +
-                    "  //app.use('/api/foo', require('body-parser').json());\n" +
-                    "  app.use('/api/foo', fooRouter);\n" +
-                    "};\n"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('dummy http-mock foo', function() {
+    return generateInAddon(['http-mock', 'foo', '--dummy']).then(function() {
+      assertFile('server/index.js', {
+        contains:"mocks.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/mocks/foo.js', {
+        contains: "module.exports = function(app) {\n" +
+                  "  var express = require('express');\n" +
+                  "  var fooRouter = express.Router();\n" +
+                  "\n" +
+                  "  fooRouter.get('/', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': []\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.post('/', function(req, res) {\n" +
+                  "    res.status(201).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.get('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.put('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.delete('/:id', function(req, res) {\n" +
+                  "    res.status(204).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  // The POST and PUT call will not contain a request body\n" +
+                  "  // because the body-parser is not included by default.\n" +
+                  "  // To use req.body, run:\n" +
+                  "\n" +
+                  "  //    npm install --save-dev body-parser\n" +
+                  "\n" +
+                  "  // After installing, you need to `use` the body-parser for\n" +
+                  "  // this mock uncommenting the following line:\n" +
+                  "  //\n" +
+                  "  //app.use('/api/foo', require('body-parser').json());\n" +
+                  "  app.use('/api/foo', fooRouter);\n" +
+                  "};\n"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('dummy http-mock foo-bar', function() {
-      return generateInAddon(['http-mock', 'foo-bar', '--dummy']).then(function() {
-        assertFile('server/index.js', {
-          contains: "mocks.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/mocks/foo-bar.js', {
-          contains: "module.exports = function(app) {\n" +
-                    "  var express = require('express');\n" +
-                    "  var fooBarRouter = express.Router();\n" +
-                    "\n" +
-                    "  fooBarRouter.get('/', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': []\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.post('/', function(req, res) {\n" +
-                    "    res.status(201).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                    "    res.status(204).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  // The POST and PUT call will not contain a request body\n" +
-                    "  // because the body-parser is not included by default.\n" +
-                    "  // To use req.body, run:\n" +
-                    "\n" +
-                    "  //    npm install --save-dev body-parser\n" +
-                    "\n" +
-                    "  // After installing, you need to `use` the body-parser for\n" +
-                    "  // this mock uncommenting the following line:\n" +
-                    "  //\n" +
-                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                    "};\n"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('dummy http-mock foo-bar', function() {
+    return generateInAddon(['http-mock', 'foo-bar', '--dummy']).then(function() {
+      assertFile('server/index.js', {
+        contains: "mocks.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/mocks/foo-bar.js', {
+        contains: "module.exports = function(app) {\n" +
+                  "  var express = require('express');\n" +
+                  "  var fooBarRouter = express.Router();\n" +
+                  "\n" +
+                  "  fooBarRouter.get('/', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': []\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.post('/', function(req, res) {\n" +
+                  "    res.status(201).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                  "    res.status(204).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  // The POST and PUT call will not contain a request body\n" +
+                  "  // because the body-parser is not included by default.\n" +
+                  "  // To use req.body, run:\n" +
+                  "\n" +
+                  "  //    npm install --save-dev body-parser\n" +
+                  "\n" +
+                  "  // After installing, you need to `use` the body-parser for\n" +
+                  "  // this mock uncommenting the following line:\n" +
+                  "  //\n" +
+                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                  "};\n"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('dummy http-proxy foo', function() {
-      return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000', '--dummy']).then(function() {
-        assertFile('server/index.js', {
-          contains: "proxies.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/proxies/foo.js', {
-          contains: "var proxyPath = '/foo';\n" +
-                    "\n" +
-                    "module.exports = function(app) {\n" +
-                    "  // For options, see:\n" +
-                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                    "\n" +
-                    "  proxy.on('error', function(err, req) {\n" +
-                    "    console.error(err, req.url);\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  app.use(proxyPath, function(req, res, next){\n" +
-                    "    // include root path in proxied request\n" +
-                    "    req.url = proxyPath + '/' + req.url;\n" +
-                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                    "  });\n" +
-                    "};"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('dummy http-proxy foo', function() {
+    return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000', '--dummy']).then(function() {
+      assertFile('server/index.js', {
+        contains: "proxies.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/proxies/foo.js', {
+        contains: "var proxyPath = '/foo';\n" +
+                  "\n" +
+                  "module.exports = function(app) {\n" +
+                  "  // For options, see:\n" +
+                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "\n" +
+                  "  proxy.on('error', function(err, req) {\n" +
+                  "    console.error(err, req.url);\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  app.use(proxyPath, function(req, res, next){\n" +
+                  "    // include root path in proxied request\n" +
+                  "    req.url = proxyPath + '/' + req.url;\n" +
+                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                  "  });\n" +
+                  "};"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('dummy server', function() {
-      return generateInAddon(['server', '--dummy']).then(function() {
-        assertFile('server/index.js');
-        assertFile('server/.jshintrc');
-      });
+  it('dummy server', function() {
+    return generateInAddon(['server', '--dummy']).then(function() {
+      assertFile('server/index.js');
+      assertFile('server/.jshintrc');
     });
+  });
 
-    it('dummy acceptance-test foo', function() {
-      return generateInAddon(['acceptance-test', 'foo', '--dummy']).then(function() {
-        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-expected.js');
+  it('dummy acceptance-test foo', function() {
+    return generateInAddon(['acceptance-test', 'foo', '--dummy']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-expected.js');
 
-        assertFileEquals('tests/acceptance/foo-test.js', expected);
-        assertFileToNotExist('app/acceptance-tests/foo.js');
-      });
+      assertFileEquals('tests/acceptance/foo-test.js', expected);
+      assertFileToNotExist('app/acceptance-tests/foo.js');
     });
+  });
 
-    it('dummy acceptance-test foo/bar', function() {
-      return generateInAddon(['acceptance-test', 'foo/bar', '--dummy']).then(function() {
-        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');
+  it('dummy acceptance-test foo/bar', function() {
+    return generateInAddon(['acceptance-test', 'foo/bar', '--dummy']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');
 
-        assertFileEquals('tests/acceptance/foo/bar-test.js', expected);
-        assertFileToNotExist('app/acceptance-tests/foo/bar.js');
-      });
+      assertFileEquals('tests/acceptance/foo/bar-test.js', expected);
+      assertFileToNotExist('app/acceptance-tests/foo/bar.js');
     });
+  });
 
 });

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -907,201 +907,201 @@ describe('Acceptance: ember generate in-addon', function() {
                   "  //   // Perform extra work here.\n" +
                   "  // }\n" +
                   "};"
-        });
       });
     });
+  });
 
-    it('in-addon blueprint foo/bar', function() {
-      return generateInAddon(['blueprint', 'foo/bar']).then(function() {
-        assertFile('blueprints/foo/bar/index.js', {
-          contains: "module.exports = {\n" +
-                    "  description: ''\n" +
-                    "\n" +
-                    "  // locals: function(options) {\n" +
-                    "  //   // Return custom template variables here.\n" +
-                    "  //   return {\n" +
-                    "  //     foo: options.entity.options.foo\n" +
-                    "  //   };\n" +
-                    "  // }\n" +
-                    "\n" +
-                    "  // afterInstall: function(options) {\n" +
-                    "  //   // Perform extra work here.\n" +
-                    "  // }\n" +
-                    "};"
-        });
+  it('in-addon blueprint foo/bar', function() {
+    return generateInAddon(['blueprint', 'foo/bar']).then(function() {
+      assertFile('blueprints/foo/bar/index.js', {
+        contains: "module.exports = {\n" +
+                  "  description: ''\n" +
+                  "\n" +
+                  "  // locals: function(options) {\n" +
+                  "  //   // Return custom template variables here.\n" +
+                  "  //   return {\n" +
+                  "  //     foo: options.entity.options.foo\n" +
+                  "  //   };\n" +
+                  "  // }\n" +
+                  "\n" +
+                  "  // afterInstall: function(options) {\n" +
+                  "  //   // Perform extra work here.\n" +
+                  "  // }\n" +
+                  "};"
       });
     });
+  });
 
-    it('in-addon http-mock foo', function() {
-      return generateInAddon(['http-mock', 'foo']).then(function() {
-        assertFile('server/index.js', {
-          contains:"mocks.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/mocks/foo.js', {
-          contains: "module.exports = function(app) {\n" +
-                    "  var express = require('express');\n" +
-                    "  var fooRouter = express.Router();\n" +
-                    "\n" +
-                    "  fooRouter.get('/', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': []\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.post('/', function(req, res) {\n" +
-                    "    res.status(201).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.get('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.put('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooRouter.delete('/:id', function(req, res) {\n" +
-                    "    res.status(204).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  // The POST and PUT call will not contain a request body\n" +
-                    "  // because the body-parser is not included by default.\n" +
-                    "  // To use req.body, run:\n" +
-                    "\n" +
-                    "  //    npm install --save-dev body-parser\n" +
-                    "\n" +
-                    "  // After installing, you need to `use` the body-parser for\n" +
-                    "  // this mock uncommenting the following line:\n" +
-                    "  //\n" +
-                    "  //app.use('/api/foo', require('body-parser').json());\n" +
-                    "  app.use('/api/foo', fooRouter);\n" +
-                    "};"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('in-addon http-mock foo', function() {
+    return generateInAddon(['http-mock', 'foo']).then(function() {
+      assertFile('server/index.js', {
+        contains:"mocks.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/mocks/foo.js', {
+        contains: "module.exports = function(app) {\n" +
+                  "  var express = require('express');\n" +
+                  "  var fooRouter = express.Router();\n" +
+                  "\n" +
+                  "  fooRouter.get('/', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': []\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.post('/', function(req, res) {\n" +
+                  "    res.status(201).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.get('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.put('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooRouter.delete('/:id', function(req, res) {\n" +
+                  "    res.status(204).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  // The POST and PUT call will not contain a request body\n" +
+                  "  // because the body-parser is not included by default.\n" +
+                  "  // To use req.body, run:\n" +
+                  "\n" +
+                  "  //    npm install --save-dev body-parser\n" +
+                  "\n" +
+                  "  // After installing, you need to `use` the body-parser for\n" +
+                  "  // this mock uncommenting the following line:\n" +
+                  "  //\n" +
+                  "  //app.use('/api/foo', require('body-parser').json());\n" +
+                  "  app.use('/api/foo', fooRouter);\n" +
+                  "};"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('in-addon http-mock foo-bar', function() {
-      return generateInAddon(['http-mock', 'foo-bar']).then(function() {
-        assertFile('server/index.js', {
-          contains: "mocks.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/mocks/foo-bar.js', {
-          contains: "module.exports = function(app) {\n" +
-                    "  var express = require('express');\n" +
-                    "  var fooBarRouter = express.Router();\n" +
-                    "\n" +
-                    "  fooBarRouter.get('/', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': []\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.post('/', function(req, res) {\n" +
-                    "    res.status(201).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                    "    res.send({\n" +
-                    "      'foo-bar': {\n" +
-                    "        id: req.params.id\n" +
-                    "      }\n" +
-                    "    });\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                    "    res.status(204).end();\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  // The POST and PUT call will not contain a request body\n" +
-                    "  // because the body-parser is not included by default.\n" +
-                    "  // To use req.body, run:\n" +
-                    "\n" +
-                    "  //    npm install --save-dev body-parser\n" +
-                    "\n" +
-                    "  // After installing, you need to `use` the body-parser for\n" +
-                    "  // this mock uncommenting the following line:\n" +
-                    "  //\n" +
-                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                    "};"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('in-addon http-mock foo-bar', function() {
+    return generateInAddon(['http-mock', 'foo-bar']).then(function() {
+      assertFile('server/index.js', {
+        contains: "mocks.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/mocks/foo-bar.js', {
+        contains: "module.exports = function(app) {\n" +
+                  "  var express = require('express');\n" +
+                  "  var fooBarRouter = express.Router();\n" +
+                  "\n" +
+                  "  fooBarRouter.get('/', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': []\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.post('/', function(req, res) {\n" +
+                  "    res.status(201).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                  "    res.send({\n" +
+                  "      'foo-bar': {\n" +
+                  "        id: req.params.id\n" +
+                  "      }\n" +
+                  "    });\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                  "    res.status(204).end();\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  // The POST and PUT call will not contain a request body\n" +
+                  "  // because the body-parser is not included by default.\n" +
+                  "  // To use req.body, run:\n" +
+                  "\n" +
+                  "  //    npm install --save-dev body-parser\n" +
+                  "\n" +
+                  "  // After installing, you need to `use` the body-parser for\n" +
+                  "  // this mock uncommenting the following line:\n" +
+                  "  //\n" +
+                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                  "};"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('in-addon http-proxy foo', function() {
-      return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
-        assertFile('server/index.js', {
-          contains: "proxies.forEach(function(route) { route(app); });"
-        });
-        assertFile('server/proxies/foo.js', {
-          contains: "var proxyPath = '/foo';\n" +
-                    "\n" +
-                    "module.exports = function(app) {\n" +
-                    "  // For options, see:\n" +
-                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                    "\n" +
-                    "  proxy.on('error', function(err, req) {\n" +
-                    "    console.error(err, req.url);\n" +
-                    "  });\n" +
-                    "\n" +
-                    "  app.use(proxyPath, function(req, res, next){\n" +
-                    "    // include root path in proxied request\n" +
-                    "    req.url = proxyPath + '/' + req.url;\n" +
-                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                    "  });\n" +
-                    "};"
-        });
-        assertFile('server/.jshintrc', {
-          contains: '{\n  "node": true\n}'
-        });
+  it('in-addon http-proxy foo', function() {
+    return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
+      assertFile('server/index.js', {
+        contains: "proxies.forEach(function(route) { route(app); });"
+      });
+      assertFile('server/proxies/foo.js', {
+        contains: "var proxyPath = '/foo';\n" +
+                  "\n" +
+                  "module.exports = function(app) {\n" +
+                  "  // For options, see:\n" +
+                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "\n" +
+                  "  proxy.on('error', function(err, req) {\n" +
+                  "    console.error(err, req.url);\n" +
+                  "  });\n" +
+                  "\n" +
+                  "  app.use(proxyPath, function(req, res, next){\n" +
+                  "    // include root path in proxied request\n" +
+                  "    req.url = proxyPath + '/' + req.url;\n" +
+                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                  "  });\n" +
+                  "};"
+      });
+      assertFile('server/.jshintrc', {
+        contains: '{\n  "node": true\n}'
       });
     });
+  });
 
-    it('in-addon server', function() {
-      return generateInAddon(['server']).then(function() {
-        assertFile('server/index.js');
-        assertFile('server/.jshintrc');
-      });
+  it('in-addon server', function() {
+    return generateInAddon(['server']).then(function() {
+      assertFile('server/index.js');
+      assertFile('server/.jshintrc');
     });
+  });
 
-    it('in-addon acceptance-test foo', function() {
-      return generateInAddon(['acceptance-test', 'foo']).then(function() {
-        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-expected.js');
+  it('in-addon acceptance-test foo', function() {
+    return generateInAddon(['acceptance-test', 'foo']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-expected.js');
 
-        assertFileEquals('tests/acceptance/foo-test.js', expected);
-        assertFileToNotExist('app/acceptance-tests/foo.js');
-      });
+      assertFileEquals('tests/acceptance/foo-test.js', expected);
+      assertFileToNotExist('app/acceptance-tests/foo.js');
     });
+  });
 
-    it('in-addon acceptance-test foo/bar', function() {
-      return generateInAddon(['acceptance-test', 'foo/bar']).then(function() {
-        var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');
+  it('in-addon acceptance-test foo/bar', function() {
+    return generateInAddon(['acceptance-test', 'foo/bar']).then(function() {
+      var expected = path.join(__dirname, '../fixtures/generate/addon-acceptance-test-nested-expected.js');
 
-        assertFileEquals('tests/acceptance/foo/bar-test.js', expected);
-        assertFileToNotExist('app/acceptance-tests/foo/bar.js');
-      });
+      assertFileEquals('tests/acceptance/foo/bar-test.js', expected);
+      assertFileToNotExist('app/acceptance-tests/foo/bar.js');
     });
+  });
 });

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -245,7 +245,7 @@ describe('Acceptance: ember destroy', function() {
       });
   });
 
-    it('route foo --skip-router', function() {
+  it('route foo --skip-router', function() {
     var commandArgs = ['route', 'foo', '--skip-router'];
     var files       = [
       'app/routes/foo.js',

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -359,7 +359,7 @@ describe('Acceptance: ember generate', function() {
     });
   });
 
-    it('route foo with --skip-router', function() {
+  it('route foo with --skip-router', function() {
     return generate(['route', 'foo', '--skip-router']).then(function() {
       assertFile('app/router.js', {
         doesNotContain: 'this.route(\'foo\')'
@@ -1330,33 +1330,30 @@ describe('Acceptance: ember generate', function() {
   });
 
   it('custom blueprint availableOptions', function() {
-    return initApp()
-      .then(function() {
-        return ember(['generate', 'blueprint', 'foo'])
-          .then(function() {
-            replaceFile('blueprints/foo/index.js', 'module.exports = {',
-              'module.exports = {\navailableOptions: [ \n' +
-              '{ name: \'foo\',\ntype: String, \n' +
-              'values: [\'one\', \'two\'],\n' +
-              'default: \'one\',\n' +
-              'aliases: [ {\'one\': \'one\'}, {\'two\': \'two\'} ] } ],\n' +
-              'locals: function(options) {\n' +
-              'return { foo: options.foo };\n' +
-              '},');
-            return outputFile(
-              'blueprints/foo/files/app/foos/__name__.js',
-              "import Ember from 'ember';\n" +
-              'export default Ember.Object.extend({ foo: <%= foo %> });\n'
-            )
-              .then(function() {
-                return ember(['generate','foo','bar','-two']);
-              });
-      });
-    })
-      .then(function() {
-        assertFile('app/foos/bar.js', {
-          contain: ['export default Ember.Object.extend({ foo: two });']
+    return initApp().then(function() {
+      return ember(['generate', 'blueprint', 'foo']).then(function() {
+        replaceFile('blueprints/foo/index.js', 'module.exports = {',
+          'module.exports = {\navailableOptions: [ \n' +
+          '{ name: \'foo\',\ntype: String, \n' +
+          'values: [\'one\', \'two\'],\n' +
+          'default: \'one\',\n' +
+          'aliases: [ {\'one\': \'one\'}, {\'two\': \'two\'} ] } ],\n' +
+          'locals: function(options) {\n' +
+          'return { foo: options.foo };\n' +
+          '},');
+
+        return outputFile(
+          'blueprints/foo/files/app/foos/__name__.js',
+          "import Ember from 'ember';\n" +
+          'export default Ember.Object.extend({ foo: <%= foo %> });\n'
+        ).then(function() {
+          return ember(['generate','foo','bar','-two']);
         });
       });
+    }).then(function() {
+      assertFile('app/foos/bar.js', {
+        contain: ['export default Ember.Object.extend({ foo: two });']
+      });
+    });
   });
 });

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -78,11 +78,11 @@ describe('Acceptance: ember init', function() {
 
   function pickSync(filePath, pattern) {
     return glob.sync(path.join('**', pattern), {
-        cwd: filePath,
-        dot: true,
-        mark: true,
-        strict: true
-      }).sort();
+      cwd: filePath,
+      dot: true,
+      mark: true,
+      strict: true
+    }).sort();
   }
   function removeIgnored(array) {
     remove(array, function(fn) {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -189,14 +189,14 @@ describe('Acceptance: ember new', function() {
       })
       .then(function() {
         fs.writeFileSync('./tmp/my_blueprint/index.js', [
-            'module.exports = {',
-            '  availableOptions: [ { name: \'custom-option\' } ],',
-            '  locals: function(options) {',
-            '    return {',
-            '      customOption: options.customOption',
-            '    };',
-            '  }',
-            '};'
+          'module.exports = {',
+          '  availableOptions: [ { name: \'custom-option\' } ],',
+          '  locals: function(options) {',
+          '    return {',
+          '      customOption: options.customOption',
+          '    };',
+          '  }',
+          '};'
         ].join('\n'));
         fs.writeFileSync('./tmp/my_blueprint/files/gitignore', '<%= customOption %>');
 

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -882,7 +882,7 @@ describe('Acceptance: ember generate pod', function() {
             '});'
           ]
         });
-    });
+      });
   });
 
   it('route foo --pod with --reset-namespace', function() {

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -112,16 +112,14 @@ function createTestTargets(projectName, options) {
   }
 
   return createTmp(function() {
-    return command().
-      catch(handleResult).
-      then(function(value) {
-        if (noNodeModules) {
-          return exec('npm install ember-disable-prototype-extensions').then(function() {
-            return value;
-          });
-        }
+    return command().catch(handleResult).then(function(value) {
+      if (noNodeModules) {
+        return exec('npm install ember-disable-prototype-extensions').then(function() {
+          return value;
+        });
+      }
 
-        return value;
+      return value;
     });
   });
 }

--- a/tests/helpers/assert-file-to-not-exist.js
+++ b/tests/helpers/assert-file-to-not-exist.js
@@ -15,9 +15,9 @@ module.exports = function assertFileToNotExist(pathToCheck) {
     exists = fs.readFileSync(pathToCheck, { encoding: 'utf-8' });
   } catch (e) {
     if (e.code === 'ENOENT') {
-        exists = null;
+      exists = null;
     } else {
-        throw e;
+      throw e;
     }
   }
   expect(exists).to.not.exist;

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -444,45 +444,45 @@ describe('broccoli/ember-app', function() {
       });
     });
     describe('postprocessTree is called properly', function() {
-        var postprocessTreeStub;
-        beforeEach(function() {
-          emberApp = new EmberApp({
-            project: project
-          });
-
-          postprocessTreeStub = stub(emberApp, 'addonPostprocessTree', ['batman']);
+      var postprocessTreeStub;
+      beforeEach(function() {
+        emberApp = new EmberApp({
+          project: project
         });
 
-
-        it('styles calls addonTreesFor', function() {
-          emberApp.styles();
-
-          expect(postprocessTreeStub.calledWith[0][0]).to.equal('css');
-          expect(postprocessTreeStub.calledWith[0][1].description).to.equal('styles', 'should be called with consolidated tree');
-        });
+        postprocessTreeStub = stub(emberApp, 'addonPostprocessTree', ['batman']);
+      });
 
 
-        it('template type is called', function() {
-          var oldLoad = emberApp.registry.load;
-          emberApp.registry.load = function(type) {
-            if (type === 'template'){
-              return [
-                {
-                  toTree: function() {
-                    return {
-                      description: 'template'
-                    };
-                  }
-                }];
-            } else {
-              return oldLoad.call(emberApp.registry, type);
-            }
-          };
+      it('styles calls addonTreesFor', function() {
+        emberApp.styles();
 
-          emberApp._processedTemplatesTree();
-          expect(postprocessTreeStub.calledWith[0][0]).to.equal('template');
-          expect(postprocessTreeStub.calledWith[0][1].description).to.equal('template', 'should be called with consolidated tree');
-        });
+        expect(postprocessTreeStub.calledWith[0][0]).to.equal('css');
+        expect(postprocessTreeStub.calledWith[0][1].description).to.equal('styles', 'should be called with consolidated tree');
+      });
+
+
+      it('template type is called', function() {
+        var oldLoad = emberApp.registry.load;
+        emberApp.registry.load = function(type) {
+          if (type === 'template'){
+            return [
+              {
+                toTree: function() {
+                  return {
+                    description: 'template'
+                  };
+                }
+              }];
+          } else {
+            return oldLoad.call(emberApp.registry, type);
+          }
+        };
+
+        emberApp._processedTemplatesTree();
+        expect(postprocessTreeStub.calledWith[0][0]).to.equal('template');
+        expect(postprocessTreeStub.calledWith[0][1].description).to.equal('template', 'should be called with consolidated tree');
+      });
     });
 
     describe('toTree', function() {

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -64,7 +64,7 @@ describe('build command', function() {
   it('BuildWatch task is provided with a watcher option', function() {
     return command.validateAndRun(['--watch', '--watcher poller']).then(function() {
       var buildWatchRun = tasks.BuildWatch.prototype.run,
-        calledWith = buildWatchRun.calledWith[0]['0'];
+          calledWith = buildWatchRun.calledWith[0]['0'];
 
       expect(buildWatchRun.called).to.equal(1, 'expected run to be called once');
       expect(calledWith.watcherPoller).to.equal(true, 'expected run to be called with a poller option');

--- a/tests/unit/commands/install-bower-test.js
+++ b/tests/unit/commands/install-bower-test.js
@@ -37,7 +37,7 @@ describe('install:bower command', function() {
   });
 
   it('throws a friendly slient error without args', function() {
-     return command.validateAndRun([]).then(function() {
+    return command.validateAndRun([]).then(function() {
       expect(false, 'should reject with error').to.be.ok;
     }).catch(function(error) {
       expect(error.message).to.equal(

--- a/tests/unit/commands/install-npm-test.js
+++ b/tests/unit/commands/install-npm-test.js
@@ -37,7 +37,7 @@ describe('install:npm command', function() {
   });
 
   it('throws a friendly slient error without args', function() {
-     return command.validateAndRun([]).then(function() {
+    return command.validateAndRun([]).then(function() {
       expect(false, 'should reject with error').to.be.ok;
     }).catch(function(error) {
       expect(error.message).to.equal(

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -376,15 +376,12 @@ help in detail');
       });
 
       it('iterates options', function() {
-        var availableOptions = [
-          {
-            type: 'my-string-type',
-            showAnything: true
-          },
-          {
-            type: function myFunctionType() {}
-          }
-        ];
+        var availableOptions = [{
+          type: 'my-string-type',
+          showAnything: true
+        }, {
+          type: function myFunctionType() {}
+        }];
 
         assign(blueprint, {
           test1: 'a test',
@@ -509,16 +506,14 @@ help in detail');
 
           expect(actualFiles).to.deep.equal(basicBlueprintFiles);
 
-          expect( function(){
-            fs.readFile(path.join(tmpdir , 'test.txt'), 'utf-8',
-                function(err, content){
-                    if(err){
-                        throw 'error';
-                    }
-                    expect(content).to.match(/I AM TESTY/);
-                });
-            }
-          ).not.to.throw();
+          expect(function() {
+            fs.readFile(path.join(tmpdir , 'test.txt'), 'utf-8', function(err, content) {
+              if(err){
+                throw 'error';
+              }
+              expect(content).to.match(/I AM TESTY/);
+            });
+          }).not.to.throw();
 
         });
     });
@@ -605,11 +600,11 @@ help in detail');
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
           var globFiles = glob.sync(path.join('**', 'foo.txt'), {
-              cwd: tmpdir,
-              dot: true,
-              mark: true,
-              strict: true
-            }).sort();
+            cwd: tmpdir,
+            dot: true,
+            mark: true,
+            strict: true
+          }).sort();
           var output = ui.output.trim().split(EOL);
 
           expect(output.shift()).to.match(/^installing/);
@@ -626,11 +621,11 @@ help in detail');
         .then(function() {
           var actualFiles = walkSync(tmpdir).sort();
           var globFiles = glob.sync(path.join('**', '*.txt'), {
-              cwd: tmpdir,
-              dot: true,
-              mark: true,
-              strict: true
-            }).sort();
+            cwd: tmpdir,
+            dot: true,
+            mark: true,
+            strict: true
+          }).sort();
           var output = ui.output.trim().split(EOL);
 
           expect(output.shift()).to.match(/^installing/);
@@ -809,18 +804,17 @@ help in detail');
 
       options.entity = { name: 'foo' };
 
-      return blueprint.install(options)
-        .then(function() {
-            expect(localsCalled).to.be.true;
-            expect(normalizeEntityNameCalled).to.be.true;
-            expect(fileMapTokensCalled).to.be.true;
-            expect(filesPathCalled).to.be.true;
-            expect(beforeInstallCalled).to.be.true;
-            expect(afterInstallCalled).to.be.true;
+      return blueprint.install(options).then(function() {
+        expect(localsCalled).to.be.true;
+        expect(normalizeEntityNameCalled).to.be.true;
+        expect(fileMapTokensCalled).to.be.true;
+        expect(filesPathCalled).to.be.true;
+        expect(beforeInstallCalled).to.be.true;
+        expect(afterInstallCalled).to.be.true;
 
-            expect(beforeUninstallCalled).to.be.false;
-            expect(afterUninstallCalled).to.be.false;
-        });
+        expect(beforeUninstallCalled).to.be.false;
+        expect(afterUninstallCalled).to.be.false;
+      });
     });
   });
 
@@ -936,18 +930,17 @@ help in detail');
 
       options.entity = { name: 'foo' };
 
-      return blueprint.uninstall(options)
-        .then(function() {
-            expect(localsCalled).to.be.true;
-            expect(normalizeEntityNameCalled).to.be.true;
-            expect(fileMapTokensCalled).to.be.true;
-            expect(filesPathCalled).to.be.true;
-            expect(beforeUninstallCalled).to.be.true;
-            expect(afterUninstallCalled).to.be.true;
+      return blueprint.uninstall(options).then(function() {
+        expect(localsCalled).to.be.true;
+        expect(normalizeEntityNameCalled).to.be.true;
+        expect(fileMapTokensCalled).to.be.true;
+        expect(filesPathCalled).to.be.true;
+        expect(beforeUninstallCalled).to.be.true;
+        expect(afterUninstallCalled).to.be.true;
 
-            expect(beforeInstallCalled).to.be.false;
-            expect(afterInstallCalled).to.be.false;
-        });
+        expect(beforeInstallCalled).to.be.false;
+        expect(afterInstallCalled).to.be.false;
+      });
     });
   });
 

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -67,16 +67,14 @@ var OptionsAliasCommand = Command.extend({
       { 'hard-shell': 'hard-shell' },
       { 'soft-shell': 'soft-shell' }
     ]
-  },
-  {
+  }, {
     name: 'spicy',
     type: Boolean,
     default: true,
     aliases: [
       { 'mild': false }
     ]
-  },
-  {
+  }, {
     name: 'display-message',
     type: String,
     aliases: [
@@ -326,28 +324,25 @@ describe('models/command.js', function() {
 
   it('registerOptions() should not allow aliases with the same name.', function() {
     var optionsAlias = new OptionsAliasCommand(options);
-    var extendedAvailableOptions = [
-      {
-        name: 'filling',
-        type: String,
-        default: 'adobada',
-        aliases: [
-          { 'carne-asada': 'carne-asada' },
-          { 'carnitas': 'carnitas' },
-          { 'fish': 'fish' }
-        ]
-      },
-      {
-        name: 'favorite',
-        type: String,
-        default: 'adobada',
-        aliases: [
-          { 'carne-asada': 'carne-asada' },
-          { 'carnitas': 'carnitas' },
-          { 'fish': 'fish' }
-        ]
-      }
-    ];
+    var extendedAvailableOptions = [{
+      name: 'filling',
+      type: String,
+      default: 'adobada',
+      aliases: [
+        { 'carne-asada': 'carne-asada' },
+        { 'carnitas': 'carnitas' },
+        { 'fish': 'fish' }
+      ]
+    }, {
+      name: 'favorite',
+      type: String,
+      default: 'adobada',
+      aliases: [
+        { 'carne-asada': 'carne-asada' },
+        { 'carnitas': 'carnitas' },
+        { 'fish': 'fish' }
+      ]
+    }];
     var register = optionsAlias.registerOptions.bind(optionsAlias);
 
     optionsAlias.availableOptions = extendedAvailableOptions;
@@ -357,16 +352,14 @@ describe('models/command.js', function() {
 
   it('registerOptions() should warn on options override attempts.', function() {
     var optionsAlias = new OptionsAliasCommand(options);
-    var extendedAvailableOptions = [
-      {
-        name: 'spicy',
-        type: Boolean,
-        default: true,
-        aliases: [
-          { 'mild': true }
-        ]
-      }
-    ];
+    var extendedAvailableOptions = [{
+      name: 'spicy',
+      type: Boolean,
+      default: true,
+      aliases: [
+        { 'mild': true }
+      ]
+    }];
     optionsAlias.registerOptions({ availableOptions: extendedAvailableOptions });
     expect(ui.output).to.match(/The ".*" alias cannot be overridden. Please use a different alias./);
   });
@@ -375,13 +368,11 @@ describe('models/command.js', function() {
     //check for different types, validate proper errors are thrown
     var optionsAlias = new OptionsAliasCommand(options);
     var badArrayAvailableOptions = [{ name: 'filling', type: String, default: 'adobada', aliases: [
-        'meat', [{ 'carne-asada': 'carne-asada' }], { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
-      ]
-    }];
+      'meat', [{ 'carne-asada': 'carne-asada' }], { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
+    ]}];
     var badObjectAvailableOptions = [{ name: 'filling', type: String, default: 'adobada', aliases: [
-        'meat', { 'carne-asada': ['steak','grilled']}, { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
-      ]
-    }];
+      'meat', { 'carne-asada': ['steak','grilled']}, { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
+    ]}];
     var register = optionsAlias.registerOptions.bind(optionsAlias);
 
     optionsAlias.availableOptions = badArrayAvailableOptions;
@@ -469,13 +460,11 @@ describe('models/command.js', function() {
     ];
     optionsAlias.registerOptions({ availableOptions: garbageAvailableOptions });
     var extendedAvailableOptions = [{ name: 'filling', type: String, default: 'adobada', aliases: [
-        { 'carne-asada': 'carne-asada' }, { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
-      ]
-    }];
+      { 'carne-asada': 'carne-asada' }, { 'carnitas': 'carnitas' }, { 'fish': 'fish' }
+    ]}];
     var duplicateExtendedAvailableOptions = [{ name: 'filling', type: String, default: 'carnitas', aliases: [
-        { 'pollo-asado': 'pollo-asado' }, { 'carne-asada': 'carne-asada' }
-      ]
-    }];
+      { 'pollo-asado': 'pollo-asado' }, { 'carne-asada': 'carne-asada' }
+    ]}];
     optionsAlias.registerOptions({ availableOptions: extendedAvailableOptions });
     optionsAlias.availableOptions.push(duplicateExtendedAvailableOptions[0]);
 

--- a/tests/unit/models/update-checker-test.js
+++ b/tests/unit/models/update-checker-test.js
@@ -29,13 +29,13 @@ describe('Update Checker', function() {
 
     // overwrite doCheck so it ignores any existing configstore
     updateChecker.doCheck = (function() {
-        var doCheck = updateChecker.doCheck;
+      var doCheck = updateChecker.doCheck;
 
-        return function() {
-          updateChecker.versionConfig = versionConfig;
-          return doCheck.apply(this);
-        };
-      }());
+      return function() {
+        updateChecker.versionConfig = versionConfig;
+        return doCheck.apply(this);
+      };
+    }());
 
     updateChecker.checkNPM = function() {
       return Promise.resolve('0.0.5');
@@ -53,13 +53,13 @@ describe('Update Checker', function() {
 
     // overwrite doCheck so it ignores any existing configstore
     updateChecker.doCheck = (function() {
-        var doCheck = updateChecker.doCheck;
+      var doCheck = updateChecker.doCheck;
 
-        return function() {
-          updateChecker.versionConfig = versionConfig;
-          return doCheck.apply(this);
-        };
-      }());
+      return function() {
+        updateChecker.versionConfig = versionConfig;
+        return doCheck.apply(this);
+      };
+    }());
 
     updateChecker.checkNPM = function() {
       return Promise.resolve('0.0.1');
@@ -77,13 +77,13 @@ describe('Update Checker', function() {
 
     // overwrite doCheck so it ignores any existing configstore
     updateChecker.doCheck = (function() {
-        var doCheck = updateChecker.doCheck;
+      var doCheck = updateChecker.doCheck;
 
-        return function() {
-          updateChecker.versionConfig = versionConfig;
-          return doCheck.apply(this, arguments);
-        };
-      }());
+      return function() {
+        updateChecker.versionConfig = versionConfig;
+        return doCheck.apply(this, arguments);
+      };
+    }());
 
     updateChecker.checkNPM = function() {
       return Promise.resolve('1000.0.0');
@@ -103,14 +103,14 @@ describe('Update Checker', function() {
     var npmCalled = false;
 
     updateChecker.doCheck = (function() {
-        var doCheck = updateChecker.doCheck;
+      var doCheck = updateChecker.doCheck;
 
-        return function() {
-          updateChecker.versionConfig = versionConfig;
-          versionConfig.set('lastVersionCheckAt', now - 86400);
-          return doCheck.apply(this);
-        };
-      }());
+      return function() {
+        updateChecker.versionConfig = versionConfig;
+        versionConfig.set('lastVersionCheckAt', now - 86400);
+        return doCheck.apply(this);
+      };
+    }());
 
     updateChecker.checkNPM = function() {
       npmCalled = true;

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -675,17 +675,16 @@ describe('express-server', function() {
 
         project.initializeAddons = function() { };
         project.addons = [{
-            serverMiddleware: function() {
-              firstCalls++;
-            }
-          }, {
-            serverMiddleware: function() {
-              secondCalls++;
-            }
-          }, {
-            doesntGoBoom: null
-          }];
-
+          serverMiddleware: function() {
+            firstCalls++;
+          }
+        }, {
+          serverMiddleware: function() {
+            secondCalls++;
+          }
+        }, {
+          doesntGoBoom: null
+        }];
       });
 
       it('calls serverMiddleware on the addons on start', function() {

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -67,9 +67,9 @@ describe('livereload-server', function() {
       preexistingServer.listen(1337);
 
       return subject.start({
-          liveReloadPort: 1337,
-          liveReload: true
-        })
+        liveReloadPort: 1337,
+        liveReload: true
+      })
         .catch(function(reason) {
           expect(reason).to.equal('Livereload failed on http://localhost:1337.  It is either in use or you do not have permission.' + EOL);
         })
@@ -108,12 +108,12 @@ describe('livereload-server', function() {
       preexistingServer.listen(1337);
 
       return subject.start({
-          liveReloadPort: 1337,
-          liveReload: true,
-          ssl: true,
-          sslKey: 'tests/fixtures/ssl/server.key',
-          sslCert: 'tests/fixtures/ssl/server.crt'
-        })
+        liveReloadPort: 1337,
+        liveReload: true,
+        ssl: true,
+        sslKey: 'tests/fixtures/ssl/server.key',
+        sslCert: 'tests/fixtures/ssl/server.crt'
+      })
         .catch(function(reason) {
           expect(reason).to.equal('Livereload failed on https://localhost:1337.  It is either in use or you do not have permission.' + EOL);
         })
@@ -131,12 +131,12 @@ describe('livereload-server', function() {
       };
 
       return subject.start({
-          liveReloadPort: 1337,
-          liveReload: true
-        }).then(function () {
-          expressServer.emit('restart');
-          expect(calls).to.equal(1);
-        });
+        liveReloadPort: 1337,
+        liveReload: true
+      }).then(function () {
+        expressServer.emit('restart');
+        expect(calls).to.equal(1);
+      });
     });
   });
 
@@ -194,12 +194,12 @@ describe('livereload-server', function() {
           liveReloadPort: 1337,
           liveReload: true
         }).then(function () {
-            watcher.emit(eventName, {
-              directory: '/home/user/projects/my-project/tmp/something.tmp'
-            });
-          }).finally(function () {
-            expect(changedCount).to.equal(expectedCount);
+          watcher.emit(eventName, {
+            directory: '/home/user/projects/my-project/tmp/something.tmp'
           });
+        }).finally(function () {
+          expect(changedCount).to.equal(expectedCount);
+        });
       }
 
       it('triggers a livereload change on a watcher change event', function () {

--- a/tests/unit/utilities/print-command-test.js
+++ b/tests/unit/utilities/print-command-test.js
@@ -9,25 +9,21 @@ var EOL               = require('os').EOL;
 
 describe('printCommand', function() {
   it('handles all possible options', function() {
-    var availableOptions = [
-      {
-        name: 'test-option',
-        values: ['x', 'y'],
-        default: 'my-def-val',
-        required: true,
-        aliases: ['a', 'long-a', { b: 'c', unused: '' }, {'long-b': 'c' }],
-        description: 'option desc'
-      },
-      {
-        name: 'test-type',
-        type: Boolean,
-        aliases: ['a']
-      },
-      {
-        name: 'test-type-array',
-        type: ['a-type', Number]
-      }
-    ];
+    var availableOptions = [{
+      name: 'test-option',
+      values: ['x', 'y'],
+      default: 'my-def-val',
+      required: true,
+      aliases: ['a', 'long-a', { b: 'c', unused: '' }, {'long-b': 'c' }],
+      description: 'option desc'
+    }, {
+      name: 'test-type',
+      type: Boolean,
+      aliases: ['a']
+    }, {
+      name: 'test-type-array',
+      type: ['a-type', Number]
+    }];
 
     var obj = {
       description: 'a paragraph',


### PR DESCRIPTION
This PR enables the `indent` rule of ESLint with 2-space-indentation consistent with the `.editorconfig` file and the majority of the codebase.