### PR TITLE
print bower and phantom versions in travis logs

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -24,7 +24,9 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g bower
+  - bower --version
   - npm install phantomjs-prebuilt
+  - phantomjs --version
 
 install:
   - npm install

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -12,7 +12,9 @@ cache:
 before_install:
   - npm config set spin false
   - npm install -g bower
+  - bower --version
   - npm install phantomjs-prebuilt
+  - phantomjs --version
 
 install:
   - npm install


### PR DESCRIPTION
Added it to my app. Thought it would be useful for everyone to compliment travis' default node, npm, and nvm printing.

![capture](https://cloud.githubusercontent.com/assets/602423/15269852/f963c782-19c0-11e6-80c1-688cb3399759.PNG)
