### PR TITLE
Fix treeForAddon example

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -436,8 +436,8 @@ var Addon = CoreObject.extend({
 
     @example
     ```js
-    treeForAddon: function(tree) {
-      tree = this._super.treeForAddon.call(this, tree);
+    treeForAddon: function() {
+      var tree = this._super.treeForAddon.apply(this, arguments);
       var checker = new VersionChecker(this);
       var isOldEmber = checker.for('ember', 'bower').lt('1.13.0');
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -437,6 +437,7 @@ var Addon = CoreObject.extend({
     @example
     ```js
     treeForAddon: function(tree) {
+      tree = this._super.treeForAddon.call(this, tree);
       var checker = new VersionChecker(this);
       var isOldEmber = checker.for('ember', 'bower').lt('1.13.0');
 
@@ -444,7 +445,7 @@ var Addon = CoreObject.extend({
         tree = new Funnel(tree, { exclude: [ /instance-initializers/ ] });
       }
 
-      return this._super.treeForAddon.call(this, tree);
+      return tree;
     }
     ```
    */


### PR DESCRIPTION
The example below does not work in it's current form as the tree you pass into `this._super.treeForAddon` doesn't actually get processed and instead gets replaced.

This was introduced I believe in 2.4.2 and once the bug is fixed this example will continue to work as expected.

Related to https://github.com/ember-cli/ember-cli/issues/5745