### PR TITLE
Allow `ember install addon_name --save` in addons.

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -11,7 +11,8 @@ module.exports = Command.extend({
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'save', type: Boolean, default: false, aliases: ['s'] },
+    { name: 'save', type: Boolean, default: false, aliases: ['S'] },
+    { name: 'save-dev', type: Boolean, default: true, aliases: ['D'] }
   ],
 
   anonymousOptions: [

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -10,6 +10,10 @@ module.exports = Command.extend({
   aliases: ['i'],
   works: 'insideProject',
 
+  availableOptions: [
+    { name: 'save', type: Boolean, default: false, aliases: ['s'] },
+  ],
+
   anonymousOptions: [
     '<addon-name>'
   ],

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -16,8 +16,9 @@ module.exports = Task.extend({
   run: function(options) {
     var chalk            = require('chalk');
     var ui               = this.ui;
-    var packageNames     = options['packages'];
+    var packageNames     = options.packages;
     var blueprintOptions = options.blueprintOptions || {};
+    var commandOptions   = blueprintOptions;
 
     var npmInstall = new this.NpmInstallTask({
       ui:         this.ui,
@@ -35,8 +36,9 @@ module.exports = Task.extend({
     ui.startProgress(chalk.green('Installing addon package'), chalk.green('.'));
 
     return npmInstall.run({
-      packages: packageNames,
-      'save-dev': true,
+      'packages': packageNames,
+      'save': commandOptions.save,
+      'save-dev': !commandOptions.save && commandOptions.saveDev,
       'save-exact': true
     }).then(function() {
       return this.project.reloadAddons();

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -28,6 +28,7 @@ module.exports = Task.extend({
       color: 'always',
       // by default, do install peoples optional deps
       'optional': 'optional' in options ? options.optional : true,
+      'save': !!options.save,
       'save-dev': !!options['save-dev'],
       'save-exact': !!options['save-exact']
     };

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -94,7 +94,9 @@ ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Installs an ember-cli addon from npm.
   \u001b[90maliases: i\u001b[39m
   \u001b[36m--save\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -s\u001b[39m
+    \u001b[90maliases: -S\u001b[39m
+  \u001b[36m--save-dev\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m
+    \u001b[90maliases: -D\u001b[39m
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -90,9 +90,11 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: )\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
 
-ember install \u001b[33m<addon-name>\u001b[39m
+ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Installs an ember-cli addon from npm.
   \u001b[90maliases: i\u001b[39m
+  \u001b[36m--save\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+    \u001b[90maliases: -s\u001b[39m
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -386,7 +386,15 @@ module.exports = {
       description: 'Installs an ember-cli addon from npm.',
       aliases: ['i'],
       works: 'insideProject',
-      availableOptions: [],
+      availableOptions: [
+        {
+          name: 'save',
+          default: false,
+          aliases: ['s'],
+          key: 'save',
+          required: false
+        }
+      ],
       anonymousOptions: ['<addon-name>']
     },
     {

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -390,8 +390,15 @@ module.exports = {
         {
           name: 'save',
           default: false,
-          aliases: ['s'],
+          aliases: ['S'],
           key: 'save',
+          required: false
+        },
+        {
+          name: 'save-dev',
+          default: true,
+          aliases: ['D'],
+          key: 'saveDev',
           required: false
         }
       ],

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -94,7 +94,9 @@ ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Installs an ember-cli addon from npm.
   \u001b[90maliases: i\u001b[39m
   \u001b[36m--save\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -s\u001b[39m
+    \u001b[90maliases: -S\u001b[39m
+  \u001b[36m--save-dev\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m
+    \u001b[90maliases: -D\u001b[39m
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -90,9 +90,11 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: )\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
 
-ember install \u001b[33m<addon-name>\u001b[39m
+ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Installs an ember-cli addon from npm.
   \u001b[90maliases: i\u001b[39m
+  \u001b[36m--save\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+    \u001b[90maliases: -s\u001b[39m
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -418,7 +418,15 @@ module.exports = {
       description: 'Installs an ember-cli addon from npm.',
       aliases: ['i'],
       works: 'insideProject',
-      availableOptions: [],
+      availableOptions: [
+        {
+          name: 'save',
+          default: false,
+          aliases: ['s'],
+          key: 'save',
+          required: false
+        }
+      ],
       anonymousOptions: ['<addon-name>']
     },
     {

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -422,8 +422,15 @@ module.exports = {
         {
           name: 'save',
           default: false,
-          aliases: ['s'],
+          aliases: ['S'],
           key: 'save',
+          required: false
+        },
+        {
+          name: 'save-dev',
+          default: true,
+          aliases: ['D'],
+          key: 'saveDev',
           required: false
         }
       ],

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -386,7 +386,15 @@ module.exports = {
       description: 'Installs an ember-cli addon from npm.',
       aliases: ['i'],
       works: 'insideProject',
-      availableOptions: [],
+      availableOptions: [
+        {
+          name: 'save',
+          default: false,
+          aliases: ['s'],
+          key: 'save',
+          required: false
+        }
+      ],
       anonymousOptions: ['<addon-name>']
     },
     {

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -390,8 +390,15 @@ module.exports = {
         {
           name: 'save',
           default: false,
-          aliases: ['s'],
+          aliases: ['S'],
           key: 'save',
+          required: false
+        },
+        {
+          name: 'save-dev',
+          default: true,
+          aliases: ['D'],
+          key: 'saveDev',
           required: false
         }
       ],

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -99,18 +99,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-data'],
-          'save-dev': true,
-          'save-exact': true
-        }), {times: 1});
-      });
-    });
-
-    it('runs the npm install task with given name and save-dev true even with --save arg', function() {
-      return command.validateAndRun(['ember-data', '--save']).then(function() {
-        var npmRun = tasks.NpmInstall.prototype.run;
-
-        td.verify(npmRun({
-          packages: ['ember-data'],
+          'save': false,
           'save-dev': true,
           'save-exact': true
         }), {times: 1});
@@ -129,7 +118,21 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-data'],
+          'save': false,
           'save-dev': true,
+          'save-exact': true
+        }), {times: 1});
+      });
+    });
+
+    it('runs the npm install task with given name and save true with the --save option', function() {
+      return command.validateAndRun(['ember-data', '--save']).then(function() {
+        var npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save': true,
+          'save-dev': false,
           'save-exact': true
         }), {times: 1});
       });
@@ -147,6 +150,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-data'],
+          'save': true,
           'save-dev': false,
           'save-exact': true
         }), {times: 1});
@@ -191,6 +195,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-data', 'ember-cli-cordova', 'ember-cli-qunit'],
+          'save': false,
           'save-dev': true,
           'save-exact': true
         }), {times: 1});
@@ -207,6 +212,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-cli/ember-cli-qunit'],
+          'save': false,
           'save-dev': true,
           'save-exact': true
         }), {times: 1});
@@ -222,6 +228,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['ember-cli-qunit@1.2.0'],
+          'save': false,
           'save-dev': true,
           'save-exact': true
         }), {times: 1});
@@ -238,6 +245,7 @@ describe('install command', function() {
 
         td.verify(npmRun({
           packages: ['@ember-cli/ember-cli-qunit'],
+          'save': false,
           'save-dev': true,
           'save-exact': true
         }), {times: 1});

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -105,6 +105,54 @@ describe('install command', function() {
       });
     });
 
+    it('runs the npm install task with given name and save-dev true even with --save arg', function() {
+      return command.validateAndRun(['ember-data', '--save']).then(function() {
+        var npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save-dev': true,
+          'save-exact': true
+        }), {times: 1});
+      });
+    });
+
+    it('runs the npm install task with given name and save-dev true in an addon', function() {
+      command.project.isEmberCLIProject = function() {
+        return false;
+      };
+      command.project.isEmberCLIAddon = function() {
+        return true;
+      };
+      return command.validateAndRun(['ember-data']).then(function() {
+        var npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save-dev': true,
+          'save-exact': true
+        }), {times: 1});
+      });
+    });
+
+    it('runs the npm install task with given name and save true in an addon with the --save option', function() {
+      command.project.isEmberCLIProject = function() {
+        return false;
+      };
+      command.project.isEmberCLIAddon = function() {
+        return true;
+      };
+      return command.validateAndRun(['ember-data', '--save']).then(function() {
+        var npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save-dev': false,
+          'save-exact': true
+        }), {times: 1});
+      });
+    });
+
     it('runs the package name blueprint task with given name and args', function() {
       return command.validateAndRun(['ember-data']).then(function() {
         var generateRun = tasks.GenerateFromBlueprint.prototype.run;


### PR DESCRIPTION
My team and I are regularly annoyed when developing addons with the following scenario:

* execute `ember install whatever_addon` in the addon `our_addon`
* execute `ember install `our_addon` in the app `our_app`
* Realise that `whatever addon` is not packaged in the app `our_app`
* Cringe
* Remind ourselves why it's a perfectly sane situation
* Update `package.json` in `our_addon` to move `whatever_addon` from `devDependencies` to `dependencies`
* Rinse
* Repeat

This PR add the option `--save` to `ember install` that saves addons in `dependencies` instead of `devDependencies` iff the command is run in an addon.

Hope you'll like it!