### PR TITLE
[BUGFIX beta] Allow Node v6.0.0.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -57,7 +57,7 @@ CLI.prototype.run = function(environment) {
       }
 
       if (platform.isUntested) {
-        this.ui.writeWarnLine('WARNING: Node ' + process.version +
+        this.ui.writeWarnLine('Node ' + process.version +
                               ' has currently not been tested against Ember CLI and may result in unexpected behaviour.');
       }
     }

--- a/lib/utilities/platform-checker.js
+++ b/lib/utilities/platform-checker.js
@@ -4,7 +4,7 @@ var semver = require('semver');
 var debug = require('debug')('ember-cli:platform-checker:');
 
 var LOWER_RANGE = '0.12.0';
-var UPPER_RANGE = '6.0.0';
+var UPPER_RANGE = '7.0.0';
 
 module.exports = PlatformChecker;
 function PlatformChecker(version) {
@@ -32,4 +32,3 @@ PlatformChecker.prototype.checkIsDeprecated = function() {
 PlatformChecker.prototype.checkIsUntested = function() {
   return semver.satisfies(this.version, '>=' + UPPER_RANGE);
 };
-

--- a/tests/unit/utilities/platform-checker-test.js
+++ b/tests/unit/utilities/platform-checker-test.js
@@ -12,7 +12,8 @@ describe('platform-checker', function() {
   });
 
   it('should return isUntested for Node v6', function() {
-    expect(new PlatformChecker('v6.0.0').isUntested).to.be.equal(true);
+    expect(new PlatformChecker('v7.0.0').isUntested).to.be.equal(true);
+    expect(new PlatformChecker('v6.0.0').isUntested).to.be.equal(false);
     expect(new PlatformChecker('v0.12.0').isUntested).to.be.equal(false);
   });
 
@@ -51,5 +52,11 @@ describe('platform-checker', function() {
     expect(new PlatformChecker('v5.0.0').isValid).to.be.equal(true);
     expect(new PlatformChecker('v5.1.0').isValid).to.be.equal(true);
     expect(new PlatformChecker('v5.99.0').isValid).to.be.equal(true);
+  });
+
+  it('should return isValid for Node v6', function() {
+    expect(new PlatformChecker('v6.0.0').isValid).to.be.equal(true);
+    expect(new PlatformChecker('v6.1.0').isValid).to.be.equal(true);
+    expect(new PlatformChecker('v6.99.0').isValid).to.be.equal(true);
   });
 });


### PR DESCRIPTION
Removes warning for node `6.0.0`, and also removes duplicate `WARNING: WARNING:` from message (since `this.ui.writeWarnLine` prepends `WARNING: `).

Requires #5855 to land first.