### PR TITLE
Embed/include ember-try in ember-cli

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -37,9 +37,8 @@ module.exports = {
     // add `ember-disable-prototype-extensions` to addons by default
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.0';
 
-    // add `ember-try` to addons by default
-    contents.devDependencies['ember-try'] = '^0.2.2';
-    contents.scripts.test = 'ember try:testall';
+    // use `ember-try` as test script in addons by default
+    contents.scripts.test = 'ember try:each';
 
     contents['ember-addon'] = contents['ember-addon'] || {};
     contents['ember-addon'].configPath = 'tests/dummy/config';

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -335,12 +335,14 @@ Project.prototype.supportedInternalAddonPaths = function() {
 
   var internalMiddlewarePath = path.join(__dirname, '../tasks/server/middleware');
   var legacyBlueprintsPath = require.resolve('ember-cli-legacy-blueprints');
+  var emberTryPath = require.resolve('ember-try');
   return [
     path.join(internalMiddlewarePath, 'tests-server'),
     path.join(internalMiddlewarePath, 'history-support'),
     path.join(internalMiddlewarePath, 'serve-files'),
     path.join(internalMiddlewarePath, 'proxy-server'),
-    path.dirname(legacyBlueprintsPath)
+    path.dirname(legacyBlueprintsPath),
+    path.dirname(emberTryPath)
   ];
 };
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^2.0.0",
     "ember-cli-string-utils": "^1.0.0",
+    "ember-try": "^0.2.2",
     "escape-string-regexp": "^1.0.3",
     "exists-sync": "0.0.3",
     "exit": "^0.1.2",

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -118,15 +118,14 @@ describe('blueprint - addon', function() {
   "name": "test-project-name",\n\
   "description": "The default blueprint for ember-cli addons.",\n\
   "scripts": {\n\
-    "test": "ember try:testall"\n\
+    "test": "ember try:each"\n\
   },\n\
   "keywords": [\n\
     "ember-addon"\n\
   ],\n\
   "dependencies": {},\n\
   "devDependencies": {\n\
-    "ember-disable-prototype-extensions": "^1.1.0",\n\
-    "ember-try": "^0.2.2"\n\
+    "ember-disable-prototype-extensions": "^1.1.0"\n\
   },\n\
   "ember-addon": {\n\
     "configPath": "tests/dummy/config"\n\
@@ -225,22 +224,6 @@ describe('blueprint - addon', function() {
         expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.0');
       });
 
-      it('overwrites any version of `ember-try`', function() {
-        readFileSyncReturnValue = JSON.stringify({
-          devDependencies: {
-            'ember-try': '0.0.1'
-          }
-        });
-
-        blueprint.generatePackageJson();
-
-        expect(readFileSyncWasCalled).to.be.true;
-        expect(writeFileSyncWasCalled).to.be.true;
-
-        var json = JSON.parse(writeFileSyncArguments[1]);
-        expect(json.devDependencies['ember-try']).to.equal('^0.2.2');
-      });
-
       it('overwrites `scripts.test`', function() {
         readFileSyncReturnValue = JSON.stringify({
           scripts: {
@@ -254,7 +237,7 @@ describe('blueprint - addon', function() {
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
-        expect(json.scripts.test).to.equal('ember try:testall');
+        expect(json.scripts.test).to.equal('ember try:each');
       });
 
       it('overwrites `ember-addon.configPath`', function() {
@@ -292,7 +275,6 @@ describe('blueprint - addon', function() {
 
         var json = JSON.parse(writeFileSyncArguments[1]);
         delete json.devDependencies['ember-disable-prototype-extensions'];
-        delete json.devDependencies['ember-try'];
         expect(JSON.stringify(json.dependencies)).to.equal('{"a":"1","b":"1"}');
         expect(JSON.stringify(json.devDependencies)).to.equal('{"a":"1","b":"1"}');
       });

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -443,6 +443,7 @@ describe('broccoli/ember-app', function() {
         });
       });
     });
+
     describe('postprocessTree is called properly', function() {
       var postprocessTreeStub;
       beforeEach(function() {
@@ -554,7 +555,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = emberApp;
             expect(emberApp._addonEnabled(emberFooEnvAddonFixture)).to.be.false;
 
-            expect(emberApp.project.addons.length).to.equal(6);
+            expect(emberApp.project.addons.length).to.equal(7);
           });
 
           it('foo', function() {
@@ -564,7 +565,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = emberApp;
             expect(emberApp._addonEnabled(emberFooEnvAddonFixture)).to.be.true;
 
-            expect(emberApp.project.addons.length).to.equal(7);
+            expect(emberApp.project.addons.length).to.equal(8);
           });
         });
       });
@@ -581,7 +582,7 @@ describe('broccoli/ember-app', function() {
 
           expect(emberApp._addonDisabledByBlacklist({ name: 'ember-foo-env-addon' })).to.be.true;
           expect(emberApp._addonDisabledByBlacklist({ name: 'Ember Random Addon' })).to.be.false;
-          expect(emberApp.project.addons.length).to.equal(6);
+          expect(emberApp.project.addons.length).to.equal(7);
         });
 
         it('throws if unavailable addon is specified', function() {
@@ -644,7 +645,6 @@ describe('broccoli/ember-app', function() {
         });
       });
     });
-
 
     describe('addonLintTree', function() {
       beforeEach(function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -190,7 +190,8 @@ describe('models/project.js', function() {
       var expected = [
         'tests-server-middleware',
         'history-support-middleware', 'serve-files-middleware',
-        'proxy-server-middleware', 'ember-cli-legacy-blueprints', 'ember-random-addon', 'ember-non-root-addon',
+        'proxy-server-middleware', 'ember-cli-legacy-blueprints', 'ember-try',
+        'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon',
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
         'ember-devDeps-addon', 'ember-addon-with-dependencies', 'ember-super-button'
@@ -201,10 +202,10 @@ describe('models/project.js', function() {
     it('returns instances of the addons', function() {
       var addons = project.addons;
 
-      expect(addons[6].name).to.equal('Ember Non Root Addon');
-      expect(addons[12].name).to.equal('Ember Super Button');
-      expect(addons[12].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[12].addons[1].name).to.equal('Ember Ng');
+      expect(addons[7].name).to.equal('Ember Non Root Addon');
+      expect(addons[13].name).to.equal('Ember Super Button');
+      expect(addons[13].addons[0].name).to.equal('Ember Yagni');
+      expect(addons[13].addons[1].name).to.equal('Ember Ng');
     });
 
     it('addons get passed the project instance', function() {
@@ -216,7 +217,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       var addons = project.addons;
 
-      expect(addons[8].name).to.equal('Ember Random Addon');
+      expect(addons[9].name).to.equal('Ember Random Addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -279,8 +280,8 @@ describe('models/project.js', function() {
     it('returns an instance of an addon with an object export', function() {
       var addons = project.addons;
 
-      expect(addons[5] instanceof Addon).to.equal(true);
-      expect(addons[5].name).to.equal('Ember CLI Generated with export');
+      expect(addons[6] instanceof Addon).to.equal(true);
+      expect(addons[6].name).to.equal('Ember CLI Generated with export');
     });
 
     it('adds the project itself if it is an addon', function() {


### PR DESCRIPTION
Also:

- Remove ember-try from the addon package.json blueprints
- Update command set as the default test script for addons to `ember try:each` from `ember try:testall` (functionally equivalent).