### PR TITLE
Clean up "inquirer" code

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -191,30 +191,14 @@ UI.prototype.stopProgress = function() {
 };
 
 UI.prototype.prompt = function(questions, callback) {
-  // Pipe it to the output stream but don't forward end event
-  var promptOutputStream = this.through(null, function() {});
-  promptOutputStream.pipe(this.outputStream);
-
-  var Prompt = require('inquirer').ui.Prompt;
-  // Note: Cannot move this outside
-  //       Need a new readline interface each time, 'cause it gets torn down
-  function PromptExt() {
-    Prompt.apply(this, arguments);
-  }
-  PromptExt.prototype = Object.create(Prompt.prototype);
-  PromptExt.prototype.constructor = PromptExt;
-  PromptExt.prototype.rl = this.readline.createInterface({
-    input: this.inputStream,
-    output: promptOutputStream,
-    terminal: this.actualOutputStream.isTTY,
-  });
+  var inquirer = require('inquirer');
 
   // If no callback was provided, automatically return a promise
   if (callback) {
-    return new PromptExt(questions, callback);
+    inquirer.prompt(questions, callback);
   } else {
     return new Promise(function(resolve) {
-      new PromptExt(questions, resolve);
+      inquirer.prompt(questions, resolve);
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "glob": "7.0.3",
     "http-proxy": "^1.9.0",
     "inflection": "^1.7.0",
-    "inquirer": "0.5.1",
+    "inquirer": "^0.12.0",
     "is-git-url": "^0.2.0",
     "isbinaryfile": "^2.0.3",
     "leek": "0.0.21",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "nock": "^7.2.2",
     "proxyquire": "^1.6.0",
     "supertest": "0.15.0",
+    "testdouble": "^1.2.0",
     "yuidocjs": "0.10.0"
   }
 }

--- a/tests/helpers/mock-ui.js
+++ b/tests/helpers/mock-ui.js
@@ -31,23 +31,3 @@ MockUI.prototype.clear = function() {
   this.errors = '';
   this.errorLog = [];
 };
-
-MockUI.prototype.waitForPrompt = function() {
-  if (!this._waitingForPrompt) {
-    var promise, resolver;
-    promise = new Promise(function(resolve) {
-      resolver = resolve;
-    });
-    this._waitingForPrompt = promise;
-    this._promptResolver = resolver;
-  }
-  return this._waitingForPrompt;
-};
-
-MockUI.prototype.prompt = function(opts, cb) {
-  if (this._waitingForPrompt) {
-    this._waitingForPrompt = null;
-    this._promptResolver();
-  }
-  return UI.prototype.prompt.call(this, opts, cb);
-};

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -12,6 +12,7 @@ var root       = process.cwd();
 var tmproot    = path.join(root, 'tmp');
 var assign     = require('lodash/assign');
 var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
+var td         = require('testdouble');
 var testOutputPath;
 
 describe('Unit - FileInfo', function() {
@@ -109,44 +110,53 @@ describe('Unit - FileInfo', function() {
   });
 
   it('renders a menu with an overwrite option', function() {
+    var originalPrompt = ui.prompt;
+    var prompt = ui.prompt = td.function();
+
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'overwrite' }));
+
     var fileInfo = new FileInfo(validOptions);
 
-    ui.waitForPrompt().then(function() {
-      ui.inputStream.write('Y' + EOL);
-    });
-
-    return fileInfo.confirmOverwrite().then(function(action) {
-      var output = ui.output.trim().split(EOL);
-      expect(output.shift()).to.match(/Overwrite.*\?/);
+    return fileInfo.confirmOverwrite('test.js').then(function(action) {
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('overwrite');
+    })
+    .finally(function() {
+      ui.prompt = originalPrompt;
     });
   });
 
   it('renders a menu with an skip option', function() {
+    var originalPrompt = ui.prompt;
+    var prompt = ui.prompt = td.function();
+
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'skip' }));
+
     var fileInfo = new FileInfo(validOptions);
 
-    ui.waitForPrompt().then(function() {
-      ui.inputStream.write('n' + EOL);
-    });
-
-    return fileInfo.confirmOverwrite().then(function(action) {
-      var output = ui.output.trim().split(EOL);
-      expect(output.shift()).to.match(/Overwrite.*\?/);
+    return fileInfo.confirmOverwrite('test.js').then(function(action) {
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('skip');
+    })
+    .finally(function() {
+      ui.prompt = originalPrompt;
     });
   });
 
   it('renders a menu with an diff option', function() {
+    var originalPrompt = ui.prompt;
+    var prompt = ui.prompt = td.function();
+
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'diff' }));
+
     var fileInfo = new FileInfo(validOptions);
 
-    ui.waitForPrompt().then(function() {
-      ui.inputStream.write('d' + EOL);
-    });
-
-    return fileInfo.confirmOverwrite().then(function(action) {
-      var output = ui.output.trim().split(EOL);
-      expect(output.shift()).to.match(/Overwrite.*\?/);
+    return fileInfo.confirmOverwrite('test.js').then(function(action) {
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('diff');
+    })
+    .finally(function() {
+      ui.prompt = originalPrompt;
     });
   });
 


### PR DESCRIPTION
This PR greatly simplifies the `UI.prompt()` method by using stubs for testing instead of the error-prone stream redirection. The PR also updates the `inquirer` dependency to the most recent release.

This fixes #5665 and part of #5548. 

The test code can be simplified further once https://github.com/testdouble/testdouble.js/issues/86 is solved.