### PR TITLE
move jQuery to ember-core for now

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -252,12 +252,15 @@ EmberApp.prototype._initVendorFiles = function() {
   var developmentEmber;
   var productionEmber;
   var emberShims;
+  var jquery;
 
   if (ember) {
     developmentEmber = ember.paths.debug;
-    productionEmber = ember.paths.prod;
-    emberShims      = ember.paths.shims;
+    productionEmber  = ember.paths.prod;
+    emberShims       = ember.paths.shims;
+    jquery           = ember.paths.jquery;
   } else {
+    jquery = this.bowerDirectory + '/jquery/dist/jquery.js';
     emberShims = this.bowerDirectory + '/ember-cli-shims/app-shims.js';
     // in Ember 1.10 and higher `ember.js` is deprecated in favor of
     // the more aptly named `ember.debug.js`.
@@ -279,7 +282,7 @@ EmberApp.prototype._initVendorFiles = function() {
   }
 
   this.vendorFiles = omitBy(merge({
-    'jquery.js': this.bowerDirectory + '/jquery/dist/jquery.js',
+    'jquery.js': jquery,
     'handlebars.js': handlebarsVendorFiles,
     'ember.js': {
       development: developmentEmber,


### PR DESCRIPTION
this is backwards compat, merely if someone has ember-core installed we will prefer that jQuery