### PR TITLE
Allow using empty directories.

### DIFF
--- a/lib/tasks/create-and-step-into-directory.js
+++ b/lib/tasks/create-and-step-into-directory.js
@@ -22,7 +22,7 @@ module.exports = Task.extend({
     var directoryName = this.directoryName = options.directoryName;
     if (options.dryRun) {
       return new Promise(function(resolve, reject) {
-        if (existsSync(directoryName)) {
+        if (existsSync(directoryName) && fs.readdirSync(directoryName).length) {
           return reject(this.warnDirectoryAlreadyExists());
         }
         resolve();
@@ -32,7 +32,10 @@ module.exports = Task.extend({
     return mkdir(directoryName)
       .catch(function(err) {
         if (err.code === 'EEXIST') {
-          throw this.warnDirectoryAlreadyExists();
+          // Allow using directory if it is empty.
+          if (fs.readdirSync(directoryName).length) {
+            throw this.warnDirectoryAlreadyExists();
+          }
         } else {
           throw err;
         }

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -105,20 +105,37 @@ describe('Acceptance: ember new', function() {
     });
   });
 
-  it('Cannot create new ember project with the same name as an existing directory', function() {
-    fs.mkdirsSync('foo');
+  it('Can create new ember project in an existing empty directory', function() {
+    fs.mkdirsSync('bar');
 
     return ember([
       'new',
       'foo',
       '--skip-npm',
       '--skip-bower',
-      '--skip-git'
+      '--skip-git',
+      '--directory=bar'
+    ]).catch(function(error) {
+      throw new Error('this command should work');
+    });
+  });
+
+  it('Cannot create new ember project in a populated directory', function() {
+    fs.mkdirsSync('bar');
+    fs.writeFileSync(path.join('bar', 'package.json'), '{}');
+
+    return ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--directory=bar'
     ]).then(function() {
       throw new Error('this promise should be rejected');
     }).catch(function(error) {
       expect(error.name).to.equal('SilentError');
-      expect(error.message).to.equal('Directory \'foo\' already exists.');
+      expect(error.message).to.equal('Directory \'bar\' already exists.');
     });
   });
 


### PR DESCRIPTION
The usecase of `--directory` inside of Ember CLI allows you to specify where you wish to place the output from the `ember new` and `ember addon` commands. It's likely in those scenarios that the directory you're trying to populate already exists. Our goal was to make sure we played nicely with the existing assets. An empty directory meets that bar for safety and improves the ergonomics of the `--directory` command, also making it more suitable for testing.