### PR TITLE
re-point ember-cli-portfinder -> portfinder

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -4,7 +4,7 @@ var assign      = require('lodash/assign');
 var Command     = require('../models/command');
 var Promise     = require('../ext/promise');
 var SilentError = require('silent-error');
-var PortFinder  = require('ember-cli-portfinder');
+var PortFinder  = require('portfinder');
 var win         = require('../utilities/windows-admin');
 var EOL         = require('os').EOL;
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "nopt": "^3.0.1",
     "npm": "2.14.21",
     "ora": "^0.2.0",
-    "ember-cli-portfinder": "^1.0.3",
+    "portfinder": "^1.0.3",
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.5",
     "readline2": "0.1.1",

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -6,7 +6,7 @@ var stub           = require('../../helpers/stub');
 var commandOptions = require('../../factories/command-options');
 var Task           = require('../../../lib/models/task');
 var Promise        = require('../../../lib/ext/promise');
-var PortFinder     = require('ember-cli-portfinder');
+var PortFinder     = require('portfinder');
 
 PortFinder.basePort = 32768;
 


### PR DESCRIPTION
- the official repo has been released to npm, point to it

cc @stefanpenner (should just be an easy merge)