### PR TITLE
broccoli: Add "__esModule" property to "./config/environment" export

### DIFF
--- a/lib/broccoli/app-config-from-meta.js
+++ b/lib/broccoli/app-config-from-meta.js
@@ -5,7 +5,11 @@ try {
   var rawConfig = Ember['default'].$('meta[name="' + metaName + '"]').attr('content');
   var config = JSON.parse(unescape(rawConfig));
 
-  return { 'default': config };
+  var exports = { 'default': config };
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
 }
 catch(err) {
   throw new Error('Could not read config from meta tag with name "' + metaName + '".');

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1713,7 +1713,9 @@ EmberApp.prototype._contentForConfigModule = function(content, config) {
     content.push('var prefix = \'' + config.modulePrefix + '\';');
     content.push(fs.readFileSync(path.join(__dirname, 'app-config-from-meta.js')));
   } else {
-    content.push('return { \'default\': ' + JSON.stringify(config) + '};');
+    content.push('var exports = {\'default\': ' + JSON.stringify(config) + '};' +
+      'Object.defineProperty(exports, \'__esModule\', {value: true});' +
+      'return exports;');
   }
 };
 


### PR DESCRIPTION
This adds some Babel 6 compatibility.

/cc @rwjblue @stefanpenner 