### PR TITLE
Prevent deprecation from `ember-cli-babel` config options.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -185,18 +185,6 @@ EmberApp.prototype._initProject = function(options) {
   @param {Object} options
 */
 EmberApp.prototype._initOptions = function(options) {
-  var babelOptions = {};
-
-  if (this._addonInstalled('ember-cli-babel')) {
-    var amdNameResolver = require('amd-name-resolver').moduleResolve;
-    babelOptions = {
-      compileModules: true,
-      modules: 'amdStrict',
-      moduleIds: true,
-      resolveModuleSource: amdNameResolver
-    };
-  }
-
   var appTree = new WatchedDir(this._resolveLocal('app'));
 
   var testsPath = this._resolveLocal('tests');
@@ -217,8 +205,12 @@ EmberApp.prototype._initOptions = function(options) {
   var publicPath = this._resolveLocal('public');
   var publicTree = existsSync(publicPath) ? new WatchedDir(publicPath) : null;
 
-  this.options = defaultsDeep(options, {
-    babel: babelOptions,
+  var detectedDefaultOptions = {
+    babel: {
+      modules: 'amdStrict',
+      moduleIds: true,
+      resolveModuleSource: require('amd-name-resolver').moduleResolve
+    },
     jshintrc: {
       app: this.project.root,
       tests: this._resolveLocal('tests')
@@ -250,7 +242,21 @@ EmberApp.prototype._initOptions = function(options) {
       vendor: vendorTree,
       public: publicTree
     }
-  }, DEFAULT_CONFIG);
+  };
+
+  var emberCLIBabelInstance = this.project.findAddonByName('ember-cli-babel');
+  if (emberCLIBabelInstance) {
+    // future versions of ember-cli-babel will be moving the location for its
+    // own configuration options out of `babel` and will be issuing a deprecation
+    // if used in the older way
+    //
+    // see: https://github.com/babel/ember-cli-babel/pull/105
+    var emberCLIBabelConfigKey = emberCLIBabelInstance.configKey || 'babel';
+    detectedDefaultOptions[emberCLIBabelConfigKey] = detectedDefaultOptions[emberCLIBabelConfigKey] || {};
+    detectedDefaultOptions[emberCLIBabelConfigKey].compileModules = true;
+  }
+
+  this.options = defaultsDeep(options, detectedDefaultOptions, DEFAULT_CONFIG);
 
   // For now we must disable Babel sourcemaps due to unforseen
   // performance regressions.


### PR DESCRIPTION
Future versions of ember-cli-babel will be moving the location for its own configuration options out of `babel` and will be issuing a deprecation if used in the older way.

This changes things around to detect the correct (undeprecated) options location, and use it when possible.  Otherwise it falls back to `babel` (which is backwards compatible without a deprecation and forwards compatible with a deprecation).

/cc @Turbo87 

Reference: https://github.com/babel/ember-cli-babel/pull/105