### PR TITLE
Propagates testem errors

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -2,7 +2,6 @@
 
 var TestTask = require('./test');
 var Promise  = require('../ext/promise');
-var remove   = Promise.denodeify(require('fs-extra').remove);
 var chalk    = require('chalk');
 
 module.exports = TestTask.extend({
@@ -13,12 +12,10 @@ module.exports = TestTask.extend({
   invokeTestem: function(options) {
     var task = this;
 
-    return new Promise(function(resolve) {
-      task.testem.startDev(task.testemOptions(options), function(code) {
-        remove(options.outputPath)
-        .finally(function() {
-          resolve(code);
-        });
+    return new Promise(function(resolve, reject) {
+      task.testem.startDev(task.testemOptions(options), function(code, error) {
+        if (error) { reject(error); }
+        else       { resolve(code); }
       });
     });
   },
@@ -29,21 +26,26 @@ module.exports = TestTask.extend({
     var task = this;
 
     // The building has actually started already, but we want some output while we wait for the server
-    ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
-    return new Promise(function(resolve) {
+    return new Promise(function(resolve, reject) {
+      ui.startProgress(chalk.green('Building'), chalk.green('.'));
+
       var watcher = options.watcher;
       var started = false;
 
       // Wait for a build and then either start or restart testem
       watcher.on('change', function() {
-        if (started) {
-          testem.restart();
-        } else {
-          started = true;
+        try {
+          if (started) {
+            testem.restart();
+          } else {
+            started = true;
 
-          ui.stopProgress();
-          resolve(task.invokeTestem(options));
+            ui.stopProgress();
+            resolve(task.invokeTestem(options));
+          }
+        } catch(e) {
+          reject(e);
         }
       });
     });


### PR DESCRIPTION
* when testem crashes, reject with its error (not just status code)
* remove extra remove within the test task, the caller creates the dir, the caller must clean it up (which it already does)
* when wrapping the watcher, the entire event emitter callback needs to be try/catch wrapped to propogate the error
* move ui.StartProcess to within the promise executor (so the functions signature is accurate, always returning a promise)
* improve test coverage