### PR TITLE
Use roadrunner to cache module paths.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,8 +1,16 @@
 'use strict';
 
+var roadrunner = require('roadrunner');
+roadrunner.load();
+
 // work around misbehaving libraries, so we can correctly cleanup before
 // actually exiting.
-require('capture-exit').captureExit();
+var captureExit = require('capture-exit');
+captureExit.captureExit();
+
+captureExit.onExit(function() {
+  roadrunner.save();
+});
 
 // Main entry point
 var requireAsHash = require('../utilities/require-as-hash');

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "promise-map-series": "^0.2.1",
     "quick-temp": "0.1.6",
     "resolve": "^1.1.6",
+    "roadrunner": "^1.1.0",
     "rsvp": "^3.3.3",
     "sane": "^1.1.1",
     "semver": "^5.1.1",


### PR DESCRIPTION
I stumbled across the [roadrunner](https://github.com/kittens/roadrunner) package while reading through some yarn source. Essentially it caches `Module._pathCache` and `Module._realpathCache` across restarts.

Times for `ember v`:

```
% \time ember v

        1.11 real         0.91 user         0.23 sys

% \time ember v

        0.83 real         0.74 user         0.12 sys
```

Times for `ember b` (warmed build):

```
% \time ember b

        3.62 real         2.65 user         1.16 sys

% \time ember b

        3.30 real         2.40 user         1.05 sys
```

Obviously, we need to think this through carefully.  A few specific things to iron out:

- [ ] Cache invalidation.  We need to ensure we don't troll ourselves
  while working locally.
- [ ] Cache storage location.  Currently `roadrunner` will save these
  caches in `.roadrunner.json` in the project's working directory.
- [ ] Decide if this is worth the savings...