### PR TITLE
[BUGFIX beta] Fix addon linting regression.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -732,8 +732,8 @@ var Addon = CoreObject.extend({
 
     var addonJs = this.addonJsFiles(addonPath);
     var addonTemplates = this._addonTemplateFiles(addonPath);
-    var lintJsTrees = this.eachAddonInvoke('lintTree', ['addon', addonJs]);
-    var lintTemplateTrees = this.eachAddonInvoke('lintTree', ['templates', addonTemplates]);
+    var lintJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
+    var lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
     var lintTrees = [].concat(lintJsTrees, lintTemplateTrees).filter(Boolean);
     var lintedAddon = mergeTrees(lintTrees, {
       overwrite: true,


### PR DESCRIPTION
This was originally fixed in https://github.com/ember-cli/ember-cli/pull/5592, but likely regressed during the "great core-object migration of 2016" (:smiling_imp:). https://github.com/ember-cli/ember-cli/issues/5498 contains a good description of why using `eachAddonInvoke` doesn't work and shows the reasoning behind `_eachProjectAddonInvoke`.


