### PR TITLE
Revert "tests: Use td.replace() convenience method"

### DIFF
--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -468,16 +468,17 @@ help in detail');
     var project;
     var options;
     var tmpdir;
+    var originalPrompt;
+    var prompt;
 
     beforeEach(function() {
       return mkTmpDirIn(tmproot).then(function(dir) {
         tmpdir = dir;
         blueprint = new BasicBlueprintClass(basicBlueprint);
-
         ui        = new MockUI();
-        td.replace(ui, 'prompt');
-
         project   = new MockProject();
+        originalPrompt = ui.prompt;
+        prompt = ui.prompt = td.function();
         options   = {
           ui: ui,
           project: project,
@@ -487,7 +488,7 @@ help in detail');
     });
 
     afterEach(function() {
-      td.reset();
+      ui.prompt = originalPrompt;
       return remove(tmproot);
     });
 
@@ -554,7 +555,7 @@ help in detail');
     });
 
     it('re-installing conflicting files', function() {
-      td.when(ui.prompt(td.matchers.anything())).thenReturn(
+      td.when(prompt(td.matchers.anything())).thenReturn(
         Promise.resolve({ answer: 'skip' }),
         Promise.resolve({ answer: 'overwrite' }));
 
@@ -577,7 +578,7 @@ help in detail');
         })
         .then(function() {
 
-          td.verify(ui.prompt(td.matchers.anything()), {times: 2});
+          td.verify(prompt(td.matchers.anything()), {times: 2});
 
           var actualFiles = walkSync(tmpdir).sort();
           // Prompts contain \n EOL
@@ -639,9 +640,15 @@ help in detail');
 
     describe('called on an existing project', function() {
       beforeEach(function() {
+        originalPrompt = ui.prompt;
+        prompt = ui.prompt = td.function();
         Blueprint.ignoredUpdateFiles.push('foo.txt');
 
-        td.when(ui.prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'skip' }));
+        td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'skip' }));
+      });
+
+      afterEach(function() {
+        ui.prompt = originalPrompt;
       });
 
       it('ignores files in ignoredUpdateFiles', function() {
@@ -665,7 +672,7 @@ help in detail');
             return blueprintNew.install(options);
           })
           .then(function() {
-            td.verify(ui.prompt(td.matchers.anything()), {times: 1});
+            td.verify(prompt(td.matchers.anything()), {times: 1});
 
             var actualFiles = walkSync(tmpdir).sort();
             // Prompts contain \n EOL

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -17,15 +17,14 @@ var testOutputPath;
 
 describe('Unit - FileInfo', function() {
 
-  var validOptions, ui;
+  var validOptions, ui, originalPrompt, prompt;
 
   beforeEach(function() {
     return mkTmpDirIn(tmproot).then(function(tmpdir) {
       testOutputPath = path.join(tmpdir, 'outputfile');
-
       ui = new MockUI();
-      td.replace(ui, 'prompt');
-
+      originalPrompt = ui.prompt;
+      prompt = ui.prompt = td.function();
       validOptions = {
         action: 'write',
         outputPath: testOutputPath,
@@ -39,7 +38,7 @@ describe('Unit - FileInfo', function() {
   });
 
   afterEach(function(done) {
-    td.reset();
+    ui.prompt = originalPrompt;
     fs.remove(tmproot, done);
   });
 
@@ -114,34 +113,34 @@ describe('Unit - FileInfo', function() {
   });
 
   it('renders a menu with an overwrite option', function() {
-    td.when(ui.prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'overwrite' }));
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'overwrite' }));
 
     var fileInfo = new FileInfo(validOptions);
 
     return fileInfo.confirmOverwrite('test.js').then(function(action) {
-      td.verify(ui.prompt(td.matchers.anything()), {times: 1});
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('overwrite');
     });
   });
 
   it('renders a menu with an skip option', function() {
-    td.when(ui.prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'skip' }));
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'skip' }));
 
     var fileInfo = new FileInfo(validOptions);
 
     return fileInfo.confirmOverwrite('test.js').then(function(action) {
-      td.verify(ui.prompt(td.matchers.anything()), {times: 1});
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('skip');
     });
   });
 
   it('renders a menu with an diff option', function() {
-    td.when(ui.prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'diff' }));
+    td.when(prompt(td.matchers.anything())).thenReturn(Promise.resolve({ answer: 'diff' }));
 
     var fileInfo = new FileInfo(validOptions);
 
     return fileInfo.confirmOverwrite('test.js').then(function(action) {
-      td.verify(ui.prompt(td.matchers.anything()), {times: 1});
+      td.verify(prompt(td.matchers.anything()), {times: 1});
       expect(action).to.equal('diff');
     });
   });


### PR DESCRIPTION
This reverts commit 47d4ef5c5af51f043749150a1d1b2bf6ad8dfb3f. Under suspicion for breaking AppVeyor builds.