### PR TITLE
Ensure application templates overwrite addon templates.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -789,10 +789,15 @@ EmberApp.prototype._processedTemplatesTree = function() {
     annotation: 'ProcessedTemplateTree'
   });
 
-  var templates = this.addonPreprocessTree('template', mergeTrees([
+  var combinedTemplates = mergeTrees([
     addonTemplates,
     this._templatesTree()
-  ], { annotation: 'addonPreprocessTree(template)' }));
+  ], {
+    annotation: 'addonPreprocessTree(template)',
+    overwrite: true
+  });
+
+  var templates = this.addonPreprocessTree('template', combinedTemplates);
 
   return this.addonPostprocessTree('template', preprocessTemplates(templates, {
     registry: this.registry,

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -7,6 +7,7 @@ var expect   = require('chai').expect;
 var walkSync = require('walk-sync');
 var appName  = 'some-cool-app';
 var EOL      = require('os').EOL;
+var mkdirp   = require('mkdirp');
 
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
@@ -51,10 +52,18 @@ describe('Acceptance: smoke-test', function() {
         return ember(['generate', 'in-repo-addon', 'my-addon']);
       })
       .then(function() {
-        return ember(['generate', 'template', 'foo', '--in-repo-addon=my-addon']);
+        // this should work, but generating a template in an addon/in-repo-addon doesn't
+        // do the right thing: update once https://github.com/ember-cli/ember-cli/issues/5687
+        // is fixed
+        //return ember(['generate', 'template', 'foo', '--in-repo-addon=my-addon']);
+
+        // temporary work around
+        var templatePath = path.join('lib', 'my-addon', 'app', 'templates', 'foo.hbs');
+        mkdirp.sync(path.dirname(templatePath));
+        fs.writeFileSync(templatePath, 'Hi, Mom!', { encoding: 'utf8' });
       })
       .then(function() {
-        var packageJsonPath = path.join('lib','my-addon','package.json');;
+        var packageJsonPath = path.join('lib','my-addon','package.json');
         var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = '*';


### PR DESCRIPTION
Fixes a regression that I introduced in 2.4.2 that triggered an error if
a template is present in both an addon and the app. The established
semantics here is that latter trees "win" (and the app "wins" over
anything), but I missed that during my latest refactor.