### PR TITLE
Tell greenkeeper to ignore default packages

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -40,5 +40,30 @@
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.1",
     "loader.js": "^4.0.1"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "broccoli-asset-rev",
+      "ember-ajax",
+      "ember-cli",
+      "ember-cli-app-version",
+      "ember-cli-babel",
+      "ember-cli-dependency-checker",
+      "ember-cli-htmlbars",
+      "ember-cli-htmlbars-inline-precompile",
+      "ember-cli-inject-live-reload",
+      "ember-cli-jshint",
+      "ember-cli-qunit",
+      "ember-cli-release",
+      "ember-cli-sri",
+      "ember-cli-test-loader",
+      "ember-cli-uglify",
+      "ember-data",
+      "ember-export-application-global",
+      "ember-load-initializers",
+      "ember-resolver",
+      "ember-welcome-page",
+      "loader.js"
+    ]
   }
 }


### PR DESCRIPTION
After using ember-cli in combination with greenkeeper on my projects for a while, I've noticed that it's getting very irritating that greenkeeper is trying to update the default packages of the blueprint.

If you ask me, this shouldn't be the case. Greenkeeper should only be responsible for packages that have been added manually and that aren't part of the default blueprint.

This will ensure that people use the [update instructions](https://github.com/ember-cli/ember-cli/releases/latest) when a new version comes out (which prevents a lot of errors, compared to updating one of the default packages separately).

But if someone wants to do it like that nevertheless, they could still remove the package from the "ignore" property added in the commit of this PR.