### PR TITLE
[BUGFIX beta] ServerWatcher disregards --watcher=*

### DIFF
--- a/lib/models/server-watcher.js
+++ b/lib/models/server-watcher.js
@@ -1,62 +1,48 @@
 'use strict';
 
-var Task    = require('./task');
+var Watcher = require('./watcher');
 
-module.exports = Task.extend({
-  verbose: true,
+var ServerWatcher = Watcher.extend({
+  constructWatcher: function(options) {
+    return new (require('sane'))(this.watchedDir, options);
+  },
 
   init: function() {
-    this._super.apply(this, arguments);
-    this.watcher = this.watcher || new (require('sane'))(this.watchedDir, {
-      verbose: this.verbose,
-      poll: this.polling()
-    });
+    this._super.init.apply(this, arguments);
 
-    this.watcher.on('change', this.didChange.bind(this));
     this.watcher.on('add',    this.didAdd.bind(this));
     this.watcher.on('delete', this.didDelete.bind(this));
   },
 
-  didChange: function (filepath) {
-    this.ui.writeLine('Server file changed: ' + filepath);
+  didChange: function(relativePath) {
+    var description = 'File changed: "' + relativePath + '"';
 
+    this.ui.writeLine(description);
     this.analytics.track({
-      name: 'server file change',
-      description: 'File changed: "' + filepath + '"'
+      name: 'server file changed',
+      description: description
     });
   },
 
-  didAdd: function (filepath) {
-    this.ui.writeLine('Server file added: ' + filepath);
+  didAdd: function (relativePath) {
+    var description = 'File added: "' + relativePath + '"';
 
+    this.ui.writeLine(description);
     this.analytics.track({
       name: 'server file addition',
-      description: 'File added: "' + filepath + '"'
+      description: description
     });
   },
 
-  didDelete: function (filepath) {
-    this.ui.writeLine('Server file deleted: ' + filepath);
+  didDelete: function (relativePath) {
+    var description = 'File deleted: "' + relativePath + '"';
 
+    this.ui.writeLine(description);
     this.analytics.track({
       name: 'server file deletion',
-      description: 'File deleted: "' + filepath + '"'
+      description: description
     });
   },
-
-  then: function() {
-    return this.watcher.then.apply(this.watcher, arguments);
-  },
-
-  on: function() {
-    this.watcher.on.apply(this.watcher, arguments);
-  },
-
-  off: function() {
-    this.watcher.off.apply(this.watcher, arguments);
-  },
-
-  polling: function () {
-    return this.options && this.options.watcher === 'polling';
-  }
 });
+
+module.exports = ServerWatcher;

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -12,14 +12,19 @@ var Watcher = Task.extend({
 
   init: function() {
     this._super.apply(this, arguments);
+
     var options = this.buildOptions();
 
     debug('initialize %o', options);
 
-    this.watcher = this.watcher || new (require('broccoli-sane-watcher'))(this.builder, options);
+    this.watcher = this.watcher || this.constructWatcher(options);
 
     this.watcher.on('error', this.didError.bind(this));
     this.watcher.on('change', this.didChange.bind(this));
+  },
+
+  constructWatcher: function(options) {
+    return new (require('broccoli-sane-watcher'))(this.builder, options);
   },
 
   didError: function(error) {
@@ -61,6 +66,7 @@ var Watcher = Task.extend({
   off: function() {
     this.watcher.off.apply(this.watcher, arguments);
   },
+
   buildOptions: function() {
     var watcher = this.options && this.options.watcher;
 

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -7,8 +7,8 @@ var ExpressServer    = require('./server/express-server');
 var Promise          = require('../ext/promise');
 var Task             = require('../models/task');
 var Watcher          = require('../models/watcher');
-var Builder          = require('../models/builder');
 var ServerWatcher    = require('../models/server-watcher');
+var Builder          = require('../models/builder');
 
 module.exports = Task.extend({
   run: function(options) {
@@ -32,7 +32,8 @@ module.exports = Task.extend({
       serverWatcher = new ServerWatcher({
         ui: this.ui,
         analytics: this.analytics,
-        watchedDir: path.resolve(serverRoot)
+        watchedDir: path.resolve(serverRoot),
+        options: options
       });
     }
 

--- a/tests/unit/models/server-watcher-test.js
+++ b/tests/unit/models/server-watcher-test.js
@@ -25,35 +25,18 @@ describe('Server Watcher', function() {
     });
   });
 
-  describe('watcher strategy selection', function() {
-    it('selects the events-based watcher by default', function () {
-      subject.options = null;
-      expect(!!subject.polling()).to.equal(false);
-    });
-
-    it('selects the events-based watcher when given events watcher option', function () {
-      subject.options = { watcher: 'events' };
-      expect(!!subject.polling()).to.equal(false);
-    });
-
-    it('selects the polling watcher when given polling watcher option', function () {
-      subject.options = { watcher: 'polling' };
-      expect(!!subject.polling()).to.be.ok;
-    });
-  });
-
   describe('watcher:change', function() {
     beforeEach(function () {
       watcher.emit('change', 'foo.txt');
     });
 
     it('logs that the file was changed', function() {
-      expect(ui.output).to.equal('Server file changed: foo.txt' + EOL);
+      expect(ui.output).to.equal('File changed: "foo.txt"' + EOL);
     });
 
     it('tracks changes', function() {
       expect(analytics.tracks).to.deep.equal([{
-        name: 'server file change',
+        name: 'server file changed',
         description: 'File changed: "foo.txt"'
       }]);
     });
@@ -65,7 +48,7 @@ describe('Server Watcher', function() {
     });
 
     it('logs that the file was added', function() {
-      expect(ui.output).to.equal('Server file added: foo.txt' + EOL);
+      expect(ui.output).to.equal('File added: "foo.txt"' + EOL);
     });
 
     it('tracks additions', function() {
@@ -82,7 +65,7 @@ describe('Server Watcher', function() {
     });
 
     it('logs that the file was deleted', function() {
-      expect(ui.output).to.equal('Server file deleted: foo.txt' + EOL);
+      expect(ui.output).to.equal('File deleted: "foo.txt"' + EOL);
     });
 
     it('tracks deletions', function() {


### PR DESCRIPTION
* models/server-watcher is now a subclass of models/watcher, delegating all arguments parsing to models/server (this should prevent them from diverging)
* models/server now makes constructing the watcher instance an optional refinement a subclass can add. This is done by extracting watcher construction to `constructWatcher`
* make models/server-watcher output more consistent