### PR TITLE
[BUGFIX] Fix remaining ember-source issues.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -334,9 +334,11 @@ EmberApp.prototype._initVendorFiles = function() {
     delete this.vendorFiles['ember-resolver.js'];
   }
 
-  // don't crash if ember-cli-shims is not included
-  if (!bowerDeps['ember-cli-shims']) {
-    delete this.vendorFiles['app-shims.js'];
+  // Warn if ember-cli-shims is not included.
+  // `ember-source` bundles them by default, so we must check if that is the
+  // load mechanism of ember before checking `bower`.
+  if (!ember && !bowerDeps['ember-cli-shims']) {
+    this.project.ui.writeWarnLine('You have not included `ember-cli-shims` in your project\'s `bower.json`. This only works if you provide an alternative yourself and unset `app.vendorFiles[\'app-shims.js\']`.');
   }
 
   // this is needed to support versions of Ember older than

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -892,6 +892,11 @@ EmberApp.prototype._processedBowerTree = function() {
     return;
   }
 
+    // Don't blow up if there is no bower_components folder.
+  if (!existsSync(this.bowerDirectory)) {
+    return;
+  }
+
   this._cachedBowerTree = new Funnel(this.trees.bower, {
     srcDir: '/',
     destDir: this.bowerDirectory + '/',

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -210,14 +210,6 @@ describe('broccoli/ember-app', function() {
         expect(app.vendorFiles['ember-resolver']).to.equal(undefined);
       });
     });
-
-    describe('ember-cli-shims', function() {
-      it('removes app-shims.js from vendorFiles when ember-cli-shims is not in bower.json', function() {
-        project.bowerDependencies = function() { return { 'ember': {} }; }
-        var app = new EmberApp({ project: project });
-        expect(app.vendorFiles['app-shims.js']).to.equal(undefined);
-      });
-    });
   });
 
   describe('contentFor', function() {


### PR DESCRIPTION
The removal from `bower` meant that we were erroneously removing it from `ember-source`. No longer.