### PR TITLE
[BUGFIX beta] Prevent Ember Data from overriding Date.parse.

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -10,6 +10,10 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 


### PR DESCRIPTION
This updates the defaults for `config/environment.js` so Ember Data no longer logs a deprecation warning when it overrides `Date.parse`.

Crosslink: https://github.com/emberjs/data/issues/4501