### PR TITLE
BUGFIX Unable to name a add-on/project as a substring of "ember-core"

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -522,16 +522,17 @@ Project.prototype.reloadAddons = function() {
 Project.prototype.findAddonByName = function(name) {
   this.initializeAddons();
 
-  var exactMatch = find(this.addons, function(addon) {
-    return name === addon.name || (addon.pkg && name === addon.pkg.name);
-  });
+  var unqualifiedName = name;
+  if (name.indexOf('/') !== -1) {
+    unqualifiedName = name.slice(name.lastIndexOf('/') + 1);
+  }
 
-  if (exactMatch) {
-    return exactMatch;
+  function matchAddon(name, addon) {
+    return name === addon.name || (addon.pkg && name === addon.pkg.name);
   }
 
   return find(this.addons, function(addon) {
-    return name.indexOf(addon.name) > -1 || (addon.pkg && name.indexOf(addon.pkg.name) > -1);
+    return matchAddon(name, addon) || matchAddon(unqualifiedName, addon);
   });
 };
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -461,6 +461,16 @@ describe('models/project.js', function() {
       var addon = project.findAddonByName('not-an-addon');
       expect(addon).to.equal(undefined, 'not found addon should be undefined');
     });
+
+    it('should not return an addon that is a substring of requested name', function() {
+      var addon = project.findAddonByName('foo-ba');
+      expect(addon).to.equal(undefined, 'foo-ba should not be found');
+    })
+
+    it('should return an addon that is the unqualified name of requested name', function() {
+      var addon = project.findAddonByName('qux/foo');
+      expect(addon.name).to.equal('foo', 'should have found the foo addon');
+    })
   });
 
   describe('bowerDirectory', function() {


### PR DESCRIPTION
Fixes #5751

I changed `findAddonByName` from matching on a substring of the requested name
to matching on the suffix.