### PR TITLE
Update `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "node-modules-path": "^1.0.0",
     "node-uuid": "^1.4.3",
     "nopt": "^3.0.1",
-    "npm": "2.14.10",
+    "npm": "2.14.21",
     "pleasant-progress": "^1.0.2",
     "portfinder": "^0.4.0",
     "promise-map-series": "^0.2.1",


### PR DESCRIPTION
Newer `npm` fixes the deprecation warning:
`npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3...`

Related to https://github.com/ember-cli/ember-cli/issues/5539.