### PR TITLE
Avoid pod template processing for addons without pod templates.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -632,12 +632,45 @@ var Addon = CoreObject.extend({
     @return {Boolean} indicates if templates need to be compiled for this addon
   */
   shouldCompileTemplates: function() {
+    return this._detectTemplateInfo().hasTemplates;
+  },
+
+  /**
+     Looks in the addon/ and addon/templates trees to determine if template files
+     exists in the pods format that need to be precompiled.
+
+     This is executed once when building, but not on rebuilds.
+
+     @private
+     @method _shouldCompilePodTemplates
+     @return {Boolean} indicates if pod based templates need to be compiled for this addon
+  */
+  _shouldCompilePodTemplates: function() {
+    return this._detectTemplateInfo().hasPodTemplates;
+  },
+
+  _detectTemplateInfo: function() {
+    if (this._cachedTemplateInfo) {
+      return this._cachedTemplateInfo;
+    }
+
     var templateExtensions = this.registry.extensionsForType('template');
     var addonTreePath = this._treePathFor('addon');
     var addonTemplatesTreePath = this._treePathFor('addon-templates');
     var addonTemplatesTreeInAddonTree = addonTemplatesTreePath.indexOf(addonTreePath) === 0;
 
     var files = this._getAddonTreeFiles();
+
+    var addonTemplatesRelativeToAddonPath = addonTemplatesTreeInAddonTree && addonTemplatesTreePath.replace(addonTreePath + '/', '');
+    var podTemplateMatcher = new RegExp('template\.(' + templateExtensions.join('|') + ')$');
+    var hasPodTemplates = files.some(function(file) {
+      // short curcuit if this is actually a `addon/templates` file
+      if (addonTemplatesTreeInAddonTree && file.indexOf(addonTemplatesRelativeToAddonPath) === 0) {
+        return false;
+      }
+
+      return file.match(podTemplateMatcher);
+    });
 
     if (!addonTemplatesTreeInAddonTree) {
       files = files.concat(this._getAddonTemplatesTreeFiles());
@@ -646,10 +679,16 @@ var Addon = CoreObject.extend({
     files = files.filter(Boolean);
 
     var extensionMatcher = new RegExp('(' + templateExtensions.join('|') + ')$');
-
-    return files.some(function(file) {
+    var hasTemplates = files.some(function(file) {
       return file.match(extensionMatcher);
     });
+
+    this._cachedTemplateInfo = {
+      hasTemplates: hasTemplates,
+      hasPodTemplates: hasPodTemplates
+    };
+
+    return this._cachedTemplateInfo;
   },
 
   _getAddonTreeFiles: function() {
@@ -692,17 +731,19 @@ var Addon = CoreObject.extend({
       trees.push(standardTemplates);
     }
 
-    var includePatterns = this.registry.extensionsForType('template').map(function(extension) {
-      return '**/*/template.' + extension;
-    });
+    if (this._shouldCompilePodTemplates()) {
+      var includePatterns = this.registry.extensionsForType('template').map(function(extension) {
+        return '**/*/template.' + extension;
+      });
 
-    var podTemplates = new Funnel(tree, {
-      include: includePatterns,
-      destDir: 'modules/' + this.name + '/',
-      annotation: 'Funnel: Addon Pod Templates'
-    });
+      var podTemplates = new Funnel(tree, {
+        include: includePatterns,
+        destDir: 'modules/' + this.name + '/',
+        annotation: 'Funnel: Addon Pod Templates'
+      });
 
-    trees.push(podTemplates);
+      trees.push(podTemplates);
+    }
 
     this._cachedAddonTemplateFiles = mergeTrees(trees, {
       annotation: 'TreeMerge (' + this.name + ' templates)'


### PR DESCRIPTION
This turned out to be a significant performance issue, and the majority of addons do not have pod templates. This lets us opt-out of the work when possible...

TODO:

- [x] Properly detect `addon/templates` and ensure `shouldCompilePodTemplates` does not falsely return true when only `addon/templates` templates exist.
- [x] Tests
  - [x] Test with addon/templates templates, but no pods based templates
  - [x] Test with addon pods based templates but no addon/templates
  - [x] Test with both addon pods based templates and addon/templates templates
- [x] Rebase on top of https://github.com/ember-cli/ember-cli/pull/6515