### PR TITLE
fix help for unknown command

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -59,6 +59,6 @@ module.exports = function(commands, commandName, commandArgs, optionHash) {
 
   // if we didn't find anything, return an "UnknownCommand"
   return UnknownCommand.extend({
-    commandName: commandName
+    name: commandName
   });
 };

--- a/lib/commands/unknown.js
+++ b/lib/commands/unknown.js
@@ -6,13 +6,14 @@ var chalk       = require('chalk');
 
 module.exports = Command.extend({
   skipHelp: true,
+  unknown: true,
 
   printBasicHelp: function() {
-    this.ui.writeLine(chalk.red('No help entry for \'' + this.commandName + '\''));
+    return chalk.red('No help entry for \'' + this.name + '\'');
   },
 
   validateAndRun: function() {
-    throw new SilentError('The specified command ' + this.commandName +
+    throw new SilentError('The specified command ' + this.name +
                           ' is invalid. For available options, see' +
                           ' `ember help`.');
   }

--- a/lib/utilities/json-generator.js
+++ b/lib/utilities/json-generator.js
@@ -80,7 +80,7 @@ JsonGenerator.prototype.generate = function(commandOptions, rawArgs) {
 
 JsonGenerator.prototype._addCommandHelpToJson = function(commandName, single, options, json) {
   var command = this._lookupCommand(commandName);
-  if (!command.skipHelp || single) {
+  if ((!command.skipHelp || single) && !command.unknown) {
     json.commands.push(command.getJson(options));
   }
 };

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -99,6 +99,15 @@ describe('Acceptance: ember help', function() {
     expect(output).to.contain(expected);
   });
 
+  it('prints helpfull message for unknown command', function() {
+    command.run(options, ['asdf']);
+
+    var output = options.ui.output;
+
+    expect(output).to.contain("No help entry for 'asdf'");
+    expect(output).to.not.contain('undefined');
+  });
+
   it('prints a single blueprints', function() {
     command.run(options, ['generate', 'route']);
 
@@ -133,6 +142,17 @@ describe('Acceptance: ember help', function() {
 
       var json = convertToJson(options.ui.output);
       var expected = require('../fixtures/help/help.js');
+
+      expect(json).to.deep.equal(expected);
+    });
+
+    it('returns empty list for unknown command', function() {
+      options.json = true;
+
+      command.run(options, ['asdf']);
+
+      var json = convertToJson(options.ui.output);
+      var expected = require('../fixtures/help/help-unknown.js');
 
       expect(json).to.deep.equal(expected);
     });

--- a/tests/fixtures/help/help-unknown.js
+++ b/tests/fixtures/help/help-unknown.js
@@ -1,0 +1,16 @@
+var versionUtils      = require('../../../lib/utilities/version-utils');
+var emberCLIVersion   = versionUtils.emberCLIVersion;
+
+module.exports = {
+  name: "ember",
+  description: null,
+  aliases: [],
+  works: "insideProject",
+  availableOptions: [],
+  anonymousOptions: [
+    "<command (Default: help)>"
+  ],
+  version: emberCLIVersion(),
+  commands: [],
+  addons: []
+};

--- a/tests/unit/cli/lookup-command-test.js
+++ b/tests/unit/cli/lookup-command-test.js
@@ -163,6 +163,9 @@ describe('cli/lookup-command.js', function() {
       ui: ui,
       project: project
     });
+
+    expect(command.name).to.equal('something-else');
+
     expect(function() {
       command.validateAndRun([]);
     }).to.throw(/command.*something-else.*is invalid/);

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -492,16 +492,7 @@ Available commands from my-addon:' + EOL);
 
       var json = convertToJson(options.ui.output);
 
-      expect(json.commands).to.deep.equal([
-        {
-          name: 'core-object',
-          description: null,
-          aliases: [],
-          works: 'insideProject',
-          availableOptions: [],
-          anonymousOptions: []
-        }
-      ]);
+      expect(json.commands).to.deep.equal([]);
     });
 
     it('respects skipHelp when listing', function() {


### PR DESCRIPTION
the output of help command is corrupt when you ask for an unknown command.

```
➜ ember help asdf
version: 2.4.2-master-ada0309dcf
Requested ember-cli commands:

No help entry for 'asdf'
undefined
```

(note the last line: undefined)
and even worse:

```
➜  ember help asdf --json
{
  "name": "ember",
  "description": null,
  "aliases": [],
  "works": "insideProject",
  "availableOptions": [],
  "anonymousOptions": [
    "<command (Default: help)>"
  ],
  "version": "2.4.2-master-ada0309dcf",
  "commands": [
    {
      "name": "core-object",
      "description": null,
      "aliases": [],
      "works": "insideProject",
      "availableOptions": [],
      "anonymousOptions": []
    }
  ],
  "addons": []
}
```

This PR fixes both outputs to be:

```
➜  ember help asdf
version: 2.4.2-fix_help_for_unknown_command-2725e5af73
Requested ember-cli commands:

No help entry for 'asdf'
```

and

```
➜ ember help asdf --json
{
  "name": "ember",
  "description": null,
  "aliases": [],
  "works": "insideProject",
  "availableOptions": [],
  "anonymousOptions": [
    "<command (Default: help)>"
  ],
  "version": "2.4.2-fix_help_for_unknown_command-2725e5af73",
  "commands": [],
  "addons": []
}
```