### PR TITLE
blueprints/app/testem.js: Remove unused "framework" property

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -1,6 +1,5 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [


### PR DESCRIPTION
The `framework` property seems only relevant when e.g. `serve_files` is used, but not when we're setting `test_page` and including the test framework ourselves.

As visible in e.g. https://github.com/skylines-project/skylines/blob/master/ember/testem.js#L2 you could even set the property to `qunit` and use Mocha at the same time. 

To prevent further confusion I propose to remove that property completely.

/cc @johanneswuerbach @rwjblue @nathanhammond @stefanpenner @trentmwillis 