### PR TITLE
Replace JSHint with ESLint

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -131,7 +131,7 @@ module.exports = Command.extend({
         if (!commandOptions.skipNpm) {
           return addonInstall.run({
             verbose: commandOptions.verbose,
-            packages: ['ember-cli-jshint']
+            packages: ['ember-cli-eslint@2']
           });
         }
       })


### PR DESCRIPTION
This PR replaces `ember-cli-jshint` with `ember-cli-eslint` in the default app/addon blueprints.

Resolves #6501 and unblocks #3529 🎉 

/cc @nathanhammond @stefanpenner @rwjblue @alexlafroscia @BrianSipple 