### PR TITLE
Adding json out for 'ember asset-sizes'

### DIFF
--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -29,6 +29,15 @@ AssetPrinterSize.prototype.print = function () {
   }.bind(this));
 };
 
+AssetPrinterSize.prototype.printJSON = function () {
+  var ui = this.ui;
+  return this.makeAssetSizesObject().then(function (files) {
+    this.validateAssetPath(files);
+
+    ui.writeLine(JSON.stringify({files: files}));
+  }.bind(this));
+};
+
 AssetPrinterSize.prototype.makeAssetSizesObject = function () {
   var fs = require('fs');
   var zlib = require('zlib');

--- a/lib/tasks/show-asset-sizes.js
+++ b/lib/tasks/show-asset-sizes.js
@@ -10,6 +10,10 @@ module.exports = Task.extend({
       outputPath: options.outputPath
     });
 
+    if (options.json) {
+      return sizePrinter.printJSON();
+    }
+
     return sizePrinter.print();
   }
 });

--- a/tests/unit/models/asset-size-printer-test.js
+++ b/tests/unit/models/asset-size-printer-test.js
@@ -107,6 +107,24 @@ describe('models/asset-size-printer', function () {
       });
   });
 
+  it('can print out to JSON', function () {
+    var assetObjectKeys;
+    var sizePrinter = new AssetSizePrinter({
+      ui: new MockUi(),
+      outputPath: storedTmpDir
+    });
+
+    return sizePrinter.printJSON()
+      .then(function () {
+        var output = JSON.parse(sizePrinter.ui.output);
+
+        expect(output.files[0].name).to.include('nested-asset.css');
+        expect(output.files[1].name).to.include('nested-asset.js');
+        expect(output.files[1].size).to.equal(32);
+        expect(output.files[1].gzipSize).to.equal(52);
+      });
+  });
+
   it('creates an array of asset objects', function () {
     var assetObjectKeys;
     var sizePrinter = new AssetSizePrinter({


### PR DESCRIPTION
This is simply `JSON.stringify` the result of `AssetPrinterSize.prototype.makeAssetSizesObject`
We could make the json object a little more helpful. Thoughts?

```sh
ember asset-sizes --json
```

Will produce something like this:
```json
{"files":[{"name":"dist/assets/dummy.css","size":114,"gzipSize":109,"showGzipped":true},{"name":"dist/assets/dummy.js","size":31531,"gzipSize":5381,"showGzipped":true},{"name":"dist/assets/tests.js","size":33828,"gzipSize":3818,"showGzipped":true},{"name":"dist/assets/vendor.css","size":0,"gzipSize":20,"showGzipped":false},{"name":"dist/assets/vendor.js","size":3738032,"gzipSize":848035,"showGzipped":true}]}
```
