### PR TITLE
[ENHANCEMENT] Remove ember-data from generated addon package.json

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -30,6 +30,9 @@ module.exports = {
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];
     delete contents.devDependencies['ember-cli-babel'];
 
+    // 99% of blueprints don't need ember-data, make it opt-in instead
+    delete contents.devDependencies['ember-data'];
+
     if (contents.keywords.indexOf('ember-addon') === -1) {
       contents.keywords.push('ember-addon');
     }


### PR DESCRIPTION
In 99% of addons, authors do not need or want ember-data in their `package.json`. This PR removes ember-data from an addon's `package.json` `devDependencies`.
