### PR TITLE
Use Ember.assign instead of Ember.merge if possible

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = (Ember.assign | Ember.merge)({}, config.APP);
-  attributes = (Ember.assign | Ember.merge)(attributes, attrs); // use defaults, but you can override;
+  let attributes = (Ember.assign || Ember.merge)({}, config.APP);
+  attributes = (Ember.assign || Ember.merge)(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = (Ember.assign | Ember.merge)({}, config.APP);
+  attributes = (Ember.assign | Ember.merge)(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Newly created apps and addons throw deprecation warnings if used w/ `ember#release`. This is a :-1: UX. Unfortunately, I have no good ideas around how we can build tests around this, because `ember#release` is intentionally and inherently a moving target (zing!).

Additionally, we shouldn't set ourselves on a path where setting up an addon to test against older versions of Ember (i.e., the 2.4 LTS release, 1.13) would require *each* project maintainer to set up a similar adjustment.

**Note:** Typically this would be handled w/ a polyfill, but [it seems like that's not the plan in this case of Ember.assign](https://github.com/emberjs/ember.js/pull/12303#issuecomment-140040603)

## Failing case

```
ember new hello718 && \
  cd hello718 && \
  bower install --save ember#release && \
  ember g route hello && \
  ember g acceptance-test hello
```

Update your
**config/environment.js**
```
ENV.EmberENV.RAISE_ON_DEPRECATION = true;
```

And now run
```
ember test ci
```

You’ll see test fail due to deprecation warnings

