### PR TITLE
[ENHANCEMENT] Add 2.8-lts scenario to default ember-try config

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -14,6 +14,7 @@ env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -24,6 +24,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
Now that the [2.8 LTS release is out](http://emberjs.com/blog/2016/10/17/ember-2-9-released.html), it may be beneficial to add this to the blueprint for an addon's `ember-try` scenarios.