### PR TITLE
include global npm version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ it will make it easier for us to track down the issue you're having.
 
 ---
 
-Output from ember version --verbose:
+Output from `ember version --verbose && npm --version`:
 ```
 [Replace this line with the output.]
 ```


### PR DESCRIPTION
This would be useful for users that didn't use `ember install` or those that cloned then `npm install`ed. It would be nice to include this in code, but in code, every use of npm resolves to the locally installed 2.x version.