### PR TITLE
tests/errors/silent: Move deprecated require() call into test

### DIFF
--- a/tests/unit/errors/silent-test.js
+++ b/tests/unit/errors/silent-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var SilentError    = require('silent-error');
-var SilentErrorLib = require('../../../lib/errors/silent');
 var expect         = require('chai').expect;
 
 describe('SilentError', function() {
   it('return silent-error and print a deprecation', function() {
+    var SilentErrorLib = require('../../../lib/errors/silent');
     expect(SilentErrorLib, 'returns silent-error').to.equal(SilentError);
   });
 });


### PR DESCRIPTION
This moves the deprecation warning output closer to the corresponding test.