### PR TITLE
[BUGFIX] Adds in fix for #5620 to see if the actualOutputStream isTTY by default.

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -205,7 +205,8 @@ UI.prototype.prompt = function(questions, callback) {
   PromptExt.prototype.constructor = PromptExt;
   PromptExt.prototype.rl = this.readline.createInterface({
     input: this.inputStream,
-    output: promptOutputStream
+    output: promptOutputStream,
+    terminal: this.actualOutputStream.isTTY,
   });
 
   // If no callback was provided, automatically return a promise


### PR DESCRIPTION
So I filed the bug in #5620 and after digging deeper into the code, I found the problem.

https://github.com/ember-cli/ember-cli/blob/master/lib/ui/index.js#L40-L55

`actualOutputStream` is equal to `process.stdout`. So `process.stdout.isTTY` exists. Making a call to `outputStream` using `through` gets rid of the `isTTY` function from the actualOutputStream because it's no longer returning a `tty.WriteStream` anymore. 

Looking at createInterface options [here](https://nodejs.org/api/readline.html#readline_readline_createinterface_options), you can see that they say that the `terminal` option defaults to 

> terminal - pass true if the input and output streams should be treated like a TTY, and have ANSI/VT100 escape codes written to it. Defaults to checking isTTY on the output stream upon instantiation.

Since the outputStream in `createInterface` is not the actual output stream, the `isTTY` function therefore does not exist. Therefore, we have to make a call to `this.actualOutputStream.isTTY`in the `terminal`option to get expected behavior, thus fixing errors with the Inquirer package and multiple selection in prompts. See screencaps.

HIghlighting on selection.
![image](https://cloud.githubusercontent.com/assets/956631/13833762/19dd7fd8-ebbf-11e5-97f8-14f384f5c358.png)

Scrolling fixed.
![image](https://cloud.githubusercontent.com/assets/956631/13833769/32772544-ebbf-11e5-9814-0b2f2d912da6.png)

Checkbox selection.
![image](https://cloud.githubusercontent.com/assets/956631/13833775/3f30bb06-ebbf-11e5-95c0-8ba19e5216a2.png)

It was a one-line fix and wasn't sure how to test it...so let me know if there's any way I can improve this pull request. =) 

resolves #5620