### PR TITLE
Allow custom config paths

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -172,7 +172,7 @@ EmberApp.prototype._initProject = function(options) {
   this.project = options.project || Project.closestSync(process.cwd());
 
   if (options.configPath) {
-    this.project.configPath = function() { return app._resolveLocal(options.configPath); };
+    this.project.configPath = app._resolveLocal(options.configPath);
   }
 };
 
@@ -995,7 +995,7 @@ EmberApp.prototype._configTree = function() {
     return this._cachedConfigTree;
   }
 
-  var configPath = this.project.configPath();
+  var configPath = this.project.configPath;
   var configTree = new ConfigLoader(path.dirname(configPath), {
     env: this.env,
     tests: this.tests,

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -176,15 +176,31 @@ Project.prototype.isEmberCLIAddon = function() {
   @method configPath
   @return {String} Configuration path
  */
-Project.prototype.configPath = function() {
-  var configPath = 'config';
 
-  if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
-    configPath = this.pkg['ember-addon']['configPath'];
+Object.defineProperty(Project.prototype, 'configPath', {
+  get: function() {
+    if (this._configPath) { return this._configPath; }
+
+    var configPath = 'config',
+        hasAddonConfig = !!(this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']),
+        hasCustomConfigPath = !!(this.pkg['directories'] && this.pkg['directories']['configPath']);
+
+    if (hasCustomConfigPath && !hasAddonConfig) {
+      configPath = this.pkg['directories']['configPath'];
+    }
+
+    if (hasAddonConfig) {
+      configPath = this.pkg['ember-addon']['configPath'];
+    }
+
+    return path.join(this.root, configPath, 'environment');
+  },
+
+  set: function(value) {
+    this._configPath = value;
+    return value;
   }
-
-  return path.join(this.root, configPath, 'environment');
-};
+});
 
 /**
   Loads the configuration for this project and its addons.
@@ -195,7 +211,7 @@ Project.prototype.configPath = function() {
   @return {Object}     Merged confiration object
  */
 Project.prototype.config = function(env) {
-  var configPath = this.configPath();
+  var configPath = this.configPath;
 
   if (existsSync(configPath + '.js')) {
     var appConfig = this.require(configPath)(env);

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -53,7 +53,7 @@ describe('broccoli/ember-app', function() {
         configPath: expected
       });
 
-      expect(project.configPath().slice(-expected.length)).to.equal(expected);
+      expect(project.configPath.slice(-expected.length)).to.equal(expected);
     });
 
     it('should set bowerDirectory for app', function() {
@@ -955,4 +955,3 @@ describe('broccoli/ember-app', function() {
     });
   });
 });
-

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -50,7 +50,7 @@ describe('models/project.js', function() {
       expect(called).to.equal(true);
     });
 
-    it('configPath() returns tests/dummy/config/environment', function() {
+    it('configPath returns tests/dummy/config/environment', function() {
       project.pkg = {
         'ember-addon': {
           'configPath': 'tests/dummy/config'
@@ -59,7 +59,19 @@ describe('models/project.js', function() {
 
       var expected = path.normalize('tests/dummy/config/environment');
 
-      expect(project.configPath().slice(-expected.length)).to.equal(expected);
+      expect(project.configPath.slice(-expected.length)).to.equal(expected);
+    });
+
+    it('configPath returns tests/custom/config/environment', function() {
+      project.pkg = {
+        'directories': {
+          'configPath': 'tests/custom/config'
+        }
+      };
+
+      var expected = path.normalize('tests/custom/config/environment');
+
+      expect(project.configPath.slice(-expected.length)).to.equal(expected);
     });
 
     it('calls getAddonsConfig', function() {


### PR DESCRIPTION
If you are running an Ember App **not** in the root directory of your app, you need to be able to specify where your config is located in order for Ember CLI to run correctly.

This adds the option to allow configuring the configPath via package.json - specifically via package.directories.configPath.

This is a follow up from #4042