### PR TITLE
Use proper formatting for `options.outputPaths.testSupport.js`

### DIFF
--- a/tests/fixtures/brocfile-tests/custom-output-paths/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/custom-output-paths/ember-cli-build.js
@@ -19,7 +19,10 @@ module.exports = function (defaults) {
       },
       testSupport: {
         css: '/css/test-support.css',
-        js: '/js/test-support.js'
+        js: {
+          testSupport: '/js/test-support.js',
+          testLoader: '/js/test-loader.js'
+        }
       }
     }
   });


### PR DESCRIPTION
Fixes #5852

```bash
% node --version
v5.6.0
% node
> path.dirname(undefined)
'.'
```

```bash
% node --version
v6.0.0
% node
> path.dirname(undefined)
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at repl:1:6
    at REPLServer.defaultEval (repl.js:272:27)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:441:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
    at REPLServer.Interface._onLine (readline.js:219:10)                                                                                                                                                
```