### PR TITLE
Fix addon pod template detection on windows.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -25,6 +25,7 @@ var Project = require('./project');
 var mergeTrees = require('../broccoli/merge-trees');
 var Funnel     = require('broccoli-funnel');
 var walkSync   = require('walk-sync');
+var ensurePosixPath = require('ensure-posix-path');
 
 function warn(message) {
   if (this.ui) {
@@ -294,7 +295,11 @@ var Addon = CoreObject.extend({
   },
 
   _treePathFor: function _treePathFor(treeName) {
-    return path.normalize(path.join(this.root, this.treePaths[treeName]));
+    var treePath = this.treePaths[treeName];
+    var absoluteTreePath = path.join(this.root, treePath);
+    var normalizedAbsoluteTreePath = path.normalize(absoluteTreePath);
+
+    return ensurePosixPath(normalizedAbsoluteTreePath);
   },
 
   /* @private

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-try": "^0.2.6",
+    "ensure-posix-path": "^1.0.2",
     "escape-string-regexp": "^1.0.3",
     "execa": "^0.4.0",
     "exists-sync": "0.0.4",

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -19,6 +19,7 @@ var root    = process.cwd();
 var tmproot = path.join(root, 'tmp');
 
 var fixturePath = path.resolve(__dirname, '../../fixtures/addon');
+var ensurePosixPath = require('ensure-posix-path');
 
 describe('models/addon.js', function() {
   var addon, project, projectPath;
@@ -110,7 +111,7 @@ describe('models/addon.js', function() {
         addon.root = root;
 
         addon.jshintAddonTree();
-        expect(addonPath).to.eql(path.join(root, 'addon'));
+        expect(addonPath).to.eql(ensurePosixPath(path.join(root, 'addon')));
       });
 
       it('lints the files before preprocessing', function() {


### PR DESCRIPTION
When run under windows, the path separator used by `path.join` in `this._treePathFor` will be `\` which will reek havoc on later path manipulation logic (e.g. when we attempt to determine if `addon-templates` tree is within `addon` tree).