### PR TITLE
[Enhancement] Return raw asset-size as data instead of strings

### DIFF
--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -10,6 +10,7 @@ function AssetPrinterSize(options) {
 }
 
 AssetPrinterSize.prototype.print = function () {
+  var filesize = require('filesize');
   var ui = this.ui;
 
   return this.makeAssetSizesObject().then(function (files) {
@@ -17,9 +18,9 @@ AssetPrinterSize.prototype.print = function () {
 
     ui.writeLine(chalk.green('File sizes:'));
     return files.forEach(function (file) {
-      var sizeOutput = file.size;
+      var sizeOutput = filesize(file.size);
       if (file.showGzipped) {
-        sizeOutput += ' (' + file.gzipSize + ' gzipped)';
+        sizeOutput += ' (' + filesize(file.gzipSize) + ' gzipped)';
       }
 
       ui.writeLine(chalk.blue(' - ' + file.name + ': ') + chalk.white(sizeOutput));
@@ -29,7 +30,6 @@ AssetPrinterSize.prototype.print = function () {
 };
 
 AssetPrinterSize.prototype.makeAssetSizesObject = function () {
-  var filesize = require('filesize');
   var fs = require('fs');
   var zlib = require('zlib');
   var gzip = Promise.denodeify(zlib.gzip);
@@ -49,8 +49,8 @@ AssetPrinterSize.prototype.makeAssetSizesObject = function () {
       return gzip(contentsBuffer).then(function (buffer) {
         return {
           name: filename,
-          size: filesize(contentsBuffer.length),
-          gzipSize: filesize(buffer.length),
+          size: contentsBuffer.length,
+          gzipSize: buffer.length,
           showGzipped: contentsBuffer.length > 0
         };
       });


### PR DESCRIPTION
Before:
The asset-size object returned a string `"259.1 KB"` for the file size.

After: 
The file size is returned as raw data `265318` then as it is printed to the command line it is turned into a string. 

The print out is still the same:
![image](https://cloud.githubusercontent.com/assets/647691/16626031/03eb668c-435c-11e6-9882-b0ade88fa2eb.png)


