### PR TITLE
[BUGFIX beta] Ensure `--no-color` option is present for all commands.

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -26,6 +26,12 @@ var allowedWorkOptions = {
   everywhere: true
 };
 
+var globallyAllowedOptions = [
+  'argv',  // Why?
+  'h',     // -h
+  'help'   // --help
+];
+
 path.name = 'Path';
 // extend nopt to recognize 'gitUrl' as a type
 nopt.typeDefs.gitUrl = {
@@ -132,6 +138,13 @@ var Command = CoreObject.extend({
      * ```
      */
     this.availableOptions = this.availableOptions || [];
+    this.availableOptions.push({
+      name: 'no-color',
+      type: Boolean,
+      default: false,
+      aliases: [ ],
+      description: 'To disable usage of colors in the output.'
+    });
 
     /**
      * An array of anonymous options for the command
@@ -476,8 +489,7 @@ var Command = CoreObject.extend({
     };
 
     var validateParsed = function(key) {
-      // ignore 'argv', 'h', and 'help'
-      if (!commandOptions.hasOwnProperty(key) && key !== 'argv' && key !== 'h' && key !== 'help') {
+      if (!commandOptions.hasOwnProperty(key) && globallyAllowedOptions.indexOf(key) === -1) {
         this.ui.writeLine(chalk.yellow('The option \'--' + key + '\' is not registered with the ' + this.name + ' command. ' +
                                        'Run `ember ' + this.name + ' --help` for a list of supported options.'));
       }

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -140,6 +140,13 @@ describe('models/command.js', function() {
     });
   });
 
+  it('parseArgs() should allow --no-color option', function() {
+    new ServeCommand(assign(options, {
+      settings: config.getAll()
+    })).parseArgs(['--no-color']);
+    expect(ui.output).to.not.match(/is not registered with the serve command/);
+  });
+
   it('parseArgs() should warn if an option is invalid.', function() {
     new ServeCommand(assign(options, {
       settings: config.getAll()

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -114,7 +114,8 @@ describe('models/command.js', function() {
         host: '0.1.0.1',
         proxy: 'http://iamstef.net/ember-cli',
         liveReload: false,
-        checkForUpdates: true
+        checkForUpdates: true,
+        noColor: false
       },
       args: []
     });
@@ -135,7 +136,8 @@ describe('models/command.js', function() {
         proxy: 'http://iamstef.net/ember-cli',
         liveReload: false,
         port: 80,
-        checkForUpdates: true
+        checkForUpdates: true,
+        noColor: false
       }
     });
   });
@@ -216,7 +218,8 @@ describe('models/command.js', function() {
     expect(new OptionsAliasCommand(options).parseArgs(['-soft-shell'])).to.deep.equal({
       options: {
         taco: 'soft-shell',
-        spicy: true
+        spicy: true,
+        noColor: false
       },
       args: []
     });
@@ -226,7 +229,8 @@ describe('models/command.js', function() {
     expect(new OptionsAliasCommand(options).parseArgs(['-so'])).to.deep.equal({
       options: {
         taco: 'soft-shell',
-        spicy: true
+        spicy: true,
+        noColor: false
       },
       args: []
     });
@@ -237,7 +241,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        displayMessage: 'hi'
+        displayMessage: 'hi',
+        noColor: false
       },
       args: []
     });
@@ -246,7 +251,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        displayMessage: 'Hello world'
+        displayMessage: 'Hello world',
+        noColor: false
       },
       args: []
     });
@@ -271,7 +277,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'adobada'
+        filling: 'adobada',
+        noColor: false
       },
       args: []
     });
@@ -280,7 +287,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'carne-asada'
+        filling: 'carne-asada',
+        noColor: false
       },
       args: []
     });
@@ -289,7 +297,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'fish'
+        filling: 'fish',
+        noColor: false
       },
       args: []
     });
@@ -323,7 +332,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'adobada'
+        filling: 'adobada',
+        noColor: false
       },
       args: []
     });
@@ -332,7 +342,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'carne-asada'
+        filling: 'carne-asada',
+        noColor: false
       },
       args: []
     });
@@ -342,7 +353,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'carnitas'
+        filling: 'carnitas',
+        noColor: false
       },
       args: []
     });
@@ -351,7 +363,8 @@ describe('models/command.js', function() {
       options: {
         taco: 'traditional',
         spicy: true,
-        filling: 'pollo-asado'
+        filling: 'pollo-asado',
+        noColor: false
       },
       args: []
     });
@@ -526,6 +539,15 @@ describe('models/command.js', function() {
         required: false
       },
       {
+        aliases: [],
+        default: false,
+        description: "To disable usage of colors in the output.",
+        key: "noColor",
+        name: "no-color",
+        required: false,
+        type: Boolean
+      },
+      {
         name: 'spicy',
         type: Boolean,
         default: true,
@@ -555,7 +577,8 @@ describe('models/command.js', function() {
     expect(new OptionsAliasCommand(options).parseArgs(['-s', 'false', '-t', 'hard-shell'])).to.deep.equal({
       options: {
         taco: 'hard-shell',
-        spicy: false
+        spicy: false,
+        noColor: false
       },
       args: []
     });


### PR DESCRIPTION
Using this option has always worked to disable `chalk` from actually emitting colored output (and therefore already has the desired effect), but it would emit a warning to the user when used suggesting that the option was not valid.

This adds `--no-color` as a global option to all commands, and adds a test to ensure that no warning is printed when it is used.

Addresses part of https://github.com/ember-cli/rfcs/issues/83.