### PR TITLE
reset aliases for deprecated install commands

### DIFF
--- a/lib/commands/install-addon.js
+++ b/lib/commands/install-addon.js
@@ -5,6 +5,7 @@ var InstallCommand = require('./install');
 module.exports = InstallCommand.extend({
   name: 'install:addon',
   description: 'This command has been deprecated. Please use `ember install` instead.',
+  aliases: [],
   works: 'insideProject',
   skipHelp: true,
 


### PR DESCRIPTION
Since the old install-addon command was inheriting the aliases of its parent, this happened:
```
>ember i ember-cli-mirage
DEPRECATION: This command has been deprecated. Please use `ember install <addonName>` instead.
```