### PR TITLE
Add information about inverting the test filter

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -21,7 +21,7 @@ module.exports = Command.extend({
     { name: 'server',      type: Boolean, default: false,           aliases: ['s'] },
     { name: 'host',        type: String,                            aliases: ['H'] },
     { name: 'test-port',   type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running with --server.' },
-    { name: 'filter',      type: String,                            aliases: ['f'],  description: 'A string to filter tests to run' },
+    { name: 'filter',      type: String,                            aliases: ['f'],  description: 'A string to filter tests to run. Invert filter by prefixing with !.' },
     { name: 'module',      type: String,                            aliases: ['m'],  description: 'The name of a test module to run' },
     { name: 'watcher',     type: String,  default: 'events',        aliases: ['w'] },
     { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -155,7 +155,7 @@ ember test \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
   \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server.
     \u001b[90maliases: -tp <value>\u001b[39m
-  \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run
+  \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run. Invert filter by prefixing with !.
     \u001b[90maliases: -f <value>\u001b[39m
   \u001b[36m--module\u001b[39m \u001b[36m(String)\u001b[39m The name of a test module to run
     \u001b[90maliases: -m <value>\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -605,7 +605,7 @@ module.exports = {
         },
         {
           name: 'filter',
-          description: 'A string to filter tests to run',
+          description: 'A string to filter tests to run. Invert filter by prefixing with !.',
           aliases: ['f'],
           key: 'filter',
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -155,7 +155,7 @@ ember test \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
   \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server.
     \u001b[90maliases: -tp <value>\u001b[39m
-  \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run
+  \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run. Invert filter by prefixing with !.
     \u001b[90maliases: -f <value>\u001b[39m
   \u001b[36m--module\u001b[39m \u001b[36m(String)\u001b[39m The name of a test module to run
     \u001b[90maliases: -m <value>\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -637,7 +637,7 @@ module.exports = {
         },
         {
           name: 'filter',
-          description: 'A string to filter tests to run',
+          description: 'A string to filter tests to run. Invert filter by prefixing with !.',
           aliases: ['f'],
           key: 'filter',
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -605,7 +605,7 @@ module.exports = {
         },
         {
           name: 'filter',
-          description: 'A string to filter tests to run',
+          description: 'A string to filter tests to run. Invert filter by prefixing with !.',
           aliases: ['f'],
           key: 'filter',
           required: false


### PR DESCRIPTION
QUnit accepts a prefixed ! to invert the filter.  I'm not sure if this is supported by other test frameworks or even what test frameworks ember-cli officially documents and supported.  I'm also not sure where else to put this information which makes it trivial to run non acceptance tests, but is fairly difficult to discover.

eg `ember test --filter='!acceptance'`

Maybe there isn't a good place for this info to go if it isn't globally supported.