### PR TITLE
blueprints/app: Update Ember and Ember Data to v2.9.0

### DIFF
--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "<%= name %>",
   "dependencies": {
-    "ember": "~2.9.0-beta.1",
+    "ember": "~2.9.0",
     "ember-cli-shims": "0.1.3"
   }
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -34,7 +34,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.9.0-beta.1",
+    "ember-data": "^2.9.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
This will most likely need a v2.9.1 release... sorry...

/cc @nathanhammond 