### PR TITLE
docs: Blueprint:renamedFiles

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1330,7 +1330,7 @@ Blueprint.list = function(options) {
 
 /**
   @static
-  @property renameFiles
+  @property renamedFiles
 */
 Blueprint.renamedFiles = {
   'gitignore': '.gitignore'

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1329,8 +1329,16 @@ Blueprint.list = function(options) {
 };
 
 /**
+  Files that are renamed when installed into the target directory.
+  This allows including files in the blueprint that would have an effect
+  on another process, such as a file named `.gitignore`.
+
+  The keys are the filenames used in the files folder.
+  The values are the filenames used in the target directory.
+
   @static
   @property renamedFiles
+  ```
 */
 Blueprint.renamedFiles = {
   'gitignore': '.gitignore'


### PR DESCRIPTION
This PR contains two small documentation updates broken into 2 commits.

The first commit simply corrects a typo in the property name used for `ember-cli/Blueprint:renameFiles`.

The second commit (which can be removed if folks object) adds some documentation for that property. I would like to contribute more documentation of this kind if folks are interested. The doc comment I have included is:

    /**
      Files that are renamed when installed into the target directory.
      This allows including files in the blueprint that would have an effect
      on another process, such as a file named `.gitignore`.

      The keys are the filenames used in the files folder.
      The values are the filenames used in the target directory.

      @static
      @property renamedFiles
      ```
    */