### PR TITLE
bump portfinder to v1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "npm": "2.15.5",
     "npm-package-arg": "^4.1.1",
     "ora": "^0.2.0",
-    "portfinder": "^1.0.4",
+    "portfinder": "^1.0.7",
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.5",
     "resolve": "^1.1.6",


### PR DESCRIPTION
Will push upstream dep `portfinder@1.0.7` once we receive consensus from the crowd that this works on all machines. This PR is for book keeping.

See https://github.com/ember-cli/ember-cli/issues/6083 to help out with the testing process. It should only take a minute of your time. :)

fixes #6083 