### PR TITLE
models/project: Remove "testing" code path from closestSync()

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -613,7 +613,7 @@ Project.closestSync = function(pathName, _ui, _cli) {
   }
 
   var pkg = fs.readJsonSync(path.join(directory, 'package.json'));
-  debug('package.json: %s', pkg);
+  debug('project name: %s', pkg && pkg.name);
 
   if (pkg && pkg.name === 'ember-cli') {
     debug('ignoring parent project since it is ember-cli itself');

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -599,32 +599,27 @@ Project.closest = function(pathName, _ui, _cli) {
   @return {Project}         Project instance
  */
 Project.closestSync = function(pathName, _ui, _cli) {
+  debug('looking for package.json starting at %s', pathName);
+
   var ui = ensureUI(_ui);
-  var directory, pkg;
 
-  if (_cli && _cli.testing) {
-    directory = existsSync(path.join(pathName, 'package.json')) && process.cwd();
-    if (!directory) {
-      if (pathName.indexOf(path.sep + 'app') > -1) {
-        directory = findupPath(pathName);
-      } else {
-        pkg = {name: 'ember-cli'};
-      }
-    }
-  } else {
-    directory = findupPath(pathName);
-  }
-  if (!pkg) {
-    pkg = fs.readJsonSync(path.join(directory, 'package.json'));
-  }
+  var directory = findupPath(pathName);
+  debug('found package.json at %s', directory);
 
-  debug('dir' + directory);
-  debug('pkg: %s', pkg);
-  if (pkg && pkg.name === 'ember-cli') {
+  var relative = path.relative(directory, pathName);
+  if (relative.indexOf('tmp') === 0) {
+    debug('ignoring parent project since we are in the tmp folder of the project');
     return Project.nullProject(_ui, _cli);
   }
 
-  debug('closestSync %s -> %s', pathName, directory);
+  var pkg = fs.readJsonSync(path.join(directory, 'package.json'));
+  debug('package.json: %s', pkg);
+
+  if (pkg && pkg.name === 'ember-cli') {
+    debug('ignoring parent project since it is ember-cli itself');
+    return Project.nullProject(_ui, _cli);
+  }
+
   return new Project(directory, pkg, ui, _cli);
 };
 


### PR DESCRIPTION
Instead we check if pathName is in the "tmp" folder of the parent project and in this case we assume we're *not* inside a project.

This codepath was originally created for the blueprint-test-helpers and the proposed solution works for them as well.