### PR TITLE
Ember & Ember Data beta version bumps.

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember": "~2.7.0-beta.3",
+    "ember": "~2.7.0-beta.4",
     "ember-cli-shims": "0.1.1",
     "ember-qunit-notifications": "0.1.0"
   }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -34,7 +34,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0-beta.1",
+    "ember-data": "^2.7.0-beta.3",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
Hold until Ember is able to be successfully released. CI dep cache may have been destroyed.

![Diff demonstrating that it may be broken.](https://cloud.githubusercontent.com/assets/20542/16751950/1d1932c6-4792-11e6-8424-7ae07f7f37e4.png)

/cc @chancancode @rwjblue