### PR TITLE
Fix wrong normalization in EmberApp._getAssetPath

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1636,7 +1636,7 @@ EmberApp.prototype._getAssetPath = function(asset) {
     return;
   }
 
-  assetPath = assetPath.replace(path.sep, '/');
+  assetPath = assetPath.split(path.sep).join('/');
 
   if (assetPath.split('/').length < 2) {
     console.log(chalk.red('Using `app.import` with a file in the root of `vendor/` causes a significant performance penalty. Please move `' + assetPath + '` into a subdirectory.'));

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1636,7 +1636,7 @@ EmberApp.prototype._getAssetPath = function(asset) {
     return;
   }
 
-  assetPath = assetPath.split(path.sep).join('/');
+  assetPath = assetPath.split('\\').join('/');
 
   if (assetPath.split('/').length < 2) {
     console.log(chalk.red('Using `app.import` with a file in the root of `vendor/` causes a significant performance penalty. Please move `' + assetPath + '` into a subdirectory.'));

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -851,6 +851,14 @@ describe('broccoli/ember-app', function() {
 
       expect(app._scriptOutputFiles['/assets/vendor.js']).to.not.contain('vendor/jquery.js');
     });
+
+    it('normalizes asset path correctly', function() {
+      app.import('vendor\\path\\to\\lib.js', {type: 'vendor'});
+      app.import('vendor/path/to/lib2.js', {type: 'vendor'});
+
+      expect(app._scriptOutputFiles['/assets/vendor.js']).to.contain('vendor/path/to/lib.js');
+      expect(app._scriptOutputFiles['/assets/vendor.js']).to.contain('vendor/path/to/lib2.js');
+    });
   });
 
   describe('vendorFiles', function() {


### PR DESCRIPTION
I believe the intended behavior here was to replace all of `path.sep` to `/` but String.replace only replaces first match. This change should fix it.

I found it because on Windows, all assets imported with windows path separator were imported twice into output, and were in source map referenced by both windows and posix path. Maybe someone could look into why, if file has non-posix path, it's imported twice on Windows.