### PR TITLE
Make startApp functional

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -3,16 +3,13 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let application;
-
   let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
-    application = Application.create(attributes);
+  return Ember.run(() => {
+    let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
+    return application;
   });
-
-  return application;
 }


### PR DESCRIPTION
Instead of using `let`, then setting the closure of `application` inside an immediately-run function callback, return the new application object, and then return that result directly.

This looks like a relic of [upgrading from `var`](https://github.com/ember-cli/ember-cli/commit/cc65668f9065d300e0daee49a3a201bfcca9c663) and the dated "put all `var` declarations at the top" [convention](https://github.com/ember-cli/ember-cli/commit/18a5f621b3f41b3a5f4139fc3d38118cde5e11df#diff-06761a3424465f8bb1a3e0fe86b96c31).

Note that if `Ember.run` ever becomes an asynchronous function, startApp will return `undefined` even without this change. `Ember.run` [does](https://github.com/emberjs/ember.js/blob/v2.10.0/packages/ember-metal/lib/run_loop.js#L76-L78) run [immediately](https://github.com/ebryn/backburner.js/blob/v0.3.1/lib/backburner/index.js#L151) and [returns what is returned](https://github.com/ebryn/backburner.js/blob/v0.3.1/lib/backburner/index.js#L196) from the callback.
