### PR TITLE
Update .gitignore for npm-debug.log

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log


### PR DESCRIPTION
I am not only receive `npm-debug.log`, but also `npm-debug.log.29765927623`