### PR TITLE
Confirm whether or not npm is breaking Windows CI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "node-modules-path": "^1.0.0",
     "node-uuid": "^1.4.3",
     "nopt": "^3.0.1",
-    "npm": "3.10.9",
+    "npm": "3.10.8",
     "npm-package-arg": "^4.1.1",
     "ora": "^0.2.0",
     "portfinder": "^1.0.7",


### PR DESCRIPTION
Confirm whether or not `npm` is breaking Windows CI.

This reverts commit 078bb2cb2308a65c04c8b32bf3ae519e7457acae.