### PR TITLE
Revert Enable X-Forwarded-* headers in http-proxy

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -14,8 +14,7 @@ ProxyServerAddon.prototype.serverMiddleware = function(options) {
       target: options.proxy,
       ws: true,
       secure: !options.insecureProxy,
-      changeOrigin: true,
-      xfwd: true
+      changeOrigin: true
     });
 
     proxy.on('error', function (e) {


### PR DESCRIPTION
#5524 is a breaking change as these headers cause proxying to break when using a symfony backend in development environment mode.

I'm not in any way opposed to including these headers - in fact they maybe should have always been included - just probably needs to be behind an option flag now or else indicated as a breaking.

@jbacklund is putting this as an option doable?