### PR TITLE
Adding a test to cover historySupportMiddleware with unknown location type

### DIFF
--- a/tests/unit/tasks/server/middleware/history-support-test.js
+++ b/tests/unit/tasks/server/middleware/history-support-test.js
@@ -29,6 +29,19 @@ describe('HistorySupportAddon', function () {
       expect(addon.shouldAddMiddleware()).to.true;
     });
 
+    it('add middleware when locationType is an unknown type', function() {
+      var addon = new HistorySupportAddon({
+        config: function() {
+          return {
+            locationType: 'foo-bar',
+            historySupportMiddleware: true
+          };
+        }
+      });
+
+      expect(addon.shouldAddMiddleware()).to.true;
+    });
+
     it('add middleware when historySupportMiddleware is true', function() {
       var addon = new HistorySupportAddon({
         config: function() {


### PR DESCRIPTION
Just adding a simple test to cover a discussion around the behavior of `historySupportMiddleware`.  This validates it will work correctly if you provide a locationType that might extend from HistoryLocation and the user wants to force the user of the history support middleware.

/cc @stefanpenner 