### PR TITLE
Set rootURL to / in test environment

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -30,7 +30,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
-
+    ENV.rootURL = '/';
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;


### PR DESCRIPTION
Now that this was merged https://github.com/emberjs/ember.js/pull/13520 it's important people know that setting the `rootURL` on line 7 will likely cause some breakage in tests.  Everyone likely relied on `rootURL` to not be implemented in `Ember.NoneLocation` and now that it is it will likely cause some confusion.