### PR TITLE
Update ember-cli-legacy-blueprints

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-broccoli-sane-watcher": "^2.0.3",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cli-legacy-blueprints": "^0.1.1",
+    "ember-cli-legacy-blueprints": "^0.1.2",
     "ember-cli-lodash-subset": "^1.0.11",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.0.0",


### PR DESCRIPTION
New release makes us compatible with `ember-source`.