### PR TITLE
[WORKAROUND] Stick testem at 1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
     "temp": "0.8.3",
-    "testem": "^1.6.0",
+    "testem": "1.7.4",
     "through": "^2.3.6",
     "tiny-lr": "0.2.1",
     "tree-sync": "^1.1.0",


### PR DESCRIPTION
Work around 1.8.0 see issue opened by @stefanpenner. Blocking https://github.com/tildeio/glimmer/pull/179 and likely other things.
https://github.com/testem/testem/issues/886