### PR TITLE
Lazily install fs monitor

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -12,14 +12,25 @@ var chalk       = require('chalk');
 var attemptNeverIndex = require('../utilities/attempt-never-index');
 var findBuildFile = require('../utilities/find-build-file');
 
-var FSMonitor = require('heimdalljs-fs-monitor');
-var monitor = new FSMonitor();
-monitor.start();
-
 var Sync = require('tree-sync');
 
 var signalsTrapped = false;
 var buildCount = 0;
+
+function _enableFSMonitorIfVizEnabled() {
+  var FSMonitor = require('heimdalljs-fs-monitor');
+  var monitor = new FSMonitor();
+  if (vizEnabled()) {
+    monitor.start();
+  }
+  return monitor;
+}
+
+_enableFSMonitorIfVizEnabled();
+
+function vizEnabled() {
+  return !!process.env.BROCCOLI_VIZ;
+}
 
 function outputViz(count, result) {
   var nodes = result.graph.__heimdall__.toJSONSubgraph();
@@ -216,7 +227,7 @@ module.exports = Task.extend({
       })
       .then(function(result) {
 
-        if (process.env.BROCCOLI_VIZ) {
+        if (vizEnabled()) {
           outputViz(buildCount++, result);
         }
         return result;
@@ -307,3 +318,5 @@ module.exports = Task.extend({
     }
   }
 });
+
+module.exports._enableFSMonitorIfVizEnabled = _enableFSMonitorIfVizEnabled;

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -21,6 +21,34 @@ var tmproot         = path.join(root, 'tmp');
 describe('models/builder.js', function() {
   var addon, builder, buildResults, tmpdir;
 
+  describe('._enableFSMonitorIfVizEnabled', function() {
+    var originalBroccoliViz = process.env.BROCCOLI_VIZ;
+
+    afterEach(function() {
+      delete process.env.BROCCOLI_VIZ;
+    });
+
+    it('if VIZ is enabled, monitor', function() {
+      process.env.BROCCOLI_VIZ = '1';
+      var monitor = Builder._enableFSMonitorIfVizEnabled();
+      try {
+        expect(monitor.state).to.eql('active');
+      } finally {
+        monitor.stop();
+      }
+    });
+
+    it('if VIZ is NOT enabled, monitor', function() {
+      var monitor = Builder._enableFSMonitorIfVizEnabled();
+      try {
+        expect(monitor.state).to.eql('idle');
+      } finally {
+        monitor.stop();
+      }
+    });
+
+  });
+
   describe('Windows CTRL + C Capture', function() {
     var originalPlatform, originalStdin;
 


### PR DESCRIPTION
Only install fs monitor if `process.env.BROCCOLI_VIZ`.  There's no reason to
monitor fs operations if we're not going to actually output them.