### PR TITLE
[BUGFIX release] Upgrade ember-cli-release version

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
-    "ember-cli-release": "0.2.8",
+    "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
`ember-cli-release` version was pinned to 0.2.8. `ember-cli-release@0.2.9` was just released removing the deprecation warning about an object not calling `this._super`.

This PR just changes an app blueprint to request `ember-cli-release` `^0.2.9` when installed.

See discussion [here](https://github.com/ember-cli/ember-cli/issues/5973#issuecomment-226638063)