### PR TITLE
Bump portfinder to v1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm": "2.15.5",
     "npm-package-arg": "^4.1.1",
     "ora": "^0.2.0",
-    "portfinder": "^1.0.3",
+    "portfinder": "^1.0.4",
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.5",
     "resolve": "^1.1.6",


### PR DESCRIPTION
Adds support for/fixes issues outlined in https://github.com/indexzero/node-portfinder/pull/33