### PR TITLE
Prevent running babel twice.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -920,17 +920,10 @@ EmberApp.prototype._addonTree = function _addonTree() {
     annotation: 'TreeMerger (addons)'
   });
 
-  var addonES6 = new Funnel(addonTrees, {
+  var addonTranspiledModules = new Funnel(addonTrees, {
     srcDir: 'modules',
     allowEmpty: true,
     annotation: 'Funnel: Addon JS'
-  });
-
-  var transpiledAddonTree = new Babel(addonES6, this._prunedBabelOptions());
-  var trees = [ transpiledAddonTree ];
-
-  var reexportsAndTranspiledAddonTree = mergeTrees(trees, {
-    annotation: 'TreeMerger: (re-exports)'
   });
 
   return this._cachedAddonTree = [
@@ -941,7 +934,7 @@ EmberApp.prototype._addonTree = function _addonTree() {
       annotation: 'Concat: Addon CSS'
     }),
 
-    this._concatFiles(reexportsAndTranspiledAddonTree, {
+    this._concatFiles(addonTranspiledModules, {
       inputFiles: ['**/*.js'],
       outputFile: '/addons.js',
       allowNone: true,

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -28,6 +28,7 @@ var walkSync   = require('walk-sync');
 var ensurePosixPath = require('ensure-posix-path');
 var defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
 var Babel = require('broccoli-babel-transpiler');
+var findAddonByName = require('../utilities/find-addon-by-name');
 
 function warn(message) {
   if (this.ui) {
@@ -143,13 +144,15 @@ var Addon = CoreObject.extend({
 
     this.options = defaultsDeep(this.options, {
       babel: {
-        // TODO: coordinate with @turbo87 on exactly how to do
-        // this without issuing a deprecation
-        compileModules: true,
         modules: 'amdStrict',
         moduleIds: true,
         resolveModuleSource: require('amd-name-resolver').moduleResolve
       }
+    });
+
+    var emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
+    this.options[emberCLIBabelConfigKey] = defaultsDeep(this.options[emberCLIBabelConfigKey], {
+      compileModules: true
     });
   },
 
@@ -331,6 +334,18 @@ var Addon = CoreObject.extend({
    * @method _warn
    */
   _warn: warn,
+
+  _emberCLIBabelConfigKey: function() {
+    // future versions of ember-cli-babel will be moving the location for its
+    // own configuration options out of `babel` and will be issuing a deprecation
+    // if used in the older way
+    //
+    // see: https://github.com/babel/ember-cli-babel/pull/105
+    var emberCLIBabelInstance = findAddonByName(this.addons, 'ember-cli-babel');
+    var emberCLIBabelConfigKey = (emberCLIBabelInstance && emberCLIBabelInstance.configKey) || 'babel';
+
+    return emberCLIBabelConfigKey;
+  },
 
   /**
     Returns a given type of tree (if present), merged with the
@@ -829,8 +844,13 @@ var Addon = CoreObject.extend({
   compileAddon: function(tree) {
     this._requireBuildPackages();
 
-    if (!this.options.babel.compileModules) {
-      throw new Error('y u clobber!?!!?!');
+    var emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
+    if (!this.options[emberCLIBabelConfigKey].compileModules) {
+      throw new SilentError(
+        'Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. ' +
+          '`' + this.name + '` has overridden the `this.options.' + emberCLIBabelConfigKey + '.compileModules` ' +
+          'value which conflicts with the addons ability to transpile its `addon/` files properly.'
+      );
     }
 
     var addonJs = this.processedAddonJsFiles(tree);

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -26,6 +26,7 @@ var mergeTrees = require('../broccoli/merge-trees');
 var Funnel     = require('broccoli-funnel');
 var walkSync   = require('walk-sync');
 var ensurePosixPath = require('ensure-posix-path');
+var defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
 
 function warn(message) {
   if (this.ui) {
@@ -126,6 +127,17 @@ var Addon = CoreObject.extend({
     if (!this.name) {
       throw new SilentError('An addon must define a `name` property.');
     }
+
+    this.options = defaultsDeep(this.options, {
+      babel: {
+        // TODO: coordinate with @turbo87 on exactly how to do
+        // this without issuing a deprecation
+        compileModules: true,
+        modules: 'amdStrict',
+        moduleIds: true,
+        resolveModuleSource: require('amd-name-resolver').moduleResolve
+      }
+    });
   },
 
   hintingEnabled: function() {
@@ -730,7 +742,7 @@ var Addon = CoreObject.extend({
     if (addonTemplates) {
       standardTemplates = new Funnel(addonTemplates, {
         srcDir: '/',
-        destDir: 'modules/' + this.name + '/templates'
+        destDir: this.name + '/templates'
       });
 
       trees.push(standardTemplates);
@@ -743,7 +755,7 @@ var Addon = CoreObject.extend({
 
       var podTemplates = new Funnel(tree, {
         include: includePatterns,
-        destDir: 'modules/' + this.name + '/',
+        destDir: this.name + '/',
         annotation: 'Funnel: Addon Pod Templates'
       });
 
@@ -797,15 +809,22 @@ var Addon = CoreObject.extend({
   compileAddon: function(tree) {
     this._requireBuildPackages();
 
-    var reexported;
+    if (!this.options.babel.compileModules) {
+      throw new Error('y u clobber!?!!?!');
+    }
 
     var addonJs = this.processedAddonJsFiles(tree);
     var templatesTree = this.compileTemplates(tree);
 
-    var trees = [addonJs, templatesTree, reexported].filter(Boolean);
+    var trees = [addonJs, templatesTree].filter(Boolean);
 
-    return mergeTrees(trees, {
+    var combinedJSAndTemplates = mergeTrees(trees, {
       annotation: 'Addon#compileAddon(' + this.name + ') '
+    });
+
+    return new Funnel(combinedJSAndTemplates, {
+      destDir: 'modules/',
+      annotation: 'Funnel: compileAddon'
     });
   },
 
@@ -852,7 +871,7 @@ var Addon = CoreObject.extend({
     this._requireBuildPackages();
 
     return new Funnel(tree, {
-      destDir: 'modules/' + this.moduleName(),
+      destDir: this.moduleName(),
       description: 'Funnel: Addon JS'
     });
   },

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -27,6 +27,7 @@ var Funnel     = require('broccoli-funnel');
 var walkSync   = require('walk-sync');
 var ensurePosixPath = require('ensure-posix-path');
 var defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
+var Babel = require('broccoli-babel-transpiler');
 
 function warn(message) {
   if (this.ui) {
@@ -791,9 +792,15 @@ var Addon = CoreObject.extend({
                               '`' + this.name + '`\'s `package.json`.');
       }
 
-      return preprocessTemplates(this._addonTemplateFiles(tree), {
+      var processedTemplateTree = preprocessTemplates(this._addonTemplateFiles(tree), {
         annotation: 'compileTemplates(' + this.name + ')',
         registry: this.registry
+      });
+
+      return new Babel(processedTemplateTree, {
+        modules: 'amdStrict',
+        moduleIds: true,
+        whitelist: ['es6.modules']
       });
     }
   },

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -30,6 +30,12 @@ var defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
 var Babel = require('broccoli-babel-transpiler');
 var findAddonByName = require('../utilities/find-addon-by-name');
 
+var DEFAULT_BABEL_CONFIG = {
+  modules: 'amdStrict',
+  moduleIds: true,
+  resolveModuleSource: require('amd-name-resolver').moduleResolve
+};
+
 function warn(message) {
   if (this.ui) {
     this.ui.writeDeprecateLine(message);
@@ -51,11 +57,10 @@ function deprecatedAddonFilters(addon, name, insteadUse, fn) {
 }
 
 function processModulesOnly(tree) {
-  return new Babel(tree, {
-    modules: 'amdStrict',
-    moduleIds: true,
-    whitelist: ['es6.modules']
-  });
+  var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
+  options.whitelist = ['es6.modules'];
+
+  return new Babel(tree, options);
 }
 
 function registryHasPreprocessor(registry, type) {
@@ -143,11 +148,7 @@ var Addon = CoreObject.extend({
     }
 
     this.options = defaultsDeep(this.options, {
-      babel: {
-        modules: 'amdStrict',
-        moduleIds: true,
-        resolveModuleSource: require('amd-name-resolver').moduleResolve
-      }
+      babel: DEFAULT_BABEL_CONFIG
     });
 
     var emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
@@ -848,7 +849,7 @@ var Addon = CoreObject.extend({
     if (!this.options[emberCLIBabelConfigKey].compileModules) {
       throw new SilentError(
         'Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. ' +
-          '`' + this.name + '` has overridden the `this.options.' + emberCLIBabelConfigKey + '.compileModules` ' +
+          '`' + this.name + '` (found at `' + this.root + '`) has overridden the `this.options.' + emberCLIBabelConfigKey + '.compileModules` ' +
           'value which conflicts with the addons ability to transpile its `addon/` files properly.'
       );
     }

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -49,6 +49,18 @@ function deprecatedAddonFilters(addon, name, insteadUse, fn) {
   };
 }
 
+function processModulesOnly(tree) {
+  return new Babel(tree, {
+    modules: 'amdStrict',
+    moduleIds: true,
+    whitelist: ['es6.modules']
+  });
+}
+
+function registryHasPreprocessor(registry, type) {
+  return !!registry.load(type).length;
+}
+
 /**
   Root class for an Addon. If your addon module exports an Object this
   will be extended from this base class. If you export a constructor (function),
@@ -650,7 +662,7 @@ var Addon = CoreObject.extend({
     @return {Boolean} indicates if templates need to be compiled for this addon
   */
   shouldCompileTemplates: function() {
-    return this._detectTemplateInfo().hasTemplates;
+    return this._fileSystemInfo().hasTemplates;
   },
 
   /**
@@ -664,14 +676,15 @@ var Addon = CoreObject.extend({
      @return {Boolean} indicates if pod based templates need to be compiled for this addon
   */
   _shouldCompilePodTemplates: function() {
-    return this._detectTemplateInfo().hasPodTemplates;
+    return this._fileSystemInfo().hasPodTemplates;
   },
 
-  _detectTemplateInfo: function() {
+  _fileSystemInfo: function() {
     if (this._cachedTemplateInfo) {
       return this._cachedTemplateInfo;
     }
 
+    var jsExtensions = this.registry.extensionsForType('js');
     var templateExtensions = this.registry.extensionsForType('template');
     var addonTreePath = this._treePathFor('addon');
     var addonTemplatesTreePath = this._treePathFor('addon-templates');
@@ -690,6 +703,11 @@ var Addon = CoreObject.extend({
       return file.match(podTemplateMatcher);
     });
 
+    var jsMatcher = new RegExp('(' + jsExtensions.join('|') + ')$');
+    var hasJSFiles = files.some(function(file) {
+      return file.match(jsMatcher);
+    });
+
     if (!addonTemplatesTreeInAddonTree) {
       files = files.concat(this._getAddonTemplatesTreeFiles());
     }
@@ -702,6 +720,7 @@ var Addon = CoreObject.extend({
     });
 
     this._cachedTemplateInfo = {
+      hasJSFiles: hasJSFiles,
       hasTemplates: hasTemplates,
       hasPodTemplates: hasPodTemplates
     };
@@ -782,9 +801,7 @@ var Addon = CoreObject.extend({
     this._requireBuildPackages();
 
     if (this.shouldCompileTemplates()) {
-      var plugins = this.registry.load('template');
-
-      if (plugins.length === 0) {
+      if (!registryHasPreprocessor(this.registry, 'template')) {
         throw new SilentError('Addon templates were detected, but there ' +
                               'are no template compilers registered for `' + this.name + '`. ' +
                               'Please make sure your template precompiler (commonly `ember-cli-htmlbars`) ' +
@@ -797,11 +814,7 @@ var Addon = CoreObject.extend({
         registry: this.registry
       });
 
-      return new Babel(processedTemplateTree, {
-        modules: 'amdStrict',
-        moduleIds: true,
-        whitelist: ['es6.modules']
-      });
+      return processModulesOnly(processedTemplateTree);
     }
   },
 
@@ -904,9 +917,22 @@ var Addon = CoreObject.extend({
     @return {Tree} Processed javascript file tree
   */
   processedAddonJsFiles: function(tree) {
-    return this.preprocessJs(this.addonJsFiles(tree), '/', this.name, {
-      registry: this.registry
-    });
+    if (this._fileSystemInfo().hasJSFiles) {
+      var processedJsFiles = this.preprocessJs(this.addonJsFiles(tree), '/', this.name, {
+        registry: this.registry
+      });
+
+      if (!registryHasPreprocessor(this.registry, 'js')) {
+        this._warn('Addon files were detected in `' + this._treePathFor('addon') + '`, but no JavaScript ' +
+                   'preprocessors were found for `' + this.name + '`. Please make sure to add a preprocessor ' +
+                   '(most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in ' +
+                   '`' + this.name + '`\'s `package.json`.');
+
+        processedJsFiles = processModulesOnly(processedJsFiles);
+      }
+
+      return processedJsFiles;
+    }
   },
 
   /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -64,7 +64,7 @@ function processModulesOnly(tree) {
 }
 
 function registryHasPreprocessor(registry, type) {
-  return !!registry.load(type).length;
+  return registry.load(type).length > 0;
 }
 
 /**

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -14,6 +14,7 @@ var logger          = require('heimdalljs-logger')('ember-cli:project');
 var nodeModulesPath = require('node-modules-path');
 var versionUtils    = require('../utilities/version-utils');
 var emberCLIVersion = versionUtils.emberCLIVersion;
+var findAddonByName = require('../utilities/find-addon-by-name');
 
 /**
   The Project model is tied to your package.json. It is instantiated
@@ -524,13 +525,7 @@ Project.prototype.reloadAddons = function() {
 Project.prototype.findAddonByName = function(name) {
   this.initializeAddons();
 
-  function matchAddon(name, addon) {
-    return name === addon.name || (addon.pkg && name === addon.pkg.name);
-  }
-
-  return _.find(this.addons, function(addon) {
-    return matchAddon(name, addon);
-  });
+  return findAddonByName(this.addons, name);
 };
 
 /**

--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var find = require('ember-cli-lodash-subset').find;
+
+module.exports = function findAddonByName(addons, name) {
+  function matchAddon(name, addon) {
+    return name === addon.name || (addon.pkg && name === addon.pkg.name);
+  }
+
+  return find(addons, function(addon) {
+    return matchAddon(name, addon);
+  });
+};

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -622,7 +622,7 @@ describe('models/addon.js', function() {
     });
   });
 
-  describe('_detectTemplateInfo', function() {
+  describe('_fileSystemInfo', function() {
     beforeEach(function() {
       projectPath = path.resolve(fixturePath, 'simple');
       var packageContents = require(path.join(projectPath, 'package.json'));
@@ -641,7 +641,7 @@ describe('models/addon.js', function() {
         return [];
       };
 
-      addon._detectTemplateInfo();
+      addon._fileSystemInfo();
 
       expect(wasCalled).to.not.be.ok;
     });
@@ -654,7 +654,7 @@ describe('models/addon.js', function() {
         return [];
       };
 
-      addon._detectTemplateInfo();
+      addon._fileSystemInfo();
 
       expect(wasCalled).to.be.ok;
     });
@@ -668,7 +668,8 @@ describe('models/addon.js', function() {
         ];
       };
 
-      expect(addon._detectTemplateInfo()).to.deep.equal({
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: true,
         hasTemplates: true,
         hasPodTemplates: true
       });
@@ -683,7 +684,8 @@ describe('models/addon.js', function() {
         ];
       };
 
-      expect(addon._detectTemplateInfo()).to.deep.equal({
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: false,
         hasTemplates: true,
         hasPodTemplates: false
       });
@@ -699,7 +701,8 @@ describe('models/addon.js', function() {
         ];
       };
 
-      expect(addon._detectTemplateInfo()).to.deep.equal({
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: false,
         hasTemplates: true,
         hasPodTemplates: false
       });
@@ -715,7 +718,25 @@ describe('models/addon.js', function() {
         ];
       };
 
-      expect(addon._detectTemplateInfo()).to.deep.equal({
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: true,
+        hasTemplates: false,
+        hasPodTemplates: false
+      });
+    });
+
+    it('does not hasJSFiles when none found', function() {
+      addon._getAddonTreeFiles = function() {
+        return [
+          'components/',
+          'templates/',
+          'templates/components/',
+          'styles/foo.css'
+        ];
+      };
+
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: false,
         hasTemplates: false,
         hasPodTemplates: false
       });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -436,35 +436,14 @@ describe('models/project.js', function() {
       td.verify(project.initializeAddons(), {ignoreExtraArgs: true});
     });
 
-    it('should return the foo addon from name', function() {
-      var addon = project.findAddonByName('foo');
+    it('generally should work and defer to findAddonByName utlity', function() {
+      var addon;
+      addon = project.findAddonByName('foo');
       expect(addon.name).to.equal('foo', 'should have found the foo addon');
-    });
 
-    it('should return the foo-bar addon from name when a foo also exists', function() {
-      var addon = project.findAddonByName('foo-bar');
-      expect(addon.name).to.equal('foo-bar', 'should have found the foo-bar addon');
-    });
-
-    it('should return the bar-pkg addon from package name', function() {
-      var addon = project.findAddonByName('bar-pkg');
+      addon = project.findAddonByName('bar-pkg');
       expect(addon.pkg.name).to.equal('bar-pkg', 'should have found the bar-pkg addon');
     });
-
-    it('should return undefined if addon doesn\'t exist', function() {
-      var addon = project.findAddonByName('not-an-addon');
-      expect(addon).to.equal(undefined, 'not found addon should be undefined');
-    });
-
-    it('should not return an addon that is a substring of requested name', function() {
-      var addon = project.findAddonByName('foo-ba');
-      expect(addon).to.equal(undefined, 'foo-ba should not be found');
-    });
-
-    it('should not guess addon name from string with slashes', function() {
-      var addon = project.findAddonByName('qux/foo');
-      expect(addon).to.equal(undefined, 'should not have found the foo addon');
-    })
   });
 
   describe('bowerDirectory', function() {

--- a/tests/unit/utilities/find-addon-by-name-test.js
+++ b/tests/unit/utilities/find-addon-by-name-test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var expect = require('chai').expect;
+var findAddonByName = require('../../../lib/utilities/find-addon-by-name');
+
+describe('findAddonByName', function() {
+  var addons;
+  beforeEach(function() {
+    addons = [{
+      name: 'foo',
+      pkg: { name: 'foo' }
+    }, {
+      pkg: { name: 'bar-pkg' }
+    }, {
+      name: 'foo-bar',
+      pkg: { name: 'foo-bar' }
+    }];
+  });
+
+  it('should return the foo addon from name', function() {
+    var addon = findAddonByName(addons, 'foo');
+    expect(addon.name).to.equal('foo', 'should have found the foo addon');
+  });
+
+  it('should return the foo-bar addon from name when a foo also exists', function() {
+    var addon = findAddonByName(addons, 'foo-bar');
+    expect(addon.name).to.equal('foo-bar', 'should have found the foo-bar addon');
+  });
+
+  it('should return the bar-pkg addon from package name', function() {
+    var addon = findAddonByName(addons, 'bar-pkg');
+    expect(addon.pkg.name).to.equal('bar-pkg', 'should have found the bar-pkg addon');
+  });
+
+  it('should return undefined if addon doesn\'t exist', function() {
+    var addon = findAddonByName(addons, 'not-an-addon');
+    expect(addon).to.equal(undefined, 'not found addon should be undefined');
+  });
+
+  it('should not return an addon that is a substring of requested name', function() {
+    var addon = findAddonByName(addons, 'foo-ba');
+    expect(addon).to.equal(undefined, 'foo-ba should not be found');
+  });
+
+  it('should not guess addon name from string with slashes', function() {
+    var addon = findAddonByName(addons, 'qux/foo');
+    expect(addon).to.equal(undefined, 'should not have found the foo addon');
+  })
+});


### PR DESCRIPTION
We currently transpile the output of all addon's `addon/` trees twice.  Once inside the addon's `treeForAddon` step (this one excludes module transpilation by adding `es6.modules` to babel's blacklist) and the second time in [lib/broccoli/ember-app.js](https://github.com/ember-cli/ember-cli/blob/2df251ce018fd12570bdce72c167ff14a427fa74/lib/broccoli/ember-app.js#L929). 

This was originally done because we didn't require that addon's include their own preprocessors for JS (mostly due to performance reasons IIRC).  In the time since that decision was made, we have swapped from a few different systems `es6-module-transpiler` -> `esperanto` -> `babel`.  Now that our module transpilation step is using the same thing as we recommend addon's use (`ember-cli-babel`) what we are doing seems pretty whacky.  

This PR removes the double processing of addon's `addon/` files through babel, and includes a deprecation message for the scenario that originally prompted the second pass (where an addon didn't include a module transpiling preprocessor).

TODO: 

- [x] Confirm that we have tests that already confirm this is working properly (I believe that our existing nested addon tests cover these changes, but I'd like to confirm).
- [ ] Consider / discuss backporting the deprecation message for addons that do not have a transpiler and are relying on the global processing step.
- [X] Add helpful error if an addon overrides `this.options.babel.compileModules`
- [X] Implement logic to avoid deprecation being added in https://github.com/babel/ember-cli-babel/pull/105.
- [X] Split out `findAddonByName` into a utility method to be shared
- [ ] r?

Addresses parts of https://github.com/ember-cli/ember-cli/issues/5015