### PR TITLE
Enable X-Forwarded-* headers in http-proxy

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -14,7 +14,8 @@ ProxyServerAddon.prototype.serverMiddleware = function(options) {
       target: options.proxy,
       ws: true,
       secure: !options.insecureProxy,
-      changeOrigin: true
+      changeOrigin: true,
+      xfwd: true
     });
 
     proxy.on('error', function (e) {


### PR DESCRIPTION
Reasoning: when using e.g. a Rails backend running on a separate port, proxying it using the ember-cli proxy feature, the generated _links_ sometimes tends to be incorrect. They are based on settings in the X-Forwarded-* headers. Hence, xfwd must be enabled.

If you like, we can make this a command-line option.

/cc @perlun, @jesjos