### PR TITLE
[BUGFIX release] allow more then 10 exit handlers

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -13,6 +13,15 @@ var debug         = require('debug')('ember-cli:cli/index');
 var merge         = require('lodash/merge');
 var path          = require('path');
 
+// ember-cli and user apps have many dependencies, many of which require
+// process.addListener('exit', ....) for cleanup, by default this limit for
+// such listeners is 10, recently users have been increasing this and not to
+// their fault, rather they are including large and more diverse sets of
+// node_modules.
+//
+// https://github.com/babel/ember-cli-babel/issues/76
+process.setMaxListeners(1000);
+
 var version      = packageConfig.version;
 var name         = packageConfig.name;
 var trackingCode = packageConfig.trackingCode;


### PR DESCRIPTION
We can decide on a more appropriate number (if others feel that is required). 

Resolves https://github.com/babel/ember-cli-babel/issues/76