### PR TITLE
[ENHANCEMENT] Warn when empty rootURL is used with history addon

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -7,7 +7,7 @@ var cleanBaseURL = require('clean-base-url');
 
 /**
  * This addon is used to serve the `index.html` file at every requested
- * URL that begins with `baseURL` and is expecting `text/html` output.
+ * URL that begins with `rootURL` and is expecting `text/html` output.
  *
  * @class HistorySupportAddon
  * @constructor
@@ -31,6 +31,10 @@ HistorySupportAddon.prototype.shouldAddMiddleware = function(environment) {
 
 HistorySupportAddon.prototype.serverMiddleware = function(config) {
   if (this.shouldAddMiddleware(config.options.environment)) {
+    this.project.ui.writeWarnLine(
+      'Empty `rootURL` is not supported. Disable history support, or use an absolute `rootURL`',
+      config.options.rootURL !== '');
+
     this.addMiddleware(config);
   }
 };


### PR DESCRIPTION
With `rootURL = ''` and `locationType='auto'/'history'` the app doesn't work for nested entry paths like `http://localhost:4200/my/test`.

This is due to failing to resolve the relative location of the basic assets referenced in `index.html` like `assets/vendor.js`.

This patch fixes it by catching such requests on the server, and redirecting them to the `rootURL` appended with the hash-based location. Once the page is loaded the built-in router will rewrite the URL to the originally requested URL.

I have configured this feature to be triggered automatically when `rootURL = ''`.
