### PR TITLE
Use `CoreObject` for builder and watcher

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -6,7 +6,7 @@ var fs          = require('fs-extra');
 var existsSync  = require('exists-sync');
 var path        = require('path');
 var Promise     = require('../ext/promise');
-var Task        = require('./task');
+var CoreObject  = require('core-object');
 var SilentError = require('silent-error');
 var chalk       = require('chalk');
 var attemptNeverIndex = require('../utilities/attempt-never-index');
@@ -57,7 +57,7 @@ function outputViz(count, result) {
  * @constructor
  * @extends Task
  */
-module.exports = Task.extend({
+module.exports = CoreObject.extend({
 
   init: function() {
     this._super.apply(this, arguments);

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var chalk   = require('chalk');
-var Task    = require('./task');
 var logger  = require('heimdalljs-logger')('ember-cli:watcher');
+var CoreObject = require('core-object');
 
-var Watcher = Task.extend({
+var Watcher = CoreObject.extend({
   verbose: true,
 
   init: function() {


### PR DESCRIPTION
For some reason, `builder` and `watcher` inherited from `Task` which
isn't necessary. Switching to `CoreObject` instead.

Fixes #6504