### PR TITLE
Anonymous AMD Support

### DIFF
--- a/lib/broccoli/amd-shim.js
+++ b/lib/broccoli/amd-shim.js
@@ -1,0 +1,19 @@
+'use strict';
+var stew = require('broccoli-stew');
+
+module.exports = function shimAmd(tree, nameMapping) {
+  return stew.map(tree, function(content, relativePath) {
+    var name = nameMapping[relativePath];
+    if (name) {
+      return [
+        '(function(define){\n',
+        content,
+        '\n})((function(){ function newDefine(){ var args = Array.prototype.slice.call(arguments); args.unshift("',
+        name,
+        '"); return define.apply(null, args); }; newDefine.amd = true; return newDefine; })());'
+      ].join('');
+    } else {
+      return content;
+    }
+  });
+};

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -31,6 +31,7 @@ var concat = require('broccoli-concat');
 var ConfigReplace = require('broccoli-config-replace');
 var ConfigLoader  = require('broccoli-config-loader');
 var mergeTrees    = require('./merge-trees');
+var shimAmd    = require('./amd-shim');
 var WatchedDir    = require('broccoli-source').WatchedDir;
 var UnwatchedDir  = require('broccoli-source').UnwatchedDir;
 
@@ -122,6 +123,7 @@ function EmberApp(defaults, options) {
 
   this._styleOutputFiles       = {};
   this._scriptOutputFiles      = {};
+  this.amdModuleNames          = null;
 
   this.legacyFilesToAppend     = [];
   this.vendorStaticStyles      = [];
@@ -980,9 +982,22 @@ EmberApp.prototype._processedExternalTree = function() {
     trees.unshift(bower);
   }
 
-  return this._cachedExternalTree = mergeTrees(trees, {
+  var externalTree = mergeTrees(trees, {
     annotation: 'TreeMerger (ExternalTree)'
   });
+
+  if (this.amdModuleNames) {
+    var anonymousAmd = new Funnel(externalTree, {
+      files: Object.keys(this.amdModuleNames),
+      annotation: 'Funnel (named AMD)'
+    });
+    externalTree = mergeTrees([externalTree, shimAmd(anonymousAmd, this.amdModuleNames)], {
+      annotation: 'TreeMerger (named AMD)',
+      overwrite: true
+    });
+  }
+
+  return this._cachedExternalTree = externalTree;
 };
 
 /**
@@ -1526,6 +1541,25 @@ EmberApp.prototype._import = function(assetPath, options, directory, subdirector
   var basename = path.basename(assetPath);
 
   if (isType(assetPath, 'js', {registry: this.registry})) {
+    if (options.using) {
+      var self = this;
+      options.using.forEach(function(entry) {
+        if (!entry.transformation) {
+          throw new Error('while importing ' + assetPath + ': each entry in the `using` list must have a `transformation` name');
+        }
+        if (entry.transformation !== 'amd') {
+          throw new Error('while importing ' + assetPath + ': unknown transformation `' + entry.transformation + '`');
+        }
+        if (!entry.as) {
+          throw new Error('while importing ' + assetPath + ': amd transformation requires an `as` argument that specifies the desired module name');
+        }
+        if (!self.amdModuleNames) {
+          self.amdModuleNames = {};
+        }
+        self.amdModuleNames[assetPath] = entry.as;
+      });
+    }
+
     if (options.type === 'vendor') {
       options.outputFile = options.outputFile || this.options.outputPaths.vendor.js;
       addOutputFile(this._scriptOutputFiles, assetPath, options);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "broccoli-merge-trees": "^1.1.3",
     "ember-cli-broccoli-sane-watcher": "^2.0.3",
     "broccoli-source": "^1.1.0",
+    "broccoli-stew": "^1.2.0",
     "chalk": "^1.1.3",
     "clean-base-url": "^1.0.0",
     "compression": "^1.4.4",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -323,6 +323,33 @@ describe('Acceptance: brocfile-smoke-test', function() {
       });
   });
 
+  it('can use transformation to turn anonymous AMD into named AMD', function() {
+    return copyFixtureFiles('brocfile-tests/app-import-anonymous-amd')
+      .then(function () {
+        return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      })
+      .then(function() {
+        var outputJS = fs.readFileSync(path.join('.', 'dist', 'assets', 'output.js'), {
+          encoding: 'utf8'
+        });
+
+        (function() {
+          var defineCount = 0;
+          function define(name, deps, factory) {
+            expect(name).to.equal('hello-world');
+            expect(deps).to.deep.equal([]);
+            expect(factory()()).to.equal('Hello World');
+            defineCount++;
+          }
+          /* eslint-disable no-eval */
+          eval(outputJS);
+          /* eslint-enable no-eval */
+          expect(defineCount).to.eql(1);
+        })();
+      });
+  });
+
+
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', function() {
     return copyFixtureFiles('brocfile-tests/custom-output-paths')

--- a/tests/fixtures/brocfile-tests/app-import-anonymous-amd/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-anonymous-amd/ember-cli-build.js
@@ -1,0 +1,17 @@
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  var app = new EmberApp(defaults, {
+  });
+
+  app.import('vendor/anonymous-amd-example.js', {
+    using: [
+      { transformation: 'amd',  as: 'hello-world'}
+    ],
+    outputFile: '/assets/output.js'
+  });
+
+  return app.toTree();
+};

--- a/tests/fixtures/brocfile-tests/app-import-anonymous-amd/vendor/anonymous-amd-example.js
+++ b/tests/fixtures/brocfile-tests/app-import-anonymous-amd/vendor/anonymous-amd-example.js
@@ -1,0 +1,10 @@
+(function() {
+  function helloWorld() {
+    return "Hello World";
+  }
+  if (typeof define === "function" && define.amd) {
+    define([], function () { return helloWorld; });
+  } else {
+    throw new Error("No amd loader found");
+  }
+})();


### PR DESCRIPTION
This is a second attempt at #5512.

It adds an option named `amdModule` to app.import. It causes any anonymous AMD module in the imported file to be registered under the given name.

    app.import('bower_components/some-dep/some-dep.js', { amdModule: 'some-dep' });

This should work correctly with a large number of libraries that:

 - check for `typeof define === 'function' && define.amd`
 - call `define` with just a factory function, or a dependency list and factory function.

PR #5512 was reverted because the `stew.map` was running over every file in bower and vendor, which was prohibitvely expensive, and which caused binary files to get rewritten as ascii. To address those concerns, I switched to using Funnel to pull out only the explicitly named amdModules into a separate tree first.

In addition, apps that don't use this feature should incur zero cost, because we skip the extra trees entirely.