### PR TITLE
Use `ember try:one` in travis

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -35,4 +35,4 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup


### PR DESCRIPTION
Removes deprecation warning

```
DEPRECATION: tryCmd command is deprecated in favor of `ember try:one`.

Example: `ember try default-scenario serve --port 4201`, becomes:
`ember try:one default-scenario --- ember serve --port 4201`
```