### PR TITLE
Addons: Replace most of .npmignore with a `files` key in the package.json file

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -1,16 +1,2 @@
-/bower_components
 /config/ember-try.js
-/dist
-/tests
-/tmp
 **/.gitkeep
-.bowerrc
-.editorconfig
-.ember-cli
-.gitignore
-.jshintrc
-.watchmanconfig
-.travis.yml
-bower.json
-ember-cli-build.js
-testem.js

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -40,6 +40,16 @@ module.exports = {
     // use `ember-try` as test script in addons by default
     contents.scripts.test = 'ember try:each';
 
+    contents.files = [
+      'addon',
+      'app',
+      'blueprints',
+      'config',
+      'lib',
+      'vendor',
+      'index.js',
+    ];
+
     contents['ember-addon'] = contents['ember-addon'] || {};
     contents['ember-addon'].configPath = 'tests/dummy/config';
 

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -98,6 +98,15 @@ describe('blueprint - addon', function() {
   "keywords": [\n\
     "ember-addon"\n\
   ],\n\
+  "files": [\n\
+    "addon",\n\
+    "app",\n\
+    "blueprints",\n\
+    "config",\n\
+    "lib",\n\
+    "vendor",\n\
+    "index.js"\n\
+  ],\n\
   "scripts": {\n\
     "test": "ember try:each"\n\
   },\n\


### PR DESCRIPTION
This should hopefully help with things like https://github.com/ember-cli/ember-cli/issues/6149 in the future.

/cc @stefanpenner @rwjblue @locks 