### PR TITLE
tests/runner: Fix "capture-exit" compatibility

### DIFF
--- a/tests/runner.js
+++ b/tests/runner.js
@@ -5,6 +5,7 @@ var Mocha = require('mocha');
 var RSVP = require('rsvp');
 var fs = require('fs-extra');
 var mochaOnlyDetector = require('mocha-only-detector');
+var exit = require('capture-exit');
 
 if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
@@ -57,10 +58,9 @@ function checkOnlyInTests() {
 function runMocha() {
   console.time('Mocha Tests Running Time');
   mocha.run(function(failures) {
-    process.on('exit', function() {
-      console.timeEnd('Mocha Tests Running Time');
-      process.exit(failures);
-    });
+    console.timeEnd('Mocha Tests Running Time');
+    exit.releaseExit();
+    process.exit(failures);
   });
 }
 
@@ -79,5 +79,6 @@ ciVerificationStep()
   .catch(function(error) {
     console.error(error);
     console.error(error.stack);
+    exit.releaseExit();
     process.exit(1);
   });


### PR DESCRIPTION
#6437 caused our test runner to always exit with code `0` which caused the CI services to not report failed builds as such anymore. This PR fixes that issue.

/cc @rwjblue @stefanpenner @nathanhammond 