### PR TITLE
Removes deprecation messages from test suite

### DIFF
--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -15,20 +15,22 @@ describe('build command', function() {
     tasks = {
       Build: Task.extend({
         init: function() {
-          this._super.apply(this, arguments);
+          this._super.init && this._super.init.apply(this, arguments);
           buildTaskInstance = this;
         }
       }),
 
       BuildWatch: Task.extend({
         init: function() {
-          this._super.apply(this, arguments);
+          this._super.init && this._super.init.apply(this, arguments);
           buildWatchTaskInstance = this;
         }
       }),
 
       ShowAssetSizes: Task.extend({
-        init: function() {}
+        init: function() {
+          this._super.init && this._super.init.apply(this, arguments);
+        }
       })
     };
 

--- a/tests/unit/commands/show-asset-sizes-test.js
+++ b/tests/unit/commands/show-asset-sizes-test.js
@@ -20,6 +20,7 @@ describe('asset-sizes command', function () {
     tasks = {
       ShowAssetSizes: Task.extend({
         init: function () {
+          this._super.init && this._super.init.apply(this, arguments);
           taskInstance = this;
         }
       })


### PR DESCRIPTION
"DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `undefined`"