### PR TITLE
Fixups for recent two pass babel changes.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -147,12 +147,12 @@ var Addon = CoreObject.extend({
       throw new SilentError('An addon must define a `name` property.');
     }
 
-    this.options = defaultsDeep(this.options, {
+    this.__originalOptions = this.options = defaultsDeep(this.options, {
       babel: DEFAULT_BABEL_CONFIG
     });
 
     var emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
-    this.options[emberCLIBabelConfigKey] = defaultsDeep(this.options[emberCLIBabelConfigKey], {
+    this.__originalOptions[emberCLIBabelConfigKey] = this.options[emberCLIBabelConfigKey] = defaultsDeep(this.options[emberCLIBabelConfigKey], {
       compileModules: true
     });
   },
@@ -845,13 +845,38 @@ var Addon = CoreObject.extend({
   compileAddon: function(tree) {
     this._requireBuildPackages();
 
+    if (!this.options) {
+      this._warn(
+        'Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. ' +
+          '`' + this.name + '` (found at `' + this.root + '`) has removed `this.options` ' +
+          'which conflicts with the addons ability to transpile its `addon/` files properly. ' +
+          'Falling back to default babel configuration options.'
+      );
+
+      this.options = {};
+    }
+
+    if (!this.options.babel) {
+      this._warn(
+        'Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. ' +
+          '`' + this.name + '` (found at `' + this.root + '`) has overridden the `this.options.babel` ' +
+          'options which conflicts with the addons ability to transpile its `addon/` files properly. ' +
+          'Falling back to default babel configuration options.'
+      );
+
+      this.options.babel = this.__originalOptions.babel;
+    }
+
     var emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
-    if (!this.options[emberCLIBabelConfigKey].compileModules) {
-      throw new SilentError(
+    if (!this.options[emberCLIBabelConfigKey] || !this.options[emberCLIBabelConfigKey].compileModules) {
+      this._warn(
         'Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. ' +
           '`' + this.name + '` (found at `' + this.root + '`) has overridden the `this.options.' + emberCLIBabelConfigKey + '.compileModules` ' +
           'value which conflicts with the addons ability to transpile its `addon/` files properly.'
       );
+
+      this.options[emberCLIBabelConfigKey] = this.options[emberCLIBabelConfigKey] || {};
+      this.options[emberCLIBabelConfigKey].compileModules = true;
     }
 
     var addonJs = this.processedAddonJsFiles(tree);

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -975,7 +975,9 @@ var Addon = CoreObject.extend({
                    '(most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in ' +
                    '`' + this.name + '`\'s `package.json`.');
 
-        processedJsFiles = processModulesOnly(processedJsFiles);
+        var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
+
+        processedJsFiles = new Babel(processedJsFiles, options);
       }
 
       return processedJsFiles;

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -885,6 +885,7 @@ var Addon = CoreObject.extend({
     var trees = [addonJs, templatesTree].filter(Boolean);
 
     var combinedJSAndTemplates = mergeTrees(trees, {
+      overwrite: true,
       annotation: 'Addon#compileAddon(' + this.name + ') '
     });
 


### PR DESCRIPTION
We started testing out master in a very large app at work, and ran into a few small issues with the changes in #6530.  

This PR makes the following changes:

* Makes the warnings much more useful (and prevents an error that was occurring just when reading config to determine if we should warn).
* Cherry pick change from #6480, as it is now manifesting (due to internal changes in `modules/` shimming, the `overwrite` that was happening at a later stage, is now happening in `compileAddon`).
* Ensure a full pass of babel transpilation is done in the fallback case (when an addon with `addon/**/*.js` files has no JS preprocessors). This is required due to the way the migration from esperanto to babel occurred where the second pass (that was intended for only modules transpilation) was actually implemented as a full babel transpile step.