### PR TITLE
set bowerDirectory in Addon

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -91,6 +91,7 @@ var Addon = CoreObject.extend({
     this._super();
     this.parent = parent;
     this.project = project;
+    this.bowerDirectory = project.bowerDirectory;
     this.ui = project && project.ui;
     this.addonPackages = {};
     this.addons = [];

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -23,6 +23,21 @@ var fixturePath = path.resolve(__dirname, '../../fixtures/addon');
 describe('models/addon.js', function() {
   var addon, project, projectPath;
 
+  describe('constructor', function() {
+    it('should set bowerDirectory for addon', function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+      var addon = new Addon({
+        project: project
+      });
+
+      expect(addon.bowerDirectory).to.equal(project.bowerDirectory);
+      expect(addon.bowerDirectory).to.equal('bower_components');
+    });
+  });
+
   describe('root property', function() {
     it('is required', function() {
       expect(function() {


### PR DESCRIPTION
__tl;dr;__ The new import syntax allows for nested addons, but nested addons don't have the `bowerDirectory` property that allows to locate bower assets.

Considering this:

```js
// my-addon/index.js
module.exports = {
  name: 'my-addon',
  included: function(app) {
    var assetPath = app.bowerDirectory + '/whatever/dist/assets.min.js';
    this.import(assetPath);
  }
};
```

* When included in an app, `assetPath === "bower_components/whatever/dist/assets.min.js"` (by default).
* When included in an addon, `assetPath === "undefined/whatever/dist/assets.min.js"`.

This PR fixes the second behaviour to return the correct path in both cases.