### PR TITLE
Add .travis and .github folders to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,6 @@
 /docs
 /tests/!(helpers)
 /tmp
+/.travis
+/.github
 /*.*


### PR DESCRIPTION
These are added to all the different versions of ember-cli in every addon you install, so it adds up.

Should we also ignore the `/assets` folder?

See #6147 

