### PR TITLE
commands: Use plain strings instead of "option-type" utility

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -2,7 +2,6 @@
 
 var Command = require('../models/command');
 var win     = require('../utilities/windows-admin');
-var optionType = require('../utilities/option-type');
 
 module.exports = Command.extend({
   name: 'build',
@@ -10,9 +9,9 @@ module.exports = Command.extend({
   aliases: ['b'],
 
   availableOptions: [
-    { name: 'environment', type: String,             default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
-    { name: 'output-path', type: optionType('Path'), default: 'dist/',       aliases: ['o'] },
-    { name: 'watch',       type: Boolean,            default: false,         aliases: ['w'] },
+    { name: 'environment', type: String,  default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
+    { name: 'output-path', type: 'Path',  default: 'dist/',       aliases: ['o'] },
+    { name: 'watch',       type: Boolean, default: false,         aliases: ['w'] },
     { name: 'watcher',     type: String }
   ],
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -4,7 +4,6 @@ var assign      = require('lodash/assign');
 var Command     = require('../models/command');
 var Promise     = require('../ext/promise');
 var SilentError = require('silent-error');
-var optionType  = require('../utilities/option-type');
 var PortFinder  = require('portfinder');
 var win         = require('../utilities/windows-admin');
 var EOL         = require('os').EOL;
@@ -20,20 +19,20 @@ module.exports = Command.extend({
   aliases: ['server', 's'],
 
   availableOptions: [
-    { name: 'port',                 type: Number,             default: defaultPort,   aliases: ['p'] },
-    { name: 'host',                 type: String,                                    aliases: ['H'],     description: 'Listens on all interfaces by default' },
-    { name: 'proxy',                type: String,                                     aliases: ['pr', 'pxy'] },
-    { name: 'insecure-proxy',       type: Boolean,            default: false,         aliases: ['inspr'], description: 'Set false to proxy self-signed SSL certificates' },
-    { name: 'watcher',              type: String,             default: 'events',      aliases: ['w'] },
-    { name: 'live-reload',          type: Boolean,            default: true,          aliases: ['lr'] },
-    { name: 'live-reload-host',     type: String,                                     aliases: ['lrh'],   description: 'Defaults to host' },
-    { name: 'live-reload-base-url', type: String,                                     aliases: ['lrbu'],  description: 'Defaults to baseURL' },
-    { name: 'live-reload-port',     type: Number,                                     aliases: ['lrp'],   description: '(Defaults to port number within [49152...65535])' },
-    { name: 'environment',          type: String,             default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
-    { name: 'output-path',          type: optionType('Path'), default: 'dist/',       aliases: ['op', 'out'] },
-    { name: 'ssl',                  type: Boolean,            default: false },
-    { name: 'ssl-key',              type: String,             default: 'ssl/server.key' },
-    { name: 'ssl-cert',             type: String,             default: 'ssl/server.crt' }
+    { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
+    { name: 'host',                 type: String,                          aliases: ['H'],     description: 'Listens on all interfaces by default' },
+    { name: 'proxy',                type: String,                          aliases: ['pr', 'pxy'] },
+    { name: 'insecure-proxy',       type: Boolean, default: false,         aliases: ['inspr'], description: 'Set false to proxy self-signed SSL certificates' },
+    { name: 'watcher',              type: String,  default: 'events',      aliases: ['w'] },
+    { name: 'live-reload',          type: Boolean, default: true,          aliases: ['lr'] },
+    { name: 'live-reload-host',     type: String,                          aliases: ['lrh'],   description: 'Defaults to host' },
+    { name: 'live-reload-base-url', type: String,                          aliases: ['lrbu'],  description: 'Defaults to baseURL' },
+    { name: 'live-reload-port',     type: Number,                          aliases: ['lrp'],   description: '(Defaults to port number within [49152...65535])' },
+    { name: 'environment',          type: String,  default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
+    { name: 'output-path',          type: 'Path',  default: 'dist/',       aliases: ['op', 'out'] },
+    { name: 'ssl',                  type: Boolean, default: false },
+    { name: 'ssl-key',              type: String,  default: 'ssl/server.key' },
+    { name: 'ssl-cert',             type: String,  default: 'ssl/server.crt' }
   ],
 
   run: function(commandOptions) {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,7 +7,6 @@ var SilentError = require('silent-error');
 var path        = require('path');
 var win         = require('../utilities/windows-admin');
 var existsSync  = require('exists-sync');
-var optionType  = require('../utilities/option-type');
 
 var defaultPort = 7357;
 
@@ -29,7 +28,7 @@ module.exports = Command.extend({
     { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit] (default: tap)' },
     { name: 'silent',      type: Boolean, default: false,                            description: 'Suppress any output except for the test report' },
     { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
-    { name: 'path',        type: optionType('Path'),                                 description: 'Reuse an existing build at given path.' },
+    { name: 'path',        type: 'Path',                                             description: 'Reuse an existing build at given path.' },
     { name: 'query',       type: String,                                             description: 'A query string to append to the test page URL.' }
   ],
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -376,7 +376,13 @@ Command.prototype.parseArgs = function(commandArgs) {
   };
 
   this.availableOptions.forEach(function(option) {
-    knownOpts[option.name] = option.type;
+    if (typeof option.type !== 'string') {
+      knownOpts[option.name] = option.type;
+    } else if (option.type === 'Path') {
+      knownOpts[option.name] = path;
+    } else {
+      knownOpts[option.name] = String;
+    }
   });
 
   parsedOptions = nopt(knownOpts, this.optionsAliases, commandArgs, 0);

--- a/lib/utilities/option-type.js
+++ b/lib/utilities/option-type.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = function(name) {
-  return new Function('return function ' + name + '() {};')();
-};

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -90,7 +90,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['o'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'watch',
@@ -805,7 +806,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['op', 'out'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'ssl',
@@ -921,6 +923,7 @@ module.exports = {
           description: 'Reuse an existing build at given path.',
           key: 'path',
           required: false,
+          type: 'Path',
         },
         {
           name: 'query',

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -90,7 +90,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['o'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'watch',
@@ -837,7 +838,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['op', 'out'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'ssl',
@@ -953,6 +955,7 @@ module.exports = {
           description: 'Reuse an existing build at given path.',
           key: 'path',
           required: false,
+          type: 'Path',
         },
         {
           name: 'query',

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -90,7 +90,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['o'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'watch',
@@ -805,7 +806,8 @@ module.exports = {
           default: 'dist/',
           aliases: ['op', 'out'],
           key: 'outputPath',
-          required: false
+          required: false,
+          type: 'Path',
         },
         {
           name: 'ssl',
@@ -921,6 +923,7 @@ module.exports = {
           description: 'Reuse an existing build at given path.',
           key: 'path',
           required: false,
+          type: 'Path',
         },
         {
           name: 'query',


### PR DESCRIPTION
Using the "option-type" utility in #5622 broke `nopt` option validation for paths (see https://github.com/npm/nopt/blob/master/lib/nopt.js#L20) and removed the `type: 'Path'` from the JSON help output.

/cc @lazybensch @stefanpenner 