### PR TITLE
Revert old legacyFilesToAppend and vendorStaticStyles behavior as deprecated api

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -93,9 +93,11 @@ function EmberApp() {
   this._initOptions(options, isProduction);
   this._initVendorFiles();
 
-  this.legacyFilesToAppend     = {};
-  this.vendorStaticStyles      = {};
+  this._styleOutputFiles       = {};
+  this._scriptOutputFiles      = {};
 
+  this.legacyFilesToAppend     = [];
+  this.vendorStaticStyles      = [];
   this.otherAssetPaths         = [];
   this.legacyTestFilesToAppend = [];
   this.vendorTestStaticStyles  = [];
@@ -1093,13 +1095,10 @@ EmberApp.prototype._prunedBabelOptions = function() {
   @return {Tree} Merged tree
 */
 EmberApp.prototype.javascript = function() {
+  var deprecate           = this.project.ui.writeDeprecateLine.bind(this.project.ui);
   var applicationJs       = this.appAndDependencies();
   var appOutputPath       = this.options.outputPaths.app.js;
-  var appJs = applicationJs;
-
-  this.import('vendor/ember-cli/vendor-prefix.js', {prepend: true});
-  this.import('vendor/addons.js');
-  this.import('vendor/ember-cli/vendor-suffix.js');
+  var appJs               = applicationJs;
 
   // Note: If ember-cli-babel is installed we have already performed the transpilation at this point
   if (!this._addonInstalled('ember-cli-babel')) {
@@ -1134,9 +1133,20 @@ EmberApp.prototype.javascript = function() {
     annotation: 'Concat: App'
   });
 
+  if (this.legacyFilesToAppend.length > 0) {
+    deprecate('Usage of EmberApp.legacyFilesToAppend is deprecated. Please use EmberApp.import instead for the following files: \'' + this.legacyFilesToAppend.join('\', \'') + '\'');
+    this.legacyFilesToAppend.forEach(function(legacyFile) {
+      this.import(legacyFile);
+    }.bind(this));
+  }
+
+  this.import('vendor/ember-cli/vendor-prefix.js', {prepend: true});
+  this.import('vendor/addons.js');
+  this.import('vendor/ember-cli/vendor-suffix.js');
+
   var vendorFiles = [];
-  for (var outputFile in this.legacyFilesToAppend) {
-    var inputFiles = this.legacyFilesToAppend[outputFile];
+  for (var outputFile in this._scriptOutputFiles) {
+    var inputFiles = this._scriptOutputFiles[outputFile];
 
     vendorFiles.push(
       this.concatFiles(applicationJs, {
@@ -1169,8 +1179,7 @@ EmberApp.prototype.styles = function() {
     throw new SilentError('Style file cannot have the name of the application - ' + this.name);
   }
 
-  this.import('vendor/addons.css');
-
+  var deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
   var addonTrees = this.addonTreesFor('styles');
   var external = this._processedExternalTree();
   var styles = new Funnel(this.trees.styles, {
@@ -1192,9 +1201,18 @@ EmberApp.prototype.styles = function() {
 
   var preprocessedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
 
+  if (this.vendorStaticStyles.length > 0) {
+    deprecate('Usage of EmberApp.vendorStaticStyles is deprecated. Please use EmberApp.import instead for the following files: \'' + this.vendorStaticStyles.join('\', \'') + '\'');
+    this.vendorStaticStyles.forEach(function(filename) {
+      this.import(filename);
+    }.bind(this));
+  }
+
+  this.import('vendor/addons.css');
+
   var vendorStyles = [];
-  for (var outputFile in this.vendorStaticStyles) {
-    var inputFiles = this.vendorStaticStyles[outputFile];
+  for (var outputFile in this._styleOutputFiles) {
+    var inputFiles = this._styleOutputFiles[outputFile];
 
     vendorStyles.push(this.concatFiles(stylesAndVendor, {
       inputFiles: inputFiles,
@@ -1406,7 +1424,7 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   if (isType(assetPath, 'js', {registry: this.registry})) {
     if (options.type === 'vendor') {
       options.outputFile = options.outputFile || this.options.outputPaths.vendor.js;
-      addOutputFile(this.legacyFilesToAppend, assetPath, options);
+      addOutputFile(this._scriptOutputFiles, assetPath, options);
     } else if (options.type === 'test' ) {
       if (options.prepend) {
         this.legacyTestFilesToAppend.unshift(assetPath);
@@ -1419,7 +1437,7 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   } else if (extension === '.css') {
     if (options.type === 'vendor') {
       options.outputFile = options.outputFile || this.options.outputPaths.vendor.css;
-      addOutputFile(this.vendorStaticStyles, assetPath, options);
+      addOutputFile(this._styleOutputFiles, assetPath, options);
     } else {
       this.vendorTestStaticStyles.push(assetPath);
     }

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -12,6 +12,7 @@ var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
 var assertDirEmpty      = require('../helpers/assert-dir-empty');
 var existsSync          = require('exists-sync');
+var assertFile          = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
@@ -332,6 +333,27 @@ describe('Acceptance: brocfile-smoke-test', function() {
         var basePath = path.join('.', 'dist');
         files.forEach(function(file) {
           expect(existsSync(path.join(basePath, file)), file + ' exists').to.be.true;
+        });
+      });
+  });
+
+  it('supports deprecated legacyFilesToAppend and vendorStaticFiles', function() {
+    return copyFixtureFiles('brocfile-tests/app-import-with-legacy-files')
+      .then(function () {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .then(function(result) {
+        expect(result.output.join('\n')).to.include('Usage of EmberApp.legacyFilesToAppend is deprecated. Please use EmberApp.import instead for the following files: \'vendor/legacy-file.js\', \'vendor/second-legacy-file.js\'');
+        expect(result.output.join('\n')).to.include('Usage of EmberApp.vendorStaticStyles is deprecated. Please use EmberApp.import instead for the following files: \'vendor/legacy-file.css\'');
+
+        assertFile(path.join('dist', 'assets', 'vendor.js'), {
+          contains: 'legacy-file.js'
+        });
+        assertFile(path.join('dist', 'assets', 'vendor.js'), {
+          contains: 'second-legacy-file.js'
+        });
+        assertFile(path.join('dist', 'assets', 'vendor.css'), {
+          contains: 'legacy-file.css'
         });
       });
   });

--- a/tests/fixtures/brocfile-tests/app-import-with-legacy-files/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-with-legacy-files/ember-cli-build.js
@@ -1,0 +1,15 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  var app = new EmberApp(defaults, {});
+
+  app.legacyFilesToAppend.push('vendor/legacy-file.js');
+  app.legacyFilesToAppend.push('vendor/second-legacy-file.js');
+  app.vendorStaticStyles.push('vendor/legacy-file.css');
+
+  return app.toTree();
+};
+
+

--- a/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/legacy-file.css
+++ b/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/legacy-file.css
@@ -1,0 +1,3 @@
+body:after {
+  content: 'legacy-file.css';
+}

--- a/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/legacy-file.js
+++ b/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/legacy-file.js
@@ -1,0 +1,1 @@
+console.log("legacy-file.js");

--- a/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/second-legacy-file.js
+++ b/tests/fixtures/brocfile-tests/app-import-with-legacy-files/vendor/second-legacy-file.js
@@ -1,0 +1,1 @@
+console.log('second-legacy-file.js');

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -718,7 +718,7 @@ describe('broccoli/ember-app', function() {
         project: project
       });
       emberApp.import('vendor/moment.js');
-      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+      var outputFile = emberApp._scriptOutputFiles['/assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
@@ -729,7 +729,7 @@ describe('broccoli/ember-app', function() {
       });
       emberApp.import('vendor/moment.js', {type: 'vendor'});
 
-      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+      var outputFile = emberApp._scriptOutputFiles['/assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
@@ -740,7 +740,7 @@ describe('broccoli/ember-app', function() {
       });
       emberApp.import('vendor/es5-shim.js', {type: 'vendor', prepend: true});
 
-      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+      var outputFile = emberApp._scriptOutputFiles['/assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/es5-shim.js')).to.equal(0);
@@ -751,7 +751,7 @@ describe('broccoli/ember-app', function() {
       });
       emberApp.import('vendor/moment.js', {outputFile: 'moment.js', prepend: true});
 
-      var outputFile = emberApp.legacyFilesToAppend['moment.js'];
+      var outputFile = emberApp._scriptOutputFiles['moment.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(0);
@@ -762,7 +762,7 @@ describe('broccoli/ember-app', function() {
       });
       emberApp.import('vendor/moment.js', {outputFile: 'moment.js'});
 
-      var outputFile = emberApp.legacyFilesToAppend['moment.js'];
+      var outputFile = emberApp._scriptOutputFiles['moment.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
@@ -776,7 +776,7 @@ describe('broccoli/ember-app', function() {
       emberApp.import({
         'development': 'vendor/jquery.js'
       });
-      var outputFile = emberApp.legacyFilesToAppend['/assets/vendor.js'];
+      var outputFile = emberApp._scriptOutputFiles['/assets/vendor.js'];
       expect(outputFile.indexOf('vendor/jquery.js')).to.equal(outputFile.length -1);
       process.env.EMBER_ENV = undefined;
     });
@@ -789,7 +789,7 @@ describe('broccoli/ember-app', function() {
         'development': 'vendor/jquery.js',
         'production':  null
       });
-      expect(emberApp.legacyFilesToAppend['/assets/vendor.js'].indexOf('vendor/jquery.js')).to.equal(-1);
+      expect(emberApp._scriptOutputFiles['/assets/vendor.js'].indexOf('vendor/jquery.js')).to.equal(-1);
       process.env.EMBER_ENV = undefined;
     });
   });


### PR DESCRIPTION
Fixes #5537 

Moved handling of output files into new private props called `_styleOutputFiles` and `_scriptOutputFiles`. Saying the truth I'm totally unsure about naming here, would appreciate any suggestions :)