### PR TITLE
[ENHANCEMENT] Added return statement to `beforeEach` in `moduleForAcceptance`

### DIFF
--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -8,7 +8,7 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 

--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -13,11 +16,14 @@ export default function(name, options = {}) {
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
+      let result = Promise.resolve();
+      if (! options.afterEach) {
+        result = options.afterEach.apply(this, arguments);
       }
 
       destroyApp(this.application);
+
+      return result;
     }
   });
 }

--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -16,14 +16,8 @@ export default function(name, options = {}) {
     },
 
     afterEach() {
-      let result = Promise.resolve();
-      if (! options.afterEach) {
-        result = options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
-
-      return result;
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }


### PR DESCRIPTION
In order to make use of QUnit ability of handling async tasks in `beforeEach` I added the proper return statement to `moduleForAcceptance`

I left `afterEach`untouched because of #5348, but maybe we could do the same thing.