### PR TITLE
bump portfinder to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm": "2.15.5",
     "npm-package-arg": "^4.1.1",
     "ora": "^0.2.0",
-    "portfinder": "^1.0.4",
+    "portfinder": "^1.0.5",
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.5",
     "resolve": "^1.1.6",


### PR DESCRIPTION
reverts issues caused by release 1.0.4 regarding EADDRNOTAVAIL

fixes #6083

/cc @stefanpenner 