### PR TITLE
disable node 0.12.x tests on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
     - nodejs_version: "4.2"
     - nodejs_version: "5.0"
 


### PR DESCRIPTION
- we still support node 0.12 as our travis tests cover it, just dimishing returns due to already flaky windows CI issues.
- ci + thorough test-suite, result in many intermittent disk related issues. (If the vm’s are fast, it works if not, sad things happen) The failures are largely in the test setup/teardown code
- our appveyor tests are largely just a smoke test on windows in general.

