### PR TITLE
Add test to check for project name collisions

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -15,6 +15,8 @@ var conf       = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var EOL        = require('os').EOL;
 var assertFile = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var chalk      = require('chalk');
+var Promise    = require('../../lib/ext/promise');
+var mkdir      = Promise.denodeify(fs.mkdir);
 
 describe('Acceptance: ember new', function() {
   this.timeout(10000);
@@ -101,6 +103,24 @@ describe('Acceptance: ember new', function() {
 
       var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
       expect(pkgJson.name).to.equal('foo-app');
+    });
+  });
+
+  it('Cannot create new ember project with the same name as an existing directory', function() {
+
+    return mkdir('foo').then(function() {
+      return ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git'
+      ]).then(function() {
+        throw new Error('this promise should be rejected');
+      }).catch(function(error) {
+        expect(error.name).to.equal('SilentError');
+        expect(error.message).to.equal('Directory \'foo\' already exists.');
+      });
     });
   });
 


### PR DESCRIPTION
During Ember contributor workshop, wrote a test to help us explore a related issue.

Add test to specifically test for creating a new ember project with a name that conflicts with an existing folder in the current working directory.

e.g.
```
cd ~/
mkdir foo
ember new foo
```
should fail.

This test turned out not to be strictly required for the issue, but we still felt like it added value.

/cc @lukemelia 