### PR TITLE
Closes #6290 - Allow ember's bower directory to be overridden by EMBER_BOWER_DIRECTORY.

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -74,6 +74,7 @@ function Project(root, pkg, ui, cli) {
  */
 Project.prototype.setupBowerDirectory = function() {
   var bowerrcPath = path.join(this.root, '.bowerrc');
+  var envDirectory = process.env.EMBER_BOWER_DIRECTORY;
 
   logger.info('bowerrc path: %s', bowerrcPath);
 
@@ -86,7 +87,7 @@ Project.prototype.setupBowerDirectory = function() {
     }
   }
 
-  this.bowerDirectory = this.bowerDirectory || 'bower_components';
+  this.bowerDirectory = envDirectory || this.bowerDirectory || 'bower_components';
   logger.info('bowerDirectory: %s', this.bowerDirectory);
 };
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -473,6 +473,10 @@ describe('models/project.js', function() {
       project = new Project(projectPath, {}, new MockUI());
     });
 
+    afterEach(function() {
+      delete process.env.EMBER_BOWER_DIRECTORY;
+    });
+
     it('should be initialized in constructor', function() {
       expect(project.bowerDirectory).to.equal('bower_components');
     });
@@ -499,6 +503,14 @@ describe('models/project.js', function() {
       projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/invalid-bowerrc');
       project = new Project(projectPath, {}, new MockUI());
       expect(project.bowerDirectory).to.equal('bower_components');
+    });
+
+    it('should be overridden by EMBER_BOWER_DIRECTORY', function() {
+      process.env.EMBER_BOWER_DIRECTORY = 'directory_override';
+
+      projectPath = path.resolve(__dirname, '../../fixtures/bower-directory-tests/bowerrc-with-directory');
+      project = new Project(projectPath, {}, new MockUI());
+      expect(project.bowerDirectory).to.equal('directory_override');
     });
   });
 


### PR DESCRIPTION
This is an alternative MR to #6292, it's a bit simpler and might be better to include.

The problem with #6292 is that by default `bower-config` walks up the directory tree to find a `.bowerrc` file, so in nested projects it might find a parent projects `.bowerrc` and use a nested `bower_components` directory.

Fixing this might be tricky, so perhaps this is a better idea: just have an `EMBER_BOWER_DIRECTORY` environment variable to override the `bower_components` directory.