### PR TITLE
Add fastboot dist to gitignore blueprint

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+/fastboot-dist
 /tmp
 
 # dependencies


### PR DESCRIPTION
Since fastboot is an official project thought it'd make sense to add the `fastboot-dist` folder to gitignore in ember-cli's blueprint.