### PR TITLE
Anonymous AMD Support

### DIFF
--- a/lib/broccoli/amd-shim.js
+++ b/lib/broccoli/amd-shim.js
@@ -1,0 +1,19 @@
+'use strict';
+var stew = require('broccoli-stew');
+
+module.exports = function shimAmd(tree, nameMapping) {
+  return stew.map(tree, function(content, relativePath) {
+    var name = nameMapping[relativePath];
+    if (name) {
+      return [
+        '(function(define){',
+        content,
+        '})((function(){ function newDefine(){ var args = Array.prototype.slice.call(arguments); args.unshift("',
+        name,
+        '"); return define.apply(null, args); }; newDefine.amd = true; return newDefine; })());'
+      ].join('');
+    } else {
+      return content;
+    }
+  });
+};

--- a/lib/broccoli/amd-shim.js
+++ b/lib/broccoli/amd-shim.js
@@ -6,9 +6,9 @@ module.exports = function shimAmd(tree, nameMapping) {
     var name = nameMapping[relativePath];
     if (name) {
       return [
-        '(function(define){',
+        '(function(define){\n',
         content,
-        '})((function(){ function newDefine(){ var args = Array.prototype.slice.call(arguments); args.unshift("',
+        '\n})((function(){ function newDefine(){ var args = Array.prototype.slice.call(arguments); args.unshift("',
         name,
         '"); return define.apply(null, args); }; newDefine.amd = true; return newDefine; })());'
       ].join('');

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -30,6 +30,7 @@ var concat = require('broccoli-concat');
 var ConfigReplace = require('broccoli-config-replace');
 var ConfigLoader  = require('broccoli-config-loader');
 var mergeTrees    = require('./merge-trees');
+var shimAmd    = require('./amd-shim');
 var WatchedDir    = require('broccoli-source').WatchedDir;
 var UnwatchedDir  = require('broccoli-source').UnwatchedDir;
 
@@ -95,6 +96,7 @@ function EmberApp() {
 
   this.legacyFilesToAppend     = {};
   this.vendorStaticStyles      = {};
+  this.amdModuleNames          = {};
 
   this.otherAssetPaths         = [];
   this.legacyTestFilesToAppend = [];
@@ -898,9 +900,9 @@ EmberApp.prototype._processedExternalTree = function() {
     trees.unshift(bower);
   }
 
-  return this._cachedExternalTree = mergeTrees(trees, {
+  return this._cachedExternalTree = shimAmd(mergeTrees(trees, {
     annotation: 'TreeMerger (ExternalTree)'
-  });
+  }), this.amdModuleNames);
 };
 
 /**
@@ -1404,6 +1406,10 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   var basename = path.basename(assetPath);
 
   if (isType(assetPath, 'js', {registry: this.registry})) {
+    if (options.amdModule) {
+      this.amdModuleNames[assetPath] = options.amdModule;
+    }
+
     if (options.type === 'vendor') {
       options.outputFile = options.outputFile || this.options.outputPaths.vendor.js;
       addOutputFile(this.legacyFilesToAppend, assetPath, options);
@@ -1667,4 +1673,3 @@ function addOutputFile(container, assetPath, options) {
     container[outputFile].push(assetPath);
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "broccoli-plugin": "^1.2.0",
     "broccoli-sane-watcher": "^1.1.1",
     "broccoli-source": "^1.1.0",
+    "broccoli-stew": "^1.2.0",
     "broccoli-viz": "^2.0.1",
     "chalk": "^1.1.1",
     "clean-base-url": "^1.0.0",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -356,6 +356,30 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('specifying amdModule converts anonymous AMD to named AMD', function() {
+    return copyFixtureFiles('brocfile-tests/app-import-anonymous-amd')
+      .then(function () {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .then(function() {
+        var outputJS = fs.readFileSync(path.join('.', 'dist', 'assets', 'output.js'), {
+          encoding: 'utf8'
+        });
+
+        (function(){
+          function define(name, deps, factory) {
+            expect(name).to.equal('hello-world');
+            expect(deps).to.deep.equal([]);
+            expect(factory()()).to.equal('Hello World');
+          }
+          /* eslint-disable no-eval */
+          eval(outputJS);
+          /* eslint-enable no-eval */
+        })();
+      });
+  });
+
+
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', function() {
     return copyFixtureFiles('brocfile-tests/custom-output-paths')

--- a/tests/fixtures/brocfile-tests/app-import-anonymous-amd/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-anonymous-amd/ember-cli-build.js
@@ -1,0 +1,15 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  var app = new EmberApp(defaults, {
+  });
+
+  app.import('vendor/anonymous-amd-example.js', {
+    amdModule: 'hello-world',
+    outputFile: '/assets/output.js'
+  });
+
+  return app.toTree();
+};

--- a/tests/fixtures/brocfile-tests/app-import-anonymous-amd/vendor/anonymous-amd-example.js
+++ b/tests/fixtures/brocfile-tests/app-import-anonymous-amd/vendor/anonymous-amd-example.js
@@ -1,0 +1,10 @@
+(function() {
+  function helloWorld() {
+    return "Hello World";
+  }
+  if (typeof define === "function" && define.amd) {
+    define([], function () { return helloWorld; });
+  } else {
+    throw new Error("No amd loader found");
+  }
+})();


### PR DESCRIPTION
This adds an option named `amdModule` to `app.import`. It causes any anonymous AMD module in the imported file to be registered under the given name.

    app.import('bower_components/some-dep/some-dep.js', { amdModule: 'some-dep' });

This should work correctly with a large number of libraries that:

 - check for `typeof define === 'function' && define.amd`
 - call `define` with just a factory function, or a dependency list and factory function.

Question: is this use of broccoli-stew's `map` sufficiently performant?