### PR TITLE
Node.js 0.12 Under Control. Whitelist build branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ node_js:
   - "6"
   - "7"
 
-matrix:
-  allow_failures:
-    - node_js: "0.12"
-    - node_js: "node"
- 
 branches:
-  except:
-    - canary
+  only:
+    - master
+    - beta
+    - release
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,10 @@ environment:
     - nodejs_version: "6"
 
 branches:
-  except:
-    - canary
+  only:
+    - master
+    - beta
+    - release
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Reduce the number of spurious builds we do so that Travis and AppVeyor (particularly) don't get as far backed up.

Also, Node.js 0.12 appears to have stabilized on Travis.