### PR TITLE
add test to verify running destroy without generate doesn't error

### DIFF
--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -806,6 +806,10 @@ help in detail');
         expect(afterUninstallCalled).to.be.false;
       });
     });
+
+    it('doesn\'t throw when running uninstall without installing first', function() {
+      return blueprint.uninstall(options);
+    });
   });
 
   describe('basic blueprint uninstallation', function() {


### PR DESCRIPTION
You can destroy anything without generating first and no error occurs, but it's an untested feature. This fixes that.

This test needs to exist before #6241 lands to prevent a regression.