### PR TITLE
Fix preProcessTree API docs.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -504,7 +504,7 @@ EmberApp.prototype.addonTreesFor = function(type) {
 };
 
 /**
-  Runs addon postprocessing on a given tree and returns the processed tree.
+  Runs addon post-processing on a given tree and returns the processed tree.
 
   This enables addons to do process immediately **after** the preprocessor for a
   given type is run, but before concatenation occurs. If an addon wishes to
@@ -514,7 +514,7 @@ EmberApp.prototype.addonTreesFor = function(type) {
   To utilize this addons implement `postprocessTree` hook.
 
   An example, would be to apply some broccoli transform on all JS files, but
-  only after the existing pre-processors have fun.
+  only after the existing pre-processors have run.
 
   ```js
   module.exports = {
@@ -550,14 +550,13 @@ EmberApp.prototype.addonPostprocessTree = function(type, tree) {
 
 
 /**
-  Runs addon postprocessing on a given tree and returns the processed tree.
+  Runs addon pre-processing on a given tree and returns the processed tree.
 
   This enables addons to do process immediately **before** the preprocessor for a
-  given type is run, but before concatenation occurs.  If an addon wishes to
-  apply a transform  after the preprocessors run, they can instead implement the
-  postprocessTree hook.
+  given type is run.  If an addon wishes to apply a transform  after the
+  preprocessors run, they can instead implement the postprocessTree hook.
 
-  To utilize this addons implement `postprocessTree` hook.
+  To utilize this addons implement `preprocessTree` hook.
 
   An example, would be to remove some set of files before the preprocessors run.
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -75,6 +75,7 @@ function deprecatedAddonFilters(addon, name, insteadUse, fn) {
   - {{#crossLink "Addon/included:method"}}{{/crossLink}}
   - {{#crossLink "Addon/shouldIncludeChildAddon:method"}}{{/crossLink}}
   - {{#crossLink "Addon/setupPreprocessorRegistry:method"}}{{/crossLink}}
+  - {{#crossLink "Addon/preprocessTree:method"}}{{/crossLink}}
   - {{#crossLink "Addon/postprocessTree:method"}}{{/crossLink}}
   - {{#crossLink "Addon/lintTree:method"}}{{/crossLink}}
   - {{#crossLink "Addon/contentFor:method"}}{{/crossLink}}


### PR DESCRIPTION
`preProcessTree` doesn't appear in addon hooks [here](https://ember-cli.com/api/classes/Addon.html)

cc: @stefanpenner @rwjblue