### PR TITLE
add integration tests to our runner

### DIFF
--- a/tests/runner.js
+++ b/tests/runner.js
@@ -12,7 +12,7 @@ if (process.env.EOLNEWLINE) {
 
 fs.removeSync('.deps-tmp');
 
-var root = 'tests/{unit,acceptance}';
+var root = 'tests/{unit,integration,acceptance}';
 var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test,-slow}.js'));
 var optionOrFile = process.argv[2];
 var mocha = new Mocha({


### PR DESCRIPTION
I noticed this when I tried to `.only` in the integration tests, and it didn't work.