### PR TITLE
Move test-loader to NPM

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1310,7 +1310,6 @@ EmberApp.prototype.styles = function() {
  */
 EmberApp.prototype.testFiles = function(coreTestTree) {
   var testSupportPath = this.options.outputPaths.testSupport.js;
-  var testLoaderPath = this.options.outputPaths.testSupport.js.testLoader;
 
   testSupportPath = testSupportPath.testSupport || testSupportPath;
 
@@ -1362,18 +1361,24 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
     this.options.fingerprint.exclude.push('testem');
   }
 
-  var testLoader = new Funnel(external, {
-    files: ['test-loader.js'],
-    srcDir: '/' + this.bowerDirectory + '/ember-cli-test-loader',
-    destDir: path.dirname(testLoaderPath),
-    annotation: 'Funnel (testLoader)'
-  });
-
   var sourceTrees = [
     testemTree,
-    testJs,
-    testLoader
+    testJs
   ];
+
+  var bowerDeps = this.project.bowerDependencies();
+  if (bowerDeps['ember-cli-test-loader']) {
+    this.project.ui.writeDeprecateLine('ember-cli-test-loader should now be included as an NPM module with version 1.1.0 or greater.');
+    var testLoaderPath = this.options.outputPaths.testSupport.js.testLoader;
+    var testLoader = new Funnel(external, {
+      files: ['test-loader.js'],
+      srcDir: '/' + this.bowerDirectory + '/ember-cli-test-loader',
+      destDir: path.dirname(testLoaderPath),
+      annotation: 'Funnel (testLoader)'
+    });
+
+    sourceTrees.push(testLoader);
+  }
 
   if (this.vendorTestStaticStyles.length > 0) {
     sourceTrees.push(


### PR DESCRIPTION
Pretty self-explanatory. Was unsure if this needed to be 100% backwards compatible (e.g., check if `ember-cli-test-loader` is installed as a bower or npm module and behave accordingly), so I took the simple route which relies on users upgrading their dependencies (addons like `ember-cli-qunit` will need to be updated accordingly, which I will be working on).