### PR TITLE
preserve NPM/bower caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
+cache:
+  directories:
+    $HOME/.npm
+    $HOME/.cache # includes bowers cache
 
 language: node_js
 node_js:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,13 @@ install:
   # Install PhantomJS
   - cinst PhantomJS -y
   # Typical npm stuff.
-  - md C:\nc
-  - npm config set cache C:\nc
   - npm version
   - npm install
+
+cache:
+  - '%APPDATA%\npm-cache'
+  - '%APPDATA%\Roaming\bower'
+
 
 # Post-install test scripts.
 test_script:


### PR DESCRIPTION
lets give this a try:

* don't cache bower_components or node_modules directly
* cache system level caches of both

this should be better then previous attempts, as it aims to merely reduce network IO, not preserving local node_modules etc which resulted in many false positives. In addition npm cache has improved alot since the old days. so lets give it a go.