### PR TITLE
Merge v2.5.1 into beta branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ version:
 
 Thank you to all who took the time to contribute!
 
+
 ### 2.6.0-beta.1
 
 The following changes are required if you are upgrading from the previous
@@ -61,6 +62,26 @@ version:
 - [#5786](https://github.com/ember-cli/ember-cli/pull/5786) Deprecate `Project.closest` in favor of `Project.closestSync` [@jeffjewiss](https://github.com/jeffjewiss)
 
 Thank you to all who took the time to contribute!
+
+
+### 2.5.1
+
+The following changes are required if you are upgrading from the previous
+version:
+
+- Users
+  + Upgrade your project's ember-cli version - [docs](http://ember-cli.com/user-guide/#upgrading)
+- Addon Developers
+  + No changes required
+- Core Contributors
+  + No changes required
+
+#### Community Contributions
+
+- [#5867](https://github.com/ember-cli/ember-cli/pull/5867) models/addon: Kill the addonJsFiles() cache [@Turbo87](https://github.com/Turbo87)
+
+Thank you to all who took the time to contribute!
+
 
 ### 2.5.0
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -698,21 +698,15 @@ var Addon = CoreObject.extend({
   addonJsFiles: function(tree) {
     this._requireBuildPackages();
 
-    if (this._cachedAddonJsFiles) {
-      return this._cachedAddonJsFiles;
-    }
-
     var includePatterns = this.registry.extensionsForType('js').map(function(extension) {
       return new RegExp(extension + '$');
     });
 
-    this._cachedAddonJsFiles = new Funnel(tree, {
+    return new Funnel(tree, {
       include: includePatterns,
       destDir: 'modules/' + this.moduleName(),
       description: 'Funnel: Addon JS'
     });
-
-    return this._cachedAddonJsFiles;
   },
 
 


### PR DESCRIPTION
The `beta` branch is currently missing the bugfixes and changes from the `release` branch. This PR merges the `v2.5.1` tag into the `beta` branch to fix this.

Merging in releases from the stable branch has worked quite well for me on other projects. I'm happy to discuss other approaches though if there are any major disadvantages that I'm missing right now.

/cc @rwjblue @stefanpenner @nathanhammond 

PS: to keep the history somewhat flat I'd suggest merging this PR via rebase instead of hitting the big green GitHub button 😉 