### PR TITLE
Use "update-notifier" dependency to notify users of ember-cli updates

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -7,6 +7,11 @@ process.title = 'ember';
 var resolve = require('resolve');
 var exit = require('exit');
 
+var updateNotifier = require('update-notifier');
+var pkg = require('../package.json');
+
+updateNotifier({ pkg: pkg }).notify({ defer: false });
+
 resolve('ember-cli', {
   basedir: process.cwd()
 }, function(error, projectLocalCli) {

--- a/bin/ember
+++ b/bin/ember
@@ -10,7 +10,7 @@ var exit = require('exit');
 var updateNotifier = require('update-notifier');
 var pkg = require('../package.json');
 
-updateNotifier({ pkg: pkg }).notify({ defer: false });
+notifyUpdate(updateNotifier({ pkg: pkg }).update);
 
 resolve('ember-cli', {
   basedir: process.cwd()
@@ -38,3 +38,16 @@ resolve('ember-cli', {
     exit(exitCode);
   });
 });
+
+function notifyUpdate(update) {
+  if (!process.stdout.isTTY || !update || require('is-npm')) {
+    return;
+  }
+
+  var chalk = require('chalk');
+
+  var message = '\nA new ' + chalk.yellow('ember-cli') + ' release is available (' + update.current + ' → ' + chalk.yellow(update.latest) + ')\n' +
+    'Visit ' + chalk.yellow.underline('https://github.com/ember-cli/ember-cli/releases/tag/v' + update.latest) + ' for update instructions\n';
+
+  console.error(message);
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "inflection": "^1.7.0",
     "inquirer": "^0.12.0",
     "is-git-url": "^0.2.0",
+    "is-npm": "^1.0.0",
     "isbinaryfile": "^3.0.0",
     "leek": "0.0.21",
     "lodash": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "through": "^2.3.6",
     "tiny-lr": "0.2.1",
     "tree-sync": "^1.1.0",
+    "update-notifier": "^0.6.3",
     "walk-sync": "^0.2.6",
     "yam": "0.0.19"
   },


### PR DESCRIPTION
![bildschirmfoto 2016-03-21 um 23 09 52](https://cloud.githubusercontent.com/assets/141300/13935877/1646c772-efba-11e5-9d1f-845d693767a7.png)

The version will be checked at most once a day and once the notice has been shown it won't be shown until the next day either to not bother the users too much.

Also this will only check the globally installed `ember` unless it's explicitly called via `node_modules/.bin/ember` from some project outside of any NPM scripts.

(v2.0.0 was faked for the screenshot)

---

Before landing:
- [ ] Never `stderr`.
- [ ] Confirm it works behind a firewall.
- [ ] Check interaction with `--json`.