### PR TITLE
Fix ordering of if clause.

### DIFF
--- a/dev/changelog
+++ b/dev/changelog
@@ -35,8 +35,8 @@ compareCommits({
     return message.indexOf('Merge pull request #') > -1 || message.indexOf('Auto merge of #') > -1;
 
   }).map(function(message) {
-    if (message.indexOf('Merge pull request #') > -1) {
-      var numAndAuthor = message.match(/#(\d+) from (.*)\//).slice(1,3);
+    if (message.indexOf('Auto merge of #') > -1) {
+      var numAndAuthor = message.match(/#(\d+) - (.*):/).slice(1,3);
       var title        = message.split('\n\n')[1];
 
       return {
@@ -44,8 +44,8 @@ compareCommits({
         author:  numAndAuthor[1],
         title:   title
       };
-    } else if (message.indexOf('Auto merge of #') > -1) {
-      var numAndAuthor = message.match(/#(\d+) - (.*):/).slice(1,3);
+    } else if (message.indexOf('Merge pull request #') > -1) {
+      var numAndAuthor = message.match(/#(\d+) from (.*)\//).slice(1,3);
       var title        = message.split('\n\n')[1];
 
       return {


### PR DESCRIPTION
Greenkeeper adds a bunch of additional text into the log messaging which
confuses our previous release script. Inverting the clause order makes it play
nicely.