### PR TITLE
`insertInto` - insert at the beginning of the file

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -4,7 +4,6 @@ var fs = require('fs-extra');
 var existsSync = require('exists-sync');
 var EOL = require('os').EOL;
 var Promise = require('../ext/promise');
-var util = require('util');
 
 var writeFile = Promise.denodeify(fs.outputFile);
 
@@ -66,8 +65,8 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
   var insert            = !alreadyPresent;
   var insertBehavior    = 'end';
 
-  if (util.isString(options.before)) { insertBehavior = 'before'; }
-  if (util.isString(options.after))  { insertBehavior = 'after'; }
+  if (typeof options.before === 'string') { insertBehavior = 'before'; }
+  if (typeof options.after === 'string')  { insertBehavior = 'after'; }
 
   if (options.force) { insert = true; }
 

--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -14,10 +14,13 @@ var writeFile = Promise.denodeify(fs.outputFile);
   is passed.
 
   If `options.before` is specified, `contentsToInsert` will be inserted before
-  the first instance of that string.  If `options.after` is specified, the
-  contents will be inserted after the first instance of that string.
-  If the string specified by options.before or options.after is not in the file,
-  no change will be made.
+  the first instance of that string. Note that `options.before` can be an empty
+  string, signifying that `contentsToInsert` will be inserted at the beginning
+  of the file.
+
+  If `options.after` is specified, the contents will be inserted after the first
+  instance of that string.  If the string specified by options.before or
+  options.after is not in the file, no change will be made.
 
   If neither `options.before` nor `options.after` are present, `contentsToInsert`
   will be inserted at the end of the file.

--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -4,6 +4,7 @@ var fs = require('fs-extra');
 var existsSync = require('exists-sync');
 var EOL = require('os').EOL;
 var Promise = require('../ext/promise');
+var util = require('util');
 
 var writeFile = Promise.denodeify(fs.outputFile);
 
@@ -62,8 +63,8 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
   var insert            = !alreadyPresent;
   var insertBehavior    = 'end';
 
-  if (options.before) { insertBehavior = 'before'; }
-  if (options.after)  { insertBehavior = 'after'; }
+  if (util.isString(options.before)) { insertBehavior = 'before'; }
+  if (util.isString(options.after))  { insertBehavior = 'after'; }
 
   if (options.force) { insert = true; }
 

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -138,6 +138,23 @@ describe('insertIntoFile()', function() {
       });
   });
 
+  it('the "before" string can be empty, meaning beginning of file', function() {
+    var toInsert = 'blahzorz blammo';
+    var originalContent = 'some original content\n';
+
+    fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+    return insertIntoFile(filePath, toInsert, { before: '' })
+      .then(function(result) {
+        var contents = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+        expect(contents).to.equal(toInsert + EOL + originalContent, 'inserted contents should be prepended to original');
+        expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+        expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
+      });
+  });
+
+
   it('will insert into the file before the first instance of options.before only', function() {
     var toInsert = 'blahzorz blammo';
     var line1 = 'line1 is here';


### PR DESCRIPTION
### Use case

I'm working on a blueprint that (among other things) inserts an `import` statement at the beginning of a file. At the moment, the options for `insertIntoFile` don't allow doing this cleanly.

For example, take an original file such as this one:

```js
export default function() {
  // ...
}
```

I want my generator to be able to turn it into this:

```js
import SomeModule from 'some-module';

export default function() {
  // ...
}
```

I could do it by doing `insertIntoFile(path, myInsert, { before: 'export default' })`, but the risk is that the user may have changed the `export` line in some way that leaves me looking for a red herring (eg: if the user added support functions before the export).

The ability to simply insert at the beginning of the file is much more natural and less error prone in this case.

### Implementation

Using the approach on this PR, client code can simply specify an empty string as `before` option:

```js
insertIntoFile(path, myInsert, { before: '' })
```

Since an empty string is always found at the beginning of another string (by `indexOf` anyway), the code for this behaviour is almost there. We only need to be a bit more picky with what we consider falsy when it comes to reading `before`.

So what do you think?