### PR TITLE
Handle all valid URL path characters for rootURL/baseURL in tests-server

### DIFF
--- a/lib/tasks/server/middleware/tests-server/index.js
+++ b/lib/tasks/server/middleware/tests-server/index.js
@@ -24,7 +24,7 @@ TestsServerAddon.prototype.serverMiddleware = function(config) {
   var watcher = options.watcher;
 
   var baseURL = cleanBaseURL(options.rootURL || options.baseURL);
-  var testsRegexp = new RegExp('^' + baseURL + 'tests');
+  var testsPath = baseURL + 'tests';
 
   app.use(function(req, res, next) {
     watcher.then(function(results) {
@@ -32,7 +32,7 @@ TestsServerAddon.prototype.serverMiddleware = function(config) {
       var hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
       var hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
 
-      var isForTests = testsRegexp.test(req.path);
+      var isForTests = req.path.indexOf(testsPath) === 0;
 
       debug('isForTests: %o', isForTests);
 
@@ -41,7 +41,8 @@ TestsServerAddon.prototype.serverMiddleware = function(config) {
         var filePath = path.join(results.directory, assetPath);
 
         if (!existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-          var newURL = baseURL + '/tests/index.html';
+          // N.B., `baseURL` will end with a slash as it went through `cleanBaseURL`
+          var newURL = baseURL + 'tests/index.html';
 
           debug('url: %s resolved to path: %s which is not a file. Assuming %s instead', req.path, filePath, newURL);
           req.url = newURL;

--- a/tests/unit/tasks/server/middleware/tests-server-test.js
+++ b/tests/unit/tasks/server/middleware/tests-server-test.js
@@ -20,6 +20,16 @@ describe('TestServerAddon', function () {
       }
     };
 
+    afterEach(function() {
+      nextWasCalled = false;
+      mockRequest = {
+        method: 'GET',
+        path: '',
+        url: 'http://example.com',
+        headers: {}
+      };
+    });
+
     it('invokes next when the watcher succeeds', function(done) {
       addon.serverMiddleware({
         app: app,
@@ -45,6 +55,38 @@ describe('TestServerAddon', function () {
           expect(nextWasCalled).to.true;
           done();
         }
+      });
+    });
+
+    it('allows baseURL containing `+` character', function(done) {
+      mockRequest.path = '/braden/+/tests/any-old-file';
+      mockRequest.headers.accept = ['*/*'];
+      addon.serverMiddleware({
+        app: app,
+        options: {
+          watcher: Promise.resolve({ directory: 'nothing' }),
+          baseURL: '/braden/+'
+        },
+        finally: function() {
+          expect(mockRequest.url).to.equal('/braden/+/tests/index.html');
+          done();
+        }
+      });
+
+      it('allows rootURL containing `+` character', function(done) {
+        mockRequest.path = '/grayson/+/tests/any-old-file';
+        mockRequest.headers.accept = ['text/html'];
+        addon.serverMiddleware({
+          app: app,
+          options: {
+            watcher: Promise.resolve({directory: 'nothing'}),
+            rootURL: '/grayson/+'
+          },
+          finally: function () {
+            expect(mockRequest.url).to.equal('/grayson/+/tests/index.html');
+            done();
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
The previous implementation used a regular expression for matching the
beginning of the request path against the baseURL + 'tests' but did
not escape the baseURL. Because RFC 3986 allows some characters that
are not valid in regexes, this caused problems when using them for
the baseURL.

Closes #5876