### PR TITLE
blueprints/addon: Fix path to "ember" executable in ".travis.yml"

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -37,4 +37,4 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup


### PR DESCRIPTION
Resolves the issues caused by travis-ci/travis-cookbooks#786

Note that I opened https://github.com/ember-cli/ember-cli-mocha/pull/155 to test if this change actually works.