### PR TITLE
Improve Windows Symlink Related messaging

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Command = require('../models/command');
-var win     = require('../utilities/windows-admin');
+var Win = require('../utilities/windows-admin');
 
 module.exports = Command.extend({
   name: 'build',
@@ -28,7 +28,7 @@ module.exports = Command.extend({
       ui: this.ui
     });
 
-    return win.checkWindowsElevation(this.ui).then(function () {
+    return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(function () {
       return buildTask.run(commandOptions)
         .then(function () {
           if (!commandOptions.suppressSizes && commandOptions.environment === 'production') {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,7 +5,7 @@ var Command     = require('../models/command');
 var Promise     = require('../ext/promise');
 var SilentError = require('silent-error');
 var PortFinder  = require('portfinder');
-var win         = require('../utilities/windows-admin');
+var Win         = require('../utilities/windows-admin');
 var EOL         = require('os').EOL;
 
 PortFinder.basePort = 49152;
@@ -72,7 +72,7 @@ module.exports = Command.extend({
           project: this.project
         });
 
-        return win.checkWindowsElevation(this.ui).then(function() {
+        return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(function() {
           return serve.run(commandOptions);
         });
       }.bind(this));

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -5,7 +5,7 @@ var Watcher     = require('../models/watcher');
 var Builder     = require('../models/builder');
 var SilentError = require('silent-error');
 var path        = require('path');
-var win         = require('../utilities/windows-admin');
+var Win         = require('../utilities/windows-admin');
 var existsSync  = require('exists-sync');
 var assign      = require('ember-cli-lodash-subset').assign;
 var defaultPort = 7357;
@@ -128,7 +128,7 @@ module.exports = Command.extend({
       project: this.project
     };
 
-    return win.checkWindowsElevation(this.ui).then(function() {
+    return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(function() {
       var session;
 
       if (commandOptions.server) {

--- a/lib/utilities/windows-admin.js
+++ b/lib/utilities/windows-admin.js
@@ -2,40 +2,134 @@
 
 var Promise = require('../ext/promise');
 var chalk   = require('chalk');
-var exec    = require('child_process').exec;
 
-module.exports = {
-  /**
-   * Uses the eon-old command NET SESSION to determine whether or not the
-   * current user has elevated rights (think sudo, but Windows).
-   *
-   * @method checkWindowsElevation
-   * @param  {Object} ui - ui object used to call writeLine();
-   * @return {Object} Object describing whether we're on windows and if admin rights exist
-   */
-  checkWindowsElevation: function (ui) {
-    return new Promise(function (resolve) {
-      if (/^win/.test(process.platform)) {
-        exec('NET SESSION', function (error, stdout, stderr) {
-          var elevated = (!stderr || stderr.length === 0);
+module.exports = WindowsSymlinkChecker;
 
-          if (!elevated && ui && ui.writeLine) {
-            ui.writeLine(chalk.yellow('\nRunning without elevated rights. ' +
-              'Running Ember CLI "as Administrator" increases performance significantly.'));
-            ui.writeLine('See ember-cli.com/user-guide/#windows for details.\n');
-          }
+/**
+ *
+ * On windows users will have a much better experience if symlinks are enabled
+ * an usable. This object when queried informs windows users, if they can
+ * improve there build performance, and how.
+ *
+ *  > Windows vista: nothing we can really do, so we fall back to junctions for folders + copying of files
+ *  <= Windows vista: symlinks are available but using them is somewhat tricky
+ *    * if the users is an admin, the process needed to have been started with elevated privs
+ *    * if the user is not an admin, a specific setting needs to be enabled
+ *  <= Windows 10 Insiders build 14972
+ *    * if developer mode is enabled, symlinks "just work"
+ *    * https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10
+ *
+ * ```js
+ * let checker = WindowsSymlinkChecker;
+ * let {
+ *   windows,
+ *   elevated
+ * } = await = checker.checkIfSymlinksNeedToBeEnabled(); // aslso emits helpful warnings
+ * ```
+ *
+ * @public
+ * @class WindowsSymlinkChecker
+ */
+function WindowsSymlinkChecker(ui, isWindows, canSymlink, exec) {
+  this.ui = ui;
+  this.isWindows = isWindows;
+  this.canSymlink = canSymlink;
+  this.exec = exec;
+}
 
-          resolve({
-            windows: true,
-            elevated: elevated
-          });
-        });
-      } else {
-        resolve({
-          windows: false,
-          elevated: null
-        });
+/**
+ *
+ * if not windows, will fulfill with:
+ *  `{ windows: false, elevated: null)`
+ *
+ * if windows, and elevated will fulfill with:
+ *  `{ windows: false, elevated: true)`
+ *
+ * if windows, and is NOT elevated will fulfill with:
+ *  `{ windows: false, elevated: false)`
+ *
+ *  will include heplful warning, so that users know (if possible) how to
+ *  achieve better windows build performance
+ *
+ * @public
+ * @method checkIfSymlinksNeedToBeEnabled
+ * @return {Promise<Object>} Object describing whether we're on windows and if admin rights exist
+ */
+WindowsSymlinkChecker.checkIfSymlinksNeedToBeEnabled = function(ui) {
+  return this._setup(ui).checkIfSymlinksNeedToBeEnabled();
+};
+
+/**
+ * sets up a WindowsSymlinkChecker
+ *
+ * providing it with defaults for:
+ *
+ * * if we are on windows
+ * * if we can symlink
+ * * a reference to exec
+ *
+ * @private
+ * @method _setup
+ * @param UI {UI}
+ * @return {WindowsSymlinkChecker}
+ */
+WindowsSymlinkChecker._setup = function(ui) {
+  var exec          = require('child_process').exec;
+  var symlinkOrCopy = require('symlink-or-copy');
+
+  return new WindowsSymlinkChecker(ui, /^win/.test(process.platform), symlinkOrCopy.canSymlink, exec)
+};
+
+/**
+ * @public
+ * @method checkIfSymlinksNeedToBeEnabled
+ * @return {Promise<Object>} Object describing whether we're on windows and if admin rights exist
+ */
+WindowsSymlinkChecker.prototype.checkIfSymlinksNeedToBeEnabled = function() {
+  return new Promise(function(resolve) {
+    if (!this.isWindows) {
+      resolve({
+        windows: false,
+        elevated: null
+      });
+    } else if (this.canSymlink) {
+      resolve({
+        windows: true,
+        elevated: null
+      });
+    } else {
+      resolve(this._checkForElevatedRights(this.ui));
+    }
+  }.bind(this));
+};
+
+/**
+ *
+ * Uses the eon-old command NET SESSION to determine whether or not the
+ * current user has elevated rights (think sudo, but Windows).
+ *
+ * @private
+ * @method _checkForElevatedRights
+ * @param  {Object} ui - ui object used to call writeLine();
+ * @return {Object} Object describing whether we're on windows and if admin rights exist
+ */
+WindowsSymlinkChecker.prototype._checkForElevatedRights = function () {
+  var ui = this.ui;
+  var exec = this.exec;
+
+  return new Promise(function (resolve) {
+    exec('NET SESSION', function (error, stdout, stderr) {
+      var elevated = (!stderr || stderr.length === 0);
+
+      if (!elevated) {
+        ui.writeLine(chalk.yellow('\nRunning without permission to symlink will degrade build peformance.'));
+        ui.writeLine('See http://ember-cli.com/user-guide/#windows for details.\n');
       }
+
+      resolve({
+        windows: true,
+        elevated: elevated
+      });
     });
-  }
+  });
 };

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "semver": "^5.1.1",
     "silent-error": "^1.0.0",
     "sort-package-json": "^1.4.0",
-    "symlink-or-copy": "^1.0.1",
+    "symlink-or-copy": "^1.1.8",
     "temp": "0.8.3",
     "testem": "^1.8.1",
     "tiny-lr": "^1.0.3",

--- a/tests/unit/utilities/windows-admin-test.js
+++ b/tests/unit/utilities/windows-admin-test.js
@@ -1,41 +1,106 @@
 'use strict';
 
-var win = require('../../../lib/utilities/windows-admin');
+var WindowsSymlinkChecker = require('../../../lib/utilities/windows-admin');
 var expect = require('chai').expect;
 var MockUI = require('console-ui/mock');
+var td = require('testdouble');
+var symlinkOrCopy = require('symlink-or-copy');
 
 describe('windows-admin', function() {
-  before(function() {
-    this.originalPlatform = process.platform;
+  var ui;
+
+  beforeEach(function() {
+    ui = new MockUI();
   });
 
-  after(function () {
-    Object.defineProperty(process, 'platform', {
-      value: this.originalPlatform
+  describe('on windows', function() {
+    var isWindows = true;
+
+    describe('can symlink', function() {
+      var canSymlink = true;
+
+      it('attempts to determine admin rights if Windows', function() {
+        var exec = td.function('exec');
+
+        var checker = new WindowsSymlinkChecker(ui, isWindows, canSymlink, exec);
+
+        return checker.checkIfSymlinksNeedToBeEnabled().then(function(result) {
+          expect(result).to.be.ok;
+          expect(result.windows).to.be.eql(true);
+          expect(result.elevated).to.be.eql(null);
+          td.verify(exec(), { times: 0 });
+          expect(ui.output).to.eql('');
+        });
+      });
+    });
+
+    describe('cannot symlink', function() {
+      var canSymlink = false;
+
+      describe('attempts to determine admin rights', function() {
+        it('gets STDERR during NET SESSION exec', function() {
+          var exec = td.function('exec');
+          td.when(exec('NET SESSION', td.callback(null, null, 'error'))).thenReturn();
+
+          var checker = new WindowsSymlinkChecker(ui, isWindows, canSymlink, exec);
+
+          return checker.checkIfSymlinksNeedToBeEnabled().then(function(result) {
+            expect(result.windows, 'is windows').to.be.eql(true)
+            expect(result.elevated, 'is not elevated').to.be.eql(false);
+            td.verify(exec(td.matchers.contains('NET SESSION'), td.matchers.anything()), { times: 1 });
+            expect(ui.output).to.match(/Running without permission to symlink will degrade build peformance/);
+            expect(ui.output).to.match(/See http\:\/\/ember-cli\.com\/user-guide\/#windows for details./);
+          });
+        });
+
+        it('gets no stdrrduring NET  SESSION exec', function() {
+          var exec = td.function('exec');
+          td.when(exec('NET SESSION', td.callback(null, null, null))).thenReturn();
+
+          var checker = new WindowsSymlinkChecker(ui, isWindows, canSymlink, exec);
+
+          return checker.checkIfSymlinksNeedToBeEnabled().then(function(result) {
+            expect(result.windows, 'is windows').to.be.eql(true)
+            expect(result.elevated, 'is elevated').to.be.eql(true);
+            td.verify(exec(td.matchers.contains('NET SESSION'), td.matchers.anything()), { times: 1 });
+            expect(ui.output).to.eql('');
+          });
+        });
+      });
     });
   });
 
-  it('attempts to determine admin rights if Windows', function(done) {
-    Object.defineProperty(process, 'platform', {
-      value: 'win'
-    });
+  describe('on linux', function() {
+    var isWindows = false;
+    var canSymlink = true;
 
-    win.checkWindowsElevation(new MockUI()).then(function (result) {
-      expect(result).to.be.ok;
-      expect(result.windows).to.be.true;
-      done();
+    it('does not attempt to determine admin', function() {
+      var exec = td.function('exec');
+      var checker = new WindowsSymlinkChecker(ui, isWindows, canSymlink, exec);
+
+      return checker.checkIfSymlinksNeedToBeEnabled().then(function(result) {
+        expect(result.windows).to.be.eql(false);
+        expect(result.elevated).to.be.eql(null);
+        expect(td.explain(exec).callCount).to.eql(0);
+        expect(ui.output).to.eql('');
+      });
     });
   });
 
-  it('does not attempt to determine admin rights if not on Windows', function(done) {
-    Object.defineProperty(process, 'platform', {
-      value: 'MockOS'
-    });
+  describe('on darwin', function() {
+    var isWindows = false;
+    var canSymlink = true;
 
-    win.checkWindowsElevation(new MockUI()).then(function (result) {
-      expect(result).to.be.ok;
-      expect(result.windows).to.be.false;
-      done();
+    it('does not attempt to determine admin', function() {
+      var checker = new WindowsSymlinkChecker(ui, isWindows, canSymlink /* exec spy */);
+      var exec = td.function('exec');
+
+      return checker.checkIfSymlinksNeedToBeEnabled().then(function(result) {
+        expect(result.windows).to.be.eql(false);
+        expect(result.elevated).to.be.eql(null);
+        expect(td.explain(exec).callCount).to.eql(0);
+        expect(ui.output).to.eql('');
+      });
     });
   });
 });


### PR DESCRIPTION
* refactor to be more testable (but maintain same external API)
* improve tests
* don’t warn if canSymlink is already true (may have: https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/ setup, or some other mechanism)
* make sure the URL is formatted correctly

- [x] fix YUIDoc lint issue
- [x] get reviews

--- 


- [x] issue to update website: https://github.com/ember-cli/ember-cli.github.io/issues/113