### PR TITLE
Update to latest capture-exit, revert work around.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -239,7 +239,7 @@ module.exports = Task.extend({
    * @return {Promise}
    */
   cleanup: function() {
-    var ui = this.ui;
+    var ui = this.project.ui;
     ui.startProgress('cleaning up');
     ui.writeLine('cleaning up...');
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "broccoli-middleware": "^0.18.1",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.2.0",
-    "capture-exit": "^1.0.5",
+    "capture-exit": "^1.0.7",
     "chalk": "^1.1.3",
     "clean-base-url": "^1.0.0",
     "compression": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "broccoli-middleware": "^0.18.1",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.2.0",
-    "capture-exit": "^1.0.4",
+    "capture-exit": "^1.0.5",
     "chalk": "^1.1.3",
     "clean-base-url": "^1.0.0",
     "compression": "^1.4.4",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var captureExit = require('capture-exit');
+captureExit.captureExit();
+
 var glob = require('glob');
 var Mocha = require('mocha');
 var RSVP = require('rsvp');
 var fs = require('fs-extra');
 var mochaOnlyDetector = require('mocha-only-detector');
-var exit = require('capture-exit');
 
 if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
@@ -59,7 +61,6 @@ function runMocha() {
   console.time('Mocha Tests Running Time');
   mocha.run(function(failures) {
     console.timeEnd('Mocha Tests Running Time');
-    exit.releaseExit();
     process.exit(failures);
   });
 }
@@ -79,6 +80,5 @@ ciVerificationStep()
   .catch(function(error) {
     console.error(error);
     console.error(error.stack);
-    exit.releaseExit();
     process.exit(1);
   });

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -54,7 +54,7 @@ describe('models/builder.js', function() {
 
       builder = new Builder({
         setupBroccoliBuilder: function() { },
-        cleanupOnExit: function() { },
+        cleanup: function() { },
         trapWindowsSignals: trapWindowsSignals,
         project: new MockProject()
       });


### PR DESCRIPTION
`capture-exit` has been released upstream to fix the original issue we were working around.

This reverts a prior change to call `captureExit.releaseExit()` before calling `process.exit(1)` and ensures we have the correct version of `capture-exit` installed.