### PR TITLE
Move "coveralls" and "codeclimate" dependencies into TravisCI manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,6 @@ install:
 script: npm run-script test-all:cover
 
 after_script:
+  - npm install coveralls codeclimate-test-reporter
   - cat coverage/lcov.info | codeclimate
   - cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -125,8 +125,6 @@
     "broccoli-filter": "^1.2.2",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
-    "codeclimate-test-reporter": "0.1.1",
-    "coveralls": "^2.11.2",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "eslint-plugin-chai-expect": "^1.1.1",
     "github": "^0.2.3",


### PR DESCRIPTION
This PR moves the "coveralls" and "codeclimate" dependencies into the TravisCI manifest. They are usually only needed for CI and not on developer machines.