### PR TITLE
Ensure shared EMPTY_MERGE_TREE is reset after mocking in tests.

### DIFF
--- a/lib/broccoli/merge-trees.js
+++ b/lib/broccoli/merge-trees.js
@@ -12,10 +12,22 @@ function getEmptyTree() {
     return EMPTY_MERGE_TREE;
   }
 
-  return EMPTY_MERGE_TREE = upstreamMergeTrees([], {
+  EMPTY_MERGE_TREE = upstreamMergeTrees([], {
     annotation: 'EMPTY_MERGE_TREE',
     description: 'EMPTY_MERGE_TREE'
   });
+
+  var originalCleanup = EMPTY_MERGE_TREE.cleanup;
+  EMPTY_MERGE_TREE.cleanup = function() {
+    // this tree is being cleaned up, we must
+    // ensure that our shared EMPTY_MERGE_TREE is
+    // reset (otherwise it will not have a valid
+    // `outputPath`)
+    EMPTY_MERGE_TREE = null;
+    return originalCleanup.apply(this, arguments);
+  };
+
+  return EMPTY_MERGE_TREE;
 }
 
 module.exports = function mergeTrees(_inputTrees, options) {

--- a/tests/unit/broccoli/merge-trees-test.js
+++ b/tests/unit/broccoli/merge-trees-test.js
@@ -5,7 +5,6 @@
 var fs         = require('fs');
 var expect     = require('chai').expect;
 var proxyquire = require('proxyquire');
-var td = require('testdouble');
 
 var MockUI = require('console-ui/mock');
 
@@ -18,7 +17,15 @@ var mergeTrees = proxyquire('../../../lib/broccoli/merge-trees', {
 
 describe('broccoli/merge-trees', function() {
   beforeEach(function() {
-    mergeTreesStub = td.function();
+    mergeTreesStub = function() {
+      return {};
+    };
+  });
+
+  afterEach(function() {
+    // reset the shared EMPTY_MERGE_TREE to ensure
+    // we end up back in a consistent state
+    mergeTrees._overrideEmptyTree(null);
   });
 
   it('returns the first item when merging single item array', function() {


### PR DESCRIPTION
The override functionality was being used in two different tests to ensure that the various exepected semantics were working properly, however this was not being cleaned up properly and therefore caused test failures for tests running afterwards that utilized the shared `EMPTY_MERGE_TREE`.