### PR TITLE
[ENHANCEMENT] Exclude dist and tmp dirs from search in vscode

### DIFF
--- a/blueprints/app/files/.vscode/settings.json
+++ b/blueprints/app/files/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "dist": true,
+    "tmp": true
+  }
+}


### PR DESCRIPTION
Improve find in files in Visual Studio Code by excluding generated files in
a workspace config file.

---

Not sure if you accept editor-specific changes like this but I found ember-cli far more convenient with vscode when this was included after a little experimentation. (FYI I work on vscode)

![image](https://cloud.githubusercontent.com/assets/2193314/13902372/5110a3b4-ee02-11e5-8413-7877ac3af38a.png)

I couldn't find any similar tests but let me know if you want one.