### PR TITLE
Replace "findup" with "find-up"

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -10,7 +10,7 @@ var existsSync = require('exists-sync');
 var path       = require('path');
 var CoreObject = require('core-object');
 var resolve    = require('resolve');
-var findup     = require('findup');
+var findup     = require('find-up');
 
 /**
   AddonDiscovery is responsible for collecting information about all of the
@@ -133,7 +133,7 @@ var AddonDiscovery = CoreObject.extend({
 
       var entryModulePath = resolve.sync(packageName, { basedir: root });
 
-      return findup.sync(entryModulePath, 'package.json');
+      return path.dirname(findup.sync('package.json', { cwd: entryModulePath }));
     } catch (e) {
       var acceptableError = 'Cannot find module \'' + packageName + '\' from \'' + root + '\'';
       // pending: https://github.com/substack/node-resolve/pull/80

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -5,7 +5,7 @@
 */
 var Promise            = require('../ext/promise');
 var path               = require('path');
-var findup             = Promise.denodeify(require('findup'));
+var findup             = require('find-up');
 var resolve            = Promise.denodeify(require('resolve'));
 var fs                 = require('fs-extra');
 var existsSync         = require('exists-sync');
@@ -663,8 +663,9 @@ Project.projectOrnullProject = function(_ui, _cli) {
  */
 Project.getProjectRoot = function () {
   try {
-    var directory = findup.sync(process.cwd(), 'package.json');
-    var pkg = require(path.join(directory, 'package.json'));
+    var packagePath = findup.sync('package.json');
+    var directory = path.dirname(packagePath);
+    var pkg = require(packagePath);
 
     if (pkg && pkg.name === 'ember-cli') {
       debug('getProjectRoot: named \'ember-cli\'. Will use cwd: %s', process.cwd());
@@ -711,18 +712,18 @@ function ensureUI(_ui) {
 }
 
 function closestPackageJSON(pathName) {
-  return findup(pathName, 'package.json')
-    .then(function(directory) {
+  return findup('package.json', { cwd: pathName })
+    .then(function(packagePath) {
       return {
-        directory: directory,
-        pkg: require(path.join(directory, 'package.json'))
+        directory: path.dirname(packagePath),
+        pkg: require(packagePath)
       };
     });
 }
 
 function findupPath(pathName) {
   try {
-    return findup.sync(pathName, 'package.json');
+    return path.dirname(findup.sync('package.json', { cwd: pathName }));
   } catch (reason) {
     handleFindupError(pathName, reason);
   }

--- a/lib/utilities/find-build-file.js
+++ b/lib/utilities/find-build-file.js
@@ -1,22 +1,21 @@
 'use strict';
 
-var findUp = require('findup');
+var findUp = require('find-up');
 var path = require('path');
 
 module.exports = function(file) {
-  var buildFileDir;
-  try {
-    buildFileDir = findUp.sync(process.cwd(), file);
-  } catch (e) {
-    // Note: In the future this should throw
+  var buildFilePath = findUp.sync(file);
+
+  // Note: In the future this should throw
+  if (!buildFilePath) {
     return null;
   }
 
-  process.chdir(buildFileDir);
+  process.chdir(path.dirname(buildFilePath));
 
   var buildFile = null;
   try {
-    buildFile = require(path.join(buildFileDir, file));
+    buildFile = require(buildFilePath);
   } catch (err) {
     err.message = 'Could not require \'' + file + '\': ' + err.message;
     throw err;

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "exit": "^0.1.2",
     "express": "^4.12.3",
     "filesize": "^3.1.3",
-    "findup": "0.1.5",
+    "find-up": "^1.1.2",
     "fs-extra": "0.28.0",
     "fs-monitor-stack": "^1.0.2",
     "fs-tree-diff": "^0.4.4",


### PR DESCRIPTION
"find-up" by @sindresorhus seems to be better maintained and is more commonly used. also "findup" bundles a CLI tool which we don't use, but we still need to pay the cost for downloading their CLI dependencies.