### PR TITLE
Use "fs-extra" convenience functions

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -152,7 +152,7 @@ module.exports = {
 
 function readContentsFromFile(fileName) {
   var packagePath = path.join(this._appBlueprint.path, 'files', fileName);
-  return fs.readJsonSync(packagePath, { encoding: 'utf8'});
+  return fs.readJsonSync(packagePath);
 }
 
 function alphabetizeDependencies(contents) {

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -62,9 +62,7 @@ module.exports = {
     var bowerPath = path.join(this.path, 'files', 'bower.json');
 
     [packagePath, bowerPath].forEach(function(filePath) {
-      if (existsSync(filePath)) {
-        fs.unlinkSync(filePath);
-      }
+      fs.remove(filePath);
     });
   },
 

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 
-var fs          = require('fs');
+var fs          = require('fs-extra');
 var existsSync  = require('exists-sync');
 var path        = require('path');
 var walkSync    = require('walk-sync');
@@ -154,7 +154,7 @@ module.exports = {
 
 function readContentsFromFile(fileName) {
   var packagePath = path.join(this._appBlueprint.path, 'files', fileName);
-  return JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+  return fs.readJsonSync(packagePath, { encoding: 'utf8'});
 }
 
 function alphabetizeDependencies(contents) {

--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
   afterInstall: function(options) {
     var packagePath = path.join(this.project.root, 'package.json');
-    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    var contents    = fs.readJsonSync(packagePath, { encoding: 'utf8' });
     var name        = stringUtil.dasherize(options.entity.name);
     var newPath     = ['lib', name].join('/');
     var paths;

--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
   afterInstall: function(options) {
     var packagePath = path.join(this.project.root, 'package.json');
-    var contents    = fs.readJsonSync(packagePath, { encoding: 'utf8' });
+    var contents    = fs.readJsonSync(packagePath);
     var name        = stringUtil.dasherize(options.entity.name);
     var newPath     = ['lib', name].join('/');
     var paths;

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,12 +1,12 @@
 'use strict';
 
+var fs                    = require('fs-extra');
 var chalk                 = require('chalk');
 var Command               = require('../models/command');
 var Promise               = require('../ext/promise');
 var Project               = require('../models/project');
 var SilentError           = require('silent-error');
-var rimraf                = require('rimraf');
-var rmdir                 = Promise.denodeify(rimraf);
+var rmdir                 = Promise.denodeify(fs.remove);
 var validProjectName      = require('../utilities/valid-project-name');
 var normalizeBlueprint    = require('../utilities/normalize-blueprint-option');
 var mergeBlueprintOptions = require('../utilities/merge-blueprint-options');

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -24,7 +24,7 @@ function outputViz(count, result, monitor) {
   });
 
   fs.writeFileSync('graph.' + count + '.dot', viz.dot(processed));
-  fs.writeFileSync('graph.' + count + '.json', JSON.stringify({
+  fs.writeJsonSync('graph.' + count + '.json', {
     summary: {
       buildCount: count,
       output: result.directory,
@@ -35,7 +35,7 @@ function outputViz(count, result, monitor) {
       }
     },
     nodes: processed
-  }));
+  });
 }
 
 module.exports = Task.extend({

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -12,7 +12,6 @@ var findBuildFile = require('../utilities/find-build-file');
 var viz = require('broccoli-viz');
 var FSMonitor = require('fs-monitor-stack');
 var Sync = require('tree-sync');
-var mkdirp = require('mkdirp');
 
 var signalsTrapped = false;
 var buildCount = 0;
@@ -110,7 +109,7 @@ module.exports = Task.extend({
   copyToOutputPath: function(inputPath) {
     var outputPath = this.outputPath;
 
-    mkdirp.sync(outputPath);
+    fs.mkdirsSync(outputPath);
 
     if (!this.canDeleteOutputPath(outputPath)) {
       throw new SilentError('Using a build destination path of `' + outputPath + '` is not supported.');

--- a/lib/models/installation-checker.js
+++ b/lib/models/installation-checker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var debug       = require('debug')('ember-cli:installation-checker');
-var fs          = require('fs');
+var fs          = require('fs-extra');
 var existsSync  = require('exists-sync');
 var path        = require('path');
 var SilentError = require('silent-error');
@@ -44,7 +44,7 @@ function hasDependencies(pkg) {
 
 function readJSON(path) {
   try {
-    return JSON.parse(fs.readFileSync(path).toString());
+    return fs.readJsonSync(path);
   } catch (e) {
     throw new SilentError('InstallationChecker: Unable to parse: ' + path);
   }

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -7,7 +7,7 @@ var Promise            = require('../ext/promise');
 var path               = require('path');
 var findup             = Promise.denodeify(require('findup'));
 var resolve            = Promise.denodeify(require('resolve'));
-var fs                 = require('fs');
+var fs                 = require('fs-extra');
 var existsSync         = require('exists-sync');
 var find               = require('lodash/find');
 var assign             = require('lodash/assign');
@@ -79,9 +79,8 @@ Project.prototype.setupBowerDirectory = function() {
   debug('bowerrc path: %s', bowerrcPath);
 
   if (existsSync(bowerrcPath)) {
-    var bowerrcContent = fs.readFileSync(bowerrcPath);
     try {
-      this.bowerDirectory = JSON.parse(bowerrcContent).directory;
+      this.bowerDirectory = fs.readJsonSync(bowerrcPath).directory;
     } catch (exception) {
       debug('failed to parse bowerc: %s', exception);
       this.bowerDirectory = null;
@@ -494,7 +493,7 @@ Project.prototype.reloadPkg = function() {
   var pkgPath = path.join(this.root, 'package.json');
 
   // We use readFileSync instead of require to avoid the require cache.
-  this.pkg = JSON.parse(fs.readFileSync(pkgPath, { encoding: 'utf-8' }));
+  this.pkg = fs.readJsonSync(pkgPath, { encoding: 'utf-8' });
 
   return this.pkg;
 };
@@ -617,7 +616,7 @@ Project.closestSync = function(pathName, _ui, _cli) {
     directory = findupPath(pathName);
   }
   if (!pkg) {
-    pkg = JSON.parse(fs.readFileSync(path.join(directory, 'package.json')));
+    pkg = fs.readJsonSync(path.join(directory, 'package.json'));
   }
 
   debug('dir' + directory);

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -493,7 +493,7 @@ Project.prototype.reloadPkg = function() {
   var pkgPath = path.join(this.root, 'package.json');
 
   // We use readFileSync instead of require to avoid the require cache.
-  this.pkg = fs.readJsonSync(pkgPath, { encoding: 'utf-8' });
+  this.pkg = fs.readJsonSync(pkgPath);
 
   return this.pkg;
 };

--- a/lib/utilities/markdown-color.js
+++ b/lib/utilities/markdown-color.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var fs          = require('fs');
-var existsSync  = require('exists-sync');
 
 var chalk       = require('chalk');
 var SilentError = require('silent-error');
@@ -57,9 +56,9 @@ function MarkdownColor(options) {
 */
 MarkdownColor.prototype.renderFile = function (filePath, options) {
   var file;
-  if (existsSync(filePath)) {
+  try {
     file = fs.readFileSync(filePath, 'utf-8');
-  } else {
+  } catch (e) {
     throw new SilentError('The file \'' + filePath + '\' doesn\'t exist.' +
       ' Please check your filePath');
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "compression": "^1.4.4",
     "configstore": "^2.0.0",
     "core-object": "0.0.2",
-    "cpr": "^1.0.0",
     "debug": "^2.1.3",
     "diff": "^2.2.2",
     "ember-cli-broccoli": "0.16.9",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "markdown-it-terminal": "0.0.3",
     "merge-defaults": "^0.2.1",
     "minimatch": "^3.0.0",
-    "mkdirp": "^0.5.1",
     "morgan": "^1.5.2",
     "node-modules-path": "^1.0.0",
     "node-uuid": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.5",
     "resolve": "^1.1.6",
-    "rimraf": "^2.4.4",
     "rsvp": "^3.0.17",
     "sane": "^1.1.1",
     "semver": "^5.1.0",

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -51,14 +51,14 @@ describe('Acceptance: addon-smoke-test', function() {
   });
 
   it('generates package.json and bower.json with proper metadata', function() {
-    var packageContents = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+    var packageContents = fs.readJsonSync('package.json', { encoding: 'utf8' });
 
     expect(packageContents.name).to.equal(addonName);
     expect(packageContents.private).to.be.an('undefined');
     expect(packageContents.keywords).to.deep.equal([ 'ember-addon' ]);
     expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
 
-    var bowerContents = JSON.parse(fs.readFileSync('bower.json', { encoding: 'utf8' }));
+    var bowerContents = fs.readJsonSync('bower.json', { encoding: 'utf8' });
 
     expect(bowerContents.name).to.equal(addonName);
   });
@@ -87,11 +87,11 @@ describe('Acceptance: addon-smoke-test', function() {
     return copyFixtureFiles('addon/component-with-template')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -115,11 +115,11 @@ describe('Acceptance: addon-smoke-test', function() {
     return copyFixtureFiles('addon/pod-templates-only')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       }).then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
@@ -132,12 +132,12 @@ describe('Acceptance: addon-smoke-test', function() {
 
   it('build with addon dependencies being developed', function() {
     var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-    var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+    var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
     packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
     packageJson.dependencies['developing-addon'] = 'latest';
 
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+    fs.writeJsonSync(packageJsonPath, packageJson);
 
     symlinkOrCopySync(path.resolve('../../tests/fixtures/addon/developing-addon'), path.resolve('../../tmp/', addonName, 'node_modules/developing-addon'));
 

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -51,14 +51,14 @@ describe('Acceptance: addon-smoke-test', function() {
   });
 
   it('generates package.json and bower.json with proper metadata', function() {
-    var packageContents = fs.readJsonSync('package.json', { encoding: 'utf8' });
+    var packageContents = fs.readJsonSync('package.json');
 
     expect(packageContents.name).to.equal(addonName);
     expect(packageContents.private).to.be.an('undefined');
     expect(packageContents.keywords).to.deep.equal([ 'ember-addon' ]);
     expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
 
-    var bowerContents = fs.readJsonSync('bower.json', { encoding: 'utf8' });
+    var bowerContents = fs.readJsonSync('bower.json');
 
     expect(bowerContents.name).to.equal(addonName);
   });
@@ -87,7 +87,7 @@ describe('Acceptance: addon-smoke-test', function() {
     return copyFixtureFiles('addon/component-with-template')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
@@ -115,7 +115,7 @@ describe('Acceptance: addon-smoke-test', function() {
     return copyFixtureFiles('addon/pod-templates-only')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
@@ -132,7 +132,7 @@ describe('Acceptance: addon-smoke-test', function() {
 
   it('build with addon dependencies being developed', function() {
     var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', addonName, 'package.json');
-    var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+    var packageJson = fs.readJsonSync(packageJsonPath);
     packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
     packageJson.dependencies['developing-addon'] = 'latest';

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path                = require('path');
-var fs                  = require('fs');
+var fs                  = require('fs-extra');
 var acceptance          = require('../helpers/acceptance');
 var runCommand          = require('../helpers/run-command');
 var createTestTargets   = acceptance.createTestTargets;
@@ -47,7 +47,7 @@ describe('Acceptance: blueprint smoke tests', function() {
                       'http://localhost/api')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath, 'utf8');
 
         expect(packageJson.devDependencies).to.have.a.property('http-proxy');
         expect(packageJson.devDependencies).to.have.a.property('morgan');

--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -47,7 +47,7 @@ describe('Acceptance: blueprint smoke tests', function() {
                       'http://localhost/api')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, 'utf8');
+        var packageJson = fs.readJsonSync(packageJsonPath);
 
         expect(packageJson.devDependencies).to.have.a.property('http-proxy');
         expect(packageJson.devDependencies).to.have.a.property('morgan');

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -173,7 +173,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/app-test-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath,'utf8');
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-test-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -194,7 +194,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -215,7 +215,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return expect(copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-bad-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -229,7 +229,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/public-tree')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -264,7 +264,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/jshint-addon')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson['ember-addon'] = {
           paths: ['./lib/ember-random-thing']
         };
@@ -410,7 +410,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/multiple-sass-files')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['broccoli-sass'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -447,7 +447,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         fs.writeFileSync(brocfilePath, brocfile, 'utf8');
 
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['broccoli-sass'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -173,10 +173,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/app-test-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath,'utf8');
         packageJson.devDependencies['ember-test-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -194,10 +194,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -215,10 +215,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return expect(copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['ember-bad-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -229,10 +229,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/public-tree')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -264,12 +264,12 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/jshint-addon')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath,'utf8'));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson['ember-addon'] = {
           paths: ['./lib/ember-random-thing']
         };
 
-        fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        fs.writeJsonSync(packageJsonPath, packageJson);
 
         var badContent = 'var blah = ""\n' + 'export default Blah;';
         var appPath = path.join('.', 'lib', 'ember-random-thing', 'app',
@@ -410,10 +410,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/multiple-sass-files')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['broccoli-sass'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -447,10 +447,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
         fs.writeFileSync(brocfilePath, brocfile, 'utf8');
 
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['broccoli-sass'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -108,7 +108,7 @@ describe('Acceptance: ember new', function() {
       expect(dir('FooApp')).to.not.exist;
       expect(file('package.json')).to.exist;
 
-      var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      var pkgJson = fs.readJsonSync('package.json', 'utf8');
       expect(pkgJson.name).to.equal('foo-app');
     });
   });
@@ -311,7 +311,7 @@ describe('Acceptance: ember new', function() {
       expect(cwd).to.not.match(/foo/, 'does not use app name for directory name');
       expect(cwd).to.match(/bar/, 'uses given directory name');
 
-      var pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      var pkgJson = fs.readJsonSync('package.json', 'utf8');
       expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
     });
   });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -108,7 +108,7 @@ describe('Acceptance: ember new', function() {
       expect(dir('FooApp')).to.not.exist;
       expect(file('package.json')).to.exist;
 
-      var pkgJson = fs.readJsonSync('package.json', 'utf8');
+      var pkgJson = fs.readJsonSync('package.json');
       expect(pkgJson.name).to.equal('foo-app');
     });
   });
@@ -311,7 +311,7 @@ describe('Acceptance: ember new', function() {
       expect(cwd).to.not.match(/foo/, 'does not use app name for directory name');
       expect(cwd).to.match(/bar/, 'uses given directory name');
 
-      var pkgJson = fs.readJsonSync('package.json', 'utf8');
+      var pkgJson = fs.readJsonSync('package.json');
       expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
     });
   });

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path       = require('path');
-var fs         = require('fs');
+var fs         = require('fs-extra');
 
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
@@ -47,11 +47,11 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['broccoli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -66,11 +66,11 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-registry-ordering')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
         packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -87,11 +87,11 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['broccoli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -113,10 +113,10 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-2')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -145,10 +145,10 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-3')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
         packageJson.devDependencies['ember-shallow-addon'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -154,14 +154,6 @@ describe('Acceptance: preprocessor-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var appJs = fs.readFileSync(path.join('.', 'dist', 'assets', 'some-cool-app.js'), {
-          encoding: 'utf8'
-        });
-
-        var vendorJs = fs.readFileSync(path.join('.', 'dist', 'assets', 'vendor.js'), {
-          encoding: 'utf8'
-        });
-
         expect(file('dist/assets/some-cool-app.js'))
           .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
           .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -47,7 +47,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['broccoli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
@@ -66,7 +66,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-registry-ordering')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
         packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
 
@@ -87,7 +87,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['broccoli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
@@ -113,7 +113,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-2')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);
@@ -145,7 +145,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-3')
       .then(function() {
         var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
-        var packageJson = fs.readJsonSync(packageJsonPath, { encoding: 'utf8' });
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-shallow-addon'] = 'latest';
 
         return fs.writeJsonSync(packageJsonPath, packageJson);

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var path     = require('path');
-var fs       = require('fs');
+var fs       = require('fs-extra');
 var crypto   = require('crypto');
 var walkSync = require('walk-sync');
 var appName  = 'some-cool-app';
 var EOL      = require('os').EOL;
-var mkdirp   = require('mkdirp');
 
 var runCommand          = require('../helpers/run-command');
 var acceptance          = require('../helpers/acceptance');
@@ -66,7 +65,7 @@ describe('Acceptance: smoke-test', function() {
 
         // temporary work around
         var templatePath = path.join('lib', 'my-addon', 'app', 'templates', 'foo.hbs');
-        mkdirp.sync(path.dirname(templatePath));
+        fs.mkdirsSync(path.dirname(templatePath));
         fs.writeFileSync(templatePath, 'Hi, Mom!', { encoding: 'utf8' });
       })
       .then(function() {

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -70,11 +70,11 @@ describe('Acceptance: smoke-test', function() {
       })
       .then(function() {
         var packageJsonPath = path.join('lib','my-addon','package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.dependencies = packageJson.dependencies || {};
         packageJson.dependencies['ember-cli-htmlbars'] = '*';
 
-        fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+        fs.writeJsonSync(packageJsonPath, packageJson);
 
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build')
           .then(function(result) {
@@ -401,11 +401,11 @@ describe('Acceptance: smoke-test', function() {
     return copyFixtureFiles('smoke-tests/with-template-failing-linting')
       .then(function() {
         var packageJsonPath = 'package.json';
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+        var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies = packageJson.devDependencies || {};
         packageJson.devDependencies['fake-template-linter'] = 'latest';
 
-        return fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+        return fs.writeJsonSync(packageJsonPath, packageJson);
       })
       .then(function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test')

--- a/tests/fixtures/smoke-tests/with-template-failing-linting/node_modules/fake-template-linter/index.js
+++ b/tests/fixtures/smoke-tests/with-template-failing-linting/node_modules/fake-template-linter/index.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var Plugin = require('broccoli-plugin');
 var walkSync = require('walk-sync');
-var mkdirp = require('mkdirp');
 
 module.exports = {
   name: 'fake-template-linter',
@@ -45,7 +44,7 @@ TemplateLinter.prototype.build = function () {
     var testFilePath = path.join(this.outputPath, templateFilePath + '-test.js');
 
     if (/BADJUJU/.test(contents)) {
-      mkdirp.sync(path.dirname(testFilePath));
+      fs.mkdirsSync(path.dirname(testFilePath));
 
       fs.writeFileSync(testFilePath, testContents, { encoding: 'utf8' });
     }

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -8,7 +8,7 @@ var Promise           = require('../../lib/ext/promise');
 var tmp               = require('./tmp');
 var conf              = require('./conf');
 var existsSync        = require('exists-sync');
-var copy              = Promise.denodeify(require('cpr'));
+var copy              = Promise.denodeify(fs.copy);
 var root              = process.cwd();
 var exec              = Promise.denodeify(require('child_process').exec);
 

--- a/tests/helpers/copy-fixture-files.js
+++ b/tests/helpers/copy-fixture-files.js
@@ -1,11 +1,12 @@
 'use strict';
 
+var fs      = require('fs-extra');
 var path    = require('path');
 var Promise = require('../../lib/ext/promise');
-var copy    = Promise.denodeify(require('cpr'));
+var copy    = Promise.denodeify(fs.copy);
 
 var rootPath = process.cwd();
 
 module.exports = function copyFixtureFiles(sourceDir) {
-  return copy(path.join(rootPath, 'tests', 'fixtures', sourceDir), '.', { overwrite: true });
+  return copy(path.join(rootPath, 'tests', 'fixtures', sourceDir), '.', { clobber: true });
 };

--- a/tests/helpers/tmp.js
+++ b/tests/helpers/tmp.js
@@ -17,10 +17,5 @@ module.exports.setup = function(path) {
 
 module.exports.teardown = function(path) {
   process.chdir(root);
-
-  if (existsSync(path)) {
-    return remove(path);
-  } else {
-    return Promise.resolve();
-  }
+  return remove(path);
 };

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -3,15 +3,15 @@
 var glob = require('glob');
 var Mocha = require('mocha');
 var RSVP = require('rsvp');
-var rimraf = require('rimraf');
+var fs = require('fs-extra');
 var mochaOnlyDetector = require('mocha-only-detector');
 
 if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
 }
 
-rimraf.sync('.node_modules-tmp');
-rimraf.sync('.bower_components-tmp');
+fs.removeSync('.node_modules-tmp');
+fs.removeSync('.bower_components-tmp');
 
 var root = 'tests/{unit,acceptance}';
 var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test,-slow}.js'));

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -54,19 +54,19 @@ describe('blueprint - addon', function() {
 
   describe('direct blueprint require', function() {
     var blueprint;
-    var readFileSyncStub;
-    var readFileSyncWasCalled;
-    var readFileSyncArguments;
-    var readFileSyncReturnValue;
+    var readJsonSyncStub;
+    var readJsonSyncWasCalled;
+    var readJsonSyncArguments;
+    var readJsonSyncReturnValue;
     var writeFileSyncStub;
     var writeFileSyncWasCalled;
     var writeFileSyncArguments;
 
     beforeEach(function() {
       blueprint = proxyquire('../../../blueprints/addon', {
-        'fs': {
-          readFileSync: function() {
-            return readFileSyncStub.apply(this, arguments);
+        'fs-extra': {
+          readJsonSync: function() {
+            return readJsonSyncStub.apply(this, arguments);
           },
           writeFileSync: function() {
             return writeFileSyncStub.apply(this, arguments);
@@ -83,16 +83,15 @@ describe('blueprint - addon', function() {
       };
       blueprint.path = 'test-blueprint-path';
 
-      readFileSyncStub = fs.readFileSync;
-      readFileSyncWasCalled = false;
-      readFileSyncArguments = [];
-      readFileSyncReturnValue = '{}';
-      readFileSyncStub = function() {
-        readFileSyncWasCalled = true;
-        readFileSyncArguments = arguments;
-        return readFileSyncReturnValue;
+      readJsonSyncWasCalled = false;
+      readJsonSyncArguments = [];
+      readJsonSyncReturnValue = {};
+      readJsonSyncStub = function() {
+        readJsonSyncWasCalled = true;
+        readJsonSyncArguments = arguments;
+        return readJsonSyncReturnValue;
       };
-      writeFileSyncStub = fs.writeFileSync;
+
       writeFileSyncWasCalled = false;
       writeFileSyncArguments = [];
       writeFileSyncStub = function() {
@@ -105,13 +104,12 @@ describe('blueprint - addon', function() {
       it('works', function() {
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
-        expect(readFileSyncArguments[0]).to.equal(path.normalize('test-app-blueprint-path/files/package.json'));
+        expect(readJsonSyncArguments[0]).to.equal(path.normalize('test-app-blueprint-path/files/package.json'));
         expect(writeFileSyncArguments[0]).to.equal(path.normalize('test-blueprint-path/files/package.json'));
 
-        expect(readFileSyncArguments[1]).to.deep.equal({ encoding: 'utf8' });
         // string to test ordering
         expect(writeFileSyncArguments[1]).to.deep.equal('\
 {\n\
@@ -134,13 +132,13 @@ describe('blueprint - addon', function() {
       });
 
       it('removes the `private` property', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           private: true
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -148,13 +146,13 @@ describe('blueprint - addon', function() {
       });
 
       it('overwrites `name`', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           name: 'test-name'
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -162,13 +160,13 @@ describe('blueprint - addon', function() {
       });
 
       it('overwrites `description`', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           description: 'test-description'
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -176,15 +174,15 @@ describe('blueprint - addon', function() {
       });
 
       it('moves `ember-cli-babel` from devDependencies to dependencies', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           devDependencies: {
             'ember-cli-babel': '1.0.0'
           }
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -195,13 +193,13 @@ describe('blueprint - addon', function() {
       });
 
       it('does not push multiple `ember-addon` keywords', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           keywords: ['ember-addon']
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -209,15 +207,15 @@ describe('blueprint - addon', function() {
       });
 
       it('overwrites any version of `ember-disable-prototype-extensions`', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           devDependencies: {
             'ember-disable-prototype-extensions': '0.0.1'
           }
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -225,15 +223,15 @@ describe('blueprint - addon', function() {
       });
 
       it('overwrites `scripts.test`', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           scripts: {
             test: 'test-string'
           }
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -241,15 +239,15 @@ describe('blueprint - addon', function() {
       });
 
       it('overwrites `ember-addon.configPath`', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           'ember-addon': {
             configPath: 'test-path'
           }
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -257,7 +255,7 @@ describe('blueprint - addon', function() {
       });
 
       it('preserves dependency ordering', function() {
-        readFileSyncReturnValue = JSON.stringify({
+        readJsonSyncReturnValue = {
           dependencies: {
             b: '1',
             a: '1'
@@ -266,11 +264,11 @@ describe('blueprint - addon', function() {
             b: '1',
             a: '1'
           }
-        });
+        };
 
         blueprint.generatePackageJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
         var json = JSON.parse(writeFileSyncArguments[1]);
@@ -293,13 +291,12 @@ describe('blueprint - addon', function() {
       it('works', function() {
         blueprint.generateBowerJson();
 
-        expect(readFileSyncWasCalled).to.be.true;
+        expect(readJsonSyncWasCalled).to.be.true;
         expect(writeFileSyncWasCalled).to.be.true;
 
-        expect(readFileSyncArguments[0]).to.equal(path.normalize('test-app-blueprint-path/files/bower.json'));
+        expect(readJsonSyncArguments[0]).to.equal(path.normalize('test-app-blueprint-path/files/bower.json'));
         expect(writeFileSyncArguments[0]).to.equal(path.normalize('test-blueprint-path/files/bower.json'));
 
-        expect(readFileSyncArguments[1]).to.deep.equal({ encoding: 'utf8' });
         // string to test ordering
         expect(writeFileSyncArguments[1]).to.deep.equal('\
 {\n\

--- a/tests/unit/models/asset-size-printer-test.js
+++ b/tests/unit/models/asset-size-printer-test.js
@@ -6,7 +6,6 @@ var AssetSizePrinter = require('../../../lib/models/asset-size-printer');
 var Promise          = require('../../../lib/ext/promise');
 var path             = require('path');
 var fs               = require('fs-extra');
-var existsSync       = require('exists-sync');
 var root             = process.cwd();
 var mkTmpDirIn       = require('../../../lib/utilities/mk-tmp-dir-in');
 var tmpRoot          = path.join(root, 'tmp');
@@ -35,12 +34,9 @@ describe('models/asset-size-printer', function () {
       storedTmpDir = tmpdir;
       assetDir = path.join(storedTmpDir, 'assets');
       assetChildDir = path.join(assetDir, 'childDir');
-      if (!existsSync(assetDir)) {
-        fs.mkdirSync(assetDir);
-      }
-      if (!existsSync(assetChildDir)) {
-        fs.mkdirSync(assetChildDir);
-      }
+
+      fs.mkdirsSync(assetDir);
+      fs.mkdirsSync(assetChildDir);
 
       writeFiles();
     });

--- a/tests/unit/tasks/update-test.js
+++ b/tests/unit/tasks/update-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var fs         = require('fs');
+var fs         = require('fs-extra');
 var path       = require('path');
 var expect     = require('chai').expect;
 var MockUI     = require('../../helpers/mock-ui');
@@ -110,7 +110,7 @@ describe('update task', function() {
 
     afterEach(function() {
       pkg.devDependencies['ember-cli'] = '0.0.1';
-      fs.writeFileSync(path.join(__dirname, dummyPkgPath), JSON.stringify(pkg, null, 2));
+      fs.writeJsonSync(path.join(__dirname, dummyPkgPath), pkg);
     });
 
     it('says \'a new version is available\' and asks you to confirm you want to update', function() {


### PR DESCRIPTION
We already depend on the `fs-extra` package for some of our code, but also on other dependencies that do some of the same things. This PR removes a few of those other dependencies in favor of using `fs-extra` everywhere.