### PR TITLE
Use --save-dev by default when installing addons

### DIFF
--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -38,7 +38,7 @@ module.exports = Task.extend({
     return npmInstall.run({
       'packages': packageNames,
       'save': commandOptions.save,
-      'save-dev': !commandOptions.save && commandOptions.saveDev,
+      'save-dev': !commandOptions.save,
       'save-exact': true
     }).then(function() {
       return this.project.reloadAddons();

--- a/tests/unit/tasks/addon-install-test.js
+++ b/tests/unit/tasks/addon-install-test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+var AddonInstallTask = require('../../../lib/tasks/addon-install');
+var MockProject      = require('../../helpers/mock-project');
+var expect           = require('chai').expect;
+var CoreObject       = require('core-object');
+var Promise          = require('rsvp').Promise;
+
+describe('addon install task', function() {
+  var ui;
+  var project;
+
+  beforeEach(function() {
+    ui = {
+      startProgress: function() {
+
+      }
+    };
+  });
+
+  afterEach(function() {
+    // ui.stopProgress();
+    ui = undefined;
+    project = undefined;
+  });
+
+  describe('when no save flag specified in blueprintOptions', function() {
+    it('calls npm install with --save-dev as a default', function() {
+      var mockNpmInstallTask = CoreObject.extend({
+        run: function(options) {
+          expect(options.save).to.not.equal(true);
+          expect(options['save-dev']).to.equal(true);
+          return new Promise(function(resolve, reject) {
+            resolve();
+          });
+        }
+      });
+
+      var addonInstallTask = new AddonInstallTask({
+        ui: ui,
+        project: project,
+        NpmInstallTask: mockNpmInstallTask
+      });
+
+      addonInstallTask.run({});
+    });
+  });
+
+  describe('when save flag specified in blueprintOptions', function() {
+    it('calls npm install with --save', function() {
+      var mockNpmInstallTask = CoreObject.extend({
+        run: function(options) {
+          expect(options.save).to.equal(true);
+          expect(options['save-dev']).to.not.equal(true);
+          return new Promise(function(resolve, reject) {
+            resolve();
+          });
+        }
+      });
+
+      var addonInstallTask = new AddonInstallTask({
+        ui: ui,
+        project: project,
+        NpmInstallTask: mockNpmInstallTask
+      });
+
+      addonInstallTask.run({
+        blueprintOptions: {
+          save: true
+        }
+      });
+    });
+  });
+
+  describe('when saveDev flag specified in blueprintOptions', function() {
+    it('calls npm install with --save-dev', function() {
+      var mockNpmInstallTask = CoreObject.extend({
+        run: function(options) {
+          expect(options.save).to.not.equal(true);
+          expect(options['save-dev']).to.equal(true);
+          return new Promise(function(resolve, reject) {
+            resolve();
+          });
+        }
+      });
+
+      var addonInstallTask = new AddonInstallTask({
+        ui: ui,
+        project: project,
+        NpmInstallTask: mockNpmInstallTask
+      });
+
+      addonInstallTask.run({
+        blueprintOptions: {
+          saveDev: true
+        }
+      });
+    });
+  });
+
+  describe('when both save and saveDev flag specified in blueprintOptions', function() {
+    it('calls npm install with --save', function() {
+      var mockNpmInstallTask = CoreObject.extend({
+        run: function(options) {
+          expect(options.save).to.equal(true);
+          expect(options['save-dev']).to.not.equal(true);
+          return new Promise(function(resolve, reject) {
+            resolve();
+          });
+        }
+      });
+
+      var addonInstallTask = new AddonInstallTask({
+        ui: ui,
+        project: project,
+        NpmInstallTask: mockNpmInstallTask
+      });
+
+      addonInstallTask.run({
+        blueprintOptions: {
+          save: true,
+          saveDev: true
+        }
+      });
+    });
+  });
+});

--- a/tests/unit/tasks/addon-install-test.js
+++ b/tests/unit/tasks/addon-install-test.js
@@ -26,20 +26,18 @@ describe('addon install task', function() {
 
   describe('when no save flag specified in blueprintOptions', function() {
     it('calls npm install with --save-dev as a default', function() {
-      var mockNpmInstallTask = CoreObject.extend({
+      var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
-          expect(options.save).to.not.equal(true);
-          expect(options['save-dev']).to.equal(true);
-          return new Promise(function(resolve, reject) {
-            resolve();
-          });
+          expect(options.save).to.not.be.true;
+          expect(options['save-dev']).to.be.true;
+          return Promise.resolve();
         }
       });
 
       var addonInstallTask = new AddonInstallTask({
         ui: ui,
         project: project,
-        NpmInstallTask: mockNpmInstallTask
+        NpmInstallTask: MockNpmInstallTask
       });
 
       addonInstallTask.run({});
@@ -48,20 +46,18 @@ describe('addon install task', function() {
 
   describe('when save flag specified in blueprintOptions', function() {
     it('calls npm install with --save', function() {
-      var mockNpmInstallTask = CoreObject.extend({
+      var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
-          expect(options.save).to.equal(true);
-          expect(options['save-dev']).to.not.equal(true);
-          return new Promise(function(resolve, reject) {
-            resolve();
-          });
+          expect(options.save).to.be.true;
+          expect(options['save-dev']).to.not.be.true;
+          return Promise.resolve();
         }
       });
 
       var addonInstallTask = new AddonInstallTask({
         ui: ui,
         project: project,
-        NpmInstallTask: mockNpmInstallTask
+        NpmInstallTask: MockNpmInstallTask
       });
 
       addonInstallTask.run({
@@ -74,20 +70,18 @@ describe('addon install task', function() {
 
   describe('when saveDev flag specified in blueprintOptions', function() {
     it('calls npm install with --save-dev', function() {
-      var mockNpmInstallTask = CoreObject.extend({
+      var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
-          expect(options.save).to.not.equal(true);
-          expect(options['save-dev']).to.equal(true);
-          return new Promise(function(resolve, reject) {
-            resolve();
-          });
+          expect(options.save).to.not.be.true;
+          expect(options['save-dev']).to.be.true;
+          return Promise.resolve();
         }
       });
 
       var addonInstallTask = new AddonInstallTask({
         ui: ui,
         project: project,
-        NpmInstallTask: mockNpmInstallTask
+        NpmInstallTask: MockNpmInstallTask
       });
 
       addonInstallTask.run({
@@ -100,20 +94,18 @@ describe('addon install task', function() {
 
   describe('when both save and saveDev flag specified in blueprintOptions', function() {
     it('calls npm install with --save', function() {
-      var mockNpmInstallTask = CoreObject.extend({
+      var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
-          expect(options.save).to.equal(true);
-          expect(options['save-dev']).to.not.equal(true);
-          return new Promise(function(resolve, reject) {
-            resolve();
-          });
+          expect(options.save).to.be.true;
+          expect(options['save-dev']).to.not.be.true;
+          return Promise.resolve();
         }
       });
 
       var addonInstallTask = new AddonInstallTask({
         ui: ui,
         project: project,
-        NpmInstallTask: mockNpmInstallTask
+        NpmInstallTask: MockNpmInstallTask
       });
 
       addonInstallTask.run({

--- a/tests/unit/tasks/addon-install-test.js
+++ b/tests/unit/tasks/addon-install-test.js
@@ -25,11 +25,12 @@ describe('addon install task', function() {
   });
 
   describe('when no save flag specified in blueprintOptions', function() {
-    it('calls npm install with --save-dev as a default', function() {
+    it('calls npm install with --save-dev as a default', function(done) {
       var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
           expect(options.save).to.not.be.true;
           expect(options['save-dev']).to.be.true;
+          done();
           return Promise.resolve();
         }
       });
@@ -45,11 +46,12 @@ describe('addon install task', function() {
   });
 
   describe('when save flag specified in blueprintOptions', function() {
-    it('calls npm install with --save', function() {
+    it('calls npm install with --save', function(done) {
       var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
           expect(options.save).to.be.true;
           expect(options['save-dev']).to.not.be.true;
+          done();
           return Promise.resolve();
         }
       });
@@ -69,11 +71,12 @@ describe('addon install task', function() {
   });
 
   describe('when saveDev flag specified in blueprintOptions', function() {
-    it('calls npm install with --save-dev', function() {
+    it('calls npm install with --save-dev', function(done) {
       var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
           expect(options.save).to.not.be.true;
           expect(options['save-dev']).to.be.true;
+          done();
           return Promise.resolve();
         }
       });
@@ -93,11 +96,12 @@ describe('addon install task', function() {
   });
 
   describe('when both save and saveDev flag specified in blueprintOptions', function() {
-    it('calls npm install with --save', function() {
+    it('calls npm install with --save', function(done) {
       var MockNpmInstallTask = CoreObject.extend({
         run: function(options) {
           expect(options.save).to.be.true;
           expect(options['save-dev']).to.not.be.true;
+          done();
           return Promise.resolve();
         }
       });


### PR DESCRIPTION
Currently, installing an addon with `this.addAddonsToProject` in a blueprint will fail. See #6318 for details.

Having stepped through the code it looks like the issue is that by default npm is not run with the `save-dev` flag. The consequence is that when ember-cli looks for the installed addon it can't find it.

This PR makes npm be called with a `--save-dev` argument if no specific options are specified. Namely by making `blueprintOptions` default to `{ saveDev: true}`.

My understanding is that the following happens:

1. `this.addAddonsToProject` is called with a list of addons (say in the `afterInstall` hook).
2. These are passed to the `addon-install` task.
3. This triggers `npm install` with the list of packages without `--save-dev`.
4. The addon is not added to `packages.json`
5. The addons are reloaded
6. Ember-cli tries to run the default blueprints for the newly installed addons.
7. Ember tries to find the addon in `project.addons` but it isn't there.
8. Error message, install failed.

I'm not 100% convinced this is the best place to set a default, we may equivalently want to set this up in the `addon-install` task.

I've added a unit test, we could potentially add an acceptance test here too.

Fixes #6318