### PR TITLE
Set platform checker minimum version to node 4.0

### DIFF
--- a/lib/utilities/platform-checker.js
+++ b/lib/utilities/platform-checker.js
@@ -3,7 +3,7 @@
 var semver = require('semver');
 var debug = require('debug')('ember-cli:platform-checker:');
 
-var LOWER_RANGE = '0.12.0';
+var LOWER_RANGE = '4.0.0';
 var UPPER_RANGE = '6.0.0';
 
 module.exports = PlatformChecker;

--- a/tests/unit/utilities/platform-checker-test.js
+++ b/tests/unit/utilities/platform-checker-test.js
@@ -8,35 +8,38 @@ describe('platform-checker', function() {
     expect(new PlatformChecker('v0.10.1').isDeprecated).to.be.equal(true);
     expect(new PlatformChecker('v0.10.15').isDeprecated).to.be.equal(true);
     expect(new PlatformChecker('v0.10.30').isDeprecated).to.be.equal(true);
-    expect(new PlatformChecker('v0.12.0').isDeprecated).to.be.equal(false);
+    expect(new PlatformChecker('v0.12.0').isDeprecated).to.be.equal(true);
   });
 
   it('should return isUntested for Node v6', function() {
     expect(new PlatformChecker('v6.0.0').isUntested).to.be.equal(true);
+    expect(new PlatformChecker('v4.0.0').isUntested).to.be.equal(false);
     expect(new PlatformChecker('v0.12.0').isUntested).to.be.equal(false);
   });
 
-  it('should return isValid for iojs', function() {
-    expect(new PlatformChecker('v1.0.0').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.0.1').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.0.2').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.0.3').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.0.4').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.1.0').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v1.2.0').isValid).to.be.equal(true);
+  it('should not return isValid for iojs', function() {
+    expect(new PlatformChecker('v1.0.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.0.1').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.0.2').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.0.3').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.0.4').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.1.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v1.2.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v2.0.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v3.0.0').isValid).to.be.equal(false);
   });
 
-  it('should return isValid for Node v0.12', function() {
-    expect(new PlatformChecker('v0.12.0').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v0.12.15').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v0.12.30').isValid).to.be.equal(true);
+  it('should not return isValid for Node v0.12', function() {
+    expect(new PlatformChecker('v0.12.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v0.12.15').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v0.12.30').isValid).to.be.equal(false);
     expect(new PlatformChecker('v0.10.0').isValid).to.be.equal(false);
   });
 
-  it('should return isValid for Node v0.13', function() {
-    expect(new PlatformChecker('v0.13.0').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v0.13.15').isValid).to.be.equal(true);
-    expect(new PlatformChecker('v0.13.30').isValid).to.be.equal(true);
+  it('should not return isValid for Node v0.13', function() {
+    expect(new PlatformChecker('v0.13.0').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v0.13.15').isValid).to.be.equal(false);
+    expect(new PlatformChecker('v0.13.30').isValid).to.be.equal(false);
   });
 
   it('should return isValid for Node v4', function() {


### PR DESCRIPTION
This is in accordance with proposed change to node support policy here:

https://github.com/ember-cli/rfcs/pull/47