### PR TITLE
Fix: Prepend legacy files

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1174,7 +1174,7 @@ EmberApp.prototype.javascript = function() {
   if (this.legacyFilesToAppend.length > 0) {
     deprecate('Usage of EmberApp.legacyFilesToAppend is deprecated. Please use EmberApp.import instead for the following files: \'' + this.legacyFilesToAppend.join('\', \'') + '\'');
     this.legacyFilesToAppend.forEach(function(legacyFile) {
-      this.import(legacyFile);
+      this.import(legacyFile, {prepend: true});
     }.bind(this));
   }
 


### PR DESCRIPTION
Fixes #5589

I believe  some day we will have a backward compatible implementation of `app.import(.., {outputFile: ..})`  :)