### PR TITLE
Fix many test and test server issues

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -113,6 +113,7 @@ module.exports = Command.extend({
     }
 
     process.env['EMBER_CLI_TEST_OUTPUT'] = outputPath;
+
     var testOptions = this.assign({}, commandOptions, {
       ui: this.ui,
       outputPath: outputPath,
@@ -126,46 +127,49 @@ module.exports = Command.extend({
       project: this.project
     };
 
-    if (commandOptions.server) {
-      if (hasBuild) {
-        throw new SilentError('Specifying a build is not allowed with the `--server` option.');
+    return win.checkWindowsElevation(this.ui).then(function() {
+      var session;
+
+      if (commandOptions.server) {
+        if (hasBuild) {
+          throw new SilentError('Specifying a build is not allowed with the `--server` option.');
+        }
+
+        var TestServerTask = this.tasks.TestServer;
+        var testServer     = new TestServerTask(options);
+        var builder        = new this.Builder(testOptions);
+
+        testOptions.watcher = new this.Watcher(this.assign(options, {
+          builder: builder,
+          verbose: false,
+          options: commandOptions
+        }));
+
+        session = testServer.run(testOptions).finally(function() {
+          return builder.cleanup();
+        });
+
+      } else {
+        var TestTask = this.tasks.Test;
+        var test     = new TestTask(options);
+
+        if (hasBuild) {
+          session = test.run(testOptions);
+        } else {
+          var BuildTask = this.tasks.Build;
+          var build = new BuildTask(options);
+
+          session = build.run({
+            environment: commandOptions.environment,
+            outputPath: outputPath
+          })
+          .then(function() {
+            return test.run(testOptions);
+          })
+        }
       }
 
-      options.builder = new this.Builder(testOptions);
-
-      var TestServerTask = this.tasks.TestServer;
-      var testServer     = new TestServerTask(options);
-
-      testOptions.watcher = new this.Watcher(this.assign(options, {
-        verbose: false,
-        options: commandOptions
-      }));
-
-      return testServer.run(testOptions)
-        .finally(this.rmTmp.bind(this));
-    } else {
-      var TestTask  = this.tasks.Test;
-      var test  = new TestTask(options);
-
-      if (hasBuild) {
-        return win.checkWindowsElevation(this.ui).then(function() {
-          return test.run(testOptions).finally(this.rmTmp.bind(this));
-        }.bind(this));
-      }
-
-      var BuildTask = this.tasks.Build;
-      var build = new BuildTask(options);
-
-      return win.checkWindowsElevation(this.ui).then(function() {
-        return build.run({
-          environment: commandOptions.environment,
-          outputPath: outputPath
-        })
-        .then(function() {
-          return test.run(testOptions);
-        })
-        .finally(this.rmTmp.bind(this));
-      }.bind(this));
-    }
+      return session.finally(this.rmTmp.bind(this));
+    }.bind(this));
   }
 });

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -5,10 +5,6 @@ var Promise  = require('../ext/promise');
 var chalk    = require('chalk');
 
 module.exports = TestTask.extend({
-  init: function() {
-    this.testem = this.testem || new (require('testem'))();
-  },
-
   invokeTestem: function(options) {
     var task = this;
 

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -8,18 +8,21 @@ module.exports = Task.extend({
   init: function() {
     this.testem = this.testem || new (require('testem'))();
   },
+
   invokeTestem: function (options) {
     var testem = this.testem;
+    var task = this;
 
     return new Promise(function(resolve, reject) {
-      testem.startCI(this.testemOptions(options), function(exitCode) {
-        if (!testem.app.reporter.total) {
+      testem.startCI(task.testemOptions(options), function(exitCode, error) {
+        if (error) { reject(error); }
+        else if (!testem.app.reporter.total) {
           reject(new SilentError('No tests were run, please check whether any errors occurred in the page (ember test --server) and ensure that you have a test launcher (e.g. PhantomJS) enabled.'));
+        } else {
+          resolve(exitCode);
         }
-
-        resolve(exitCode);
       });
-    }.bind(this));
+    });
   },
 
   addonMiddlewares: function() {

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -155,8 +155,14 @@ describe('test command', function() {
   });
 
   describe('--server option', function() {
+    var buildCleanupWasCalled;
     beforeEach(function() {
-      options.Builder = CoreObject.extend();
+      buildCleanupWasCalled = false;
+      options.Builder = CoreObject.extend({
+        cleanup: function() {
+          buildCleanupWasCalled = true;
+        }
+      });
       options.Watcher = CoreObject.extend();
 
       buildCommand();
@@ -167,6 +173,8 @@ describe('test command', function() {
         var testOptions = testServerRun.calledWith[0][0];
 
         expect(testOptions.watcher.verbose).to.be.false;
+      }).finally(function() {
+        expect(buildCleanupWasCalled).to.be.true;
       });
     });
 
@@ -175,6 +183,8 @@ describe('test command', function() {
         var testOptions = testServerRun.calledWith[0][0];
 
         expect(testOptions.watcher.options.watcher).to.equal('polling');
+      }).finally(function() {
+        expect(buildCleanupWasCalled).to.be.true;
       });
     });
 


### PR DESCRIPTION
clean test and test —server tasks
* share more
* always cleanup build
* use existing inheritance (don’t override methods that are basically the same)
* correctly propogate testem failures without —server being set