### PR TITLE
Allow ember-testing.js to be false

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -316,7 +316,7 @@ EmberApp.prototype._initVendorFiles = function() {
 
   // this is needed to support versions of Ember older than
   // 1.8.0 (when ember-testing.js was added to the deployment)
-  if (!existsSync(this.vendorFiles['ember-testing.js'][0])) {
+  if (this.vendorFiles['ember-testing.js'] && !existsSync(this.vendorFiles['ember-testing.js'][0])) {
     delete this.vendorFiles['ember-testing.js'];
   }
 };


### PR DESCRIPTION
Check for `vendorFiles['ember-testing.js']` before deleting.

Closes #5177