### PR TITLE
Move to bundled install test.

### DIFF
--- a/tests/acceptance/install-test-slow.js
+++ b/tests/acceptance/install-test-slow.js
@@ -44,20 +44,27 @@ describe('Acceptance: ember install', function() {
     ]);
   }
 
-  function installAddon(args) {
-    var generateArgs = ['install'].concat(args);
+  function installAddon(addon) {
+    addon = path.resolve(path.join(__dirname, '..', 'fixtures', 'install', addon));
+
+    var commandArgs = ['install'].concat(addon);
 
     return initApp().then(function() {
-      return ember(generateArgs);
+      return ember(commandArgs);
     });
   }
 
   it('installs addons via npm and runs generators', function() {
-    return installAddon(['ember-cli-fastclick', 'ember-cli-photoswipe']).then(function(result) {
+    return installAddon('ember-cli-photoswipe-1.2.0.tgz')
+    .then(function(result) {
       expect(file('package.json'))
-        .to.match(/"ember-cli-fastclick": ".*"/)
         .to.match(/"ember-cli-photoswipe": ".*"/);
 
+      expect(result.outputStream.join()).to.include('WARNING: Could not figure out blueprint name from:');
+
+      return ember(["generate", "photoswipe"]);
+    })
+    .then(function(result) {
       expect(file('bower.json'))
         .to.match(/"photoswipe": ".*"/);
 


### PR DESCRIPTION
Closes #6322.

Caveats:
- Includes a large .tgz file into the repo. (bundled the dependencies)
- Doesn't actually make us 100% offline capable, but reduces network exposure for `npm`.
- No longer tests for automatically invoking blueprints because package wasn't installed by package name.
- Protects us from random external addons breaking our test suite.
- We could do what [I describe here](https://github.com/ember-cli/ember-cli/issues/6323#issuecomment-252120185) in some future state and get the auto-invocation test back. (Though since likely nobody will claim this task we should consider this PR as if it will never happen.)
- [Would allow us to revert this line.](https://github.com/ember-cli/ember-cli/pull/6317#discussion_r82209740)

Discuss.