### PR TITLE
Update "inquirer" to v1.0.2

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var ora              = require('ora');
-var Promise          = require('../ext/promise');
 var EOL              = require('os').EOL;
 var chalk            = require('chalk');
 var writeError       = require('./write-error');
@@ -192,17 +191,17 @@ UI.prototype.stopProgress = function() {
   }
 };
 
+/**
+ * @method writeLevelVisible
+ * @param {Object} questions
+ * @param {Function} [callback]
+ * @return {Promise}
+ */
 UI.prototype.prompt = function(questions, callback) {
   var inquirer = require('inquirer');
 
   // If no callback was provided, automatically return a promise
-  if (callback) {
-    inquirer.prompt(questions, callback);
-  } else {
-    return new Promise(function(resolve) {
-      inquirer.prompt(questions, resolve);
-    });
-  }
+  return inquirer.prompt(questions, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "glob": "7.0.5",
     "http-proxy": "^1.9.0",
     "inflection": "^1.7.0",
-    "inquirer": "^0.12.0",
+    "inquirer": "^1.0.2",
     "is-git-url": "^0.2.0",
     "isbinaryfile": "^3.0.0",
     "leek": "0.0.21",


### PR DESCRIPTION
Now that SBoudrias/Inquirer.js#362 is fixed we can update our "inquirer" dependency to the v1.x release series.