### PR TITLE
Closes #6290 - Use bower-config to get bower directory

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -13,6 +13,7 @@ var _               = require('ember-cli-lodash-subset');
 var logger          = require('heimdalljs-logger')('ember-cli:project');
 var nodeModulesPath = require('node-modules-path');
 var versionUtils    = require('../utilities/version-utils');
+var bowerConfig     = require('bower-config');
 var emberCLIVersion = versionUtils.emberCLIVersion;
 
 /**
@@ -73,20 +74,17 @@ function Project(root, pkg, ui, cli) {
   @method setupBowerDirectory
  */
 Project.prototype.setupBowerDirectory = function() {
-  var bowerrcPath = path.join(this.root, '.bowerrc');
+  var config;
+  try {
+    config = bowerConfig.read(this.root);
+  } catch (e) {
+    logger.warn('%s: %s', e.code, e.message);
+    logger.warn('Defaulting to %s/bower_components', this.root);
 
-  logger.info('bowerrc path: %s', bowerrcPath);
-
-  if (existsSync(bowerrcPath)) {
-    try {
-      this.bowerDirectory = fs.readJsonSync(bowerrcPath).directory;
-    } catch (exception) {
-      logger.info('failed to parse bowerc: %s', exception);
-      this.bowerDirectory = null;
-    }
+    config = {directory: 'bower_components'};
   }
 
-  this.bowerDirectory = this.bowerDirectory || 'bower_components';
+  this.bowerDirectory = config.directory;
   logger.info('bowerDirectory: %s', this.bowerDirectory);
 };
 

--- a/tests/fixtures/bower-directory-tests/bowerrc-nested-directory/.bowerrc
+++ b/tests/fixtures/bower-directory-tests/bowerrc-nested-directory/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "vendor"
+}

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -500,6 +500,22 @@ describe('models/project.js', function() {
       project = new Project(projectPath, {}, new MockUI());
       expect(project.bowerDirectory).to.equal('bower_components');
     });
+
+    it('should be overriden by bower_directory environment variable', function() {
+      process.env.BOWER_DIRECTORY = 'test_path';
+      projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/bowerrc-with-directory');
+      project = new Project(projectPath, {}, new MockUI());
+      expect(project.bowerDirectory).to.equal('test_path');
+      delete process.env.BOWER_DIRECTORY;
+    });
+
+    it('should support .bowerrc files in parent directories', function() {
+      process.env.BOWER_DIRECTORY = 'test_path';
+      projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/bowerrc-nested-directory/nested');
+      project = new Project(projectPath, {}, new MockUI());
+      expect(project.bowerDirectory).to.equal('test_path');
+      delete process.env.BOWER_DIRECTORY;
+    })
   });
 
   describe('nodeModulesPath', function() {


### PR DESCRIPTION
Use `bower-config` to read the correct bower directory, following the bower config spec here: https://bower.io/docs/config/
