### PR TITLE
Avoid double walking of addon/templates in default scenario.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -293,6 +293,10 @@ var Addon = CoreObject.extend({
     return tree;
   },
 
+  _treePathFor: function _treePathFor(treeName) {
+    return path.normalize(path.join(this.root, this.treePaths[treeName]));
+  },
+
   /* @private
    * @method _warn
    */
@@ -629,24 +633,43 @@ var Addon = CoreObject.extend({
   */
   shouldCompileTemplates: function() {
     var templateExtensions = this.registry.extensionsForType('template');
-    var addonTreePath = path.join(this.root, this.treePaths['addon']);
-    var addonTemplatesTreePath = path.join(this.root, this.treePaths['addon-templates']);
+    var addonTreePath = this._treePathFor('addon');
+    var addonTemplatesTreePath = this._treePathFor('addon-templates');
+    var addonTemplatesTreeInAddonTree = addonTemplatesTreePath.indexOf(addonTreePath) === 0;
 
-    var files = [];
+    var files = this._getAddonTreeFiles();
 
-    if (existsSync(addonTreePath)) {
-      files = files.concat(walkSync(addonTreePath));
+    if (!addonTemplatesTreeInAddonTree) {
+      files = files.concat(this._getAddonTemplatesTreeFiles());
     }
 
-    if (existsSync(addonTemplatesTreePath)) {
-      files = files.concat(walkSync(addonTemplatesTreePath));
-    }
+    files = files.filter(Boolean);
 
     var extensionMatcher = new RegExp('(' + templateExtensions.join('|') + ')$');
 
     return files.some(function(file) {
       return file.match(extensionMatcher);
     });
+  },
+
+  _getAddonTreeFiles: function() {
+    var addonTreePath = this._treePathFor('addon');
+
+    if (existsSync(addonTreePath)) {
+      return walkSync(addonTreePath);
+    }
+
+    return [];
+  },
+
+  _getAddonTemplatesTreeFiles: function() {
+    var addonTemplatesTreePath = this._treePathFor('addon-templates');
+
+    if (existsSync(addonTemplatesTreePath)) {
+      return walkSync(addonTemplatesTreePath);
+    }
+
+    return [];
   },
 
   _addonTemplateFiles: function addonTemplateFiles(tree) {
@@ -750,7 +773,7 @@ var Addon = CoreObject.extend({
   jshintAddonTree: function() {
     this._requireBuildPackages();
 
-    var addonPath = path.join(this.root, this.treePaths['addon']);
+    var addonPath = this._treePathFor('addon');
 
     if (!existsSync(addonPath)) {
       return;

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -619,6 +619,33 @@ describe('models/addon.js', function() {
         addon.compileTemplates();
       }).not.to.throw();
     });
+
+    it('should not call _getAddonTemplatesTreeFiles when default treePath is used', function() {
+      addon.root = path.join(fixturePath, 'with-empty-addon-templates');
+      var wasCalled = false;
+      addon._getAddonTemplatesTreeFiles = function() {
+        wasCalled = true;
+        return [];
+      };
+
+      addon.compileTemplates();
+
+      expect(wasCalled).to.not.be.ok;
+    });
+
+    it('should call _getAddonTemplatesTreeFiles when custom treePaths[\'addon-templates\'] is used', function() {
+      addon.root = path.join(fixturePath, 'with-empty-addon-templates');
+      addon.treePaths['addon-templates'] = 'foo';
+      var wasCalled = false;
+      addon._getAddonTemplatesTreeFiles = function() {
+        wasCalled = true;
+        return [];
+      };
+
+      addon.compileTemplates();
+
+      expect(wasCalled).to.be.ok;
+    });
   });
 
   describe('addonDiscovery', function() {


### PR DESCRIPTION
By default `addon-templates` path is `addon/templates/` and would have already been walked when we check `addon/`. This is just wasteful work that is done on first build for each addon.