### PR TITLE
fixed typo in the example code in the comments in the blueprint.js

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -138,7 +138,7 @@ var removeFile          = Promise.denodeify(fs.remove);
       return entityName;
     },
 
-    fileMapTokens: function(options) (
+    fileMapTokens: function(options) {
       // Return custom tokens to be replaced in your files
       return {
         __token__: function(options){


### PR DESCRIPTION
Background
===
There's a typo in the comments at https://github.com/ember-cli/ember-cli/blob/master/lib/models/blueprint.js#L141

Right now, it says:
```javascript
fileMapTokens: function(options) (
```
where it should instead say
```javascript
fileMapTokens: function(options) {
```

Granted this is super trivial and literally nobody cares, but I came across it while copy-and-pasting the example code in the comments while writing my own blueprints; anyway, it would be nice if the example code is correct.

Changes
===
* replaced `(` with `{` in the comments in `lib/models/blueprint.js`

