### PR TITLE
`testem.js` must be loaded from `/`.

### DIFF
--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/<%= name %>.js"></script>


### PR DESCRIPTION
`testem` expects that `testem.js` is loaded from the root (`/`) not relative to the apps `rootURL`.