### PR TITLE
Enable ES6 sourcemaps

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -254,7 +254,9 @@ EmberApp.prototype._initOptions = function(options) {
 
   // For now we must disable Babel sourcemaps due to unforseen
   // performance regressions.
-  this.options.babel.sourceMaps = false;
+  if (!('sourceMaps' in this.options.babel)) {
+    this.options.babel.sourceMaps = false;
+  }
 };
 
 /**

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -209,6 +209,27 @@ describe('broccoli/ember-app', function() {
         expect(app.vendorFiles['ember-resolver']).to.equal(undefined);
       });
     });
+
+    describe('options.babel.sourceMaps', function() {
+      it('disables babel sourcemaps by default', function() {
+        var app = new EmberApp({
+          project: project
+        });
+
+        expect(app.options.babel.sourceMaps).to.be.false;
+      });
+
+      it('can enable babel sourcemaps with the option', function() {
+        var app = new EmberApp({
+          project: project,
+          babel: {
+            sourceMaps: 'inline'
+          }
+        });
+
+        expect(app.options.babel.sourceMaps).to.equal('inline');
+      });
+    });
   });
 
   describe('contentFor', function() {


### PR DESCRIPTION
I know there are ongoing efforts to support sourcemaps, but this small change can improve debugging right now. ES6 sourcemaps will appear in the debugger:
![chrome debugger](https://cloud.githubusercontent.com/assets/752885/20574643/6cb83844-b16a-11e6-974b-14a0cbff7902.png)

## Performance

I think the biggest concern was that sourcemaps are too slow. I can see only a small performance impact. And I don't need to recompile to add `debugger` statements since I can use breakpoints in my IDE.

These are incremental build times for my project on two machines:

OSX with `sourceMaps = false`:
```
Build successful - 1047ms.

Slowest Trees                                 | Total               
----------------------------------------------+---------------------
SassCompiler                                  | 88ms                
StubGenerator                                 | 77ms                
SourceMapConcat: Concat: App                  | 73ms                
Babel                                         | 55ms                

Slowest Trees (cumulative)                    | Total (avg)         
----------------------------------------------+---------------------
Babel (36)                                    | 114ms (3 ms)        
SassCompiler (1)                              | 88ms                
StubGenerator (2)                             | 79ms (39 ms)        
SourceMapConcat: Concat: App (1)              | 73ms                
```

OSX with `sourceMaps = 'inline'`:
```
Build successful - 1478ms.

Slowest Trees                                 | Total               
----------------------------------------------+---------------------
SourceMapConcat: Concat: App                  | 684ms               

Slowest Trees (cumulative)                    | Total (avg)         
----------------------------------------------+---------------------
SourceMapConcat: Concat: App (1)              | 684ms               
Babel (36)                                    | 124ms (3 ms)        
```

Windows with `sourceMaps = false`:
```
Build successful - 3054ms.

Slowest Trees                                 | Total
----------------------------------------------+---------------------
SassCompiler                                  | 712ms
WebpackWriter                                 | 242ms
LessCompiler                                  | 226ms
SourceMapConcat: Concat: App                  | 161ms
Babel                                         | 160ms

Slowest Trees (cumulative)                    | Total (avg)
----------------------------------------------+---------------------
SassCompiler (1)                              | 712ms
Babel (28)                                    | 348ms (12 ms)
WebpackWriter (1)                             | 242ms
LessCompiler (1)                              | 226ms
SourceMapConcat: Concat: App (1)              | 161ms
```

Windows with `sourceMaps = 'inline'`:
```
Build successful - 3459ms.

Slowest Trees                                 | Total
----------------------------------------------+---------------------
SassCompiler                                  | 706ms
SourceMapConcat: Concat: App                  | 525ms
WebpackWriter                                 | 237ms
LessCompiler                                  | 232ms

Slowest Trees (cumulative)                    | Total (avg)
----------------------------------------------+---------------------
SassCompiler (1)                              | 706ms
SourceMapConcat: Concat: App (1)              | 525ms
Babel (28)                                    | 345ms (12 ms)
WebpackWriter (1)                             | 237ms
LessCompiler (1)                              | 232ms
```
