### PR TITLE
[ENHANCEMENT] Allow tests to be passed into moduleForAcceptance

### DIFF
--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -5,8 +5,8 @@ import destroyApp from '../helpers/destroy-app';
 
 const { RSVP: { Promise } } = Ember;
 
-export default function(name, options = {}) {
-  module(name, {
+export default function(name, options = {}, tests = undefined) {
+  let hooks = {
     beforeEach() {
       this.application = startApp();
 
@@ -19,5 +19,7 @@ export default function(name, options = {}) {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
       return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
-  });
+  };
+
+  module(name, hooks, tests);
 }


### PR DESCRIPTION
One of the biggest complaints I hear about QUnit when compared to mocha is that you cannot nest tests. QUnit supports nested modules (https://api.qunitjs.com/QUnit.module/), but it's hard to do with ember-cli's current `moduleForAcceptance` blueprint.

This PR adds a non breaking change to `moduleForAcceptance` allowing the tester to pass in a nested block of tests. The following would now work.

```javascript
import { test, module } from 'qunit';
import moduleForAcceptance from 'my-app/tests/helpers/module-for-acceptance';

let a, b, c;

moduleForAcceptance('Acceptance | Nested 1', {
  beforeEach() {
    a = 'a';
  },
  afterEach() {
    a = undefined;
  }
}, function() {

  // pass tests into moduleForAcceptance in order
  // to use nested modules.

  test('a', function(assert) {
    assert.equal(a, 'a');
  });

  // example of nested module
  module('Nested 2', {
    beforeEach() {
      b = 'b';
    },
    afterEach() {
      b = undefined;
    }
  }, function() {

    // nested tests
    test('nested a', function(assert) {
      assert.equal(a, 'a');
    });

    test('b', function(assert) {
      assert.equal(b, 'b');
    });

    // old syntax will work as well
    module('Nested 3', {
      beforeEach() {
        c = 'c';
      },
      afterEach() {
        c = undefined;
      }
    });

    test('3 levels', function(assert) {
      assert.equal(a, 'a');
      assert.equal(b, 'b');
      assert.equal(c, 'c');
    });
  });
});
```

In the QUnit UI these tests will have nice names.

The dropdown will look like this:

![](https://cv-screenshots.s3.amazonaws.com/Screen_Shot_2016-07-28_at_10.42.04_AM.jpg)

and the runner output will look like this.

![](https://cv-screenshots.s3.amazonaws.com/_EmberMap_Tests_44_2016-07-28_10-43-30.jpg)


