### PR TITLE
Moves ember dependency to `ember-source` npm package

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -10,6 +10,11 @@ module.exports = {
         resolutions: {
           'ember': 'lts-2-4'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -20,6 +25,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -32,27 +42,26 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
       name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
+      npm: {
+        devDependencies: {
+          'ember-source': 'git://github.com/emberjs/ember.js.git#beta'
         }
       }
     },
     {
       name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
+      npm: {
+        devDependencies: {
+          'ember-source': 'git://github.com/emberjs/ember.js.git#master'
         }
       }
     }

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember-cli-shims": "0.1.3"
   }
 }

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3"
   }
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -34,6 +34,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-source": "^2.11.0-beta.1",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.0.10"
   },

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -21,7 +21,7 @@
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",


### PR DESCRIPTION
Still to do:
- [ ] Unit tests covering this new functionality. (Should also cover ensuring that we have all assets needed published.)
- [x] Properly set up Ember Try.

All other comments in this thread [before this one](https://github.com/ember-cli/ember-cli/pull/6324#issuecomment-255447801) have been addressed.

---

Supersedes https://github.com/ember-cli/ember-cli/pull/5921
- [x] removes `ember` bower dependency
- [x] adds `ember-source` npm dependency
- @nathanhammond 
  - [x] Add `ember-source` to the default addon/app blueprints.
  - [x] Drop `ember-cli-legacy-blueprints` from the default addon/app blueprints.
  - [x] Relatedly we must change `ember-cli-legacy-blueprints`'s `before` definition to be `ember-source`. https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/62
  - [x] Bump up `ember-cli-legacy-blueprints` dependency
