### PR TITLE
Replace more internal assertion helpers with "chai-files" assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "broccoli-plugin": "^1.2.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
-    "chai-files": "^1.1.0",
+    "chai-files": "^1.2.0",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "eslint-plugin-chai-expect": "^1.1.1",
     "github": "^0.2.3",

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -7,20 +7,25 @@ var remove     = Promise.denodeify(fs.remove);
 var addonName  = 'some-cool-addon';
 var spawn      = require('child_process').spawn;
 var chalk      = require('chalk');
-var expect     = require('chai').expect;
-var EOL        = require('os').EOL;
 
 var symlinkOrCopySync   = require('symlink-or-copy').sync;
 var runCommand          = require('../helpers/run-command');
 var ember               = require('../helpers/ember');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
 var killCliProcess      = require('../helpers/kill-cli-process');
-var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var acceptance          = require('../helpers/acceptance');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var dir = chaiFiles.dir;
 
 describe('Acceptance: addon-smoke-test', function() {
   this.timeout(450000);
@@ -41,7 +46,7 @@ describe('Acceptance: addon-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -46,7 +46,7 @@ describe('Acceptance: addon-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -36,7 +36,7 @@ describe('Acceptance: blueprint smoke tests', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -2,15 +2,20 @@
 
 var path                = require('path');
 var fs                  = require('fs');
-var expect              = require('chai').expect;
 var acceptance          = require('../helpers/acceptance');
 var runCommand          = require('../helpers/run-command');
-var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
 
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var dir = chaiFiles.dir;
 
 var appName  = 'some-cool-app';
 
@@ -31,7 +36,7 @@ describe('Acceptance: blueprint smoke tests', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -8,7 +8,6 @@ var remove     = Promise.denodeify(fs.remove);
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
-var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var existsSync          = require('exists-sync');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
@@ -22,6 +21,7 @@ chai.use(chaiFiles);
 
 var expect = chai.expect;
 var file = chaiFiles.file;
+var dir = chaiFiles.dir;
 
 var appName  = 'some-cool-app';
 
@@ -42,7 +42,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -42,7 +42,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 

--- a/tests/acceptance/express-server-restart-slow.js
+++ b/tests/acceptance/express-server-restart-slow.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var path                = require('path');
-var expect              = require('chai').expect;
 var fs                  = require('fs-extra');
 var Promise             = require('../../lib/ext/promise');
 var acceptance          = require('../helpers/acceptance');
@@ -12,9 +11,16 @@ var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
 
-
 var copyFixtureFiles = require('../helpers/copy-fixture-files');
-var assertDirEmpty   = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var dir = chaiFiles.dir;
+
 
 // skipped because brittle. needs some TLC
 describe.skip('Acceptance: express server restart', function () {
@@ -42,7 +48,7 @@ describe.skip('Acceptance: express server restart', function () {
   afterEach(function() {
     this.timeout(15000);
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/express-server-restart-slow.js
+++ b/tests/acceptance/express-server-restart-slow.js
@@ -48,7 +48,7 @@ describe.skip('Acceptance: express server restart', function () {
   afterEach(function() {
     this.timeout(15000);
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -38,7 +38,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -2,16 +2,22 @@
 
 var path       = require('path');
 var fs         = require('fs');
-var expect     = require('chai').expect;
 
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
-var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var dir = chaiFiles.dir;
 
 var appName  = 'some-cool-app';
 
@@ -32,7 +38,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
 
   afterEach(function() {
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -3,7 +3,6 @@
 var path     = require('path');
 var fs       = require('fs');
 var crypto   = require('crypto');
-var expect   = require('chai').expect;
 var walkSync = require('walk-sync');
 var appName  = 'some-cool-app';
 var EOL      = require('os').EOL;
@@ -13,12 +12,19 @@ var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
 var copyFixtureFiles    = require('../helpers/copy-fixture-files');
 var killCliProcess      = require('../helpers/kill-cli-process');
-var assertDirEmpty      = require('ember-cli-internal-test-helpers/lib/helpers/assert-dir-empty');
 var ember               = require('../helpers/ember');
 var createTestTargets   = acceptance.createTestTargets;
 var teardownTestTargets = acceptance.teardownTestTargets;
 var linkDependencies    = acceptance.linkDependencies;
 var cleanupRun          = acceptance.cleanupRun;
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var dir = chaiFiles.dir;
 
 describe('Acceptance: smoke-test', function() {
   this.timeout(500000);
@@ -38,7 +44,7 @@ describe('Acceptance: smoke-test', function() {
     delete process.env._TESTEM_CONFIG_JS_RAN;
 
     return cleanupRun().then(function() {
-      assertDirEmpty('tmp');
+      expect(dir('tmp')).to.be.empty;
     });
   });
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -44,7 +44,7 @@ describe('Acceptance: smoke-test', function() {
     delete process.env._TESTEM_CONFIG_JS_RAN;
 
     return cleanupRun().then(function() {
-      expect(dir('tmp')).to.be.empty;
+      expect(dir('tmp')).to.not.exist;
     });
   });
 


### PR DESCRIPTION
This PR replaces `assertDirEmpty(...)` calls with `expect(dir(...)).to.be.empty` assertions that were introduced in `chai-files@1.2.0`