### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -42,7 +42,7 @@ function clientId() {
   if (id) {
     return id;
   } else {
-    id = require('node-uuid').v4().toString();
+    id = require('uuid').v4().toString();
     configStore.set('client-id', id);
     return id;
   }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "minimatch": "^3.0.0",
     "morgan": "^1.5.2",
     "node-modules-path": "^1.0.0",
-    "node-uuid": "^1.4.3",
     "nopt": "^3.0.1",
     "npm": "3.10.8",
     "npm-package-arg": "^4.1.1",
@@ -114,6 +113,7 @@
     "through": "^2.3.6",
     "tiny-lr": "^1.0.3",
     "tree-sync": "^1.1.4",
+    "uuid": "^3.0.0",
     "walk-sync": "^0.3.0",
     "yam": "0.0.22"
   },


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.