### PR TITLE
Bump ember-cli-sri from 2.0.0 to 2.1.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^2.0.0",
+    "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.4.0",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
ember-cli-sri and broccoli-sri-hash v2.0.0 contain a pair of bugs
that essentially inhibit the generation of SRI attributes if 1. the
files contain any UTF-8 characters (yes, even with paranoiaCheck
disabled) or if 2. the files contain any links to other
fingerprinted/prepended assets (e.g. a background image). These bugs
were fixed in v2.1.0. cc @jonathanKingston 