### PR TITLE
Use jshint's esversion option instead of esnext option

### DIFF
--- a/blueprints/app/files/.jshintrc
+++ b/blueprints/app/files/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/blueprints/app/files/tests/.jshintrc
+++ b/blueprints/app/files/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }


### PR DESCRIPTION
esnext option is deprecated and will be removed. See http://jshint.com/docs/options/#esnext