### PR TITLE
Ignore fastboot-dist

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+/fastboot-dist
 
 # dependencies
 /node_modules


### PR DESCRIPTION
I've been experiment with fast boot and one of the first thing I need to do in every repo is add fastboot-dist to the gitignore.