### PR TITLE
fix documentation for app-boot contentFor

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1679,7 +1679,7 @@ EmberApp.prototype.toTree = function(additionalTrees) {
   Currently supported types:
   - 'head'
   - 'config-module'
-  - 'app'
+  - 'app-boot'
   - 'head-footer'
   - 'test-header-footer'
   - 'body-footer'


### PR DESCRIPTION
I don't see any 'app' contentFor. But there *is* an 'app-boot' contentFor that's mysteriously missing.