### PR TITLE
Extract JSON help generator from HelpCommand code

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -34,8 +34,6 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions, rawArgs) {
-    var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
-    var command;
     var json;
     var rootCommand = new RootCommand({
       ui: this.ui,
@@ -92,8 +90,9 @@ module.exports = Command.extend({
         }.bind(this));
       }
 
+      var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
       if (multipleCommands.indexOf(rawArgs[0]) > -1) {
-        command = rawArgs.shift();
+        var command = rawArgs.shift();
         if (rawArgs.length > 0) {
           commandOptions.rawArgs = rawArgs;
         }

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -7,8 +7,7 @@ var string          = require('../utilities/string');
 var assign          = require('lodash/assign');
 var GenerateCommand = require('./generate');
 var RootCommand     = require('../utilities/root-command');
-var versionUtils    = require('../utilities/version-utils');
-var emberCLIVersion = versionUtils.emberCLIVersion;
+var JsonGenerator   = require('../utilities/json-generator');
 
 module.exports = Command.extend({
   name: 'help',
@@ -94,7 +93,14 @@ module.exports = Command.extend({
   },
 
   _printJsonHelp: function(commandOptions, rawArgs) {
-    var json = this._generateJson(commandOptions, rawArgs);
+    var generator = new JsonGenerator({
+      ui: this.ui,
+      project: this.project,
+      commands: this.commands,
+      tasks: this.tasks
+    });
+
+    var json = generator.generate(commandOptions, rawArgs);
 
     var outputJsonString = JSON.stringify(json, function(key, value) {
       // build command has a recursive property
@@ -105,73 +111,6 @@ module.exports = Command.extend({
     }, 2);
 
     this.ui.writeLine(outputJsonString);
-  },
-
-  _generateJson: function(commandOptions, rawArgs) {
-    var rootCommand = new RootCommand({
-      ui: this.ui,
-      project: this.project,
-      commands: this.commands,
-      tasks: this.tasks
-    });
-
-    var json = rootCommand.getJson(commandOptions);
-    json.version = emberCLIVersion();
-    json.commands = [];
-    json.addons = [];
-
-    if (rawArgs.length === 0) {
-      Object.keys(this.commands).forEach(function(commandName) {
-        this._addCommandHelpToJson(commandName, false, commandOptions, json);
-      }, this);
-
-      if (this.project.eachAddonCommand) {
-        this.project.eachAddonCommand(function(addonName, commands) {
-          this.commands = commands;
-
-          var addonJson = { name: addonName };
-          addonJson.commands = [];
-          json.addons.push(addonJson);
-
-          Object.keys(this.commands).forEach(function(commandName) {
-            this._addCommandHelpToJson(commandName, false, commandOptions, addonJson);
-          }, this);
-        }.bind(this));
-      }
-    } else {
-      // If args were passed to the help command,
-      // attempt to look up the command for each of them.
-
-      if (this.project.eachAddonCommand) {
-        this.project.eachAddonCommand(function(addonName, commands) {
-          assign(this.commands, commands);
-        }.bind(this));
-      }
-
-      var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
-      if (multipleCommands.indexOf(rawArgs[0]) > -1) {
-        var command = rawArgs.shift();
-        if (rawArgs.length > 0) {
-          commandOptions.rawArgs = rawArgs;
-        }
-        rawArgs = [command];
-      }
-
-      // Iterate through each arg beyond the initial 'help' command,
-      // and try to display usage instructions.
-      rawArgs.forEach(function(commandName) {
-        this._addCommandHelpToJson(commandName, true, commandOptions, json);
-      }, this);
-    }
-
-    return json;
-  },
-
-  _addCommandHelpToJson: function(commandName, single, options, json) {
-    var command = this._lookupCommand(commandName);
-    if (!command.skipHelp || single) {
-      json.commands.push(command.getJson(options));
-    }
   },
 
   _printHelpForCommand: function(commandName, detailed, options) {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -6,17 +6,9 @@ var lookupCommand   = require('../cli/lookup-command');
 var string          = require('../utilities/string');
 var assign          = require('lodash/assign');
 var GenerateCommand = require('./generate');
+var RootCommand     = require('../utilities/root-command');
 var versionUtils    = require('../utilities/version-utils');
 var emberCLIVersion = versionUtils.emberCLIVersion;
-
-var RootCommand = Command.extend({
-  isRoot: true,
-  name: 'ember',
-
-  anonymousOptions: [
-    '<command (Default: help)>'
-  ]
-});
 
 module.exports = Command.extend({
   name: 'help',

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -3,7 +3,7 @@
 var path            = require('path');
 var Command         = require('../models/command');
 var lookupCommand   = require('../cli/lookup-command');
-var string          = require('../utilities/string');
+var stringUtils     = require('ember-cli-string-utils');
 var assign          = require('lodash/assign');
 var GenerateCommand = require('./generate');
 var RootCommand     = require('../utilities/root-command');
@@ -126,7 +126,7 @@ module.exports = Command.extend({
   },
 
   _lookupCommand: function(commandName) {
-    var Command = this.commands[string.classify(commandName)] ||
+    var Command = this.commands[stringUtils.classify(commandName)] ||
                   lookupCommand(this.commands, commandName);
 
     return new Command({

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -34,55 +34,49 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions, rawArgs) {
-    var json;
+    if (commandOptions.json) {
+      this._printJsonHelp(commandOptions, rawArgs);
+    } else {
+      this._printHelp(commandOptions, rawArgs);
+    }
+  },
+
+  _printHelp: function(commandOptions, rawArgs) {
     var rootCommand = new RootCommand({
       ui: this.ui,
       project: this.project,
       commands: this.commands,
       tasks: this.tasks
     });
-    if (commandOptions.json) {
-      json = rootCommand.getJson(commandOptions);
-      json.version = emberCLIVersion();
-      json.commands = [];
-      json.addons = [];
-    }
+
     if (rawArgs.length === 0) {
-      if (!commandOptions.json) {
-        this.ui.writeLine(rootCommand.printBasicHelp(commandOptions));
-        // Display usage for all commands.
-        this.ui.writeLine('Available commands in ember-cli:');
-        this.ui.writeLine('');
-      }
+      this.ui.writeLine(rootCommand.printBasicHelp(commandOptions));
+      // Display usage for all commands.
+      this.ui.writeLine('Available commands in ember-cli:');
+      this.ui.writeLine('');
 
       Object.keys(this.commands).forEach(function(commandName) {
-        this._printBasicHelpForCommand(commandName, commandOptions, json);
+        this._printHelpForCommand(commandName, false, commandOptions);
       }, this);
 
       if (this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands) {
           this.commands = commands;
-          var addonJson;
-          if (commandOptions.json) {
-            addonJson = { name: addonName };
-            addonJson.commands = [];
-            json.addons.push(addonJson);
-          } else {
-            this.ui.writeLine('');
-            this.ui.writeLine('Available commands from ' + addonName + ':');
-          }
+
+          this.ui.writeLine('');
+          this.ui.writeLine('Available commands from ' + addonName + ':');
+
           Object.keys(this.commands).forEach(function(commandName) {
-            this._printBasicHelpForCommand(commandName, commandOptions, addonJson);
+            this._printHelpForCommand(commandName, false, commandOptions);
           }, this);
         }.bind(this));
       }
     } else {
       // If args were passed to the help command,
       // attempt to look up the command for each of them.
-      if (!commandOptions.json) {
-        this.ui.writeLine('Requested ember-cli commands:');
-        this.ui.writeLine('');
-      }
+
+      this.ui.writeLine('Requested ember-cli commands:');
+      this.ui.writeLine('');
 
       if (this.project.eachAddonCommand) {
         this.project.eachAddonCommand(function(addonName, commands) {
@@ -102,29 +96,83 @@ module.exports = Command.extend({
       // Iterate through each arg beyond the initial 'help' command,
       // and try to display usage instructions.
       rawArgs.forEach(function(commandName) {
-        this._printDetailedHelpForCommand(commandName, commandOptions, json);
+        this._printHelpForCommand(commandName, true, commandOptions);
+      }, this);
+    }
+  },
+
+  _printJsonHelp: function(commandOptions, rawArgs) {
+    var json = this._generateJson(commandOptions, rawArgs);
+
+    var outputJsonString = JSON.stringify(json, function(key, value) {
+      // build command has a recursive property
+      if (value === path) {
+        return 'path';
+      }
+      return value;
+    }, 2);
+
+    this.ui.writeLine(outputJsonString);
+  },
+
+  _generateJson: function(commandOptions, rawArgs) {
+    var rootCommand = new RootCommand({
+      ui: this.ui,
+      project: this.project,
+      commands: this.commands,
+      tasks: this.tasks
+    });
+
+    var json = rootCommand.getJson(commandOptions);
+    json.version = emberCLIVersion();
+    json.commands = [];
+    json.addons = [];
+
+    if (rawArgs.length === 0) {
+      Object.keys(this.commands).forEach(function(commandName) {
+        this._addCommandHelpToJson(commandName, false, commandOptions, json);
+      }, this);
+
+      if (this.project.eachAddonCommand) {
+        this.project.eachAddonCommand(function(addonName, commands) {
+          this.commands = commands;
+
+          var addonJson = { name: addonName };
+          addonJson.commands = [];
+          json.addons.push(addonJson);
+
+          Object.keys(this.commands).forEach(function(commandName) {
+            this._addCommandHelpToJson(commandName, false, commandOptions, addonJson);
+          }, this);
+        }.bind(this));
+      }
+    } else {
+      // If args were passed to the help command,
+      // attempt to look up the command for each of them.
+
+      if (this.project.eachAddonCommand) {
+        this.project.eachAddonCommand(function(addonName, commands) {
+          assign(this.commands, commands);
+        }.bind(this));
+      }
+
+      var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
+      if (multipleCommands.indexOf(rawArgs[0]) > -1) {
+        var command = rawArgs.shift();
+        if (rawArgs.length > 0) {
+          commandOptions.rawArgs = rawArgs;
+        }
+        rawArgs = [command];
+      }
+
+      // Iterate through each arg beyond the initial 'help' command,
+      // and try to display usage instructions.
+      rawArgs.forEach(function(commandName) {
+        this._addCommandHelpToJson(commandName, true, commandOptions, json);
       }, this);
     }
 
-    if (commandOptions.json) {
-      this._printJsonHelp(json);
-    }
-  },
-
-  _printBasicHelpForCommand: function(commandName, options, json) {
-    if (options.json) {
-      this._addCommandHelpToJson(commandName, false, options, json);
-    } else {
-      this._printHelpForCommand(commandName, false, options);
-    }
-  },
-
-  _printDetailedHelpForCommand: function(commandName, options, json) {
-    if (options.json) {
-      this._addCommandHelpToJson(commandName, true, options, json);
-    } else {
-      this._printHelpForCommand(commandName, true, options);
-    }
+    return json;
   },
 
   _addCommandHelpToJson: function(commandName, single, options, json) {
@@ -144,18 +192,6 @@ module.exports = Command.extend({
     if (detailed) {
       command.printDetailedHelp(options);
     }
-  },
-
-  _printJsonHelp: function(json) {
-    var outputJsonString = JSON.stringify(json, function(key, value) {
-      // build command has a recursive property
-      if (value === path) {
-        return 'path';
-      }
-      return value;
-    }, 2);
-
-    this.ui.writeLine(outputJsonString);
   },
 
   _lookupCommand: function(commandName) {

--- a/lib/utilities/json-generator.js
+++ b/lib/utilities/json-generator.js
@@ -1,0 +1,100 @@
+'use strict';
+
+var lookupCommand   = require('../cli/lookup-command');
+var string          = require('../utilities/string');
+var assign          = require('lodash/assign');
+var GenerateCommand = require('../commands/generate');
+var RootCommand     = require('./root-command');
+var versionUtils    = require('./version-utils');
+var emberCLIVersion = versionUtils.emberCLIVersion;
+
+function JsonGenerator(options) {
+  options = options || {};
+
+  this.ui = options.ui;
+  this.project = options.project;
+  this.commands = options.commands;
+  this.tasks = options.tasks;
+}
+
+JsonGenerator.prototype.generate = function(commandOptions, rawArgs) {
+  var rootCommand = new RootCommand({
+    ui: this.ui,
+    project: this.project,
+    commands: this.commands,
+    tasks: this.tasks
+  });
+
+  var json = rootCommand.getJson(commandOptions);
+  json.version = emberCLIVersion();
+  json.commands = [];
+  json.addons = [];
+
+  if (rawArgs.length === 0) {
+    Object.keys(this.commands).forEach(function(commandName) {
+      this._addCommandHelpToJson(commandName, false, commandOptions, json);
+    }, this);
+
+    if (this.project.eachAddonCommand) {
+      this.project.eachAddonCommand(function(addonName, commands) {
+        this.commands = commands;
+
+        var addonJson = { name: addonName };
+        addonJson.commands = [];
+        json.addons.push(addonJson);
+
+        Object.keys(this.commands).forEach(function(commandName) {
+          this._addCommandHelpToJson(commandName, false, commandOptions, addonJson);
+        }, this);
+      }.bind(this));
+    }
+  } else {
+    // If args were passed to the help command,
+    // attempt to look up the command for each of them.
+
+    if (this.project.eachAddonCommand) {
+      this.project.eachAddonCommand(function(addonName, commands) {
+        assign(this.commands, commands);
+      }.bind(this));
+    }
+
+    var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
+    if (multipleCommands.indexOf(rawArgs[0]) > -1) {
+      var command = rawArgs.shift();
+      if (rawArgs.length > 0) {
+        commandOptions.rawArgs = rawArgs;
+      }
+      rawArgs = [command];
+    }
+
+    // Iterate through each arg beyond the initial 'help' command,
+    // and try to display usage instructions.
+    rawArgs.forEach(function(commandName) {
+      this._addCommandHelpToJson(commandName, true, commandOptions, json);
+    }, this);
+  }
+
+  return json;
+};
+
+
+JsonGenerator.prototype._addCommandHelpToJson = function(commandName, single, options, json) {
+  var command = this._lookupCommand(commandName);
+  if (!command.skipHelp || single) {
+    json.commands.push(command.getJson(options));
+  }
+};
+
+JsonGenerator.prototype._lookupCommand = function(commandName) {
+  var Command = this.commands[string.classify(commandName)] ||
+    lookupCommand(this.commands, commandName);
+
+  return new Command({
+    ui: this.ui,
+    project: this.project,
+    commands: this.commands,
+    tasks: this.tasks
+  });
+};
+
+module.exports = JsonGenerator;

--- a/lib/utilities/json-generator.js
+++ b/lib/utilities/json-generator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var lookupCommand   = require('../cli/lookup-command');
-var string          = require('../utilities/string');
+var stringUtils     = require('ember-cli-string-utils');
 var assign          = require('lodash/assign');
 var GenerateCommand = require('../commands/generate');
 var RootCommand     = require('./root-command');
@@ -86,7 +86,7 @@ JsonGenerator.prototype._addCommandHelpToJson = function(commandName, single, op
 };
 
 JsonGenerator.prototype._lookupCommand = function(commandName) {
-  var Command = this.commands[string.classify(commandName)] ||
+  var Command = this.commands[stringUtils.classify(commandName)] ||
     lookupCommand(this.commands, commandName);
 
   return new Command({

--- a/lib/utilities/root-command.js
+++ b/lib/utilities/root-command.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var Command = require('../models/command');
+
+module.exports = Command.extend({
+  isRoot: true,
+  name: 'ember',
+
+  anonymousOptions: [
+    '<command (Default: help)>'
+  ]
+});


### PR DESCRIPTION
This PR extracts the code responsible for `ember help --json` into a `json-generator` utility, that can be reused in other parts of the code.

/cc @kellyselden @lazybensch 