### PR TITLE
display cleanup progress.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -237,8 +237,12 @@ module.exports = Task.extend({
    */
   cleanup: function() {
     var ui = this.ui;
+    ui.startProgress('cleaning up');
+    ui.writeLine('cleaning up...');
 
-    return this.builder.cleanup().catch(function(err) {
+    return this.builder.cleanup().finally(function() {
+      ui.stopProgress();
+    }).catch(function(err) {
       ui.writeLine(chalk.red('Cleanup error.'));
       ui.writeError(err);
     });


### PR DESCRIPTION
Users otherwise may assume something is frozen, and ctrl-c early