### PR TITLE
Replace "findup-sync" dependency with "findup"

### DIFF
--- a/lib/utilities/find-build-file.js
+++ b/lib/utilities/find-build-file.js
@@ -1,24 +1,22 @@
 'use strict';
 
-var findUp = require('findup-sync');
+var findUp = require('findup');
 var path = require('path');
 
 module.exports = function(file) {
-  var buildFilePath = findUp(file);
-
-  // Note
-  // In the future this should throw
-  if (buildFilePath === null) {
+  var buildFileDir;
+  try {
+    buildFileDir = findUp.sync(process.cwd(), file);
+  } catch (e) {
+    // Note: In the future this should throw
     return null;
   }
 
-  var baseDir = path.dirname(buildFilePath);
-
-  process.chdir(baseDir);
+  process.chdir(buildFileDir);
 
   var buildFile = null;
   try {
-    buildFile = require(buildFilePath);
+    buildFile = require(path.join(buildFileDir, file));
   } catch (err) {
     err.message = 'Could not require \'' + file + '\': ' + err.message;
     throw err;

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "express": "^4.12.3",
     "filesize": "^3.1.3",
     "findup": "0.1.5",
-    "findup-sync": "^0.3.0",
     "fs-extra": "0.26.7",
     "fs-monitor-stack": "^1.0.2",
     "fs-tree-diff": "^0.4.4",

--- a/tests/unit/utilities/find-build-file-test.js
+++ b/tests/unit/utilities/find-build-file-test.js
@@ -39,4 +39,9 @@ describe('find-build-file', function() {
       findBuildFile(tmpFilename);
     }).to.throw(SyntaxError, /Could not require '.*':/);
   });
+
+  it('does not throws an error when the file is mss', function() {
+    var result = findBuildFile('missing-file.js');
+    expect(result).to.be.null;
+  });
 });

--- a/tests/unit/utilities/find-build-file-test.js
+++ b/tests/unit/utilities/find-build-file-test.js
@@ -27,9 +27,9 @@ describe('find-build-file', function() {
   it('does not throws an error when the file is valid syntax', function() {
     fs.writeFileSync(tmpFilename, 'module.exports = function() {return {\'a\': \'A\', \'b\': \'B\'};}', { encoding: 'utf8' });
 
-    expect(function() {
-      findBuildFile(tmpFilename);
-    }).to.not.throw();
+    var result = findBuildFile(tmpFilename);
+    expect(result).to.be.a('function');
+    expect(result()).to.deep.equal({ a: 'A', b: 'B' });
   });
 
   it('throws an SyntaxError if the file contains a syntax mistake', function() {


### PR DESCRIPTION
Prior to the PR we had `findup` and `findup-sync` as dependencies even though `findup` supports both sync and async. This PR replaces the `findup-sync` dependency with the sync API of `findup` to reduce the amount of dependencies in `ember-cli`.

This obsoletes https://github.com/ember-cli/ember-cli/pull/5732