### PR TITLE
Use ES6 spread operator instead of apply

### DIFF
--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -11,12 +11,12 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        return options.beforeEach.apply(this, arguments);
+        return options.beforeEach(...arguments);
       }
     },
 
     afterEach() {
-      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      let afterEach = options.afterEach && options.afterEach(...arguments);
       return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });


### PR DESCRIPTION
Use a spread operator instead of using apply. Some users might have had JSCS lint warnings because using apply in this blueprint.