### PR TITLE
fix phantom use on travis

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -25,10 +25,9 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
+  - npm install -g bower phantomjs-prebuilt
   - bower --version
-  - npm install phantomjs-prebuilt
-  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+  - phantomjs --version
 
 install:
   - npm install

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -12,10 +12,9 @@ cache:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
+  - npm install -g bower phantomjs-prebuilt
   - bower --version
-  - npm install phantomjs-prebuilt
-  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+  - phantomjs --version
 
 install:
   - npm install


### PR DESCRIPTION
I noticed an issue where phantom 1.9 was being used even though we were expecting 2.1 https://travis-ci.org/ember-cli/ember-addon-output/jobs/180486782#L447-L468

turns out we needed to install it globally. Here it is in action: https://travis-ci.org/kellyselden/ember-datetimepicker/jobs/181879916#L472

I targeted release branch because this seemed like a pretty silly/low risk bug fix that we should get to people soon.