### PR TITLE
Blueprint READMEs: s/server/serve/ to match `ember help`

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -10,7 +10,7 @@ This README outlines the details of collaborating on this Ember addon.
 
 ## Running
 
-* `ember server`
+* `ember serve`
 * Visit your app at http://localhost:4200.
 
 ## Running Tests

--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -22,7 +22,7 @@ You will need the following things properly installed on your computer.
 
 ## Running / Development
 
-* `ember server`
+* `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 
 ### Code Generators


### PR DESCRIPTION
Yes, "server" works, just trying to make things a bit more consistent:
- https://github.com/ember-cli/ember-cli/blob/master/README.md says "serve"
- `ember help` says "serve"
- most other ember sub-commands (esp those performing an action, just just getting info) are verbs, not nouns (new, install, init, generate, destroy, build, test) (so this seems the right direction for normalization)

(as a docs-only change, no unit tests - in fact just did this in the GH editor. if this happens to be tested somewhere I'm not aware of please just let me know)