### PR TITLE
Upgrade packages for app/addon blueprints

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember": "~2.4.1",
-    "ember-cli-shims": "0.1.0",
+    "ember": "~2.4.3",
+    "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,24 +19,24 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.2.0",
+    "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
+    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.4.2",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4",
-    "ember-load-initializers": "^0.5.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.0"
+    "loader.js": "^4.0.1"
   }
 }


### PR DESCRIPTION
The only material change here is `ember-cli-shims` patch version ([diff](https://github.com/ember-cli/ember-cli-shims/compare/0.1.0...v0.1.1)), all other version upgrades are within the `^` versioning already in place for these blueprints, so there should be no material difference other than updating the numbers.

All tests pass locally.

@rwjblue 