### PR TITLE
Add "ember-cli-jshint" dependency to "app" blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,6 +28,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",


### PR DESCRIPTION
This PR adds `ember-cli-jshint@1.0.0` as a dependency to the "app" and "addon" blueprints. This change should makes it easier to replace JSHint with ESLint in the future. 