### PR TITLE
All JS templates to be used in addons

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -736,6 +736,7 @@ var Addon = CoreObject.extend({
     var trees = [addonJs, templatesTree, reexported].filter(Boolean);
 
     return mergeTrees(trees, {
+      overwrite: true,
       annotation: 'Addon#compileAddon(' + this.name + ') '
     });
   },


### PR DESCRIPTION
#This patch will allow JS files to be used as templates in an addon.
Without the `overwrite: true` there is a merge error as the merging at
that point has a pre-compiled `.hbs` file in one tree and a
post-compiled `.js` file in the other tree. If, however, you are relying
on importing a template from another source and are using a `.js` file
as the origin no template compilation takes place and the two trees have
a similarly named file and a merge conflict results.

It may be best to actually remove the original `.hbs` file from the
original tree but that may add unecessary cost to the build step as those files are
already being filtered out later.