### PR TITLE
Don't process CSS imports by default

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -169,7 +169,10 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     outputPaths: {},
     minifyCSS: {
       enabled: !!isProduction,
-      options: { relativeTo: 'assets' }
+      options: {
+        relativeTo: 'assets',
+        processImport: false
+      }
     },
     minifyJS: {
       enabled: !!isProduction


### PR DESCRIPTION
This is a potentially dangerous default in clean-css. Ideally they'd change it there, but it doesn't seem that it's likely. The benefits of importing files by URL is also greatly reduced in ember-cli apps. See https://github.com/jakubpawlowicz/clean-css/issues/767