### PR TITLE
Don't run babel twice for addon-test-support

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -24,7 +24,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-qunit": "^3.0.4",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1394,9 +1394,8 @@ EmberApp.prototype.testFiles = function(coreTestTree) {
     overwrite: true,
     annotation: 'TreeMerger (addon-test-support)'
   });
-  var transpiledAddonTestSupportTree = new Babel(addonTestSupportTree, this._prunedBabelOptions());
 
-  var finalAddonTestSupportTree = new Funnel(transpiledAddonTestSupportTree, {
+  var finalAddonTestSupportTree = new Funnel(addonTestSupportTree, {
     allowEmpty: true,
     destDir: 'addon-test-support',
     annotation: 'Funnel: Addon Test Support'

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -638,14 +638,25 @@ var Addon = CoreObject.extend({
       return tree;
     }
 
-    var processed = this.preprocessJs(tree, '/', this.name, {
-      registry: this.registry
-    });
-
-    return new Funnel(processed, {
+    var namespacedTree = new Funnel(tree, {
       srcDir: '/',
       destDir: '/' + this.moduleName() + '/test-support'
     });
+
+    if (registryHasPreprocessor(this.registry, 'js')) {
+      return this.preprocessJs(namespacedTree, '/', this.name, {
+        registry: this.registry
+      });
+    } else {
+      this._warn('Addon test support files were detected in `' + this._treePathFor('addon-test-support') + '`, but no JavaScript ' +
+                 'preprocessors were found for `' + this.name + '`. Please make sure to add a preprocessor ' +
+                 '(most likely `ember-cli-babel`) to `dependencies` (NOT `devDependencies`) in ' +
+                 '`' + this.name + '`\'s `package.json`.');
+
+      var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
+
+      return new Babel(namespacedTree, options);
+    }
   },
 
   /**

--- a/tests/fixtures/addon/kitchen-sink/addon-test-support/helper.js
+++ b/tests/fixtures/addon/kitchen-sink/addon-test-support/helper.js
@@ -1,0 +1,3 @@
+export default function truthyHelper() {
+  return true;
+}

--- a/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
@@ -1,5 +1,6 @@
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+import truthyHelper from 'kitchen-sink/test-support/helper';
 import { module, test } from 'qunit';
 
 module('Acceptance', {
@@ -17,6 +18,7 @@ test('renders properly', function(assert) {
   andThen(function() {
     var element = find('.basic-thing');
     assert.equal(element.first().text().trim(), 'WOOT!!');
+    assert.ok(truthyHelper(), 'addon-test-support helper');
   });
 });
 


### PR DESCRIPTION
Addressing #6554.

~~I'm unsure this is the optimal solution. It seems like individual addons should handle transpiling their `addon-test-support` trees and the consuming app should just concatenate them. The problem with that approach is that it could be considered a breaking change at this point in time, if the consumer is hooking into `treeForAddonTestSupport` and not calling super (such as in [ember-cli-qunit](https://github.com/ember-cli/ember-cli-qunit/blob/master/index.js#L45-L48)).~~