### PR TITLE
BUGFIX #6037 clean up in-repo-addon/lib directories on in-repo-addon destroy

### DIFF
--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -34,12 +34,18 @@ module.exports = {
   },
 
   afterUninstall: function(options) {
-    var packagePath = path.join(this.project.root, 'package.json');
-    var contents    = fs.readJsonSync(packagePath);
-    var name        = stringUtil.dasherize(options.entity.name);
-    var newPath     = ['lib', name].join('/');
+    var packagePath   = path.join(this.project.root, 'package.json');
+    var contents      = fs.readJsonSync(packagePath);
+    var name          = stringUtil.dasherize(options.entity.name);
+    var newPath       = ['lib', name].join('/');
+    var libBlueprint  = Blueprint.lookup('lib', {
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
     var paths;
     var newPathIndex;
+    var lib;
 
     contents['ember-addon'] = contents['ember-addon'] || {};
     paths = contents['ember-addon']['paths'] = contents['ember-addon']['paths'] || [];
@@ -52,6 +58,15 @@ module.exports = {
       }
     }
 
-    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
+    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2) + '\n');
+
+    if (!fs.readdirSync(newPath).length) {
+      fs.removeSync(newPath);
+    }
+
+    lib = fs.readdirSync('lib');
+    if (lib.length === 0 || (lib.length === 1 && lib[0] === '.jshintrc')) {
+      return libBlueprint.uninstall(options);
+    }
   }
 };

--- a/blueprints/lib/index.js
+++ b/blueprints/lib/index.js
@@ -10,6 +10,10 @@ module.exports = {
     fs.mkdirsSync('lib');
   },
 
+  afterUninstall: function() {
+    fs.removeSync('lib');
+  },
+
   files: function() {
     return this.hasJSHint() ? ['lib/.jshintrc'] : [];
   },

--- a/tests/unit/blueprints/in-repo-addon-test.js
+++ b/tests/unit/blueprints/in-repo-addon-test.js
@@ -53,4 +53,45 @@ describe('Acceptance: ember generate and destroy in-repo-addon', function() {
         expect(fs.readJsonSync('package.json')['ember-addon']['paths']).to.be.undefined;
       });
   });
+
+  it('should remove the in-repo-addon directory on destroy if empty', function() {
+    var args = ['in-repo-addon', 'fooBar'];
+    var secondArgs = ['in-repo-addon', 'bazQuux']; // Adding second addon so 'lib' isn't destroyed as well
+
+    return emberNew()
+      .then(function() {
+        return emberGenerate(args);
+      })
+      .then(function() {
+        return emberGenerate(secondArgs);
+      })
+      .then(function() {
+        return emberDestroy(args);
+      })
+      .then(function() {
+        var dir = fs.readdirSync('lib');
+        expect(dir).to.not.contain('foo-bar');
+        expect(dir).to.contain('baz-quux');
+      });
+  });
+
+  it('should not remove the in-repo-addon directory on destroy if not empty', function() {
+    var args = ['in-repo-addon', 'fooBar'];
+    var dummy = {text: 'foo'};
+
+    return emberNew()
+      .then(function() {
+        return emberGenerate(args);
+      })
+      .then(function() {
+        return fs.writeJsonSync('lib/foo-bar/dummy.json', JSON.stringify(dummy));
+      })
+      .then(function() {
+        return emberDestroy(args);
+      })
+      .then(function() {
+        var dir = fs.readdirSync('lib');
+        expect(dir).to.contain('foo-bar');
+      });
+  });
 });

--- a/tests/unit/blueprints/lib-test.js
+++ b/tests/unit/blueprints/lib-test.js
@@ -5,6 +5,8 @@ var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
 var setupTestHooks = blueprintHelpers.setupTestHooks;
 var emberNew = blueprintHelpers.emberNew;
 var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var emberGenerate = blueprintHelpers.emberGenerate;
+var emberDestroy = blueprintHelpers.emberDestroy;
 var modifyPackages = blueprintHelpers.modifyPackages;
 
 var expect = require('ember-cli-blueprint-test-helpers/chai').expect;
@@ -41,6 +43,42 @@ describe('Acceptance: ember generate and destroy lib', function() {
           expect(dir('lib')).to.exist;
           expect(file('lib/.jshintrc')).to.not.exist;
         });
+      });
+  });
+
+  it('should remove lib directory on destroy if lib empty', function() {
+    var args = ['in-repo-addon', 'fooBar'];
+
+    return emberNew()
+      .then(function() {
+        return emberGenerate(args);
+      })
+      .then(function() {
+        return emberDestroy(args);
+      })
+      .then(function() {
+        expect(dir('lib')).to.not.exist;
+      });
+  });
+
+  it('should not remove lib directory on destroy if lib not empty', function() {
+    var args = ['in-repo-addon', 'fooBar'];
+    var secondArgs = ['in-repo-addon', 'bazQuux'];
+
+    return emberNew()
+      .then(function() {
+        return emberGenerate(args);
+      })
+      .then(function() {
+        return emberGenerate(secondArgs);
+      })
+      .then(function() {
+        return emberDestroy(args);
+      })
+      .then(function() {
+        expect(dir('lib')).to.exist;
+        expect(dir('lib/foo-bar')).to.not.exist;
+        expect(dir('lib/baz-quux')).to.exist;
       });
   });
 });


### PR DESCRIPTION
Following steps in #6037 , the lib/{in-repo-addon} directory structure is cleaned up when destroying an in-repo-addon if the affected directories are empty, leaving a clean git state.