### PR TITLE
[BUGFIX canary] Remove test-loader from tests/index blueprint

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -26,7 +26,6 @@
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/<%= name %>.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
-    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
Since the test-loader was moved to NPM (#5885), calling test-loader.js from index is not necessary anymore. 