### PR TITLE
Include relative path on ember asset-sizes

### DIFF
--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -44,11 +44,10 @@ AssetPrinterSize.prototype.makeAssetSizesObject = function () {
     })
     // Print human-readable file sizes (including gzipped)
     .map(function (file) {
-      var filename = path.basename(file);
       var contentsBuffer = fs.readFileSync(file);
       return gzip(contentsBuffer).then(function (buffer) {
         return {
-          name: filename,
+          name: file,
           size: contentsBuffer.length,
           gzipSize: buffer.length,
           showGzipped: contentsBuffer.length > 0


### PR DESCRIPTION
This implements #6118. 

The result looks like this:

```
$ ember b -prod
Built project successfully. Stored in "dist/".
File sizes:
 - dist/assets/test-app-05b6e5ef3de6d96abb221d931be3a037.js: 9.58 KB (2.8 KB gzipped)
 - dist/assets/test-app-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - dist/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - dist/assets/vendor-d55002550e35ed1beba09da66fc57f99.js: 656.38 KB (175.79 KB gzipped)
 - dist/fastboot/test-app-1703e9c3df242d64c82c9962e8ce8d33.js: 10.32 KB (3.01 KB gzipped)
 - dist/fastboot/vendor-d55002550e35ed1beba09da66fc57f99.js: 656.38 KB (175.79 KB gzipped)
```