### PR TITLE
models/addon: Kill the addonJsFiles() cache

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -736,21 +736,15 @@ var Addon = CoreObject.extend({
   addonJsFiles: function(tree) {
     this._requireBuildPackages();
 
-    if (this._cachedAddonJsFiles) {
-      return this._cachedAddonJsFiles;
-    }
-
     var includePatterns = this.registry.extensionsForType('js').map(function(extension) {
       return new RegExp(extension + '$');
     });
 
-    this._cachedAddonJsFiles = new Funnel(tree, {
+    return new Funnel(tree, {
       include: includePatterns,
       destDir: 'modules/' + this.moduleName(),
       description: 'Funnel: Addon JS'
     });
-
-    return this._cachedAddonJsFiles;
   },
 
 


### PR DESCRIPTION
addonJsFiles() is called twice, by jshintAddonTree() and by treeForAddon(). in one case it gets passed the addonPath directly, while the other case might be overwritten and passes something else. If the Funnel in the first invocation is cached the second invocation parameter will be discarded which resulted in a regression.

Resolves https://github.com/ember-cli/ember-cli/issues/5745

/cc @rwjblue 