### PR TITLE
Properly call `preprocessTree` / `postprocessTree` for addons.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -46,7 +46,6 @@ const addonProcessTree = require('../utilities/addon-process-tree');
 let SECRET_DEPRECATION_PREVENTION_SYMBOL = crypto.randomBytes(8).toString('hex');
 
 let DEFAULT_CONFIG = {
-
   storeConfigInMeta: true,
   autoRun: true,
   outputPaths: {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -40,11 +40,13 @@ const omitBy = require('ember-cli-lodash-subset').omitBy;
 const isNull = require('ember-cli-lodash-subset').isNull;
 const Funnel = require('broccoli-funnel');
 const funnelReducer = require('broccoli-funnel-reducer');
-let logger = require('heimdalljs-logger')('ember-cli:ember-app');
+const logger = require('heimdalljs-logger')('ember-cli:ember-app');
+const addonProcessTree = require('../utilities/addon-process-tree');
 
 let SECRET_DEPRECATION_PREVENTION_SYMBOL = crypto.randomBytes(8).toString('hex');
 
 let DEFAULT_CONFIG = {
+
   storeConfigInMeta: true,
   autoRun: true,
   outputPaths: {
@@ -552,15 +554,7 @@ EmberApp.prototype.addonTreesFor = function(type) {
   @return {Tree}        Processed tree
  */
 EmberApp.prototype.addonPostprocessTree = function(type, tree) {
-  let workingTree = tree;
-
-  this.project.addons.forEach(addon => {
-    if (addon.postprocessTree) {
-      workingTree = addon.postprocessTree(type, workingTree);
-    }
-  });
-
-  return workingTree;
+  return addonProcessTree(this.project, 'postprocessTree', type, tree);
 };
 
 
@@ -597,8 +591,7 @@ EmberApp.prototype.addonPostprocessTree = function(type, tree) {
   @return {Tree}        Processed tree
  */
 EmberApp.prototype.addonPreprocessTree = function(type, tree) {
-  return this.project.addons.reduce((workingTree, addon) =>
-    (addon.preprocessTree ? addon.preprocessTree(type, workingTree) : workingTree), tree);
+  return addonProcessTree(this.project, 'preprocessTree', type, tree);
 };
 
 /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -33,6 +33,7 @@ const findAddonByName = require('../utilities/find-addon-by-name');
 const experiments = require('../experiments');
 const heimdall = require('heimdalljs');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+const addonProcessTree = require('../utilities/addon-process-tree');
 
 heimdall.registerMonitor('addon-tree-cache', function AddonTreeCacheSchema() {
   this.hits = 0;
@@ -355,6 +356,83 @@ let addonProto = {
         return addon[methodName].apply(addon, invokeArguments);
       }
     }).filter(Boolean);
+  },
+
+  /**
+     Runs addon post-processing on a given tree and returns the processed tree.
+
+     This enables addons to do process immediately **after** the preprocessor for a
+     given type is run, but before concatenation occurs. If an addon wishes to
+     apply a transform before the preprocessors run, they can instead implement the
+     preprocessTree hook.
+
+     To utilize this addons implement `postprocessTree` hook.
+
+     An example, would be to apply some broccoli transform on all JS files, but
+     only after the existing pre-processors have run.
+
+     ```js
+     module.exports = {
+       name: 'my-cool-addon',
+       postprocessTree: function(type, tree) {
+         if (type === 'js') {
+           return someBroccoliTransform(tree);
+         }
+
+         return tree;
+       }
+     }
+     ```
+
+     @private
+     @method addonPostprocessTree
+     @param  {String} type Type of tree
+     @param  {Tree}   tree Tree to process
+     @return {Tree}        Processed tree
+  */
+  _addonPostprocessTree: function addonPostprocessTree(type, tree) {
+    return this.addons.reduce(function(workingTree, addon) {
+      return addon.postprocessTree ? addon.postprocessTree(type, workingTree) : workingTree;
+    }, tree);
+  },
+
+
+  /**
+     Runs addon pre-processing on a given tree and returns the processed tree.
+
+     This enables addons to do process immediately **before** the preprocessor for a
+     given type is run.  If an addon wishes to apply a transform  after the
+     preprocessors run, they can instead implement the postprocessTree hook.
+
+     To utilize this addons implement `preprocessTree` hook.
+
+     An example, would be to remove some set of files before the preprocessors run.
+
+     ```js
+     var stew = require('broccoli-stew');
+
+     module.exports = {
+       name: 'my-cool-addon',
+       preprocessTree: function(type, tree) {
+         if (type === 'js' && type === 'template') {
+           return stew.rm(tree, someGlobPattern);
+         }
+
+         return tree;
+       }
+     }
+     ```
+
+     @private
+     @method addonPreprocessTree
+     @param  {String} type Type of tree
+     @param  {Tree}   tree Tree to process
+     @return {Tree}        Processed tree
+  */
+  _addonPreprocessTree: function addonPreprocessTree(type, tree) {
+    return this.addons.reduce(function(workingTree, addon) {
+      return addon.preprocessTree ? addon.preprocessTree(type, workingTree) : workingTree;
+    }, tree);
   },
 
   /**
@@ -751,17 +829,21 @@ let addonProto = {
 
     @private
     @method compileStyles
-    @param {Tree} tree Styles file tree
+    @param {Tree} addonStylesTree Styles file tree
     @return {Tree} Compiled styles tree
   */
-  compileStyles(tree) {
+  compileStyles(addonStylesTree) {
     this._requireBuildPackages();
 
-    if (tree) {
-      return preprocessCss(tree, '/', '/', {
+    if (addonStylesTree) {
+      let preprocessedStylesTree = this._addonPreprocessTree('css', addonStylesTree);
+
+      let processedStylesTree = preprocessCss(preprocessedStylesTree, '/', '/', {
         outputPaths: { 'addon': `${this.name}.css` },
         registry: this.registry,
       });
+
+      return this._addonPostprocessTree('css', processedStylesTree);
     }
   },
 
@@ -858,7 +940,7 @@ let addonProto = {
     return [];
   },
 
-  _addonTemplateFiles: function addonTemplateFiles(tree) {
+  _addonTemplateFiles: function addonTemplateFiles(addonTree) {
     this._requireBuildPackages();
 
     if (this._cachedAddonTemplateFiles) {
@@ -882,7 +964,7 @@ let addonProto = {
       let includePatterns = this.registry.extensionsForType('template')
         .map(extension => `**/*/template.${extension}`);
 
-      let podTemplates = new Funnel(tree, {
+      let podTemplates = new Funnel(addonTree, {
         include: includePatterns,
         destDir: `${this.name}/`,
         annotation: 'Funnel: Addon Pod Templates',
@@ -906,7 +988,7 @@ let addonProto = {
     @param {Tree} tree Templates file tree
     @return {Tree} Compiled templates tree
   */
-  compileTemplates(tree) {
+  compileTemplates(addonTree) {
     this._requireBuildPackages();
 
     if (this.shouldCompileTemplates()) {
@@ -916,12 +998,16 @@ let addonProto = {
           `(NOT \`devDependencies\`) in \`${this.name}\`'s \`package.json\`.`);
       }
 
-      let processedTemplateTree = preprocessTemplates(this._addonTemplateFiles(tree), {
+      let preprocessedTemplateTree = this._addonPreprocessTree('template', this._addonTemplateFiles(addonTree));
+
+      let processedTemplateTree = preprocessTemplates(preprocessedTemplateTree, {
         annotation: `compileTemplates(${this.name})`,
         registry: this.registry,
       });
 
-      return processModulesOnly(processedTemplateTree);
+      let postprocessedTemplateTree = this._addonPostprocessTree('template', processedTemplateTree);
+
+      return processModulesOnly(postprocessedTemplateTree);
     }
   },
 
@@ -1054,11 +1140,16 @@ let addonProto = {
     @param {Tree} the tree to preprocess
     @return {Tree} Processed javascript file tree
   */
-  processedAddonJsFiles(tree) {
+  processedAddonJsFiles(addonTree) {
     if (this._fileSystemInfo().hasJSFiles) {
-      let processedJsFiles = this.preprocessJs(this.addonJsFiles(tree), '/', this.name, {
+      let preprocessedAddonJS = this._addonPreprocessTree('js', this.addonJsFiles(addonTree));
+
+      let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
+        annotation: `processedAddonJsFiles(${this.name})`,
         registry: this.registry,
       });
+
+      let postprocessedAddonJs = this._addonPostprocessTree('js', processedAddonJS);
 
       if (!registryHasPreprocessor(this.registry, 'js')) {
         this._warn(`Addon files were detected in \`${this._treePathFor('addon')}\`, but no JavaScript ` +
@@ -1069,10 +1160,10 @@ let addonProto = {
         let options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
 
         const Babel = require('broccoli-babel-transpiler');
-        processedJsFiles = new Babel(processedJsFiles, options);
+        postprocessedAddonJs = new Babel(postprocessedAddonJs, options);
       }
 
-      return processedJsFiles;
+      return postprocessedAddonJs;
     }
   },
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -358,13 +358,12 @@ let addonProto = {
     }).filter(Boolean);
   },
 
-  _addonPostprocessTree: function addonPostprocessTree(type, tree) {
-    return addonProcessTree(this, 'postprocessTree', type, tree);
+  _addonPreprocessTree(type, tree) {
+    return addonProcessTree(this, 'preprocessTree', type, tree);
   },
 
-
-  _addonPreprocessTree: function addonPreprocessTree(type, tree) {
-    return addonProcessTree(this, 'preprocessTree', type, tree);
+  _addonPostprocessTree(type, tree) {
+    return addonProcessTree(this, 'postprocessTree', type, tree);
   },
 
   /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -358,81 +358,13 @@ let addonProto = {
     }).filter(Boolean);
   },
 
-  /**
-     Runs addon post-processing on a given tree and returns the processed tree.
-
-     This enables addons to do process immediately **after** the preprocessor for a
-     given type is run, but before concatenation occurs. If an addon wishes to
-     apply a transform before the preprocessors run, they can instead implement the
-     preprocessTree hook.
-
-     To utilize this addons implement `postprocessTree` hook.
-
-     An example, would be to apply some broccoli transform on all JS files, but
-     only after the existing pre-processors have run.
-
-     ```js
-     module.exports = {
-       name: 'my-cool-addon',
-       postprocessTree: function(type, tree) {
-         if (type === 'js') {
-           return someBroccoliTransform(tree);
-         }
-
-         return tree;
-       }
-     }
-     ```
-
-     @private
-     @method addonPostprocessTree
-     @param  {String} type Type of tree
-     @param  {Tree}   tree Tree to process
-     @return {Tree}        Processed tree
-  */
   _addonPostprocessTree: function addonPostprocessTree(type, tree) {
-    return this.addons.reduce(function(workingTree, addon) {
-      return addon.postprocessTree ? addon.postprocessTree(type, workingTree) : workingTree;
-    }, tree);
+    return addonProcessTree(this, 'postprocessTree', type, tree);
   },
 
 
-  /**
-     Runs addon pre-processing on a given tree and returns the processed tree.
-
-     This enables addons to do process immediately **before** the preprocessor for a
-     given type is run.  If an addon wishes to apply a transform  after the
-     preprocessors run, they can instead implement the postprocessTree hook.
-
-     To utilize this addons implement `preprocessTree` hook.
-
-     An example, would be to remove some set of files before the preprocessors run.
-
-     ```js
-     var stew = require('broccoli-stew');
-
-     module.exports = {
-       name: 'my-cool-addon',
-       preprocessTree: function(type, tree) {
-         if (type === 'js' && type === 'template') {
-           return stew.rm(tree, someGlobPattern);
-         }
-
-         return tree;
-       }
-     }
-     ```
-
-     @private
-     @method addonPreprocessTree
-     @param  {String} type Type of tree
-     @param  {Tree}   tree Tree to process
-     @return {Tree}        Processed tree
-  */
   _addonPreprocessTree: function addonPreprocessTree(type, tree) {
-    return this.addons.reduce(function(workingTree, addon) {
-      return addon.preprocessTree ? addon.preprocessTree(type, workingTree) : workingTree;
-    }, tree);
+    return addonProcessTree(this, 'preprocessTree', type, tree);
   },
 
   /**

--- a/lib/utilities/addon-process-tree.js
+++ b/lib/utilities/addon-process-tree.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function addonProcessTree(projectOrAddon, hook, processType, tree) {
+  return projectOrAddon.addons.reduce((workingTree, addon) => {
+    if (addon[hook]) {
+      return addon[hook](processType, workingTree);
+    }
+
+    return workingTree;
+  }, tree);
+};

--- a/tests/acceptance/nested-addons-smoke-test-slow.js
+++ b/tests/acceptance/nested-addons-smoke-test-slow.js
@@ -52,6 +52,20 @@ describe('Acceptance: nested-addons-smoke-test', function() {
       .then(function() {
         expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_APP_IMPORT');
         expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_THIS_IMPORT');
+
+        // RAW comments should have been converted to PREPROCESSED by
+        // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon
+        // then from PREPROCESSED to POSTPROCESSED by
+        // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon
+        expect(file('dist/assets/vendor.js')).to.contain('POSTPROCESSED node_modules/ember-top-addon/addon/templates/application.hbs');
+        expect(file('dist/assets/vendor.js')).to.contain('POSTPROCESSED node_modules/ember-top-addon/addon/index.js');
+        expect(file('dist/assets/vendor.css')).to.contain('POSTPROCESSED node_modules/ember-top-addon/addon/styles/app.css');
+
+        // the pre/post process tree hooks above should *not* have changed RAW's in the current app
+        expect(file('dist/assets/some-cool-app.js')).to.contain('RAW app/foo.js');
+
+        // should *not* have changed RAW's in sibling addons
+        expect(file('dist/assets/vendor.js')).to.contain('RAW node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js');
       });
   });
 });

--- a/tests/fixtures/addon/with-nested-addons/app/foo.js
+++ b/tests/fixtures/addon/with-nested-addons/app/foo.js
@@ -1,0 +1,1 @@
+// RAW app/foo.js

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/index.js
@@ -1,0 +1,1 @@
+// RAW node_modules/ember-top-addon/addon/index.js

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/styles/app.css
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/styles/app.css
@@ -1,0 +1,1 @@
+/* RAW node_modules/ember-top-addon/addon/styles/app.css */

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/templates/application.hbs
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/addon/templates/application.hbs
@@ -1,0 +1,1 @@
+<!-- RAW node_modules/ember-top-addon/addon/templates/application.hbs -->

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js
@@ -1,0 +1,1 @@
+// RAW node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const stew = require('broccoli-stew');
+
+module.exports = {
+  name: 'postprocesstree-addon',
+
+  postprocessTree(type, tree) {
+    return stew.map(tree, contents => contents.replace('PREPROCESSED', 'POSTPROCESSED'));
+  },
+};

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/package.json
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "postprocesstree-addon",
+  "version": "0.0.0",
+  "private": true,
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+  }
+}

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const stew = require('broccoli-stew');
+
+module.exports = {
+  name: 'preprocesstree-addon',
+
+  preprocessTree(type, tree) {
+    return stew.map(tree, contents => contents.replace('RAW', 'PREPROCESSED'));
+  },
+};

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/package.json
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "preprocesstree-addon",
+  "version": "0.0.0",
+  "private": true,
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+  }
+}

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/package.json
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/package.json
@@ -7,6 +7,9 @@
   ],
   "dependencies": {
     "ember-inner-addon": "latest",
-    "ember-inner-addon2": "latest"
+    "ember-inner-addon2": "latest",
+    "ember-cli-htmlbars": "*",
+    "preprocesstree-addon": "*",
+    "postprocesstree-addon": "*"
   }
 }


### PR DESCRIPTION
This fixes an oversight that prevented addons from properly invoking the same `preprocessTree` / `postprocessTree` hooks that were added for apps.

TODO:

- [x] The implementations for `_addonPreprocessTree` and `_addonPostprocessTree` should be extracted to a util shared with `lib/broccoli/ember-app.js`.
- [x] Types
  - [x] `js` (run for `this.treePaths['addon']`)
  - [x] `css` (run for `this.treePaths['addon-styles']`)
  - [X] `template` (run for `this.treePaths['addon-templates']`)
- [x] Tests for all types.