### PR TITLE
Remove debug from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "compression": "^1.4.4",
     "configstore": "^2.0.0",
     "core-object": "^2.0.2",
-    "debug": "^2.1.3",
     "diff": "^1.3.1",
     "ember-cli-broccoli": "0.17.2",
     "ember-cli-get-component-path-option": "^1.0.0",


### PR DESCRIPTION
We no longer need `debug`, we are using `heimdalljs-logger`

Related: https://github.com/ember-cli/ember-cli/pull/6086