### PR TITLE
Remove `app` from enumeration.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1679,7 +1679,6 @@ EmberApp.prototype.toTree = function(additionalTrees) {
   Currently supported types:
   - 'head'
   - 'config-module'
-  - 'app'
   - 'head-footer'
   - 'test-header-footer'
   - 'body-footer'


### PR DESCRIPTION
Supersedes #6343. This is not actually a hook.