### PR TITLE
Properly set up package.json for later replacement.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -18,7 +18,7 @@ module.exports = {
     var contents = this._readContentsFromFile('package.json');
 
     delete contents.private;
-    contents.name = this.project.name();
+    contents.name = '<%= addonName %>';
     contents.description = this.description;
     contents.scripts = contents.scripts || {};
     contents.keywords = contents.keywords || [];
@@ -49,7 +49,7 @@ module.exports = {
   generateBowerJson: function() {
     var contents = this._readContentsFromFile('bower.json');
 
-    contents.name = this.project.name();
+    contents.name = '<%= addonName %>';
 
     this._writeContentsToFile(contents, 'bower.json');
   },

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -279,4 +279,28 @@ describe('Acceptance: ember new', function() {
       expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
     });
   });
+
+  it('ember addon with --directory uses given directory name and has correct package name', function() {
+    var workdir = process.cwd();
+
+    return ember([
+      'addon',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--directory=bar'
+    ]).then(function() {
+      expect(dir(path.join(workdir, 'foo'))).to.not.exist;
+      expect(dir(path.join(workdir, 'bar'))).to.exist;
+
+      var cwd = process.cwd();
+      expect(cwd).to.not.match(/foo/, 'does not use addon name for directory name');
+      expect(cwd).to.match(/bar/, 'uses given directory name');
+
+      var pkgJson = fs.readJsonSync('package.json');
+      expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
+    });
+  });
+
 });

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -73,11 +73,6 @@ describe('blueprint - addon', function() {
       blueprint._appBlueprint = {
         path: 'test-app-blueprint-path'
       };
-      blueprint.project = {
-        name: function() {
-          return 'test-project-name';
-        }
-      };
       blueprint.path = 'test-blueprint-path';
     });
 
@@ -93,7 +88,7 @@ describe('blueprint - addon', function() {
         // string to test ordering
         expect(captor.value).to.equal('\
 {\n\
-  "name": "test-project-name",\n\
+  "name": "<%= addonName %>",\n\
   "description": "The default blueprint for ember-cli addons.",\n\
   "keywords": [\n\
     "ember-addon"\n\
@@ -140,7 +135,7 @@ describe('blueprint - addon', function() {
         td.verify(writeFileSync(path.normalize('test-blueprint-path/files/package.json'), captor.capture()));
 
         var json = JSON.parse(captor.value);
-        expect(json.name).to.equal('test-project-name');
+        expect(json.name).to.equal('<%= addonName %>');
       });
 
       it('overwrites `description`', function() {
@@ -288,7 +283,7 @@ describe('blueprint - addon', function() {
         // string to test ordering
         expect(captor.value).to.equal('\
 {\n\
-  "name": "test-project-name"\n\
+  "name": "<%= addonName %>"\n\
 }\n');
       });
     });


### PR DESCRIPTION
We currently use the wrong information for setting up the package name inside of addons. We're generating a blueprint at invocation time in this blueprint, which means we should be populating it with the correct replacement placeholders.