### PR TITLE
Replace custom file assertions with "chai-files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "broccoli-plugin": "^1.2.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "chai-files": "^1.0.0",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "eslint-plugin-chai-expect": "^1.1.1",
     "github": "^0.2.3",

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -1,9 +1,6 @@
 'use strict';
 
 var Promise              = require('../../lib/ext/promise');
-var assertFile           = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
-var assertFileEquals     = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-equals');
-var assertFileToNotExist = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-to-not-exist');
 var conf                 = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember                = require('../helpers/ember');
 var fs                   = require('fs-extra');
@@ -13,8 +10,15 @@ var root                 = process.cwd();
 var tmproot              = path.join(root, 'tmp');
 var Blueprint            = require('../../lib/models/blueprint');
 var BlueprintNpmTask     = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
-var expect               = require('chai').expect;
 var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember generate in-addon-dummy', function() {
   this.timeout(20000);
@@ -59,215 +63,208 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
 
   it('dummy component x-foo', function() {
     return generateInAddon(['component', 'x-foo', '--dummy']).then(function() {
-      assertFile('tests/dummy/app/components/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      });
-      assertFile('tests/dummy/app/templates/components/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFileToNotExist('app/components/x-foo.js');
-      assertFileToNotExist('tests/unit/components/x-foo-test.js');
+      expect(file('tests/dummy/app/components/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("});");
+
+      expect(file('tests/dummy/app/templates/components/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('app/components/x-foo.js')).to.not.exist;
+      expect(file('tests/unit/components/x-foo-test.js')).to.not.exist;
     });
   });
 
   it('dummy blueprint foo', function() {
     return generateInAddon(['blueprint', 'foo', '--dummy']).then(function() {
-      assertFile('blueprints/foo/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('dummy blueprint foo/bar', function() {
     return generateInAddon(['blueprint', 'foo/bar', '--dummy']).then(function() {
-      assertFile('blueprints/foo/bar/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/bar/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('dummy http-mock foo', function() {
     return generateInAddon(['http-mock', 'foo', '--dummy']).then(function() {
-      assertFile('server/index.js', {
-        contains:"mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo', require('body-parser').json());\n" +
-                  "  app.use('/api/foo', fooRouter);\n" +
-                  "};\n"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo', require('body-parser').json());\n" +
+                    "  app.use('/api/foo', fooRouter);\n" +
+                    "};\n");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('dummy http-mock foo-bar', function() {
     return generateInAddon(['http-mock', 'foo-bar', '--dummy']).then(function() {
-      assertFile('server/index.js', {
-        contains: "mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo-bar.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                  "};\n"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo-bar.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooBarRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                    "};\n");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('dummy http-proxy foo', function() {
     return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000', '--dummy']).then(function() {
-      assertFile('server/index.js', {
-        contains: "proxies.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/proxies/foo.js', {
-        contains: "var proxyPath = '/foo';\n" +
-                  "\n" +
-                  "module.exports = function(app) {\n" +
-                  "  // For options, see:\n" +
-                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                  "\n" +
-                  "  proxy.on('error', function(err, req) {\n" +
-                  "    console.error(err, req.url);\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  app.use(proxyPath, function(req, res, next){\n" +
-                  "    // include root path in proxied request\n" +
-                  "    req.url = proxyPath + '/' + req.url;\n" +
-                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                  "  });\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("proxies.forEach(function(route) { route(app); });");
+
+      expect(file('server/proxies/foo.js'))
+        .to.contain("var proxyPath = '/foo';\n" +
+                    "\n" +
+                    "module.exports = function(app) {\n" +
+                    "  // For options, see:\n" +
+                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                    "\n" +
+                    "  proxy.on('error', function(err, req) {\n" +
+                    "    console.error(err, req.url);\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  app.use(proxyPath, function(req, res, next){\n" +
+                    "    // include root path in proxied request\n" +
+                    "    req.url = proxyPath + '/' + req.url;\n" +
+                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                    "  });\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('dummy server', function() {
     return generateInAddon(['server', '--dummy']).then(function() {
-      assertFile('server/index.js');
-      assertFile('server/.jshintrc');
+      expect(file('server/index.js')).to.exist;
+      expect(file('server/.jshintrc')).to.exist;
     });
   });
 

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -1,9 +1,6 @@
 'use strict';
 
 var Promise              = require('../../lib/ext/promise');
-var assertFile           = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
-var assertFileEquals     = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-equals');
-var assertFileToNotExist = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-to-not-exist');
 var conf                 = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember                = require('../helpers/ember');
 var fs                   = require('fs-extra');
@@ -13,8 +10,15 @@ var root                 = process.cwd();
 var tmproot              = path.join(root, 'tmp');
 var Blueprint            = require('../../lib/models/blueprint');
 var BlueprintNpmTask     = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
-var expect               = require('chai').expect;
 var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember generate in-addon', function() {
   this.timeout(20000);
@@ -71,240 +75,225 @@ describe('Acceptance: ember generate in-addon', function() {
 
   it('in-addon addon-import component-addon works', function() {
     return generateInAddon(['component-addon', 'foo-bar', '--pod']).then(function() {
-      assertFile('app/components/foo-bar/component.js', {
-        contains: [
-          "export { default } from 'my-addon/components/foo-bar/component';"
-        ]
-      });
+      expect(file('app/components/foo-bar/component.js'))
+        .to.contain("export { default } from 'my-addon/components/foo-bar/component';");
     });
   });
 
   it('in-addon component x-foo', function() {
     return generateInAddon(['component', 'x-foo']).then(function() {
-      assertFile('addon/components/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "import layout from '../templates/components/x-foo';",
-          "export default Ember.Component.extend({",
-          "layout",
-          "});"
-        ]
-      });
-      assertFile('addon/templates/components/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('app/components/x-foo.js', {
-        contains: [
-          "export { default } from 'my-addon/components/x-foo';"
-        ]
-      });
-      assertFile('tests/integration/components/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('x-foo'",
-          "integration: true",
-          "{{x-foo}}",
-          "{{#x-foo}}"
-        ]
-      });
+      expect(file('addon/components/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("import layout from '../templates/components/x-foo';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("layout")
+        .to.contain("});");
+
+      expect(file('addon/templates/components/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('app/components/x-foo.js'))
+        .to.contain("export { default } from 'my-addon/components/x-foo';");
+
+      expect(file('tests/integration/components/x-foo-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('x-foo'")
+        .to.contain("integration: true")
+        .to.contain("{{x-foo}}")
+        .to.contain("{{#x-foo}}");
     });
   });
 
   it('in-addon blueprint foo', function() {
     return generateInAddon(['blueprint', 'foo']).then(function() {
-      assertFile('blueprints/foo/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('in-addon blueprint foo/bar', function() {
     return generateInAddon(['blueprint', 'foo/bar']).then(function() {
-      assertFile('blueprints/foo/bar/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/bar/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('in-addon http-mock foo', function() {
     return generateInAddon(['http-mock', 'foo']).then(function() {
-      assertFile('server/index.js', {
-        contains:"mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo', require('body-parser').json());\n" +
-                  "  app.use('/api/foo', fooRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo', require('body-parser').json());\n" +
+                    "  app.use('/api/foo', fooRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('in-addon http-mock foo-bar', function() {
     return generateInAddon(['http-mock', 'foo-bar']).then(function() {
-      assertFile('server/index.js', {
-        contains: "mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo-bar.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo-bar.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooBarRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('in-addon http-proxy foo', function() {
     return generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
-      assertFile('server/index.js', {
-        contains: "proxies.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/proxies/foo.js', {
-        contains: "var proxyPath = '/foo';\n" +
-                  "\n" +
-                  "module.exports = function(app) {\n" +
-                  "  // For options, see:\n" +
-                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                  "\n" +
-                  "  proxy.on('error', function(err, req) {\n" +
-                  "    console.error(err, req.url);\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  app.use(proxyPath, function(req, res, next){\n" +
-                  "    // include root path in proxied request\n" +
-                  "    req.url = proxyPath + '/' + req.url;\n" +
-                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                  "  });\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("proxies.forEach(function(route) { route(app); });");
+
+      expect(file('server/proxies/foo.js'))
+        .to.contain("var proxyPath = '/foo';\n" +
+                    "\n" +
+                    "module.exports = function(app) {\n" +
+                    "  // For options, see:\n" +
+                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                    "\n" +
+                    "  proxy.on('error', function(err, req) {\n" +
+                    "    console.error(err, req.url);\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  app.use(proxyPath, function(req, res, next){\n" +
+                    "    // include root path in proxied request\n" +
+                    "    req.url = proxyPath + '/' + req.url;\n" +
+                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                    "  });\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('in-addon server', function() {
     return generateInAddon(['server']).then(function() {
-      assertFile('server/index.js');
-      assertFile('server/.jshintrc');
+      expect(file('server/index.js')).to.exist;
+      expect(file('server/.jshintrc')).to.exist;
     });
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -5,18 +5,23 @@ var path       = require('path');
 var fs         = require('fs-extra');
 var remove     = Promise.denodeify(fs.remove);
 
-var expect     = require('chai').expect;
-
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
 var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var existsSync          = require('exists-sync');
-var assertFile          = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 var appName  = 'some-cool-app';
 
@@ -339,15 +344,9 @@ describe('Acceptance: brocfile-smoke-test', function() {
         expect(result.output.join('\n')).to.include('Usage of EmberApp.legacyFilesToAppend is deprecated. Please use EmberApp.import instead for the following files: \'vendor/legacy-file.js\', \'vendor/second-legacy-file.js\'');
         expect(result.output.join('\n')).to.include('Usage of EmberApp.vendorStaticStyles is deprecated. Please use EmberApp.import instead for the following files: \'vendor/legacy-file.css\'');
 
-        assertFile(path.join('dist', 'assets', 'vendor.js'), {
-          contains: 'legacy-file.js'
-        });
-        assertFile(path.join('dist', 'assets', 'vendor.js'), {
-          contains: 'second-legacy-file.js'
-        });
-        assertFile(path.join('dist', 'assets', 'vendor.css'), {
-          contains: 'legacy-file.css'
-        });
+        expect(file('dist/assets/vendor.js')).to.contain('legacy-file.js');
+        expect(file('dist/assets/vendor.js')).to.contain('second-legacy-file.js');
+        expect(file('dist/assets/vendor.css')).to.contain('legacy-file.css');
       });
   });
 

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var Promise    = require('../../lib/ext/promise');
-var expect     = require('chai').expect;
-var assertFile = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var conf       = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember      = require('../helpers/ember');
 var existsSync = require('exists-sync');
@@ -16,6 +14,14 @@ var mkTmpDirIn = require('../../lib/utilities/mk-tmp-dir-in');
 
 var Blueprint        = require('../../lib/models/blueprint');
 var BlueprintNpmTask = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember destroy', function() {
   this.timeout(60000);
@@ -97,17 +103,16 @@ describe('Acceptance: ember destroy', function() {
     return ember(destroyArgs);
   }
 
-  function assertFileNotExists(file) {
-    var filePath = path.join(process.cwd(), file);
-    expect(existsSync(filePath), 'expected ' + file + ' not to exist').to.be.false;
-  }
-
   function assertFilesExist(files) {
-    files.forEach(assertFile);
+    files.forEach(function(f) {
+      expect(file(f)).to.exist;
+    });
   }
 
   function assertFilesNotExist(files) {
-    files.forEach(assertFileNotExists);
+    files.forEach(function(f) {
+      expect(file(f)).to.not.exist;
+    });
   }
 
   function assertDestroyAfterGenerate(args, files) {
@@ -307,8 +312,8 @@ describe('Acceptance: ember destroy', function() {
       .then(function() { return generate(['http-mock', 'bar']); })
       .then(function() { return destroy(['http-mock', 'foo']); })
       .then(function() {
-        assertFile('server/index.js');
-        assertFile('server/.jshintrc');
+        expect(file('server/index.js')).to.exist;
+        expect(file('server/.jshintrc')).to.exist;
       });
   });
 

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var Promise          = require('../../lib/ext/promise');
-var assertFile       = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
-var assertFileEquals = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-equals');
 var conf             = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember            = require('../helpers/ember');
 var fs               = require('fs-extra');
@@ -14,9 +12,15 @@ var root             = process.cwd();
 var tmproot          = path.join(root, 'tmp');
 var Blueprint        = require('../../lib/models/blueprint');
 var BlueprintNpmTask = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
-var expect           = require('chai').expect;
-var MockUI             = require('../helpers/mock-ui');
 var mkTmpDirIn       = require('../../lib/utilities/mk-tmp-dir-in');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember generate', function() {
   this.timeout(20000);
@@ -64,266 +68,246 @@ describe('Acceptance: ember generate', function() {
 
   it('component x-foo', function() {
     return generate(['component', 'x-foo']).then(function() {
-      assertFile('app/components/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      });
-      assertFile('app/templates/components/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('tests/integration/components/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('x-foo'",
-          "integration: true",
-          "{{x-foo}}",
-          "{{#x-foo}}"
-        ]
-      });
+      expect(file('app/components/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("});");
+
+      expect(file('app/templates/components/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('tests/integration/components/x-foo-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('x-foo'")
+        .to.contain("integration: true")
+        .to.contain("{{x-foo}}")
+        .to.contain("{{#x-foo}}");
     });
   });
 
   it('component foo/x-foo', function() {
     return generate(['component', 'foo/x-foo']).then(function() {
-      assertFile('app/components/foo/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      });
-      assertFile('app/templates/components/foo/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('tests/integration/components/foo/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('foo/x-foo'",
-          "integration: true",
-          "{{foo/x-foo}}",
-          "{{#foo/x-foo}}"
-        ]
-      });
+      expect(file('app/components/foo/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("});");
+
+      expect(file('app/templates/components/foo/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('tests/integration/components/foo/x-foo-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('foo/x-foo'")
+        .to.contain("integration: true")
+        .to.contain("{{foo/x-foo}}")
+        .to.contain("{{#foo/x-foo}}");
     });
   });
 
   it('component x-foo ignores --path option', function() {
     return generate(['component', 'x-foo', '--path', 'foo']).then(function() {
-      assertFile('app/components/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      });
-      assertFile('app/templates/components/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('tests/integration/components/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('x-foo'",
-          "integration: true",
-          "{{x-foo}}",
-          "{{#x-foo}}"
-        ]
-      });
+      expect(file('app/components/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("});");
+
+      expect(file('app/templates/components/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('tests/integration/components/x-foo-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('x-foo'")
+        .to.contain("integration: true")
+        .to.contain("{{x-foo}}")
+        .to.contain("{{#x-foo}}");
     });
   });
 
   it('blueprint foo', function() {
     return generate(['blueprint', 'foo']).then(function() {
-      assertFile('blueprints/foo/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('blueprint foo/bar', function() {
     return generate(['blueprint', 'foo/bar']).then(function() {
-      assertFile('blueprints/foo/bar/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/bar/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('http-mock foo', function() {
     return generate(['http-mock', 'foo']).then(function() {
-      assertFile('server/index.js', {
-        contains:"mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo', require('body-parser').json());\n" +
-                  "  app.use('/api/foo', fooRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo', require('body-parser').json());\n" +
+                    "  app.use('/api/foo', fooRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('http-mock foo-bar', function() {
     return generate(['http-mock', 'foo-bar']).then(function() {
-      assertFile('server/index.js', {
-        contains: "mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo-bar.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo-bar.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooBarRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('http-proxy foo', function() {
     return generate(['http-proxy', 'foo', 'http://localhost:5000']).then(function() {
-      assertFile('server/index.js', {
-        contains: "proxies.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/proxies/foo.js', {
-        contains: "var proxyPath = '/foo';\n" +
-                  "\n" +
-                  "module.exports = function(app) {\n" +
-                  "  // For options, see:\n" +
-                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                  "\n" +
-                  "  proxy.on('error', function(err, req) {\n" +
-                  "    console.error(err, req.url);\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  app.use(proxyPath, function(req, res, next){\n" +
-                  "    // include root path in proxied request\n" +
-                  "    req.url = proxyPath + '/' + req.url;\n" +
-                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                  "  });\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("proxies.forEach(function(route) { route(app); });");
+
+      expect(file('server/proxies/foo.js'))
+        .to.contain("var proxyPath = '/foo';\n" +
+                    "\n" +
+                    "module.exports = function(app) {\n" +
+                    "  // For options, see:\n" +
+                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                    "\n" +
+                    "  proxy.on('error', function(err, req) {\n" +
+                    "    console.error(err, req.url);\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  app.use(proxyPath, function(req, res, next){\n" +
+                    "    // include root path in proxied request\n" +
+                    "    req.url = proxyPath + '/' + req.url;\n" +
+                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                    "  });\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
@@ -340,9 +324,7 @@ describe('Acceptance: ember generate', function() {
         return ember(['generate', 'foo', 'bar']);
       })
       .then(function() {
-        assertFile('app/foos/bar.js', {
-          contains: 'foo: true'
-        });
+        expect(file('app/foos/bar.js')).to.contain('foo: true');
       });
   });
 
@@ -359,9 +341,7 @@ describe('Acceptance: ember generate', function() {
         return ember(['generate', 'controller', 'foo']);
       })
       .then(function() {
-        assertFile('app/controllers/foo.js', {
-          contains: 'custom: true'
-        });
+        expect(file('app/controllers/foo.js')).to.contain('custom: true');
       });
   });
 
@@ -387,9 +367,7 @@ describe('Acceptance: ember generate', function() {
         return ember(['generate', 'customblue', 'foo', '--custom-command']);
       })
       .then(function() {
-        assertFile('app/foo.js', {
-          contains: 'A: Yes!'
-        });
+        expect(file('app/foo.js')).to.contain('A: Yes!');
       });
   });
 
@@ -412,38 +390,32 @@ describe('Acceptance: ember generate', function() {
         process.chdir(tmpdir);
       })
       .then(function() {
-        assertFile('app/controllers/foo.js', {
-          contains: 'custom: true'
-        });
+        expect(file('app/controllers/foo.js')).to.contain('custom: true');
       });
   });
 
   it('route foo --dry-run does not change router.js', function() {
     return generate(['route', 'foo', '--dry-run']).then(function() {
-      assertFile('app/router.js', {
-        doesNotContain: "route('foo')"
-      });
+      expect(file('app/router.js')).to.not.contain("route('foo')");
     });
   });
 
   it('server', function() {
     return generate(['server']).then(function() {
-      assertFile('server/index.js');
-      assertFile('server/.jshintrc');
+      expect(file('server/index.js')).to.exist;
+      expect(file('server/.jshintrc')).to.exist;
     });
   });
 
   it('availableOptions work with aliases.', function() {
     return generate(['route', 'foo', '-d']).then(function() {
-      assertFile('app/router.js', {
-        doesNotContain: "route('foo')"
-      });
+      expect(file('app/router.js')).to.not.contain("route('foo')");
     });
   });
 
   it('lib', function() {
     return generate(['lib']).then(function() {
-      assertFile('lib/.jshintrc');
+      expect(file('lib/.jshintrc')).to.exist;
     });
   });
 
@@ -469,9 +441,7 @@ describe('Acceptance: ember generate', function() {
         });
       });
     }).then(function() {
-      assertFile('app/foos/bar.js', {
-        contain: ['export default Ember.Object.extend({ foo: two });']
-      });
+      expect(file('app/foos/bar.js')).to.contain('export default Ember.Object.extend({ foo: two });');
     });
   });
 });

--- a/tests/acceptance/in-repo-addon-generate-test.js
+++ b/tests/acceptance/in-repo-addon-generate-test.js
@@ -1,9 +1,7 @@
 'use strict';
 
 var Promise              = require('../../lib/ext/promise');
-var assertFile           = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var assertFileEquals     = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-equals');
-var assertFileToNotExist = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-to-not-exist');
 var conf                 = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember                = require('../helpers/ember');
 var fs                   = require('fs-extra');
@@ -13,8 +11,15 @@ var root                 = process.cwd();
 var tmproot              = path.join(root, 'tmp');
 var Blueprint            = require('../../lib/models/blueprint');
 var BlueprintNpmTask     = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
-var expect               = require('chai').expect;
 var mkTmpDirIn           = require('../../lib/utilities/mk-tmp-dir-in');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember generate in-repo-addon', function() {
   this.timeout(20000);
@@ -69,33 +74,26 @@ describe('Acceptance: ember generate in-repo-addon', function() {
 
   it('in-repo-addon component x-foo', function() {
     return generateInRepoAddon(['component', 'x-foo', '--in-repo-addon=my-addon']).then(function() {
-      assertFile('lib/my-addon/addon/components/x-foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "import layout from '../templates/components/x-foo';",
-          "export default Ember.Component.extend({",
-          "layout",
-          "});"
-        ]
-      });
-      assertFile('lib/my-addon/addon/templates/components/x-foo.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('lib/my-addon/app/components/x-foo.js', {
-        contains: [
-          "export { default } from 'my-addon/components/x-foo';"
-        ]
-      });
-      assertFile('tests/integration/components/x-foo-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('x-foo'",
-          "integration: true",
-          "{{x-foo}}",
-          "{{#x-foo}}"
-        ]
-      });
+      expect(file('lib/my-addon/addon/components/x-foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("import layout from '../templates/components/x-foo';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("layout")
+        .to.contain("});");
+
+      expect(file('lib/my-addon/addon/templates/components/x-foo.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('lib/my-addon/app/components/x-foo.js'))
+        .to.contain("export { default } from 'my-addon/components/x-foo';");
+
+      expect(file('tests/integration/components/x-foo-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('x-foo'")
+        .to.contain("integration: true")
+        .to.contain("{{x-foo}}")
+        .to.contain("{{#x-foo}}");
     });
   });
 
@@ -104,17 +102,13 @@ describe('Acceptance: ember generate in-repo-addon', function() {
       var expected = path.join(__dirname, '../fixtures/generate/acceptance-test-expected.js');
 
       assertFileEquals('tests/acceptance/foo-test.js', expected);
-      assertFileToNotExist('app/acceptance-tests/foo.js');
+      expect(file('app/acceptance-tests/foo.js')).to.not.exist;
     });
   });
 
   it('in-repo-addon adds path to lib', function() {
     return initInRepoAddon().then(function() {
-      assertFile('package.json', {
-        contains: [
-          'lib/my-addon'
-        ]
-      });
+      expect(file('package.json')).to.contain('lib/my-addon');
     });
   });
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -3,7 +3,6 @@
 var fs         = require('fs-extra');
 var ember      = require('../helpers/ember');
 var existsSync = require('exists-sync');
-var expect     = require('chai').expect;
 var forEach    = require('lodash/forEach');
 var walkSync   = require('walk-sync');
 var Blueprint  = require('../../lib/models/blueprint');
@@ -13,10 +12,17 @@ var root       = process.cwd();
 var util       = require('util');
 var conf       = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var EOL        = require('os').EOL;
-var assertFile = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var chalk      = require('chalk');
 var Promise    = require('../../lib/ext/promise');
 var mkdir      = Promise.denodeify(fs.mkdir);
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember new', function() {
   this.timeout(10000);
@@ -237,9 +243,7 @@ describe('Acceptance: ember new', function() {
         ]);
       })
       .then(function() {
-        assertFile('.gitignore', {
-          contains: 'customValue'
-        });
+        expect(file('.gitignore')).to.contain('customValue');
       });
   });
 

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var Promise     = require('../../lib/ext/promise');
-var expect      = require('chai').expect;
-var assertFile  = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var conf        = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember       = require('../helpers/ember');
 var existsSync  = require('exists-sync');
@@ -17,6 +15,14 @@ var mkTmpDirIn  = require('../../lib/utilities/mk-tmp-dir-in');
 
 var Blueprint        = require('../../lib/models/blueprint');
 var BlueprintNpmTask = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember destroy pod', function() {
   var tmpdir;
@@ -101,17 +107,16 @@ describe('Acceptance: ember destroy pod', function() {
     return ember(destroyArgs);
   }
 
-  function assertFileNotExists(file) {
-    var filePath = path.join(process.cwd(), file);
-    expect(existsSync(filePath), 'expected ' + file + ' not to exist').to.be.false;
-  }
-
   function assertFilesExist(files) {
-    files.forEach(assertFile);
+    files.forEach(function(f) {
+      expect(file(f)).to.exist;
+    });
   }
 
   function assertFilesNotExist(files) {
-    files.forEach(assertFileNotExists);
+    files.forEach(function(f) {
+      expect(file(f)).to.not.exist;
+    });
   }
 
   function assertDestroyAfterGenerate(args, files) {

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var Promise          = require('../../lib/ext/promise');
-var assertFile       = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
-var assertFileEquals = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-equals');
 var conf             = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var ember            = require('../helpers/ember');
 var replaceFile      = require('ember-cli-internal-test-helpers/lib/helpers/file-utils').replaceFile;
@@ -12,11 +10,18 @@ var path             = require('path');
 var remove           = Promise.denodeify(fs.remove);
 var root             = process.cwd();
 var tmproot          = path.join(root, 'tmp');
-var expect           = require('chai').expect;
 var mkTmpDirIn       = require('../../lib/utilities/mk-tmp-dir-in');
 
 var Blueprint        = require('../../lib/models/blueprint');
 var BlueprintNpmTask = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
 
 describe('Acceptance: ember generate pod', function() {
   this.timeout(60000);
@@ -134,248 +139,228 @@ describe('Acceptance: ember generate pod', function() {
 
   it('.ember-cli usePods setting generates in pod structure without --pod flag', function() {
     return generateWithUsePods(['controller', 'foo']).then(function() {
-      assertFile('app/foo/controller.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Controller.extend({\n});"
-        ]
-      });
-      assertFile('tests/unit/foo/controller-test.js', {
-        contains: [
-          "import { moduleFor, test } from 'ember-qunit';",
-          "moduleFor('controller:foo'"
-        ]
-      });
+      expect(file('app/foo/controller.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Controller.extend({\n});");
+
+      expect(file('tests/unit/foo/controller-test.js'))
+        .to.contain("import { moduleFor, test } from 'ember-qunit';")
+        .to.contain("moduleFor('controller:foo'");
     });
   });
 
   it('.ember-cli usePods setting generates in classic structure with --classic flag', function() {
     return generateWithUsePods(['controller', 'foo', '--classic']).then(function() {
-      assertFile('app/controllers/foo.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Controller.extend({\n});"
-        ]
-      });
-      assertFile('tests/unit/controllers/foo-test.js', {
-        contains: [
-          "import { moduleFor, test } from 'ember-qunit';",
-          "moduleFor('controller:foo'"
-        ]
-      });
+      expect(file('app/controllers/foo.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Controller.extend({\n});");
+
+      expect(file('tests/unit/controllers/foo-test.js'))
+        .to.contain("import { moduleFor, test } from 'ember-qunit';")
+        .to.contain("moduleFor('controller:foo'");
     });
   });
 
   it('.ember-cli usePods setting generates correct component structure', function() {
     return generateWithUsePods(['component', 'x-foo']).then(function() {
-      assertFile('app/components/x-foo/component.js', {
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      });
-      assertFile('app/components/x-foo/template.hbs', {
-        contains: "{{yield}}"
-      });
-      assertFile('tests/integration/components/x-foo/component-test.js', {
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('x-foo'",
-          "integration: true"
-        ]
-      });
+      expect(file('app/components/x-foo/component.js'))
+        .to.contain("import Ember from 'ember';")
+        .to.contain("export default Ember.Component.extend({")
+        .to.contain("});");
+
+      expect(file('app/components/x-foo/template.hbs'))
+        .to.contain("{{yield}}");
+
+      expect(file('tests/integration/components/x-foo/component-test.js'))
+        .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+        .to.contain("import hbs from 'htmlbars-inline-precompile';")
+        .to.contain("moduleForComponent('x-foo'")
+        .to.contain("integration: true");
     });
   });
 
   it('blueprint foo --pod', function() {
     return generate(['blueprint', 'foo', '--pod']).then(function() {
-      assertFile('blueprints/foo/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('blueprint foo/bar --pod', function() {
     return generate(['blueprint', 'foo/bar', '--pod']).then(function() {
-      assertFile('blueprints/foo/bar/index.js', {
-        contains: "module.exports = {\n" +
-                  "  description: ''\n" +
-                  "\n" +
-                  "  // locals: function(options) {\n" +
-                  "  //   // Return custom template variables here.\n" +
-                  "  //   return {\n" +
-                  "  //     foo: options.entity.options.foo\n" +
-                  "  //   };\n" +
-                  "  // }\n" +
-                  "\n" +
-                  "  // afterInstall: function(options) {\n" +
-                  "  //   // Perform extra work here.\n" +
-                  "  // }\n" +
-                  "};"
-      });
+      expect(file('blueprints/foo/bar/index.js'))
+        .to.contain("module.exports = {\n" +
+                    "  description: ''\n" +
+                    "\n" +
+                    "  // locals: function(options) {\n" +
+                    "  //   // Return custom template variables here.\n" +
+                    "  //   return {\n" +
+                    "  //     foo: options.entity.options.foo\n" +
+                    "  //   };\n" +
+                    "  // }\n" +
+                    "\n" +
+                    "  // afterInstall: function(options) {\n" +
+                    "  //   // Perform extra work here.\n" +
+                    "  // }\n" +
+                    "};");
     });
   });
 
   it('http-mock foo --pod', function() {
     return generate(['http-mock', 'foo', '--pod']).then(function() {
-      assertFile('server/index.js', {
-        contains:"mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo', require('body-parser').json());\n" +
-                  "  app.use('/api/foo', fooRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo', require('body-parser').json());\n" +
+                    "  app.use('/api/foo', fooRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('http-mock foo-bar --pod', function() {
     return generate(['http-mock', 'foo-bar', '--pod']).then(function() {
-      assertFile('server/index.js', {
-        contains: "mocks.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/mocks/foo-bar.js', {
-        contains: "module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': []\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.post('/', function(req, res) {\n" +
-                  "    res.status(201).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.get('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.put('/:id', function(req, res) {\n" +
-                  "    res.send({\n" +
-                  "      'foo-bar': {\n" +
-                  "        id: req.params.id\n" +
-                  "      }\n" +
-                  "    });\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-                  "    res.status(204).end();\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  // The POST and PUT call will not contain a request body\n" +
-                  "  // because the body-parser is not included by default.\n" +
-                  "  // To use req.body, run:\n" +
-                  "\n" +
-                  "  //    npm install --save-dev body-parser\n" +
-                  "\n" +
-                  "  // After installing, you need to `use` the body-parser for\n" +
-                  "  // this mock uncommenting the following line:\n" +
-                  "  //\n" +
-                  "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-                  "  app.use('/api/foo-bar', fooBarRouter);\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("mocks.forEach(function(route) { route(app); });");
+
+      expect(file('server/mocks/foo-bar.js'))
+        .to.contain("module.exports = function(app) {\n" +
+                    "  var express = require('express');\n" +
+                    "  var fooBarRouter = express.Router();\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': []\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.post('/', function(req, res) {\n" +
+                    "    res.status(201).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.get('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.put('/:id', function(req, res) {\n" +
+                    "    res.send({\n" +
+                    "      'foo-bar': {\n" +
+                    "        id: req.params.id\n" +
+                    "      }\n" +
+                    "    });\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+                    "    res.status(204).end();\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  // The POST and PUT call will not contain a request body\n" +
+                    "  // because the body-parser is not included by default.\n" +
+                    "  // To use req.body, run:\n" +
+                    "\n" +
+                    "  //    npm install --save-dev body-parser\n" +
+                    "\n" +
+                    "  // After installing, you need to `use` the body-parser for\n" +
+                    "  // this mock uncommenting the following line:\n" +
+                    "  //\n" +
+                    "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+                    "  app.use('/api/foo-bar', fooBarRouter);\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
   it('http-proxy foo --pod', function() {
     return generate(['http-proxy', 'foo', 'http://localhost:5000', '--pod']).then(function() {
-      assertFile('server/index.js', {
-        contains: "proxies.forEach(function(route) { route(app); });"
-      });
-      assertFile('server/proxies/foo.js', {
-        contains: "var proxyPath = '/foo';\n" +
-                  "\n" +
-                  "module.exports = function(app) {\n" +
-                  "  // For options, see:\n" +
-                  "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
-                  "\n" +
-                  "  proxy.on('error', function(err, req) {\n" +
-                  "    console.error(err, req.url);\n" +
-                  "  });\n" +
-                  "\n" +
-                  "  app.use(proxyPath, function(req, res, next){\n" +
-                  "    // include root path in proxied request\n" +
-                  "    req.url = proxyPath + '/' + req.url;\n" +
-                  "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-                  "  });\n" +
-                  "};"
-      });
-      assertFile('server/.jshintrc', {
-        contains: '{\n  "node": true\n}'
-      });
+      expect(file('server/index.js'))
+        .to.contain("proxies.forEach(function(route) { route(app); });");
+
+      expect(file('server/proxies/foo.js'))
+        .to.contain("var proxyPath = '/foo';\n" +
+                    "\n" +
+                    "module.exports = function(app) {\n" +
+                    "  // For options, see:\n" +
+                    "  // https://github.com/nodejitsu/node-http-proxy\n" +
+                    "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                    "\n" +
+                    "  proxy.on('error', function(err, req) {\n" +
+                    "    console.error(err, req.url);\n" +
+                    "  });\n" +
+                    "\n" +
+                    "  app.use(proxyPath, function(req, res, next){\n" +
+                    "    // include root path in proxied request\n" +
+                    "    req.url = proxyPath + '/' + req.url;\n" +
+                    "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+                    "  });\n" +
+                    "};");
+
+      expect(file('server/.jshintrc'))
+        .to.contain('{\n  "node": true\n}');
     });
   });
 
@@ -392,9 +377,7 @@ describe('Acceptance: ember generate pod', function() {
         return ember(['generate', 'foo', 'bar', '--pod']);
       })
       .then(function() {
-        assertFile('app/foos/bar.js', {
-          contains: 'foo: true'
-        });
+        expect(file('app/foos/bar.js')).to.contain('foo: true');
       });
   });
 
@@ -411,9 +394,7 @@ describe('Acceptance: ember generate pod', function() {
         return ember(['generate', 'controller', 'foo', '--pod']);
       })
       .then(function() {
-        assertFile('app/foo/controller.js', {
-          contains: 'custom: true'
-        });
+        expect(file('app/foo/controller.js')).to.contain('custom: true');
       });
   });
 
@@ -448,9 +429,7 @@ describe('Acceptance: ember generate pod', function() {
         return ember(['generate', 'customblue', 'foo', '--custom-command', '--pod']);
       })
       .then(function() {
-        assertFile('app/foo.js', {
-          contains: 'A: Yes!'
-        });
+        expect(file('app/foo.js')).to.contain('A: Yes!');
       });
   });
 
@@ -473,9 +452,7 @@ describe('Acceptance: ember generate pod', function() {
         process.chdir(tmpdir);
       })
       .then(function() {
-        assertFile('app/foo/controller.js', {
-          contains: 'custom: true'
-        });
+        expect(file('app/foo/controller.js')).to.contain('custom: true');
       });
   });
 
@@ -497,17 +474,13 @@ describe('Acceptance: ember generate pod', function() {
 
   it('route foo --dry-run --pod does not change router.js', function() {
     return generate(['route', 'foo', '--dry-run', '--pod']).then(function() {
-      assertFile('app/router.js', {
-        doesNotContain: "route('foo')"
-      });
+      expect(file('app/router.js')).to.not.contain("route('foo')");
     });
   });
 
   it('availableOptions work with aliases.', function() {
     return generate(['route', 'foo', '-d', '-p']).then(function() {
-      assertFile('app/router.js', {
-        doesNotContain: "route('foo')"
-      });
+      expect(file('app/router.js')).to.not.contain("route('foo')");
     });
   });
 });


### PR DESCRIPTION
This PR is leveraging the new [chai-files](https://www.npmjs.com/package/chai-files) library for file assertions and replacing most of the old `assertFile()` calls.