### PR TITLE
use fork for better error messages

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -44,7 +44,7 @@ module.exports = Task.extend({
     this.environment = this.environment || 'development';
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
-    var broccoli = require('broccoli');
+    var broccoli = require('ember-cli-broccoli');
     var hasBrocfile = existsSync(path.join('.', 'Brocfile.js'));
     var buildFile = findBuildFile('ember-cli-build.js');
 

--- a/lib/tasks/server/middleware/serve-files/index.js
+++ b/lib/tasks/server/middleware/serve-files/index.js
@@ -12,7 +12,7 @@ ServeFilesAddon.prototype.serverMiddleware = function(options) {
   var app = options.app;
   options = options.options;
 
-  var broccoliMiddleware = options.middleware || require('broccoli/lib/middleware');
+  var broccoliMiddleware = options.middleware || require('ember-cli-broccoli/lib/middleware');
   var middleware = broccoliMiddleware(options.watcher, {
     liveReloadPath: '/ember-cli-live-reload.js',
     autoIndex: false // disable directory listings

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bower": "^1.3.12",
     "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
-    "broccoli": "0.16.9",
+    "ember-cli-broccoli": "0.16.9",
     "broccoli-babel-transpiler": "^5.4.5",
     "broccoli-concat": "^2.0.4",
     "broccoli-config-loader": "^1.0.0",

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -11,7 +11,7 @@ var findWhere = require('lodash/find');
 var MockUI = require('../../helpers/mock-ui');
 var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 
-var broccoli  = require('broccoli');
+var broccoli  = require('ember-cli-broccoli');
 var walkSync  = require('walk-sync');
 
 var root    = process.cwd();


### PR DESCRIPTION
switch to broccoli fork, for now. We improved error messages, by making it obvious:

1. which broccoli plugin was invoked via `The Broccoli Plugin: [Name + description] failed With:`
2. where it was instantiated `The Broccoli plugin was instantiated at: ... stack ...`
3. error thrown, this was what existed before.

Latest broccoli (which needs more work) has something similar.

- [x] test if browser is correctly informed when a build fails during rebuild



<img width="1098" alt="screen shot 2016-02-27 at 4 53 48 pm" src="https://cloud.githubusercontent.com/assets/1377/13376497/b911092c-dd72-11e5-8658-1b2aa8f5d933.png">


some future work should make the actual pages we reload to look pretty.