### PR TITLE
[ENHANCEMENT] Use npm 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ npm-debug.log
 /common-tmp
 *.tgz
 /docs/build
-.node_modules-tmp
-.bower_components-tmp
+.deps-tmp
 /coverage
 *.pem

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "node-modules-path": "^1.0.0",
     "node-uuid": "^1.4.3",
     "nopt": "^3.0.1",
-    "npm": "2.15.5",
+    "npm": "3.10.8",
     "npm-package-arg": "^4.1.1",
     "ora": "^0.2.0",
     "portfinder": "^1.0.7",

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -30,10 +30,10 @@ function downloaded(item) {
   var exists = false;
   switch (item) {
     case 'node_modules':
-      exists = existsSync(path.join(root, '.node_modules-tmp'));
+      exists = existsSync(path.join(root, '.deps-tmp', 'node_modules'));
       break;
     case 'bower_components':
-      exists = existsSync(path.join(root, '.bower_components-tmp'));
+      exists = existsSync(path.join(root, '.deps-tmp', 'bower_components'));
       break;
   }
 
@@ -149,16 +149,16 @@ function linkDependencies(projectName) {
     var nodeModulesPath = targetPath + '/node_modules/';
     var bowerComponentsPath = targetPath + '/bower_components/';
 
-    mvRm(nodeModulesPath, '.node_modules-tmp');
-    mvRm(bowerComponentsPath, '.bower_components-tmp');
+    mvRm(nodeModulesPath, '.deps-tmp/node_modules');
+    mvRm(bowerComponentsPath, '.deps-tmp/bower_components');
 
 
     if (!existsSync(nodeModulesPath)) {
-      symLinkDir(targetPath, '.node_modules-tmp', 'node_modules');
+      symLinkDir(targetPath, '.deps-tmp/node_modules', 'node_modules');
     }
 
     if (!existsSync(bowerComponentsPath)) {
-      symLinkDir(targetPath, '.bower_components-tmp', 'bower_components');
+      symLinkDir(targetPath, '.deps-tmp/bower_components', 'bower_components');
     }
 
     process.chdir(targetPath);

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -10,8 +10,7 @@ if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
 }
 
-fs.removeSync('.node_modules-tmp');
-fs.removeSync('.bower_components-tmp');
+fs.removeSync('.deps-tmp');
 
 var root = 'tests/{unit,acceptance}';
 var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test,-slow}.js'));


### PR DESCRIPTION
I was prepared for this to be a lot more painful, but it turns out the only thing breaking the test suite with npm 3 was transitive dependency resolution in the cached `.node_modules-tmp` directory.

Since v3 flattens dependencies where possible, where we'd have `.node_modules-tmp/pkg-a/node_modules/pkg-b` before, now we get `.node_modules-tmp/{pkg-a,pkg-b}`. Node will only resolve a `require` from one package to its peer when they're both in a directory called "node_modules", so `require('pkg-b')` would fail from `pkg-a`.

The change here is just to nest the shared directory so that it can be called `node_modules` and then node's resolution process will do the right thing.