### PR TITLE
Improve silent.js Deprecation

### DIFF
--- a/lib/errors/silent.js
+++ b/lib/errors/silent.js
@@ -3,9 +3,12 @@
 var SilentError = require('silent-error');
 var deprecate   = require('../utilities/deprecate');
 
+// Get the call stack so we can let the user know what module is using the deprecated function.
+var stack = new Error().stack;
+
 Object.defineProperty(module, 'exports', {
   get: function () {
-    deprecate('`ember-cli/lib/errors/silent.js` is deprecated, use `silent-error` instead.', true);
+    deprecate("`ember-cli/lib/errors/silent.js` is deprecated, use `silent-error` instead.  Module: \n" + stack.toString(), true);
     return SilentError;
   }
 });

--- a/lib/errors/silent.js
+++ b/lib/errors/silent.js
@@ -3,12 +3,14 @@
 var SilentError = require('silent-error');
 var deprecate   = require('../utilities/deprecate');
 
-// Get the call stack so we can let the user know what module is using the deprecated function.
-var stack = new Error().stack;
-
 Object.defineProperty(module, 'exports', {
   get: function () {
-    deprecate("`ember-cli/lib/errors/silent.js` is deprecated, use `silent-error` instead.  Module: \n" + stack.toString(), true);
+    // Get the call stack so we can let the user know what module is using the deprecated function.
+    var stack = new Error().stack;
+    stack = stack.split('\n')[5];
+    stack = stack.replace('    at ', '  ');
+
+    deprecate('`ember-cli/lib/errors/silent.js` is deprecated, use `silent-error` instead. Required here: \n' + stack.toString(), true);
     return SilentError;
   }
 });


### PR DESCRIPTION
Supersedes #6245. Closes #6190.

Example error message (added it to the version command for testing because I'm lazy):
```
DEPRECATION: `ember-cli/lib/errors/silent.js` is deprecated, use `silent-error` instead. Required here: 
  Object.<anonymous> (/Users/nathanhammond/Repos/ember-cli/lib/commands/version.js:5:11)
```

@RyanNerd thanks for making this happen!