### PR TITLE
Feature: Add current dir name to `process.title`

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -2,7 +2,9 @@
 'use strict';
 
 // Provide a title to the process in `ps`
-process.title = 'ember';
+var path = require('path');
+var parsedPath = path.parse(process.cwd());
+process.title = 'ember:' + parsedPath.name;
 
 // require('time-require');
 var resolve = require('resolve');


### PR DESCRIPTION
Just an idea for enhancement. I haven't seriously tested it yet. Just interested if it's a way to go.

When I have several ember apps/addons started it's quite difficult to differentiate all the opened terminals and point to the right one from the first attempt. All of them have the same same title: "ember".

What if we provide the process title with a current directory name?