### PR TITLE
Document analytics collection.

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -49,6 +49,12 @@ var Watcher = Task.extend({
       message: 'broccoli rebuild time: ' + totalTime + 'ms'
     });
 
+    /**
+     * We use the `rebuild` category in our analytics setup for both builds
+     * and rebuilds. This is a bit confusing, but the actual thing we
+     * delineate on in the reports is the `variable` value below. This is
+     * used both here and in `lib/tasks/build.js`.
+     */
     this.analytics.trackTiming({
       category: 'rebuild',
       variable: 'rebuild time',

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -28,6 +28,12 @@ module.exports = Task.extend({
           message: totalTime + 'ms'
         });
 
+        /**
+         * We use the `rebuild` category in our analytics setup for both builds
+         * and rebuilds. This is a bit confusing, but the actual thing we
+         * delineate on in the reports is the `variable` value below. This is
+         * used both here and in `lib/models/watcher.js`.
+         */
         analytics.trackTiming({
           category: 'rebuild',
           variable: 'build time',


### PR DESCRIPTION
~~The current analytics timing for the `build` task provides the `rebuild` category every time (per #6348). This should be `build` as the build task is only ever invoked once.~~

~~`ember build --watch` uses a different task.~~

/cc @twokul