### PR TITLE
chore(editorconfig): removed redundant rules

### DIFF
--- a/blueprints/app/files/.editorconfig
+++ b/blueprints/app/files/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
```
indent_style = space
indent_size = 2
```
are already part of `*`, no need to specify them explicitly for `*.js`, `*.hbs`, `*.css` and `*.html`.