### PR TITLE
add tests for alphabetize-object-keys

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -9,6 +9,7 @@ var date        = new Date();
 
 var normalizeEntityName = require('ember-cli-normalize-entity-name');
 var stringifyAndNormalize = require('../../lib/utilities/stringify-and-normalize');
+var alphabetizeObjectKeys = require('../../lib/utilities/alphabetize-object-keys');
 
 module.exports = {
   description: 'The default blueprint for ember-cli addons.',
@@ -157,14 +158,6 @@ function readContentsFromFile(fileName) {
 function alphabetizeDependencies(contents) {
   contents.dependencies = alphabetizeObjectKeys(contents.dependencies);
   contents.devDependencies = alphabetizeObjectKeys(contents.devDependencies);
-}
-
-function alphabetizeObjectKeys(unordered) {
-  var ordered = {};
-  Object.keys(unordered).sort().forEach(function(key) {
-    ordered[key] = unordered[key];
-  });
-  return ordered;
 }
 
 function writeContentsToFile(contents, fileName) {

--- a/lib/utilities/alphabetize-object-keys.js
+++ b/lib/utilities/alphabetize-object-keys.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function alphabetizeObjectKeys(unordered) {
+  return Object.keys(unordered).sort().reduce(function(ordered, key) {
+    ordered[key] = unordered[key];
+    return ordered;
+  }, {});
+};

--- a/tests/unit/utilities/alphabetize-object-keys-test.js
+++ b/tests/unit/utilities/alphabetize-object-keys-test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var expect                = require('chai').expect;
+var alphabetizeObjectKeys = require('../../../lib/utilities/alphabetize-object-keys');
+
+describe('alphabetize-object-keys', function() {
+  var dependencies = {
+    'b-test-package': '^1.0.0',
+    'a-test-package': '^2.0.0'
+  };
+
+  it('indents 2 spaces and ends in newline', function() {
+    var newDependencies = alphabetizeObjectKeys(dependencies);
+
+    // deep equal is not ordered
+    // this just verifies the structure hasn't changed
+    expect(newDependencies).to.deep.equal({
+      'b-test-package': '^1.0.0',
+      'a-test-package': '^2.0.0'
+    });
+
+    expect(Object.keys(newDependencies)).to.deep.equal([
+      'a-test-package',
+      'b-test-package'
+    ]);
+  });
+});


### PR DESCRIPTION
I was extracting it out to use elsewhere, then it turns out I didn't need it after all.

End result is better factored/tested code!