### PR TITLE
Fix "tmp" usage

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -45,8 +45,8 @@ describe('Acceptance: addon-smoke-test', function() {
   });
 
   afterEach(function() {
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(addonName).then(function() {
+      expect(dir('tmp/' + addonName)).to.not.exist;
     });
   });
 

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -35,8 +35,8 @@ describe('Acceptance: blueprint smoke tests', function() {
   });
 
   afterEach(function() {
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(appName).then(function() {
+      expect(dir('tmp/' + appName)).to.not.exist;
     });
   });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -42,8 +42,8 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   afterEach(function() {
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(appName).then(function() {
+      expect(dir('tmp/' + appName)).to.not.exist;
     });
   });
 

--- a/tests/acceptance/express-server-restart-slow.js
+++ b/tests/acceptance/express-server-restart-slow.js
@@ -48,8 +48,8 @@ describe.skip('Acceptance: express server restart', function () {
 
   afterEach(function() {
     this.timeout(15000);
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(appName).then(function() {
+      expect(dir('tmp/' + appName)).to.not.exist;
     });
   });
 

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -110,24 +110,6 @@ describe('Acceptance: ember init', function() {
     ]).then(confirmBlueprinted);
   });
 
-  it('ember init can run in created folder', function() {
-    return tmp.setup('./tmp/foo')
-      .then(function() {
-        process.chdir('./tmp/foo');
-      })
-      .then(function() {
-        return ember([
-          'init',
-          '--skip-npm',
-          '--skip-bower'
-        ]);
-      })
-      .then(confirmBlueprinted)
-      .then(function() {
-        return tmp.teardown('./tmp/foo');
-      });
-  });
-
   it('init an already init\'d folder', function() {
     return ember([
       'init',

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -26,6 +26,8 @@ var dir = chaiFiles.dir;
 
 var defaultIgnoredFiles = Blueprint.ignoredFiles;
 
+var tmpPath = './tmp/init-test';
+
 describe('Acceptance: ember init', function() {
   this.timeout(20000);
 
@@ -40,14 +42,14 @@ describe('Acceptance: ember init', function() {
   beforeEach(function() {
     Blueprint.ignoredFiles = defaultIgnoredFiles;
 
-    return tmp.setup('./tmp')
+    return tmp.setup(tmpPath)
       .then(function() {
-        process.chdir('./tmp');
+        process.chdir(tmpPath);
       });
   });
 
   afterEach(function() {
-    return tmp.teardown('./tmp');
+    return tmp.teardown(tmpPath);
   });
 
   function confirmBlueprinted() {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -156,10 +156,7 @@ describe('Acceptance: ember new', function() {
   });
 
   it('ember new with blueprint uses the specified blueprint directory with a relative path', function() {
-    return tmp.setup('./tmp/my_blueprint')
-      .then(function() {
-        return tmp.setup('./tmp/my_blueprint/files');
-      })
+    return tmp.setup('./tmp/my_blueprint/files')
       .then(function() {
         fs.writeFileSync('./tmp/my_blueprint/files/gitignore');
         process.chdir('./tmp');
@@ -177,10 +174,7 @@ describe('Acceptance: ember new', function() {
   });
 
   it('ember new with blueprint uses the specified blueprint directory with an absolute path', function() {
-    return tmp.setup('./tmp/my_blueprint')
-      .then(function() {
-        return tmp.setup('./tmp/my_blueprint/files');
-      })
+    return tmp.setup('./tmp/my_blueprint/files')
       .then(function() {
         fs.writeFileSync('./tmp/my_blueprint/files/gitignore');
         process.chdir('./tmp');
@@ -214,10 +208,7 @@ describe('Acceptance: ember new', function() {
   });
 
   it('ember new passes blueprint options through to blueprint', function() {
-    return tmp.setup('./tmp/my_blueprint')
-      .then(function() {
-        return tmp.setup('./tmp/my_blueprint/files');
-      })
+    return tmp.setup('./tmp/my_blueprint/files')
       .then(function() {
         fs.writeFileSync('./tmp/my_blueprint/index.js', [
           'module.exports = {',

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -38,8 +38,8 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   });
 
   afterEach(function() {
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(appName).then(function() {
+      expect(dir('tmp/' + appName)).to.not.exist;
     });
   });
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -44,8 +44,8 @@ describe('Acceptance: smoke-test', function() {
   afterEach(function() {
     delete process.env._TESTEM_CONFIG_JS_RAN;
 
-    return cleanupRun().then(function() {
-      expect(dir('tmp')).to.not.exist;
+    return cleanupRun(appName).then(function() {
+      expect(dir('tmp/' + appName)).to.not.exist;
     });
   });
 

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -143,7 +143,7 @@ function teardownTestTargets() {
  */
 function linkDependencies(projectName) {
   var targetPath = './tmp/' + projectName;
-  return tmp.setup('./tmp').then(function() {
+  return tmp.setup(targetPath).then(function() {
     return copy('./common-tmp/' + projectName, targetPath);
   }).then(function() {
     var nodeModulesPath = targetPath + '/node_modules/';
@@ -161,16 +161,14 @@ function linkDependencies(projectName) {
       symLinkDir(targetPath, '.bower_components-tmp', 'bower_components');
     }
 
-    process.chdir('./tmp');
-    var appsECLIPath = path.join(projectName, 'node_modules', 'ember-cli');
-    var pwd = process.cwd();
-    fs.removeSync(projectName + '/node_modules/ember-cli');
+    process.chdir(targetPath);
+
+    var appsECLIPath = path.join('node_modules', 'ember-cli');
+    fs.removeSync(appsECLIPath);
 
     // Need to junction on windows since we likely don't have persmission to symlink
     // 3rd arg is ignored on systems other than windows
-    fs.symlinkSync(path.join(pwd, '..'), appsECLIPath, 'junction');
-    process.chdir(projectName);
-
+    fs.symlinkSync(path.resolve('../..'), appsECLIPath, 'junction');
   });
 }
 
@@ -178,8 +176,9 @@ function linkDependencies(projectName) {
  * Clean a test run and optionally assert.
  * @return {Promise}
  */
-function cleanupRun() {
-  return tmp.teardown('./tmp');
+function cleanupRun(projectName) {
+  var targetPath = './tmp/' + projectName;
+  return tmp.teardown(targetPath);
 }
 
 module.exports = {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -24,8 +24,7 @@ describe('models/project.js', function() {
     var called;
 
     beforeEach(function() {
-      tmpPath = path.join(process.cwd(), 'tmp');
-      projectPath = path.join(tmpPath, 'test-app');
+      projectPath = 'tmp/test-app';
       called = false;
       return tmp.setup(projectPath)
         .then(function() {
@@ -43,7 +42,7 @@ describe('models/project.js', function() {
 
     afterEach(function() {
       called = null;
-      return tmp.teardown(tmpPath);
+      return tmp.teardown(projectPath);
     });
 
     it('config() finds and requires config/environment', function() {

--- a/tests/unit/utilities/find-build-file-test.js
+++ b/tests/unit/utilities/find-build-file-test.js
@@ -2,17 +2,15 @@
 
 var expect = require('chai').expect;
 var fs = require('fs-extra');
+var path = require('path');
 var tmp = require('../../helpers/tmp');
 var findBuildFile = require('../../../lib/utilities/find-build-file');
 
 describe('find-build-file', function() {
-  var tmpPath, tmpFilename, tmpFilePath;
-  var currentWorkingDir = process.cwd();
+  var tmpPath = 'tmp/find-build-file-test';
+  var tmpFilename = 'ember-cli-build.js';
 
   beforeEach(function() {
-    tmpPath = process.cwd() + '/tmp/';
-    tmpFilename = 'ember-cli-build.js';
-    tmpFilePath = tmpPath + tmpFilename;
     return tmp.setup(tmpPath)
       .then(function() {
         process.chdir(tmpPath);
@@ -20,10 +18,10 @@ describe('find-build-file', function() {
   });
 
   afterEach(function() {
+    var tmpFilePath = path.resolve(tmpFilename);
     delete require.cache[require.resolve(tmpFilePath)];
-    return tmp.teardown(tmpPath).then(function() {
-      process.chdir(currentWorkingDir);
-    });
+
+    return tmp.teardown(tmpPath);
   });
 
   it('does not throws an error when the file is valid syntax', function() {


### PR DESCRIPTION
This PR slims down the usage of `tmp.setup/teardown()` and tries to use `./tmp` subfolders in the remaining cases which should hopefully decrease the number of failing tests due to `EBUSY` on Windows/AppVeyor.