### PR TITLE
Uniform import API

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -391,6 +391,27 @@ var Addon = CoreObject.extend({
   },
 
   /**
+     Imports an asset into this addon.
+
+     Options:
+     - type - Either 'vendor' or 'test', defaults to 'vendor'
+     - prepend - Whether or not this asset should be prepended, defaults to false
+     - destDir - Destination directory, defaults to the name of the directory the asset is in
+
+     @public
+     @method import
+     @param  {(Object|String)}  asset   Either a path to the asset or an object with environment names and paths as key-value pairs.
+     @param  {Object=} options Options object
+  */
+  import: function(asset, options) {
+    var app = this.app;
+    while (app.app) {
+      app = app.app;
+    }
+    app.import(asset, options);
+  },
+
+  /**
     Returns the tree for all app files
 
     @public


### PR DESCRIPTION
This PR proposes a uniform API for importing assets into both apps and addons. It solves the most common pain point when using an addon from another addon, which is that `app.import` in the `included` hook fails.

This API gives us future flexibility to implement `import` differently depending on target you're importing into. In particular, an engine may choose to behave differently  so that vendored assets are in the appropriate bundles.

I'm opening this for discussion now, and will add tests if people think this is mergeable.