### PR TITLE
Remove unecessary Promise.hash usage

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -703,10 +703,10 @@ function ensureUI(_ui) {
 function closestPackageJSON(pathName) {
   return findup(pathName, 'package.json')
     .then(function(directory) {
-      return Promise.hash({
+      return {
         directory: directory,
         pkg: require(path.join(directory, 'package.json'))
-      });
+      };
     });
 }
 


### PR DESCRIPTION
During the contributor workshop we discovered an uncessesary usage of `Promise.hash`.

* directory is a string that is passed in (https://github.com/ember-cli/ember-cli/compare/master...ryanlabouve:unnecessary-promise?expand=1#diff-3677132bf6240059b3a3637716019c84L707)

* require is synchronous (https://github.com/ember-cli/ember-cli/compare/master...ryanlabouve:unnecessary-promise?expand=1#diff-3677132bf6240059b3a3637716019c84L708)

We have removed and re-ran the test suite to verify.

/cc @lukemelia 