### PR TITLE
Revert "chore(package): update diff to version 2.2.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "configstore": "^2.0.0",
     "core-object": "^2.0.2",
     "debug": "^2.1.3",
-    "diff": "^2.2.2",
+    "diff": "^1.3.1",
     "ember-cli-broccoli": "0.17.2",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",


### PR DESCRIPTION
This reverts commit a68fe1c35e744ec1489b8be4c44cf545f54a0d3d.

`diff ^2.0` no longer supports Node 0.10 which means we can't use it until LTS support for 0.10 is dropped.