### PR TITLE
Add "rootURL" setting to deprecate "baseURL"

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/<%= name %>.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/<%= name %>.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/<%= name %>.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: '<%= modulePrefix %>',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -29,7 +29,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/<%= name %>.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,12 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/<%= name %>.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/<%= name %>.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -693,6 +693,9 @@ EmberApp.prototype._templatesTree = function() {
 */
 EmberApp.prototype._configReplacePatterns = function() {
   return [{
+    match: /\{\{rootURL\}\}/g,
+    replacement: calculateRootURL
+  }, {
     match: /\{\{EMBER_ENV\}\}/g,
     replacement: calculateEmberENV
   }, {
@@ -1709,6 +1712,10 @@ function calculateBaseTag(config) {
   } else {
     return '';
   }
+}
+
+function calculateRootURL(config) {
+  return cleanBaseURL(config.rootURL) || '';
 }
 
 function calculateEmberENV(config) {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -43,6 +43,14 @@ module.exports = Command.extend({
       .then(function(commandOptions) {
         var config = this.project.config(commandOptions.environment);
 
+        this.ui.writeDeprecateLine(
+          'Using the `baseURL` setting is deprecated, use `rootURL` instead.',
+          !(!config.rootURL && config.baseURL));
+
+        this.ui.writeWarnLine(
+          'The `baseURL` and `rootURL` settings should not be used at the same time.',
+          !(config.rootURL && config.baseURL));
+
         commandOptions = assign({}, commandOptions, {
           rootURL: config.rootURL,
           baseURL: config.baseURL || '/'

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -44,7 +44,8 @@ module.exports = Command.extend({
         var config = this.project.config(commandOptions.environment);
 
         commandOptions = assign({}, commandOptions, {
-          baseURL: config.rootURL || config.baseURL || '/'
+          rootURL: config.rootURL,
+          baseURL: config.baseURL || '/'
         });
 
         if (commandOptions.proxy) {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -41,8 +41,10 @@ module.exports = Command.extend({
     return this._checkExpressPort(commandOptions)
       .then(this._autoFindLiveReloadPort.bind(this))
       .then(function(commandOptions) {
+        var config = this.project.config(commandOptions.environment);
+
         commandOptions = assign({}, commandOptions, {
-          baseURL: this.project.config(commandOptions.environment).baseURL || '/'
+          baseURL: config.rootURL || config.baseURL || '/'
         });
 
         if (commandOptions.proxy) {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -338,6 +338,7 @@ Project.prototype.supportedInternalAddonPaths = function() {
   var legacyBlueprintsPath = require.resolve('ember-cli-legacy-blueprints');
   var emberTryPath = require.resolve('ember-try');
   return [
+    path.join(internalMiddlewarePath, 'testem-url-rewriter'),
     path.join(internalMiddlewarePath, 'tests-server'),
     path.join(internalMiddlewarePath, 'history-support'),
     path.join(internalMiddlewarePath, 'serve-files'),

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -144,7 +144,7 @@ module.exports = Task.extend({
 
     return this.startHttpServer()
       .then(function () {
-        var baseURL = cleanBaseURL(options.baseURL);
+        var baseURL = cleanBaseURL(options.rootURL || options.baseURL);
 
         options.ui.writeLine('Serving on http' + (options.ssl ? 's' : '') +
                              '://' + this.displayHost(options.host) +

--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -40,7 +40,7 @@ HistorySupportAddon.prototype.addMiddleware = function(config) {
   var options = config.options;
   var watcher = options.watcher;
 
-  var baseURL = cleanBaseURL(options.baseURL);
+  var baseURL = cleanBaseURL(options.rootURL || options.baseURL);
   var baseURLRegexp = new RegExp('^' + baseURL);
 
   app.use(function(req, res, next) {

--- a/lib/tasks/server/middleware/serve-files/index.js
+++ b/lib/tasks/server/middleware/serve-files/index.js
@@ -25,7 +25,7 @@ ServeFilesAddon.prototype.serverMiddleware = function(options) {
     autoIndex: false // disable directory listings
   });
 
-  var baseURL = cleanBaseURL(options.baseURL);
+  var baseURL = cleanBaseURL(options.rootURL || options.baseURL);
 
   debug('serverMiddleware: baseURL: %s', baseURL);
 

--- a/lib/tasks/server/middleware/testem-url-rewriter/index.js
+++ b/lib/tasks/server/middleware/testem-url-rewriter/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var cleanBaseURL = require('clean-base-url');
+var debug = require('debug')('ember-cli:testem-url-rewriter');
+
+function TestemUrlRewriterAddon(project) {
+  this.name = 'testem-url-rewriter';
+  this.project = project;
+}
+
+TestemUrlRewriterAddon.prototype.testemMiddleware = function(app) {
+  var env = process.env.EMBER_ENV;
+  debug('Reading config for environment "%s"', env);
+
+  var config = this.project.config(env);
+  debug('config.rootURL = %s', config.rootURL);
+
+  var rootURL = cleanBaseURL(config.rootURL) || '/';
+  debug('rootURL = %s', rootURL);
+
+  app.use(function(req, res, next) {
+    var oldUrl = req.url;
+    if (rootURL !== '/' && oldUrl.indexOf(rootURL) === 0) {
+      req.url = '/' + oldUrl.slice(rootURL.length);
+      debug('Rewriting %s %s -> %s', req.method, oldUrl, req.url);
+    } else {
+      debug('Ignoring %s %s', req.method, req.url);
+    }
+
+    next();
+  });
+};
+
+module.exports = TestemUrlRewriterAddon;

--- a/lib/tasks/server/middleware/testem-url-rewriter/index.js
+++ b/lib/tasks/server/middleware/testem-url-rewriter/index.js
@@ -15,6 +15,14 @@ TestemUrlRewriterAddon.prototype.testemMiddleware = function(app) {
   var config = this.project.config(env);
   debug('config.rootURL = %s', config.rootURL);
 
+  this.project.ui.writeDeprecateLine(
+    'Using the `baseURL` setting is deprecated, use `rootURL` instead.',
+    !(!config.rootURL && config.baseURL));
+
+  this.project.ui.writeWarnLine(
+    'The `baseURL` and `rootURL` settings should not be used at the same time.',
+    !(config.rootURL && config.baseURL));
+
   var rootURL = cleanBaseURL(config.rootURL) || '/';
   debug('rootURL = %s', rootURL);
 

--- a/lib/tasks/server/middleware/testem-url-rewriter/package.json
+++ b/lib/tasks/server/middleware/testem-url-rewriter/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "testem-url-rewriter-middleware",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/lib/tasks/server/middleware/tests-server/index.js
+++ b/lib/tasks/server/middleware/tests-server/index.js
@@ -23,7 +23,7 @@ TestsServerAddon.prototype.serverMiddleware = function(config) {
   var options = config.options;
   var watcher = options.watcher;
 
-  var baseURL = cleanBaseURL(options.baseURL);
+  var baseURL = cleanBaseURL(options.rootURL || options.baseURL);
   var testsRegexp = new RegExp('^' + baseURL + 'tests');
 
   app.use(function(req, res, next) {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -304,6 +304,13 @@ describe('broccoli/ember-app', function() {
 
         expect(actual).to.not.contain(expected);
       });
+
+      it('does not include the `base` tag in `head` if baseURL is undefined', function() {
+        var expected = '<base href=';
+        var actual = emberApp.contentFor(config, defaultMatch, 'head');
+
+        expect(actual).to.not.contain(expected);
+      });
     });
 
     describe('contentFor("config-module")', function() {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -557,7 +557,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = emberApp;
             expect(emberApp._addonEnabled(emberFooEnvAddonFixture)).to.be.false;
 
-            expect(emberApp.project.addons.length).to.equal(7);
+            expect(emberApp.project.addons.length).to.equal(8);
           });
 
           it('foo', function() {
@@ -567,7 +567,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = emberApp;
             expect(emberApp._addonEnabled(emberFooEnvAddonFixture)).to.be.true;
 
-            expect(emberApp.project.addons.length).to.equal(8);
+            expect(emberApp.project.addons.length).to.equal(9);
           });
         });
       });
@@ -584,7 +584,7 @@ describe('broccoli/ember-app', function() {
 
           expect(emberApp._addonDisabledByBlacklist({ name: 'ember-foo-env-addon' })).to.be.true;
           expect(emberApp._addonDisabledByBlacklist({ name: 'Ember Random Addon' })).to.be.false;
-          expect(emberApp.project.addons.length).to.equal(7);
+          expect(emberApp.project.addons.length).to.equal(8);
         });
 
         it('throws if unavailable addon is specified', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -187,6 +187,7 @@ describe('models/project.js', function() {
 
     it('returns a listing of all ember-cli-addons directly depended on by the project', function() {
       var expected = [
+        'testem-url-rewriter-middleware',
         'tests-server-middleware',
         'history-support-middleware', 'serve-files-middleware',
         'proxy-server-middleware', 'ember-cli-legacy-blueprints', 'ember-try',
@@ -201,10 +202,10 @@ describe('models/project.js', function() {
     it('returns instances of the addons', function() {
       var addons = project.addons;
 
-      expect(addons[7].name).to.equal('Ember Non Root Addon');
-      expect(addons[13].name).to.equal('Ember Super Button');
-      expect(addons[13].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[13].addons[1].name).to.equal('Ember Ng');
+      expect(addons[8].name).to.equal('Ember Non Root Addon');
+      expect(addons[14].name).to.equal('Ember Super Button');
+      expect(addons[14].addons[0].name).to.equal('Ember Yagni');
+      expect(addons[14].addons[1].name).to.equal('Ember Ng');
     });
 
     it('addons get passed the project instance', function() {
@@ -216,7 +217,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       var addons = project.addons;
 
-      expect(addons[9].name).to.equal('Ember Random Addon');
+      expect(addons[10].name).to.equal('Ember Random Addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -279,8 +280,8 @@ describe('models/project.js', function() {
     it('returns an instance of an addon with an object export', function() {
       var addons = project.addons;
 
-      expect(addons[6] instanceof Addon).to.equal(true);
-      expect(addons[6].name).to.equal('Ember CLI Generated with export');
+      expect(addons[7] instanceof Addon).to.equal(true);
+      expect(addons[7].name).to.equal('Ember CLI Generated with export');
     });
 
     it('adds the project itself if it is an addon', function() {

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -88,7 +88,7 @@ describe('express-server', function() {
         ssl: true,
         sslCert: 'tests/fixtures/ssl/server.crt',
         sslKey: 'tests/fixtures/ssl/server.key',
-        baseURL: '/'
+        rootURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
         expect(output[0]).to.equal('Serving on https://localhost:1337/');
@@ -100,7 +100,7 @@ describe('express-server', function() {
         proxy: 'http://localhost:3001/',
         host: undefined,
         port: '1337',
-        baseURL: '/'
+        rootURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
         expect(output[1]).to.equal('Serving on http://localhost:1337/');
@@ -113,7 +113,7 @@ describe('express-server', function() {
       return subject.start({
         host: undefined,
         port: '1337',
-        baseURL: '/'
+        rootURL: '/'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
         expect(output[0]).to.equal('Serving on http://localhost:1337/');
@@ -126,6 +126,18 @@ describe('express-server', function() {
         host: undefined,
         port: '1337',
         baseURL: '/foo'
+      }).then(function() {
+        var output = ui.output.trim().split(EOL);
+        expect(output[0]).to.equal('Serving on http://localhost:1337/foo/');
+        expect(output.length).to.equal(1, 'expected only one line of output');
+      });
+    });
+
+    it('with rootURL', function() {
+      return subject.start({
+        host: undefined,
+        port: '1337',
+        rootURL: '/foo'
       }).then(function() {
         var output = ui.output.trim().split(EOL);
         expect(output[0]).to.equal('Serving on http://localhost:1337/foo/');
@@ -162,7 +174,7 @@ describe('express-server', function() {
         ssl: true,
         sslCert: 'tests/fixtures/ssl/server.crt',
         sslKey: 'tests/fixtures/ssl/server.key',
-        baseURL: '/'
+        rootURL: '/'
       })
         .then(function() {
           return new Promise(function(resolve, reject) {
@@ -193,7 +205,7 @@ describe('express-server', function() {
         proxy: 'http://localhost:3001/',
         host: undefined,
         port: '1337',
-        baseURL: '/'
+        rootURL: '/'
       })
         .then(function() {
           request(subject.app)
@@ -226,7 +238,7 @@ describe('express-server', function() {
         proxy: 'http://localhost:3001/',
         host: undefined,
         port: '1337',
-        baseURL: '/'
+        rootURL: '/'
       })
         .then(function() {
           request(subject.app)
@@ -250,7 +262,7 @@ describe('express-server', function() {
           proxy: 'http://localhost:3001/',
           host: undefined,
           port: '1337',
-          baseURL: '/'
+          rootURL: '/'
         });
       });
 
@@ -333,7 +345,7 @@ describe('express-server', function() {
           proxy: 'http://api.lvh.me',
           host: undefined,
           port: '1337',
-          baseURL: '/'
+          rootURL: '/'
         });
       });
 
@@ -442,11 +454,11 @@ describe('express-server', function() {
     });
 
     describe('without proxy', function() {
-      function startServer(baseURL) {
+      function startServer(rootURL) {
         return subject.start({
           host: undefined,
           port: '1337',
-          baseURL: baseURL || '/'
+          rootURL: rootURL || '/'
         });
       }
 
@@ -469,7 +481,7 @@ describe('express-server', function() {
 
       it('GET /tests serves tests/index.html for mime of */* (hash location)', function(done) {
         project._config = {
-          baseURL: '/',
+          rootURL: '/',
           locationType: 'hash'
         };
 
@@ -541,7 +553,7 @@ describe('express-server', function() {
           });
       });
 
-      it('serves index.html when file not found (with baseURL) with auto/history location', function(done) {
+      it('serves index.html when file not found (with rootURL) with auto/history location', function(done) {
         return startServer('/foo')
           .then(function() {
             request(subject.app)
@@ -558,9 +570,9 @@ describe('express-server', function() {
           });
       });
 
-      it('serves index.html when file not found (with baseURL) with custom history location', function(done) {
+      it('serves index.html when file not found (with rootURL) with custom history location', function(done) {
         project._config = {
-          baseURL: '/',
+          rootURL: '/',
           locationType: 'blahr',
           historySupportMiddleware: true
         };
@@ -583,7 +595,7 @@ describe('express-server', function() {
 
       it('returns a 404 when file not found with hash location', function(done) {
         project._config = {
-          baseURL: '/',
+          rootURL: '/',
           locationType: 'hash'
         };
 
@@ -627,7 +639,7 @@ describe('express-server', function() {
           });
       });
 
-      it('serves static asset up from build output without a period in name (with baseURL)', function(done) {
+      it('serves static asset up from build output without a period in name (with rootURL)', function(done) {
         return startServer('/foo')
           .then(function() {
             request(subject.app)


### PR DESCRIPTION
This PR adds a new `rootURL` setting to `config/environment.js` that should be used instead of the old `baseURL` setting which had several issues related to the use of the `<base>` tag.

- [x] `{{rootURL}}` in `index.html` files is replaced with the actual value
- [x] `rootURL` is used instead of `baseURL` for `ember serve` (if it is set)
- [x] a `testem-url-rewriter` middleware addon is added to rewrite URLs with `rootURL` prefix to URLs without that prefix to make testem happy
- [x] adjust the app blueprint
- [x] deprecate the usage of `baseURL`
- [x] test all the things!
- [x] no, srsly, write unit tests
- [x] use all available label colors
- [x] Write deprecation guide (@nathanhammond)

#### Test Cases

- `baseURL: '/'`
- `baseURL: '/foo/bar'`
- `baseURL: '/', rootURL: '/'`
- `baseURL: '/foo/bar', rootURL: '/'`
- `baseURL: '/', rootURL: '/foo/bar'`
- `baseURL: '/foo/bar', rootURL: '/foo/bar'`

---

- `ember serve` and checking if `/tests` (or `<rootURL>/tests`) works
- `ember test`
- `ember test --environment=production`
- `ember test --server`

---

resolves #4905, resolves #4507, resolves #2989, resolves #2957, resolves #2633, resolves #417

/cc @rwjblue @stefanpenner @nathanhammond 