### PR TITLE
Deprecate EmberApp.concatFiles() method

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -11,6 +11,7 @@ var p            = require('ember-cli-preprocess-registry/preprocessors');
 var chalk        = require('chalk');
 var escapeRegExp = require('escape-string-regexp');
 var EOL          = require('os').EOL;
+var crypto       = require('crypto');
 
 var Project      = require('../models/project');
 var cleanBaseURL = require('clean-base-url');
@@ -40,6 +41,7 @@ var isNull        = require('lodash/isNull');
 var Funnel        = require('broccoli-funnel');
 var funnelReducer = require('broccoli-funnel-reducer');
 
+var SECRET_DEPRECATION_PREVENTION_SYMBOL = crypto.randomBytes(8).toString('hex');
 
 var DEFAULT_CONFIG = {
   es3Safe: true,
@@ -357,8 +359,9 @@ EmberApp.env = function() {
   @param options
   @return
 */
-EmberApp.prototype.concatFiles = function(tree, options, ignoreDeprecation) {
-  this.project.ui.writeDeprecateLine('EmberApp.concatFiles() is deprecated. Please use the `broccoli-concat` module directly.', ignoreDeprecation);
+EmberApp.prototype.concatFiles = function(tree, options) {
+  this.project.ui.writeDeprecateLine('EmberApp.concatFiles() is deprecated. Please use the `broccoli-concat` module directly.',
+    arguments[2] === SECRET_DEPRECATION_PREVENTION_SYMBOL);
 
   options.sourceMapConfig = this.options.sourcemaps;
 
@@ -375,7 +378,7 @@ EmberApp.prototype.concatFiles = function(tree, options, ignoreDeprecation) {
   @return
 */
 EmberApp.prototype._concatFiles = function(tree, options) {
-  return this.concatFiles(tree, options, true);
+  return this.concatFiles(tree, options, SECRET_DEPRECATION_PREVENTION_SYMBOL);
 };
 
 /**

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -351,15 +351,31 @@ EmberApp.env = function() {
   Provides a broccoli files concatenation filter that's configured
   properly for this application.
 
+  @deprecated
   @method concatFiles
   @param tree
   @param options
   @return
 */
-EmberApp.prototype.concatFiles = function(tree, options) {
+EmberApp.prototype.concatFiles = function(tree, options, ignoreDeprecation) {
+  this.project.ui.writeDeprecateLine('EmberApp.concatFiles() is deprecated. Please use the `broccoli-concat` module directly.', ignoreDeprecation);
+
   options.sourceMapConfig = this.options.sourcemaps;
 
   return concat(tree, options);
+};
+
+/**
+  Delegates to `broccoli-concat` with the `sourceMapConfig` option set to `options.sourcemaps`.
+
+  @private
+  @method _concatFiles
+  @param tree
+  @param options
+  @return
+*/
+EmberApp.prototype._concatFiles = function(tree, options) {
+  return this.concatFiles(tree, options, true);
 };
 
 /**
@@ -896,14 +912,14 @@ EmberApp.prototype._addonTree = function _addonTree() {
   });
 
   return this._cachedAddonTree = [
-    this.concatFiles(addonTrees, {
+    this._concatFiles(addonTrees, {
       inputFiles: ['**/*.css'],
       outputFile: '/addons.css',
       allowNone: true,
       annotation: 'Concat: Addon CSS'
     }),
 
-    this.concatFiles(reexportsAndTranspiledAddonTree, {
+    this._concatFiles(reexportsAndTranspiledAddonTree, {
       inputFiles: ['**/*.js'],
       outputFile: '/addons.js',
       allowNone: true,
@@ -1101,7 +1117,7 @@ EmberApp.prototype.appTests = function(coreTestTree) {
     annotation: 'TreeMerger (appTestTrees)'
   });
 
-  return this.concatFiles(appTestTrees, {
+  return this._concatFiles(appTestTrees, {
     inputFiles: [ this.name + '/tests/**/*.js' ],
     footerFiles: [ 'vendor/ember-cli/tests-suffix.js' ],
     outputFile: this.options.outputPaths.tests.js,
@@ -1200,7 +1216,7 @@ EmberApp.prototype.javascript = function() {
     overwrite: true
   });
 
-  appJs = this.concatFiles(appJs, {
+  appJs = this._concatFiles(appJs, {
     inputFiles: [this.name + '/**/*.js'],
     headerFiles: [
       'vendor/ember-cli/app-prefix.js'
@@ -1230,7 +1246,7 @@ EmberApp.prototype.javascript = function() {
     var inputFiles = this._scriptOutputFiles[outputFile];
 
     vendorFiles.push(
-      this.concatFiles(applicationJs, {
+      this._concatFiles(applicationJs, {
         inputFiles: inputFiles,
         outputFile: outputFile,
         separator: EOL + ';',
@@ -1294,7 +1310,7 @@ EmberApp.prototype.styles = function() {
   for (var outputFile in this._styleOutputFiles) {
     var inputFiles = this._styleOutputFiles[outputFile];
 
-    vendorStyles.push(this.concatFiles(stylesAndVendor, {
+    vendorStyles.push(this._concatFiles(stylesAndVendor, {
       inputFiles: inputFiles,
       outputFile: outputFile,
       annotation: 'Concat: Vendor Styles' + outputFile
@@ -1360,7 +1376,7 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
   var footerFiles = ['vendor/ember-cli/test-support-suffix.js'];
 
   var baseMergedTree = mergeTrees([emberCLITree, external, coreTestTree, finalAddonTestSupportTree]);
-  var testJs = this.concatFiles(baseMergedTree, {
+  var testJs = this._concatFiles(baseMergedTree, {
     headerFiles: headerFiles,
     inputFiles: inputFiles,
     footerFiles: footerFiles,
@@ -1404,7 +1420,7 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
 
   if (this.vendorTestStaticStyles.length > 0) {
     sourceTrees.push(
-      this.concatFiles(external, {
+      this._concatFiles(external, {
         inputFiles: this.vendorTestStaticStyles,
         outputFile: this.options.outputPaths.testSupport.css,
         annotation: 'Concat: Test Support CSS'

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -932,5 +932,27 @@ describe('broccoli/ember-app', function() {
       expect(result).to.equal(path.join(project.root, 'foo'));
     });
   });
+
+  describe('concatFiles()', function() {
+    it('shows deprecation message if called directly', function() {
+      var emberApp = new EmberApp({ project: project });
+
+      var result = emberApp.concatFiles(null, {
+        outputFile: 'foo.js'
+      });
+
+      expect(project.ui.output).to.contain('EmberApp.concatFiles() is deprecated');
+    });
+
+    it('ignores deprecation message if called through _concatFiles()', function() {
+      var emberApp = new EmberApp({ project: project });
+
+      var result = emberApp._concatFiles(null, {
+        outputFile: 'foo.js'
+      });
+
+      expect(project.ui.output).to.not.contain('EmberApp.concatFiles() is deprecated');
+    });
+  });
 });
 


### PR DESCRIPTION
This PR resolves #5280 and continues the work started in #5814.

/cc @jeffjewiss @nathanhammond @stefanpenner @rwjblue 