### PR TITLE
Remove arbitrary *.js filtering for addon tree.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -851,12 +851,7 @@ var Addon = CoreObject.extend({
   addonJsFiles: function(tree) {
     this._requireBuildPackages();
 
-    var includePatterns = this.registry.extensionsForType('js').map(function(extension) {
-      return new RegExp(extension + '$');
-    });
-
     return new Funnel(tree, {
-      include: includePatterns,
       destDir: 'modules/' + this.moduleName(),
       description: 'Funnel: Addon JS'
     });


### PR DESCRIPTION
This seems like a needless waste of time/effort. `broccoli-filter` inheritors already intelligently handle files from unknown types ( they simply pass through untouched) and filtering here like this is fairly costly.