### PR TITLE
Fix "find-up" return value handling

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -133,7 +133,11 @@ var AddonDiscovery = CoreObject.extend({
 
       var entryModulePath = resolve.sync(packageName, { basedir: root });
 
-      return path.dirname(findup.sync('package.json', { cwd: entryModulePath }));
+      var pkgPath = findup.sync('package.json', { cwd: entryModulePath });
+      if (pkgPath) {
+        return path.dirname(pkgPath);
+      }
+
     } catch (e) {
       var acceptableError = 'Cannot find module \'' + packageName + '\' from \'' + root + '\'';
       // pending: https://github.com/substack/node-resolve/pull/80

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -584,9 +584,6 @@ Project.closest = function(pathName, _ui, _cli) {
       }
 
       return new Project(result.directory, result.pkg, ui, _cli);
-    })
-    .catch(function(reason) {
-      handleFindupError(pathName, reason);
     });
 };
 
@@ -663,26 +660,22 @@ Project.projectOrnullProject = function(_ui, _cli) {
   @return {String} The project root directory
  */
 Project.getProjectRoot = function () {
-  try {
-    var packagePath = findup.sync('package.json');
-    var directory = path.dirname(packagePath);
-    var pkg = require(packagePath);
-
-    if (pkg && pkg.name === 'ember-cli') {
-      debug('getProjectRoot: named \'ember-cli\'. Will use cwd: %s', process.cwd());
-      return process.cwd();
-    }
-
-    debug('getProjectRoot %s -> %s', process.cwd(), directory);
-    return directory;
-  } catch (reason) {
-    if (isFindupError(reason)) {
-      debug('getProjectRoot: not found. Will use cwd: %s', process.cwd());
-      return process.cwd();
-    } else {
-      throw reason;
-    }
+  var packagePath = findup.sync('package.json');
+  if (!packagePath) {
+    debug('getProjectRoot: not found. Will use cwd: %s', process.cwd());
+    return process.cwd();
   }
+
+  var directory = path.dirname(packagePath);
+  var pkg = require(packagePath);
+
+  if (pkg && pkg.name === 'ember-cli') {
+    debug('getProjectRoot: named \'ember-cli\'. Will use cwd: %s', process.cwd());
+    return process.cwd();
+  }
+
+  debug('getProjectRoot %s -> %s', process.cwd(), directory);
+  return directory;
 };
 
 function NotFoundError(message) {
@@ -715,6 +708,10 @@ function ensureUI(_ui) {
 function closestPackageJSON(pathName) {
   return findup('package.json', { cwd: pathName })
     .then(function(packagePath) {
+      if (!packagePath) {
+        throw new NotFoundError('No project found at or up from: `' + pathName + '`');
+      }
+
       return {
         directory: path.dirname(packagePath),
         pkg: require(packagePath)
@@ -723,24 +720,12 @@ function closestPackageJSON(pathName) {
 }
 
 function findupPath(pathName) {
-  try {
-    return path.dirname(findup.sync('package.json', { cwd: pathName }));
-  } catch (reason) {
-    handleFindupError(pathName, reason);
-  }
-}
-
-function isFindupError(reason) {
-  // Would be nice if findup threw error subclasses
-  return reason && /not found/i.test(reason.message);
-}
-
-function handleFindupError(pathName, reason) {
-  if (isFindupError(reason)) {
+  var pkgPath = findup.sync('package.json', { cwd: pathName });
+  if (!pkgPath) {
     throw new NotFoundError('No project found at or up from: `' + pathName + '`');
-  } else {
-    throw reason;
   }
+
+  return path.dirname(pkgPath);
 }
 
 // Export


### PR DESCRIPTION
#5842 unfortunately broke some code because it returns `null` if a file was not found instead of throwing an error like before. This PR adjusts the surrounding code to that changed behavior.

Unfortunately testing this is rather hard since we run our test suite inside the `ember-cli` folder which itself has a `package.json` file. That is also the reason why this bug wasn't caught by our current test suite.

/cc @nathanhammond 