### PR TITLE
index.html and test blueprint tune-up suggestions

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">

--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= namespace %></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -1,24 +1,24 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset='utf-8'>
     <title><%= namespace %></title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name='description' content=''>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
 
-    {{content-for "head"}}
+    {{content-for 'head'}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/<%= name %>.css">
+    <link rel='stylesheet' href='assets/vendor.css'>
+    <link rel='stylesheet' href='assets/<%= name %>.css'>
 
-    {{content-for "head-footer"}}
+    {{content-for 'head-footer'}}
   </head>
   <body>
-    {{content-for "body"}}
+    {{content-for 'body'}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/<%= name %>.js"></script>
+    <script src='assets/vendor.js'></script>
+    <script src='assets/<%= name %>.js'></script>
 
-    {{content-for "body-footer"}}
+    {{content-for 'body-footer'}}
   </body>
 </html>

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= namespace %> Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -1,33 +1,33 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset='utf-8'>
     <title><%= namespace %> Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name='description' content=''>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for 'head'}}
+    {{content-for 'test-head'}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/<%= name %>.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel='stylesheet' href='assets/vendor.css'>
+    <link rel='stylesheet' href='assets/<%= name %>.css'>
+    <link rel='stylesheet' href='assets/test-support.css'>
 
-    {{content-for "head-footer"}}
-    {{content-for "test-head-footer"}}
+    {{content-for 'head-footer'}}
+    {{content-for 'test-head-footer'}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for 'body'}}
+    {{content-for 'test-body'}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/<%= name %>.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src='testem.js' integrity=''></script>
+    <script src='assets/vendor.js'></script>
+    <script src='assets/test-support.js'></script>
+    <script src='assets/<%= name %>.js'></script>
+    <script src='assets/tests.js'></script>
+    <script src='assets/test-loader.js'></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for 'body-footer'}}
+    {{content-for 'test-body-footer'}}
   </body>
 </html>


### PR DESCRIPTION
1. Set doctype to lowercase
  -doctype is case-insensitive / I see no reason to capitolize it
  -https://www.w3.org/TR/html5/syntax.html#the-doctype

2. Remove X-UA-Compatible" content="IE=edge" tag
  -The use cases for this are very very few
  -This meta-tag should be added by the user if needed - instead of a default
  -http://stackoverflow.com/questions/26346917/why-use-x-ua-compatible-ie-edge-anymore

3. Set to single quotes
  -I see no reason not to keep every bluprint as lean as possible
  -This is generally the only page in my app that has double quotes

I end up doing this for every project. Just throwing it out there. : )