### PR TITLE
[INTERNAL] Remove unused 'es3Safe' option

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -44,7 +44,6 @@ var funnelReducer = require('broccoli-funnel-reducer');
 var SECRET_DEPRECATION_PREVENTION_SYMBOL = crypto.randomBytes(8).toString('hex');
 
 var DEFAULT_CONFIG = {
-  es3Safe: true,
   storeConfigInMeta: true,
   autoRun: true,
   outputPaths: {
@@ -83,7 +82,6 @@ module.exports = EmberApp;
   an `toTree()` method you can use to get the entire tree for your application.
 
   Available init options:
-    - es3Safe, defaults to `true`,
     - storeConfigInMeta, defaults to `true`,
     - autoRun, defaults to `true`,
     - outputPaths, defaults to `{}`,

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -876,7 +876,6 @@ var Addon = CoreObject.extend({
       - For example
         - `minifyJS`
         - `storeConfigInMeta`
-        - `es3Safe`
         - et, al
 
     @public


### PR DESCRIPTION
This option is used from no one already, so I think it can be eliminated safely.