### PR TITLE
changed --insecure-proxy to --secure-proxy in ember serve command

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -22,7 +22,7 @@ module.exports = Command.extend({
     { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
     { name: 'host',                 type: String,                          aliases: ['H'],     description: 'Listens on all interfaces by default' },
     { name: 'proxy',                type: String,                          aliases: ['pr', 'pxy'] },
-    { name: 'insecure-proxy',       type: Boolean, default: false,         aliases: ['inspr'], description: 'Set false to proxy self-signed SSL certificates' },
+    { name: 'secure-proxy',         type: Boolean, default: true,          aliases: ['spr'],   description: 'Set to false to proxy self-signed SSL certificates' },
     { name: 'transparent-proxy',    type: Boolean, default: true,          aliases: ['transp'], description: 'Set to false to omit x-forwarded-* headers when proxying' },
     { name: 'watcher',              type: String,  default: 'events',      aliases: ['w'] },
     { name: 'live-reload',          type: Boolean, default: true,          aliases: ['lr'] },

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -13,7 +13,7 @@ ProxyServerAddon.prototype.serverMiddleware = function(options) {
     var proxy = require('http-proxy').createProxyServer({
       target: options.proxy,
       ws: true,
-      secure: !options.insecureProxy,
+      secure: options.secureProxy,
       changeOrigin: true,
       xfwd: options.transparentProxy
     });

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -124,8 +124,8 @@ ember serve \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
   \u001b[36m--proxy\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -pr <value>, -pxy <value>\u001b[39m
-  \u001b[36m--insecure-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Set false to proxy self-signed SSL certificates
-    \u001b[90maliases: --inspr\u001b[39m
+  \u001b[36m--secure-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to proxy self-signed SSL certificates
+    \u001b[90maliases: -spr\u001b[39m
   \u001b[36m--transparent-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to omit x-forwarded-* headers when proxying
     \u001b[90maliases: --transp\u001b[39m
   \u001b[36m--watcher\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: events)\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -488,11 +488,11 @@ module.exports = {
           required: false
         },
         {
-          name: 'insecure-proxy',
-          default: false,
-          description: 'Set false to proxy self-signed SSL certificates',
-          aliases: ['inspr'],
-          key: 'insecureProxy',
+          name: 'secure-proxy',
+          default: true,
+          description: 'Set to false to proxy self-signed SSL certificates',
+          aliases: ['spr'],
+          key: 'secureProxy',
           required: false
         },
         {

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -124,8 +124,8 @@ ember serve \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
   \u001b[36m--proxy\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -pr <value>, -pxy <value>\u001b[39m
-  \u001b[36m--insecure-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Set false to proxy self-signed SSL certificates
-    \u001b[90maliases: --inspr\u001b[39m
+  \u001b[36m--secure-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to proxy self-signed SSL certificates
+    \u001b[90maliases: -spr\u001b[39m
   \u001b[36m--transparent-proxy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to omit x-forwarded-* headers when proxying
     \u001b[90maliases: --transp\u001b[39m
   \u001b[36m--watcher\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: events)\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -520,11 +520,11 @@ module.exports = {
           required: false
         },
         {
-          name: 'insecure-proxy',
-          default: false,
-          description: 'Set false to proxy self-signed SSL certificates',
-          aliases: ['inspr'],
-          key: 'insecureProxy',
+          name: 'secure-proxy',
+          default: true,
+          description: 'Set to false to proxy self-signed SSL certificates',
+          aliases: ['spr'],
+          key: 'secureProxy',
           required: false
         },
         {

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -488,11 +488,11 @@ module.exports = {
           required: false
         },
         {
-          name: 'insecure-proxy',
-          default: false,
-          description: 'Set false to proxy self-signed SSL certificates',
-          aliases: ['inspr'],
-          key: 'insecureProxy',
+          name: 'secure-proxy',
+          default: true,
+          description: 'Set to false to proxy self-signed SSL certificates',
+          aliases: ['spr'],
+          key: 'secureProxy',
           required: false
         },
         {

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -162,11 +162,11 @@ describe('serve command', function() {
     });
   });
 
-  it('has correct default value for insecure proxy', function() {
+  it('has correct default value for secure proxy', function() {
     return command.validateAndRun().then(function() {
       var captor = td.matchers.captor();
       td.verify(tasks.Serve.prototype.run(captor.capture()), {times: 1});
-      expect(captor.value.insecureProxy).to.equal(false, 'has correct insecure proxy option when not set');
+      expect(captor.value.secureProxy).to.equal(true, 'has correct secure proxy option when not set');
     });
   });
 


### PR DESCRIPTION
Like mentioned in #5986, ```--insecure-proxy (default: false)``` is now changed to ```secure-proxy (default: true)``` for  better alignment with the other options and also less confusing.

Strangely this still happens: 

```
  924 passing (31s)
  5 pending
  1 failing

  1) Acceptance: ember generate passes custom cli arguments to blueprint options:
     AssertionError: expected "app/foo.js" to exist
      at tests/acceptance/generate-test.js:366:39
      at lib$rsvp$$internal$$tryCatch (node_modules/rsvp/dist/rsvp.js:1036:16)
      at lib$rsvp$$internal$$invokeCallback (node_modules/rsvp/dist/rsvp.js:1048:17)
      at lib$rsvp$$internal$$publish (node_modules/rsvp/dist/rsvp.js:1019:11)
      at lib$rsvp$asap$$flush (node_modules/rsvp/dist/rsvp.js:1198:9)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```

Maybe there is something wrong with the test?
