### PR TITLE
[BUGFIX beta] ensure concat order of app.import(x)

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1250,11 +1250,11 @@ EmberApp.prototype.javascript = function() {
 
   var vendorFiles = [];
   for (var outputFile in this._scriptOutputFiles) {
-    var inputFiles = this._scriptOutputFiles[outputFile];
+    var headerFiles = this._scriptOutputFiles[outputFile];
 
     vendorFiles.push(
       this._concatFiles(applicationJs, {
-        inputFiles: inputFiles,
+        headerFiles: headerFiles,
         outputFile: outputFile,
         separator: EOL + ';',
         annotation: 'Concat: Vendor ' + outputFile
@@ -1315,10 +1315,10 @@ EmberApp.prototype.styles = function() {
 
   var vendorStyles = [];
   for (var outputFile in this._styleOutputFiles) {
-    var inputFiles = this._styleOutputFiles[outputFile];
+    var headerFiles = this._styleOutputFiles[outputFile];
 
     vendorStyles.push(this._concatFiles(stylesAndVendor, {
-      inputFiles: inputFiles,
+      headerFiles: headerFiles,
       outputFile: outputFile,
       annotation: 'Concat: Vendor Styles' + outputFile
     }));
@@ -1428,7 +1428,7 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
   if (this.vendorTestStaticStyles.length > 0) {
     sourceTrees.push(
       this._concatFiles(external, {
-        inputFiles: this.vendorTestStaticStyles,
+        headerFiles: this.vendorTestStaticStyles,
         outputFile: this.options.outputPaths.testSupport.css,
         annotation: 'Concat: Test Support CSS'
       })

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
     "broccoli-babel-transpiler": "^5.4.5",
-    "broccoli-concat": "^2.0.4",
+    "broccoli-concat": "^3.0.0",
     "broccoli-config-loader": "^1.0.0",
     "broccoli-config-replace": "^1.1.2",
     "broccoli-funnel": "^1.0.0",


### PR DESCRIPTION
Files provided to app.import should always be ordered based on insertion order (either append, or prepend).
For this broccoli-concat explicitly provides `headerFiles` and `footerFiles`. `inputFiles` previously used is explicitly un-ordered.
This patch ensures the underlying libraries are correctly used, correctly enforcing expected behavior.