### PR TITLE
Update to ember-cli-qunit@3.0.1.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^1.0.4",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",


### PR DESCRIPTION
This updates apps to use QUnit 2.0 by default.

/cc @trentmwillis 