### PR TITLE
[ENHANCEMENT] Asset Sizes I moved the creation of asset sizes to an object.

### DIFF
--- a/lib/commands/asset-sizes.js
+++ b/lib/commands/asset-sizes.js
@@ -7,7 +7,7 @@ module.exports = Command.extend({
   description: 'Shows the sizes of your asset files.',
 
   availableOptions: [
-    { name: 'output-path', type: 'Path', default: 'dist/',       aliases: ['o'] },
+    { name: 'output-path', type: 'Path', default: 'dist/', aliases: ['o'] }
   ],
 
   run: function(commandOptions) {

--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -9,56 +9,54 @@ function AssetPrinterSize(options) {
   assign(this, options);
 }
 
-AssetPrinterSize.prototype.print = function() {
+AssetPrinterSize.prototype.print = function () {
   var ui = this.ui;
 
-  return Promise.resolve()
-    .then(function () {
-      var filesize = require('filesize');
-      var fs = require('fs');
-      var zlib = require('zlib');
-      var gzip = Promise.denodeify(zlib.gzip);
-      var files = this.makeFileGlob();
-      var testFileRegex = /(test-(loader|support))|(testem)/i;
-      var promises = [];
+  return this.makeAssetSizesObject().then(function (files) {
+    this.validateAssetPath(files);
 
-      this.validateAssetPath(files);
-      ui.writeLine(chalk.green('File sizes:'));
+    ui.writeLine(chalk.green('File sizes:'));
+    return files.forEach(function (file) {
+      var sizeOutput = file.size;
+      if (file.showGzipped) {
+        sizeOutput += ' (' + file.gzipSize + ' gzipped)';
+      }
 
-      files
-        // Skip test files
-        .filter(function (file) {
-          var filename = path.basename(file);
-          return !testFileRegex.test(filename);
-        })
-        // Print human-readable file sizes (including gzipped)
-        .forEach(function (file) {
-          var filename = path.basename(file);
-          var contentsBuffer = fs.readFileSync(file);
-          var gzipPromise = gzip(contentsBuffer).then(function (buffer) {
-            return {
-              name: filename,
-              size: filesize(contentsBuffer.length),
-              gzipSize: filesize(buffer.length),
-              showGzipped: contentsBuffer.length > 0
-            };
-          });
+      ui.writeLine(chalk.blue(' - ' + file.name + ': ') + chalk.white(sizeOutput));
+    });
 
-          promises.push(gzipPromise);
-        });
+  }.bind(this));
+};
 
-      return Promise.all(promises);
-    }.bind(this))
-    .then(function (files) {
-      files.forEach(function (file) {
-        var sizeOutput = file.size;
-        if (file.showGzipped) {
-          sizeOutput += ' (' + file.gzipSize + ' gzipped)';
-        }
+AssetPrinterSize.prototype.makeAssetSizesObject = function () {
+  var filesize = require('filesize');
+  var fs = require('fs');
+  var zlib = require('zlib');
+  var gzip = Promise.denodeify(zlib.gzip);
+  var files = this.makeFileGlob();
+  var testFileRegex = /(test-(loader|support))|(testem)/i;
 
-        ui.writeLine(chalk.blue(' - ' + file.name + ': ') + chalk.white(sizeOutput));
+  var assets = files
+    // Skip test files
+    .filter(function (file) {
+      var filename = path.basename(file);
+      return !testFileRegex.test(filename);
+    })
+    // Print human-readable file sizes (including gzipped)
+    .map(function (file) {
+      var filename = path.basename(file);
+      var contentsBuffer = fs.readFileSync(file);
+      return gzip(contentsBuffer).then(function (buffer) {
+        return {
+          name: filename,
+          size: filesize(contentsBuffer.length),
+          gzipSize: filesize(buffer.length),
+          showGzipped: contentsBuffer.length > 0
+        };
       });
     });
+
+  return Promise.all(assets);
 };
 
 AssetPrinterSize.prototype.makeFileGlob = function () {

--- a/tests/unit/models/asset-size-printer-test.js
+++ b/tests/unit/models/asset-size-printer-test.js
@@ -107,6 +107,29 @@ describe('models/asset-size-printer', function () {
       });
   });
 
+  it('creates an array of asset objects', function () {
+    var assetObjectKeys;
+    var sizePrinter = new AssetSizePrinter({
+      ui: new MockUi(),
+      outputPath: storedTmpDir
+    });
+
+    return sizePrinter.makeAssetSizesObject()
+      .then(function (assetObject) {
+        assetObjectKeys = Object.keys(assetObject[0]);
+
+        expect(assetObject.length).to.eql(6);
+        expect(assetObjectKeys).to.deep.equal([ 'name', 'size', 'gzipSize', 'showGzipped' ]);
+        expect(assetObject[0].name).to.include('nested-asset.css');
+        expect(assetObject[1].name).to.include('nested-asset.js');
+        expect(assetObject[2].name).to.include('empty.js');
+        expect(assetObject[3].name).to.include('some-project.css');
+        expect(assetObject[4].name).to.include('some-project.js');
+        expect(assetObject[5].name).to.include('test.js');
+      });
+  });
+
+
   it('prints an error when no files are found', function () {
     var outputPath = path.join('path', 'that', 'does', 'not', 'exist');
     var sizePrinter = new AssetSizePrinter({


### PR DESCRIPTION
Moved the creation of asset sizes to an object.
Then print command iterates over that object.

I talked a little to @rwjblue and @kellyselden about the refactor. 

If we agree this is worth while I will write a test for the `makeAssetSizesObject` function. 

My use case I want to persist the asset-size data to a graphing server to track an apps size over time. 
 