### PR TITLE
docs: remove bad markdown block

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1338,7 +1338,6 @@ Blueprint.list = function(options) {
 
   @static
   @property renamedFiles
-  ```
 */
 Blueprint.renamedFiles = {
   'gitignore': '.gitignore'


### PR DESCRIPTION
Fixes a documenation bug introduced by https://github.com/ember-cli/ember-cli/pull/6479

There was a dangling markdown block:

    ```

Removed that!

Note - this makes the documentation site render badly.

See https://ember-cli.com/api/classes/Blueprint.html and search for `renamedFiles`.