### PR TITLE
Fix Builder._enableFSMonitorIfVizEnabled tests

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -18,9 +18,9 @@ var signalsTrapped = false;
 var buildCount = 0;
 
 function _enableFSMonitorIfVizEnabled() {
-  var FSMonitor = require('heimdalljs-fs-monitor');
-  var monitor = new FSMonitor();
+  var monitor;
   if (vizEnabled()) {
+    monitor = new FSMonitor();
     monitor.start();
   }
   return monitor;


### PR DESCRIPTION
The monitor will only be active if it is the first instance to be constructed.
This is to avoid double counting.  This could be relaxed to be that only one
monitor can be active, but it still seems good to not even require the module
when viz is disabled.