### PR TITLE
[INTERNAL] Fix typo

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1437,7 +1437,7 @@ EmberApp.prototype.dependencies = function(pkg) {
 
   @public
   @method import
-  @param  {(Object|String)}  asset   Either a path to the asset or an object with envirnoment names and paths as key-value pairs.
+  @param  {(Object|String)}  asset   Either a path to the asset or an object with environment names and paths as key-value pairs.
   @param  {Object=} options Options object
  */
 EmberApp.prototype.import = function(asset, options) {


### PR DESCRIPTION
Fix typo for the `EmberApp.prototype.import` method documentation.