### PR TITLE
blueprints/route-addon: Fix __path__ token

### DIFF
--- a/blueprints/route-addon/index.js
+++ b/blueprints/route-addon/index.js
@@ -29,13 +29,11 @@ module.exports = {
         return options.dasherizedModuleName;
       },
       __path__: function(options) {
-        var blueprintName = options.originBlueprintName;
-
         if (options.pod && options.hasPathToken) {
           return path.join(options.podPath, options.dasherizedModuleName);
         }
 
-        return inflector.pluralize(blueprintName);
+        return 'routes';
       },
       __root__: function(options) {
         if (options.inRepoAddon) {


### PR DESCRIPTION
when generated directly this caused the route to be generated in the `route-addons` folder instead of `routes`

resolves #5574 

/cc @rwjblue 