### PR TITLE
Remove "ember help <something> --json" output

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -25,7 +25,7 @@ module.exports = Command.extend({
 
   run: function(commandOptions, rawArgs) {
     if (commandOptions.json) {
-      this._printJsonHelp(commandOptions, rawArgs);
+      this._printJsonHelp(commandOptions);
     } else {
       this._printHelp(commandOptions, rawArgs);
     }
@@ -91,7 +91,7 @@ module.exports = Command.extend({
     }
   },
 
-  _printJsonHelp: function(commandOptions, rawArgs) {
+  _printJsonHelp: function(commandOptions) {
     var generator = new JsonGenerator({
       ui: this.ui,
       project: this.project,
@@ -99,7 +99,7 @@ module.exports = Command.extend({
       tasks: this.tasks
     });
 
-    var json = generator.generate(commandOptions, rawArgs);
+    var json = generator.generate(commandOptions);
 
     var outputJsonString = JSON.stringify(json, null, 2);
 

--- a/lib/utilities/json-generator.js
+++ b/lib/utilities/json-generator.js
@@ -2,8 +2,6 @@
 
 var lookupCommand   = require('../cli/lookup-command');
 var stringUtils     = require('ember-cli-string-utils');
-var assign          = require('lodash/assign');
-var GenerateCommand = require('../commands/generate');
 var RootCommand     = require('./root-command');
 var versionUtils    = require('./version-utils');
 var emberCLIVersion = versionUtils.emberCLIVersion;
@@ -17,7 +15,7 @@ function JsonGenerator(options) {
   this.tasks = options.tasks;
 }
 
-JsonGenerator.prototype.generate = function(commandOptions, rawArgs) {
+JsonGenerator.prototype.generate = function(commandOptions) {
   var rootCommand = new RootCommand({
     ui: this.ui,
     project: this.project,
@@ -30,57 +28,31 @@ JsonGenerator.prototype.generate = function(commandOptions, rawArgs) {
   json.commands = [];
   json.addons = [];
 
-  if (rawArgs.length === 0) {
-    Object.keys(this.commands).forEach(function(commandName) {
-      this._addCommandHelpToJson(commandName, false, commandOptions, json);
-    }, this);
+  Object.keys(this.commands).forEach(function(commandName) {
+    this._addCommandHelpToJson(commandName, commandOptions, json);
+  }, this);
 
-    if (this.project.eachAddonCommand) {
-      this.project.eachAddonCommand(function(addonName, commands) {
-        this.commands = commands;
+  if (this.project.eachAddonCommand) {
+    this.project.eachAddonCommand(function(addonName, commands) {
+      this.commands = commands;
 
-        var addonJson = { name: addonName };
-        addonJson.commands = [];
-        json.addons.push(addonJson);
+      var addonJson = { name: addonName };
+      addonJson.commands = [];
+      json.addons.push(addonJson);
 
-        Object.keys(this.commands).forEach(function(commandName) {
-          this._addCommandHelpToJson(commandName, false, commandOptions, addonJson);
-        }, this);
-      }.bind(this));
-    }
-  } else {
-    // If args were passed to the help command,
-    // attempt to look up the command for each of them.
-
-    if (this.project.eachAddonCommand) {
-      this.project.eachAddonCommand(function(addonName, commands) {
-        assign(this.commands, commands);
-      }.bind(this));
-    }
-
-    var multipleCommands = [GenerateCommand.prototype.name].concat(GenerateCommand.prototype.aliases);
-    if (multipleCommands.indexOf(rawArgs[0]) > -1) {
-      var command = rawArgs.shift();
-      if (rawArgs.length > 0) {
-        commandOptions.rawArgs = rawArgs;
-      }
-      rawArgs = [command];
-    }
-
-    // Iterate through each arg beyond the initial 'help' command,
-    // and try to display usage instructions.
-    rawArgs.forEach(function(commandName) {
-      this._addCommandHelpToJson(commandName, true, commandOptions, json);
-    }, this);
+      Object.keys(this.commands).forEach(function(commandName) {
+        this._addCommandHelpToJson(commandName, commandOptions, addonJson);
+      }, this);
+    }.bind(this));
   }
 
   return json;
 };
 
 
-JsonGenerator.prototype._addCommandHelpToJson = function(commandName, single, options, json) {
+JsonGenerator.prototype._addCommandHelpToJson = function(commandName, options, json) {
   var command = this._lookupCommand(commandName);
-  if ((!command.skipHelp || single) && !command.unknown) {
+  if (!command.skipHelp && !command.unknown) {
     json.commands.push(command.getJson(options));
   }
 };

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -135,9 +135,11 @@ describe('Acceptance: ember help', function() {
   });
 
   describe('--json', function() {
-    it('works', function() {
+    beforeEach(function() {
       options.json = true;
+    });
 
+    it('works', function() {
       command.run(options, []);
 
       var json = convertToJson(options.ui.output);
@@ -146,19 +148,7 @@ describe('Acceptance: ember help', function() {
       expect(json).to.deep.equal(expected);
     });
 
-    it('returns empty list for unknown command', function() {
-      options.json = true;
-
-      command.run(options, ['asdf']);
-
-      var json = convertToJson(options.ui.output);
-      var expected = require('../fixtures/help/help-unknown.js');
-
-      expect(json).to.deep.equal(expected);
-    });
-
     it('prints commands from addons', function() {
-      options.json = true;
       options.project.eachAddonCommand = function(cb) {
         cb('dummy-addon', { Foo: FooCommand });
       };
@@ -171,22 +161,7 @@ describe('Acceptance: ember help', function() {
       expect(json).to.deep.equal(expected);
     });
 
-    it('prints single command from addon', function() {
-      options.json = true;
-      options.project.eachAddonCommand = function(cb) {
-        cb('dummy-addon', { Foo: FooCommand });
-      };
-
-      command.run(options, ['foo']);
-
-      var json = convertToJson(options.ui.output);
-      var expected = require('../fixtures/help/foo.js');
-
-      expect(json).to.deep.equal(expected);
-    });
-
     it('prints blueprints from addons', function() {
-      options.json = true;
       options.project.blueprintLookupPaths = function() {
         return [path.join(__dirname, '..', 'fixtures', 'blueprints')];
       };

--- a/tests/unit/commands/help-test.js
+++ b/tests/unit/commands/help-test.js
@@ -343,118 +343,6 @@ Available commands from my-addon:' + EOL);
       ]);
     });
 
-    it('works with single command alias', function() {
-      var Command1 = function() {
-        return {
-          getJson: function() {
-            return {
-              test1: 'bar'
-            };
-          }
-        };
-      };
-      Command1.prototype.aliases = ['my-alias'];
-
-      options.commands = {
-        Command1: Command1
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['my-alias']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'bar'
-        }
-      ]);
-    });
-
-    it('passes extra commands to `generate`', function() {
-      options.commands = {
-        Generate: function() {
-          return {
-            getJson: function(options) {
-              expect(options.rawArgs).to.deep.equal(['something', 'else']);
-              return {
-                test1: 'bar'
-              };
-            }
-          };
-        }
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['generate', 'something', 'else']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'bar'
-        }
-      ]);
-    });
-
-    it('handles no extra commands to `generate`', function() {
-      options.commands = {
-        Generate: function() {
-          return {
-            getJson: function(options) {
-              expect(options.rawArgs).to.equal(undefined);
-              return {
-                test1: 'bar'
-              };
-            }
-          };
-        }
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['generate']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'bar'
-        }
-      ]);
-    });
-
-    it('passes extra commands to `generate` alias', function() {
-      var Generate = function() {
-        return {
-          getJson: function() {
-            return {
-              test1: 'bar'
-            };
-          }
-        };
-      };
-      Generate.prototype.aliases = ['g'];
-
-      options.commands = {
-        Generate: Generate
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['g', 'something', 'else']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'bar'
-        }
-      ]);
-    });
-
     it('handles special option `Path`', function() {
       options.commands = {
         Command1: function() {
@@ -479,20 +367,6 @@ Available commands from my-addon:' + EOL);
           test1: 'Path'
         }
       ]);
-    });
-
-    it('handles missing command', function() {
-      options.commands = {
-        Command1: function() {}
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['missing-command']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([]);
     });
 
     it('respects skipHelp when listing', function() {
@@ -522,33 +396,6 @@ Available commands from my-addon:' + EOL);
       expect(json.commands).to.deep.equal([
         {
           test2: 'bar'
-        }
-      ]);
-    });
-
-    it('ignores skipHelp when single', function() {
-      options.commands = {
-        Command1: function() {
-          return {
-            skipHelp: true,
-            getJson: function() {
-              return {
-                test1: 'bar'
-              };
-            }
-          };
-        }
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['command-1']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'bar'
         }
       ]);
     });
@@ -594,35 +441,6 @@ Available commands from my-addon:' + EOL);
               test2: 'bar'
             }
           ]
-        }
-      ]);
-    });
-
-    it('finds single addon command', function() {
-      options.project.eachAddonCommand = function(callback) {
-        callback('my-addon', {
-          Command1: function() {
-            return {
-              getJson: function() {
-                return {
-                  test1: 'foo'
-                };
-              }
-            };
-          },
-          Command2: function() {}
-        });
-      };
-
-      var command = new HelpCommand(options);
-
-      command.run(options, ['command-1']);
-
-      var json = convertToJson(options.ui.output);
-
-      expect(json.commands).to.deep.equal([
-        {
-          test1: 'foo'
         }
       ]);
     });


### PR DESCRIPTION
This removes the ability to call `ember help <something> --json` in favor of `ember help --json` which contains all the same information already.

Resolves https://github.com/ember-cli/ember-cli/issues/5626