### PR TITLE
Resolve directories relative to EmberApp project root

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -218,25 +218,35 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
   this.options.babel.sourceMaps = false;
 
   this.options.trees = defaults(this.options.trees, {
-    app:       new WatchedDir('app'),
-    tests:     new WatchedDir('tests'),
+    app:       new WatchedDir(this._resolveLocal('app')),
+    tests:     new WatchedDir(this._resolveLocal('tests')),
 
     // these are contained within app/ no need to watch again
     // (we should probably have the builder or the watcher dedup though)
-    styles:    new UnwatchedDir('app/styles'),
-    templates: existsSync('app/templates') ? new UnwatchedDir('app/templates') : null,
+    styles:    new UnwatchedDir(this._resolveLocal('app/styles')),
+    templates: existsSync(this._resolveLocal('app/templates')) ? new UnwatchedDir(this._resolveLocal('app/templates')) : null,
 
     // do not watch vendor/ or bower's default directory by default
     bower: this.project._watchmanInfo.enabled ? this.bowerDirectory : new UnwatchedDir(this.bowerDirectory),
-    vendor: existsSync('vendor') ? new UnwatchedDir('vendor') : null,
+    vendor: existsSync(this._resolveLocal('vendor')) ? new UnwatchedDir(this._resolveLocal('vendor')) : null,
 
-    public: existsSync('public') ? new WatchedDir('public') : null
+    public: existsSync(this._resolveLocal('public')) ? new WatchedDir(this._resolveLocal('public')) : null
   });
 
   this.options.jshintrc = defaults(this.options.jshintrc, {
     app: this.project.root,
-    tests: path.join(this.project.root, 'tests'),
+    tests: this._resolveLocal('tests'),
   });
+};
+
+/**
+  Resolves a path relative to the project's root
+
+  @private
+  @method _resolveLocal
+*/
+EmberApp.prototype._resolveLocal = function(to) {
+  return path.join(this.project.root, to);
 };
 
 /**
@@ -259,7 +269,7 @@ EmberApp.prototype._initVendorFiles = function() {
     // the more aptly named `ember.debug.js`.
     productionEmber = this.bowerDirectory + '/ember/ember.prod.js';
     developmentEmber = this.bowerDirectory + '/ember/ember.debug.js';
-    if (!existsSync(path.join(this.project.root, developmentEmber))) {
+    if (!existsSync(this._resolveLocal(developmentEmber))) {
       developmentEmber = this.bowerDirectory + '/ember/ember.js';
     }
   }

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -913,5 +913,15 @@ describe('broccoli/ember-app', function() {
     });
   });
 
+  describe('_resolveLocal', function() {
+    it('resolves a path relative to the project root', function() {
+      var emberApp = new EmberApp({
+        project: project
+      });
+
+      var result = emberApp._resolveLocal('foo');
+      expect(result).to.equal(path.join(project.root, 'foo'));
+    });
+  });
 });
 


### PR DESCRIPTION
Currently, a lot of the directories used within `EmberApp` are implicitly relative to the process' current working directory. This causes issues if you want to invoke a build from a process outside the cwd.

For example, without going into too much detail, we're working on multiple applications that we would like to build in parallel. Since the invoking command will be run outside the individual application directories, the lookups can't be relative to the process cwd.

cc @chadhietala 