### PR TITLE
Simplify EmberApp/Addon constructors

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -17,10 +17,12 @@ module.exports = EmberAddon;
   @extends EmberApp
   @constructor
   @param {Object} [defaults]
-  @param {Object} options Configuration options
+  @param {Object} [options={}] Configuration options
 */
 function EmberAddon(defaults, options) {
-  if (arguments.length === 1) {
+  if (arguments.length === 0) {
+    options = {};
+  } else if (arguments.length === 1) {
     options = defaults;
   } else {
     mergeDefaults(options, defaults);

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -16,21 +16,14 @@ module.exports = EmberAddon;
   @class EmberAddon
   @extends EmberApp
   @constructor
-  @param options
+  @param {Object} [defaults]
+  @param {Object} options Configuration options
 */
-function EmberAddon() {
-  var args = [];
-  var options = {};
-
-  for (var i = 0, l = arguments.length; i < l; i++) {
-    args.push(arguments[i]);
-  }
-
-  if (args.length === 1) {
-    options = args[0];
-  } else if (args.length > 1) {
-    args.reverse();
-    options = mergeDefaults.apply(null, args);
+function EmberAddon(defaults, options) {
+  if (arguments.length === 1) {
+    options = defaults;
+  } else {
+    mergeDefaults(options, defaults);
   }
 
   process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -4,7 +4,7 @@
 /**
 @module ember-cli
 */
-var defaults = require('merge-defaults');
+var mergeDefaults = require('merge-defaults');
 var Funnel   = require('broccoli-funnel');
 var EmberApp = require('./ember-app');
 
@@ -30,12 +30,12 @@ function EmberAddon() {
     options = args[0];
   } else if (args.length > 1) {
     args.reverse();
-    options = defaults.apply(null, args);
+    options = mergeDefaults.apply(null, args);
   }
 
   process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';
 
-  this.appConstructor(defaults(options, {
+  this.appConstructor(mergeDefaults(options, {
     name: 'dummy',
     configPath: './tests/dummy/config/environment',
     trees: {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -61,21 +61,14 @@ module.exports = EmberApp;
 
   @class EmberApp
   @constructor
+  @param {Object} [defaults]
   @param {Object} options Configuration options
 */
-function EmberApp() {
-  var args = [];
-  var options = {};
-
-  for (var i = 0, l = arguments.length; i < l; i++) {
-    args.push(arguments[i]);
-  }
-
-  if (args.length === 1) {
-    options = args[0];
-  } else if (args.length > 1) {
-    args.reverse();
-    options = mergeDefaults.apply(null, args);
+function EmberApp(defaults, options) {
+  if (arguments.length === 1) {
+    options = defaults;
+  } else {
+    mergeDefaults(options, defaults);
   }
 
   this._initProject(options);

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -33,7 +33,7 @@ var mergeTrees    = require('./merge-trees');
 var WatchedDir    = require('broccoli-source').WatchedDir;
 var UnwatchedDir  = require('broccoli-source').UnwatchedDir;
 
-var defaults      = require('merge-defaults');
+var mergeDefaults = require('merge-defaults');
 var merge         = require('lodash/merge');
 var omitBy        = require('lodash/omitBy');
 var isNull        = require('lodash/isNull');
@@ -75,7 +75,7 @@ function EmberApp() {
     options = args[0];
   } else if (args.length > 1) {
     args.reverse();
-    options = defaults.apply(null, args);
+    options = mergeDefaults.apply(null, args);
   }
 
   this._initProject(options);
@@ -180,10 +180,10 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     addons: {}
   };
 
-  this.options = defaults(options, config, babelOptions);
+  this.options = mergeDefaults(options, config, babelOptions);
 
   // needs a deeper merge than is provided above
-  this.options.outputPaths = defaults(this.options.outputPaths, {
+  this.options.outputPaths = mergeDefaults(this.options.outputPaths, {
     app: {
       html: 'index.html',
       css: {
@@ -207,7 +207,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     }
   });
 
-  this.options.sourcemaps = defaults(this.options.sourcemaps, {
+  this.options.sourcemaps = mergeDefaults(this.options.sourcemaps, {
     enabled: !isProduction,
     extensions: ['js']
   });
@@ -216,7 +216,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
   // performance regressions.
   this.options.babel.sourceMaps = false;
 
-  this.options.trees = defaults(this.options.trees, {
+  this.options.trees = mergeDefaults(this.options.trees, {
     app:       new WatchedDir(this._resolveLocal('app')),
     tests:     new WatchedDir(this._resolveLocal('tests')),
 
@@ -232,7 +232,7 @@ EmberApp.prototype._initOptions = function(options, isProduction) {
     public: existsSync(this._resolveLocal('public')) ? new WatchedDir(this._resolveLocal('public')) : null
   });
 
-  this.options.jshintrc = defaults(this.options.jshintrc, {
+  this.options.jshintrc = mergeDefaults(this.options.jshintrc, {
     app: this.project.root,
     tests: this._resolveLocal('tests'),
   });
@@ -1450,7 +1450,7 @@ EmberApp.prototype.import = function(asset, options) {
     return;
   }
 
-  options = defaults(options || {}, {
+  options = mergeDefaults(options || {}, {
     type: 'vendor',
     prepend: false
   });

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -62,10 +62,12 @@ module.exports = EmberApp;
   @class EmberApp
   @constructor
   @param {Object} [defaults]
-  @param {Object} options Configuration options
+  @param {Object} [options={}] Configuration options
 */
 function EmberApp(defaults, options) {
-  if (arguments.length === 1) {
+  if (arguments.length === 0) {
+    options = {};
+  } else if (arguments.length === 1) {
     options = defaults;
   } else {
     mergeDefaults(options, defaults);


### PR DESCRIPTION
This PR removes the undocumented feature of the `EmberApp/Addon` constructors to take more than two options objects which are the merged by `merge-defaults`. This concept is replaced by an optional `defaults` and a required `options` parameter.