### PR TITLE
[BUGFIX] Add missing ember-cli-shims to non ember-source scenarios

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -5,7 +5,8 @@ module.exports = {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-4'
+          'ember': 'components/ember#lts-2-4',
+          'ember-cli-shims': '0.1.3'
         },
         resolutions: {
           'ember': 'lts-2-4'
@@ -21,7 +22,8 @@ module.exports = {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-8'
+          'ember': 'components/ember#lts-2-8',
+          'ember-cli-shims': '0.1.3'
         },
         resolutions: {
           'ember': 'lts-2-8'
@@ -37,7 +39,8 @@ module.exports = {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          'ember': 'components/ember#release',
+          'ember-cli-shims': '0.1.3'
         },
         resolutions: {
           'ember': 'release'
@@ -53,7 +56,8 @@ module.exports = {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          'ember': 'components/ember#beta',
+          'ember-cli-shims': '0.1.3'
         },
         resolutions: {
           'ember': 'beta'
@@ -69,7 +73,8 @@ module.exports = {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          'ember': 'components/ember#canary',
+          'ember-cli-shims': '0.1.3'
         },
         resolutions: {
           'ember': 'canary'


### PR DESCRIPTION
Without this, addons that update to 2.11 will break in CI