### PR TITLE
DOC: #addBowerPackagesToProject `source` option

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1003,7 +1003,8 @@ var Blueprint = CoreObject.extend({
     available.
 
     Expects each array item to be an object with a `name`.  Each object
-    may optionally have a `target` to specify a specific version.
+    may optionally have a `target` to specify a specific version, or a
+    `source` to specify a non-local name to be resolved.
 
     @method addBowerPackagesToProject
     @param {Array} packages


### PR DESCRIPTION
This PR adds a note about the as-yet-undocumented `source` option to the descriptors of Bower packages.

It's quite a handy option.

---

_Cave_: Since I don't know what it really _does_, my wording of it is more of a "oh, this seems undocumented"