### PR TITLE
Don't bother pointless npm/bower restore in addon CI

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -32,4 +32,4 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -32,4 +32,6 @@ install:
   - bower install
 
 script:
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
   - ember try $EMBER_TRY_SCENARIO test --skip-cleanup


### PR DESCRIPTION
After tests pass (or fail), ember-try will (by default) restore `bower_components` and `node_modules` to their original states, as defined by the committed `bower.json` and `package.json`, respectively.

This is kind of pointless for most addon-ci-testing scenarios, since you're really just after the pass or fail -- no point in going back to the original dependency state.

CC: @kategengler @kellyselden 