### PR TITLE
Update ember-load-initializers@0.6.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -32,7 +32,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.10.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.0.10"


### PR DESCRIPTION
This was a "breaking" change upstream, as we officially dropped support for IE8 (by using `Object.keys` / `String.prototype.lastIndexOf` / etc). No real changes...