### PR TITLE
in-repo-addon: sort additions to ember-addon/paths

### DIFF
--- a/blueprints/in-repo-addon/index.js
+++ b/blueprints/in-repo-addon/index.js
@@ -38,6 +38,7 @@ module.exports = {
     if (isInstall) {
       if (paths.indexOf(newPath) === -1) {
         paths.push(newPath);
+        contents['ember-addon']['paths'] = paths.sort();
       }
     } else {
       var newPathIndex = paths.indexOf(newPath);

--- a/tests/unit/blueprints/in-repo-addon-test.js
+++ b/tests/unit/blueprints/in-repo-addon-test.js
@@ -174,4 +174,29 @@ describe('Unit: in-repo-addon blueprint', function() {
   "ember-addon": {}\n\
 }\n');
   });
+
+  it('alphabetizes paths', function() {
+    td.when(readJsonSync(), { ignoreExtraArgs: true }).thenReturn({
+      'ember-addon': {
+        paths: ['lib/test-entity-name-2']
+      }
+    });
+
+    blueprint.afterInstall(options);
+
+    var captor = td.matchers.captor();
+
+    td.verify(readJsonSync(path.normalize('test-project-root/package.json')));
+    td.verify(writeFileSync(path.normalize('test-project-root/package.json'), captor.capture()));
+
+    expect(captor.value).to.equal('\
+{\n\
+  "ember-addon": {\n\
+    "paths": [\n\
+      "lib/test-entity-name",\n\
+      "lib/test-entity-name-2"\n\
+    ]\n\
+  }\n\
+}\n');
+  });
 });


### PR DESCRIPTION
We should probably alphabetize additions to `ember-addon/paths` like we do to `dependencies` [here](https://github.com/ember-cli/ember-cli/blob/79a4b40a1e7c0c9cb356fc2bcf3f0348a0191eb3/blueprints/addon/index.js#L46). For consistency, and also deterministic is always better for git diffs.