### PR TITLE
[BUGFIX beta] Replace testem.json by testem.js in npmignore too

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -13,4 +13,4 @@
 .travis.yml
 bower.json
 ember-cli-build.js
-testem.json
+testem.js


### PR DESCRIPTION
Following with #5507, I forgot to update the `.npmignore` blueprint