### PR TITLE
Deprecate `Project.closest` in favor of `Project.closestSync`

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -561,6 +561,7 @@ Project.prototype.generateTestFile = function(/* moduleName, tests */) {
   Returns a new project based on the first package.json that is found
   in `pathName`.
 
+  @deprecated
   @private
   @static
   @method closest
@@ -569,6 +570,9 @@ Project.prototype.generateTestFile = function(/* moduleName, tests */) {
  */
 Project.closest = function(pathName, _ui, _cli) {
   var ui = ensureUI(_ui);
+
+  ui.writeDeprecateLine('`Project.closest` is a private method that will be removed, please use `Project.closestSync` instead.');
+
   return closestPackageJSON(pathName)
     .then(function(result) {
       debug('closest %s -> %s', pathName, result);


### PR DESCRIPTION
This adds a deprecation message for `Project.closest`.

I tried searching the code and issues for examples of adding a deprecation, but didn't find an obvious example, so please forgive me if I missed some steps.

Resolves #5755 