### PR TITLE
Remove ember-qunit-notifications

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -2,7 +2,6 @@
   "name": "<%= name %>",
   "dependencies": {
     "ember": "~2.7.0-beta.4",
-    "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0"
+    "ember-cli-shims": "0.1.1"
   }
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.0.0",
+    "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",

--- a/tests/fixtures/addon/simple/bower.json
+++ b/tests/fixtures/addon/simple/bower.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
   }
 }

--- a/tests/fixtures/project-with-handlebars/bower.json
+++ b/tests/fixtures/project-with-handlebars/bower.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
   }
 }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -174,7 +174,6 @@ describe('models/project.js', function() {
         'ember-data': '1.0.0-beta.10',
         'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3',
         'ember-qunit': '0.1.8',
-        'ember-qunit-notifications': '0.0.4',
         'qunit': '~1.15.0'
       };
 


### PR DESCRIPTION
Should no longer be needed with the newer versions of `ember-cli-qunit` (ref: https://github.com/ember-cli/ember-cli-qunit/pull/119).

Forgot to do this sooner and now confusion is ensuing (ref: https://github.com/DockYard/qunit-notifications/issues/27).