### PR TITLE
Adding debug option to be passed to testem

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -27,7 +27,7 @@ module.exports = Command.extend({
     { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
     { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit] (default: tap)' },
     { name: 'silent',      type: Boolean, default: false,                            description: 'Suppress any output except for the test report' },
-    { name: 'debug',       type: String,                                             description: 'File to write a debug log from testem' },
+    { name: 'testem-debug',type: String,                                             description: 'File to write a debug log from testem' },
     { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
     { name: 'path',        type: 'Path',                                             description: 'Reuse an existing build at given path.' },
     { name: 'query',       type: String,                                             description: 'A query string to append to the test page URL.' }

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -27,6 +27,7 @@ module.exports = Command.extend({
     { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
     { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit] (default: tap)' },
     { name: 'silent',      type: Boolean, default: false,                            description: 'Suppress any output except for the test report' },
+    { name: 'debug',       type: String,                                             description: 'File to write a debug log from testem' },
     { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
     { name: 'path',        type: 'Path',                                             description: 'Reuse an existing build at given path.' },
     { name: 'query',       type: String,                                             description: 'A query string to append to the test page URL.' }

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -44,7 +44,7 @@ module.exports = Task.extend({
       host: options.host,
       port: options.port,
       cwd: options.outputPath,
-      debug: options.debug,
+      debug: options.testemDebug,
       reporter: options.reporter,
       middleware: this.addonMiddlewares(),
       launch: options.launch,

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -44,6 +44,7 @@ module.exports = Task.extend({
       host: options.host,
       port: options.port,
       cwd: options.outputPath,
+      debug: options.debug,
       reporter: options.reporter,
       middleware: this.addonMiddlewares(),
       launch: options.launch,

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -169,7 +169,7 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--reporter\u001b[39m \u001b[36m(String)\u001b[39m Test reporter to use [tap|dot|xunit] (default: tap)
     \u001b[90maliases: -r <value>\u001b[39m
   \u001b[36m--silent\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Suppress any output except for the test report
-  \u001b[36m--debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
+  \u001b[36m--testem-debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -169,6 +169,7 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--reporter\u001b[39m \u001b[36m(String)\u001b[39m Test reporter to use [tap|dot|xunit] (default: tap)
     \u001b[90maliases: -r <value>\u001b[39m
   \u001b[36m--silent\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Suppress any output except for the test report
+  \u001b[36m--debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -662,9 +662,9 @@ module.exports = {
           required: false
         },
         {
-          name: 'debug',
+          name: 'testem-debug',
           description: 'File to write a debug log from testem',
-          key: 'debug',
+          key: 'testemDebug',
           required: false
         },
         {

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -662,6 +662,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'debug',
+          description: 'File to write a debug log from testem',
+          key: 'debug',
+          required: false
+        },
+        {
           name: 'test-page',
           description: 'Test page to invoke',
           key: 'testPage',

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -169,7 +169,7 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--reporter\u001b[39m \u001b[36m(String)\u001b[39m Test reporter to use [tap|dot|xunit] (default: tap)
     \u001b[90maliases: -r <value>\u001b[39m
   \u001b[36m--silent\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Suppress any output except for the test report
-  \u001b[36m--debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
+  \u001b[36m--testem-debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -169,6 +169,7 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--reporter\u001b[39m \u001b[36m(String)\u001b[39m Test reporter to use [tap|dot|xunit] (default: tap)
     \u001b[90maliases: -r <value>\u001b[39m
   \u001b[36m--silent\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m Suppress any output except for the test report
+  \u001b[36m--debug\u001b[39m \u001b[36m(String)\u001b[39m File to write a debug log from testem
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -694,6 +694,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'debug',
+          description: 'File to write a debug log from testem',
+          key: 'debug',
+          required: false
+        },
+        {
           name: 'test-page',
           description: 'Test page to invoke',
           key: 'testPage',

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -694,9 +694,9 @@ module.exports = {
           required: false
         },
         {
-          name: 'debug',
+          name: 'testem-debug',
           description: 'File to write a debug log from testem',
-          key: 'debug',
+          key: 'testemDebug',
           required: false
         },
         {

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -662,9 +662,9 @@ module.exports = {
           required: false
         },
         {
-          name: 'debug',
+          name: 'testem-debug',
           description: 'File to write a debug log from testem',
-          key: 'debug',
+          key: 'testemDebug',
           required: false
         },
         {

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -662,6 +662,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'debug',
+          description: 'File to write a debug log from testem',
+          key: 'debug',
+          required: false
+        },
+        {
           name: 'test-page',
           description: 'Test page to invoke',
           key: 'testPage',

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -34,7 +34,7 @@ describe('test task test', function() {
       port: 123324,
       reporter: 'xunit',
       outputPath: 'blerpy-derpy',
-      debug: 'testem.log',
+      testemDebug: 'testem.log',
       testPage: 'http://my/test/page',
       configFile: 'custom-testem-config.json'
     });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -23,6 +23,7 @@ describe('test task test', function() {
         expect(testemOptions.reporter).to.equal('xunit');
         expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
         expect(testemOptions.test_page).to.equal('http://my/test/page');
+        expect(testemOptions.debug).to.equal('testem.log');
         expect(testemOptions.config_dir).to.be.an('string');
         expect(testemOptions.file).to.equal('custom-testem-config.json');
       }
@@ -33,6 +34,7 @@ describe('test task test', function() {
       port: 123324,
       reporter: 'xunit',
       outputPath: 'blerpy-derpy',
+      debug: 'testem.log',
       testPage: 'http://my/test/page',
       configFile: 'custom-testem-config.json'
     });


### PR DESCRIPTION
Adding debug option for testem.

Testem has a built-in --debug option that is not currently exposed in ember-cli. This exposes testem's --debug option, so that users are able to get a debug log from testem from their ember-cli run. 