### PR TITLE
[BUGFIX release] Revert the reverted revert. Ember assign not available in all ember try scenarios 

### DIFF
--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  // use defaults, but you can override
-  let attributes = Ember.assign({}, config.APP, attrs);
+  let attributes = Ember.merge({}, config.APP);
+  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Changing the start-app test helper to use `Ember.assign` instead of `Ember.merge`. Broke ember try as Ember 2.4 apparently doesn't have Ember.assign. Need to revert back to using the Ember.merge for now.

This reverts commit 7b282ae9afd46aef9943c765db8aa97a6efc3f83.
