### PR TITLE
update ember-try

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -38,7 +38,7 @@ module.exports = {
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.0';
 
     // add `ember-try` to addons by default
-    contents.devDependencies['ember-try'] = '^0.1.2';
+    contents.devDependencies['ember-try'] = '^0.2.2';
     contents.scripts.test = 'ember try:testall';
 
     contents['ember-addon'] = contents['ember-addon'] || {};

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -126,7 +126,7 @@ describe('blueprint - addon', function() {
   "dependencies": {},\n\
   "devDependencies": {\n\
     "ember-disable-prototype-extensions": "^1.1.0",\n\
-    "ember-try": "^0.1.2"\n\
+    "ember-try": "^0.2.2"\n\
   },\n\
   "ember-addon": {\n\
     "configPath": "tests/dummy/config"\n\
@@ -238,7 +238,7 @@ describe('blueprint - addon', function() {
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
-        expect(json.devDependencies['ember-try']).to.equal('^0.1.2');
+        expect(json.devDependencies['ember-try']).to.equal('^0.2.2');
       });
 
       it('overwrites `scripts.test`', function() {


### PR DESCRIPTION
The only thing different is the way they call it I believe: `ember try scenario` to `ember try:one scenario`

@kategengler feel free to add.