### PR TITLE
[BUGFIX] Remove deprecated Ember.merge from blueprints

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = Ember.assign({}, config.APP);
+  attributes = Ember.assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Ember.merge has been deprecated as of 2.5.0 (http://emberjs.com/deprecations/v2.x/#toc_ember-merge), and Ember.assign is recommended to replace. It appears to be functionally equivalent in this use case.