### PR TITLE
Respect testem exit code

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -3,15 +3,21 @@
 var TestTask = require('./test');
 var Promise  = require('../ext/promise');
 var chalk    = require('chalk');
+var SilentError = require('silent-error');
 
 module.exports = TestTask.extend({
   invokeTestem: function(options) {
     var task = this;
 
     return new Promise(function(resolve, reject) {
-      task.testem.startDev(task.testemOptions(options), function(code, error) {
-        if (error) { reject(error); }
-        else       { resolve(code); }
+      task.testem.startDev(task.testemOptions(options), function(exitCode, error) {
+        if (error) {
+          reject(error);
+        } else if (exitCode !== 0) {
+          reject(new SilentError('Testem finished with non-zero exit code. Tests failed.'));
+        } else {
+          resolve(exitCode);
+        }
       });
     });
   },

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -16,9 +16,10 @@ module.exports = Task.extend({
 
     return new Promise(function(resolve, reject) {
       testem.startCI(task.testemOptions(options), function(exitCode, error) {
-        if (error) { reject(error); }
-        else if (!testem.app.reporter.total) {
-          reject(new SilentError('No tests were run, please check whether any errors occurred in the page (ember test --server) and ensure that you have a test launcher (e.g. PhantomJS) enabled.'));
+        if (error) {
+          reject(error);
+        } else if (exitCode !== 0) {
+          reject(new SilentError('Testem finished with non-zero exit code. Tests failed.'));
         } else {
           resolve(exitCode);
         }


### PR DESCRIPTION
Currently the UX around failing tests is bad as devs see a large
stack trace when tests failed.

This changes the behaviour to log a silent error depending on the
testem exit code.

The previous "No tests were run" handling has been removed as this
is already handled by testem upstream:
https://github.com/testem/testem/blob/be8348bf/lib/app.js#L439

While both checks will work with all testem versions, new versions won’t return not all tests passed / run cancelled errors any longer.
https://github.com/testem/testem/pull/1001