### PR TITLE
add ability to clean up old files in generators

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -501,6 +501,8 @@ let Blueprint = CoreObject.extend({
   */
   afterUninstall() {},
 
+  filesToRemove: [],
+
   /**
     Hook for adding custom template variables.
 
@@ -718,9 +720,14 @@ let Blueprint = CoreObject.extend({
 
     this._ignoreUpdateFiles();
 
+    let fileInfosToRemove = this._getFileInfos(this.filesToRemove, intoDir, templateVariables);
+
+    fileInfosToRemove = finishProcessingForUninstall(fileInfosToRemove);
+
     return RSVP.filter(fileInfos, isValidFile)
       .then(promises => RSVP.map(promises, prepareConfirm))
-      .then(finishProcessingForInstall);
+      .then(finishProcessingForInstall)
+      .then(fileInfos => fileInfos.concat(fileInfosToRemove));
   },
 
   /**
@@ -736,7 +743,6 @@ let Blueprint = CoreObject.extend({
     return RSVP.filter(fileInfos, isValidFile).
       then(finishProcessingForUninstall);
   },
-
 
   /**
     @method mapFile

--- a/tests/fixtures/blueprints/basic_2/index.js
+++ b/tests/fixtures/blueprints/basic_2/index.js
@@ -1,3 +1,5 @@
 module.exports = {
-  description: 'Another basic blueprint'
+  description: 'Another basic blueprint',
+
+  filesToRemove: ['file-to-remove.txt']
 };

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -96,6 +96,18 @@ let basicBlueprintFiles = [
   'app/basics/',
   'app/basics/mock-project.txt',
   'bar',
+  'file-to-remove.txt',
+  'foo.txt',
+  'test.txt',
+];
+
+let basicBlueprintFilesAfterBasic2 = [
+  '.ember-cli',
+  '.gitignore',
+  'app/',
+  'app/basics/',
+  'app/basics/mock-project.txt',
+  'bar',
   'foo.txt',
   'test.txt',
 ];
@@ -268,6 +280,7 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/create.* .gitignore/);
         expect(output.shift()).to.match(/create.* app[/\\]basics[/\\]mock-project.txt/);
         expect(output.shift()).to.match(/create.* bar/);
+        expect(output.shift()).to.match(/create.* file-to-remove.txt/);
         expect(output.shift()).to.match(/create.* foo.txt/);
         expect(output.shift()).to.match(/create.* test.txt/);
         expect(output.length).to.equal(0);
@@ -296,6 +309,7 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/create.* .gitignore/);
         expect(output.shift()).to.match(/create.* app[/\\]basics[/\\]mock-project.txt/);
         expect(output.shift()).to.match(/create.* bar/);
+        expect(output.shift()).to.match(/create.* file-to-remove.txt/);
         expect(output.shift()).to.match(/create.* foo.txt/);
         expect(output.shift()).to.match(/create.* test.txt/);
         expect(output.length).to.equal(0);
@@ -311,6 +325,7 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/identical.* .gitignore/);
         expect(output.shift()).to.match(/identical.* app[/\\]basics[/\\]mock-project.txt/);
         expect(output.shift()).to.match(/identical.* bar/);
+        expect(output.shift()).to.match(/identical.* file-to-remove.txt/);
         expect(output.shift()).to.match(/identical.* foo.txt/);
         expect(output.shift()).to.match(/identical.* test.txt/);
         expect(output.length).to.equal(0);
@@ -334,11 +349,12 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/create.* .gitignore/);
         expect(output.shift()).to.match(/create.* app[/\\]basics[/\\]mock-project.txt/);
         expect(output.shift()).to.match(/create.* bar/);
+        expect(output.shift()).to.match(/create.* file-to-remove.txt/);
         expect(output.shift()).to.match(/create.* foo.txt/);
         expect(output.shift()).to.match(/create.* test.txt/);
         expect(output.length).to.equal(0);
 
-        let blueprintNew = new Blueprint(basicNewBlueprint);
+        let blueprintNew = Blueprint.lookup(basicNewBlueprint);
 
         return blueprintNew.install(options);
       })
@@ -354,9 +370,10 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/identical.* \.gitignore/);
         expect(output.shift()).to.match(/skip.* foo.txt/);
         expect(output.shift()).to.match(/overwrite.* test.txt/);
+        expect(output.shift()).to.match(/remove.* file-to-remove.txt/);
         expect(output.length).to.equal(0);
 
-        expect(actualFiles).to.deep.equal(basicBlueprintFiles);
+        expect(actualFiles).to.deep.equal(basicBlueprintFilesAfterBasic2);
       });
     });
 
@@ -421,6 +438,7 @@ describe('Blueprint', function() {
           expect(output.shift()).to.match(/create.* .gitignore/);
           expect(output.shift()).to.match(/create.* app[/\\]basics[/\\]mock-project.txt/);
           expect(output.shift()).to.match(/create.* bar/);
+          expect(output.shift()).to.match(/create.* file-to-remove.txt/);
           expect(output.shift()).to.match(/create.* foo.txt/);
           expect(output.shift()).to.match(/create.* test.txt/);
           expect(output.length).to.equal(0);
@@ -573,6 +591,7 @@ describe('Blueprint', function() {
         expect(output.shift()).to.match(/remove.* .gitignore/);
         expect(output.shift()).to.match(/remove.* app[/\\]basics[/\\]mock-project.txt/);
         expect(output.shift()).to.match(/remove.* bar/);
+        expect(output.shift()).to.match(/remove.* file-to-remove.txt/);
         expect(output.shift()).to.match(/remove.* foo.txt/);
         expect(output.shift()).to.match(/remove.* test.txt/);
         expect(output.length).to.equal(0);


### PR DESCRIPTION
A response to https://github.com/ember-cli/ember-cli/pull/6469#issuecomment-263076360

This will probably need an RFC because it introduces a new blueprint member `oldFilesToRemove`. A blueprint can override the array and give a list of old file names that the generator (ember init or your own custom blueprint) will clean up for you.