### PR TITLE
Document `--port 0` in ember serve's command line usage

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -19,7 +19,7 @@ module.exports = Command.extend({
   aliases: ['server', 's'],
 
   availableOptions: [
-    { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
+    { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'], description: 'To use a port different than ' + defaultPort + '. Pass 0 to automatically pick an available port.' },
     { name: 'host',                 type: String,                          aliases: ['H'],     description: 'Listens on all interfaces by default' },
     { name: 'proxy',                type: String,                          aliases: ['pr', 'pxy'] },
     { name: 'secure-proxy',         type: Boolean, default: true,          aliases: ['spr'],   description: 'Set to false to proxy self-signed SSL certificates' },

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -118,7 +118,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
 ember serve \u001b[36m<options...>\u001b[39m
   Builds and serves your app, rebuilding on file changes.
   \u001b[90maliases: server, s\u001b[39m
-  \u001b[36m--port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 4200)\u001b[39m
+  \u001b[36m--port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 4200)\u001b[39m To use a port different than 4200. Pass 0 to automatically pick an available port.
     \u001b[90maliases: -p <value>\u001b[39m
   \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m Listens on all interfaces by default
     \u001b[90maliases: -H <value>\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -470,6 +470,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
+          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
           aliases: ['p'],
           key: 'port',
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -118,7 +118,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
 ember serve \u001b[36m<options...>\u001b[39m
   Builds and serves your app, rebuilding on file changes.
   \u001b[90maliases: server, s\u001b[39m
-  \u001b[36m--port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 4200)\u001b[39m
+  \u001b[36m--port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 4200)\u001b[39m To use a port different than 4200. Pass 0 to automatically pick an available port.
     \u001b[90maliases: -p <value>\u001b[39m
   \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m Listens on all interfaces by default
     \u001b[90maliases: -H <value>\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -502,6 +502,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
+          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
           aliases: ['p'],
           key: 'port',
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -470,6 +470,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
+          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
           aliases: ['p'],
           key: 'port',
           required: false


### PR DESCRIPTION
Following up on ember-cli/rfcs/pull/53, documenting the behavior of passing `--port 0` to `ember serve` to autopick an available port.