### PR TITLE
Acceptance Test Refactoring

### DIFF
--- a/tests/acceptance/blueprint-test-slow.js
+++ b/tests/acceptance/blueprint-test-slow.js
@@ -13,7 +13,8 @@ var chai = require('../chai');
 var expect = chai.expect;
 var dir = chai.dir;
 
-var appName  = 'some-cool-app';
+var appName = 'some-cool-app';
+var appRoot;
 
 describe('Acceptance: blueprint smoke tests', function() {
   this.timeout(500000);
@@ -27,12 +28,14 @@ describe('Acceptance: blueprint smoke tests', function() {
   });
 
   beforeEach(function() {
-    return linkDependencies(appName);
+    return linkDependencies(appName).then(function(result) {
+      appRoot = result;
+    });
   });
 
   afterEach(function() {
     return cleanupRun(appName).then(function() {
-      expect(dir('tmp/' + appName)).to.not.exist;
+      expect(dir(appRoot)).to.not.exist;
     });
   });
 
@@ -42,7 +45,7 @@ describe('Acceptance: blueprint smoke tests', function() {
                       'api',
                       'http://localhost/api')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
 
         expect(packageJson.devDependencies).to.have.a.property('http-proxy');

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -18,7 +18,8 @@ var expect = chai.expect;
 var file = chai.file;
 var dir = chai.dir;
 
-var appName  = 'some-cool-app';
+var appName = 'some-cool-app';
+var appRoot;
 
 describe('Acceptance: brocfile-smoke-test', function() {
   this.timeout(500000);
@@ -32,12 +33,14 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   beforeEach(function() {
-    return linkDependencies(appName);
+    return linkDependencies(appName).then(function(result) {
+      appRoot = result;
+    });
   });
 
   afterEach(function() {
     return cleanupRun(appName).then(function() {
-      expect(dir('tmp/' + appName)).to.not.exist;
+      expect(dir(appRoot)).to.not.exist;
     });
   });
 
@@ -79,7 +82,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var appFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', appName + '.js'), {
+        var appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', appName + '.js'), {
           encoding: 'utf8'
         });
 
@@ -126,7 +129,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var appFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', appName + '.js'), {
+        var appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', appName + '.js'), {
           encoding: 'utf8'
         });
 
@@ -141,7 +144,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var appFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', appName + '.js'), {
+        var appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', appName + '.js'), {
           encoding: 'utf8'
         });
 
@@ -152,7 +155,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('app.import works properly with test tree files', function() {
     return copyFixtureFiles('brocfile-tests/app-test-import')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-test-addon'] = 'latest';
 
@@ -162,7 +165,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var subjectFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', 'test-support.js'), {
+        var subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'test-support.js'), {
           encoding: 'utf8'
         });
 
@@ -173,7 +176,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('app.import works properly with non-js/css files', function() {
     return copyFixtureFiles('brocfile-tests/app-import')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
@@ -183,7 +186,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var subjectFileContents = fs.readFileSync(path.join('.', 'dist', 'assets', 'file-to-import.txt'), {
+        var subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'file-to-import.txt'), {
           encoding: 'utf8'
         });
 
@@ -194,7 +197,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('addons can have a public tree that is merged and returned namespaced by default', function() {
     return copyFixtureFiles('brocfile-tests/public-tree')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-random-addon'] = 'latest';
 
@@ -204,7 +207,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var subjectFileContents = fs.readFileSync(path.join('.', 'dist', 'ember-random-addon', 'some-root-file.txt'), {
+        var subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'ember-random-addon', 'some-root-file.txt'), {
           encoding: 'utf8'
         });
 
@@ -229,7 +232,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('addon trees are not jshinted', function() {
     return copyFixtureFiles('brocfile-tests/jshint-addon')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson['ember-addon'] = {
           paths: ['./lib/ember-random-thing']
@@ -245,7 +248,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('specifying custom output paths works properly', function() {
     return copyFixtureFiles('brocfile-tests/custom-output-paths')
       .then(function () {
-        var themeCSSPath = path.join(__dirname, '..', '..', 'tmp', appName, 'app', 'styles', 'theme.css');
+        var themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
         return fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
       })
       .then(function() {
@@ -263,7 +266,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
           '/my-app.html'
         ];
 
-        var basePath = path.join('.', 'dist');
+        var basePath = path.join(appRoot, 'dist');
         files.forEach(function(f) {
           expect(file(path.join(basePath, f))).to.exist;
         });
@@ -281,7 +284,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
           '/assets/other.css'
         ];
 
-        var basePath = path.join('.', 'dist');
+        var basePath = path.join(appRoot, 'dist');
         files.forEach(function(f) {
           expect(file(path.join(basePath, f))).to.exist;
         });
@@ -316,7 +319,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
           '/assets/vendor.js'
         ];
 
-        var basePath = path.join('.', 'dist');
+        var basePath = path.join(appRoot, 'dist');
         files.forEach(function(f) {
           expect(file(path.join(basePath, f))).to.exist;
         });
@@ -329,7 +332,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
         return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
       })
       .then(function() {
-        var outputJS = fs.readFileSync(path.join('.', 'dist', 'assets', 'output.js'), {
+        var outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
           encoding: 'utf8'
         });
 
@@ -355,10 +358,10 @@ describe('Acceptance: brocfile-smoke-test', function() {
     return copyFixtureFiles('brocfile-tests/custom-output-paths')
       .then(function () {
 
-        var themeCSSPath = path.join(__dirname, '..', '..', 'tmp', appName, 'app', 'styles', 'theme.css');
+        var themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
         fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
 
-        var brocfilePath = path.join(__dirname, '..', '..', 'tmp', appName, 'ember-cli-build.js');
+        var brocfilePath = path.join(appRoot, 'ember-cli-build.js');
         var brocfile = fs.readFileSync(brocfilePath, 'utf8');
 
         // remove outputPaths.app.js option
@@ -381,7 +384,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
           '/js/test-support.js'
         ];
 
-        var basePath = path.join('.', 'dist');
+        var basePath = path.join(appRoot, 'dist');
         files.forEach(function(f) {
           expect(file(path.join(basePath, f))).to.exist;
         });
@@ -393,7 +396,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('multiple paths can be CSS preprocessed', function() {
     return copyFixtureFiles('brocfile-tests/multiple-sass-files')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cli-sass'] = 'latest';
 
@@ -422,7 +425,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   it('app.scss is output to <app name>.css by default', function() {
     return copyFixtureFiles('brocfile-tests/multiple-sass-files')
       .then(function() {
-        var brocfilePath = path.join(__dirname, '..', '..', 'tmp', appName, 'ember-cli-build.js');
+        var brocfilePath = path.join(appRoot, 'ember-cli-build.js');
         var brocfile = fs.readFileSync(brocfilePath, 'utf8');
 
         // remove custom preprocessCss paths, use app.scss instead
@@ -430,7 +433,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
         fs.writeFileSync(brocfilePath, brocfile, 'utf8');
 
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cli-sass'] = 'latest';
 

--- a/tests/acceptance/nested-addons-smoke-test-slow.js
+++ b/tests/acceptance/nested-addons-smoke-test-slow.js
@@ -16,7 +16,8 @@ var expect = chai.expect;
 var file = chai.file;
 var dir = chai.dir;
 
-var appName  = 'some-cool-app';
+var appName = 'some-cool-app';
+var appRoot;
 
 describe('Acceptance: nested-addons-smoke-test', function() {
   this.timeout(360000);
@@ -30,19 +31,21 @@ describe('Acceptance: nested-addons-smoke-test', function() {
   });
 
   beforeEach(function() {
-    return linkDependencies(appName);
+    return linkDependencies(appName).then(function(result) {
+      appRoot = result;
+    });
   });
 
   afterEach(function() {
     return cleanupRun(appName).then(function() {
-      expect(dir('tmp/' + appName)).to.not.exist;
+      expect(dir(appRoot)).to.not.exist;
     });
   });
 
   it('addons with nested addons compile correctly', function() {
     return copyFixtureFiles('addon/with-nested-addons')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-top-addon'] = 'latest';
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -16,7 +16,8 @@ var expect = chai.expect;
 var file = chai.file;
 var dir = chai.dir;
 
-var appName  = 'some-cool-app';
+var appName = 'some-cool-app';
+var appRoot;
 
 describe('Acceptance: preprocessor-smoke-test', function() {
   this.timeout(360000);
@@ -30,19 +31,21 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   });
 
   beforeEach(function() {
-    return linkDependencies(appName);
+    return linkDependencies(appName).then(function(result) {
+      appRoot = result;
+    });
   });
 
   afterEach(function() {
     return cleanupRun(appName).then(function() {
-      expect(dir('tmp/' + appName)).to.not.exist;
+      expect(dir(appRoot)).to.not.exist;
     });
   });
 
   it('addons with standard preprocessors compile correctly', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
@@ -61,7 +64,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   it('addon registry entries are added in the proper order', function() {
     return copyFixtureFiles('preprocessor-tests/app-registry-ordering')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
         packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
@@ -82,7 +85,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   it('addons without preprocessors compile correctly', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cli-sass'] = 'latest';
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
@@ -108,7 +111,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   it('addons depending on preprocessor addon preprocesses addon but not app', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-2')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-cool-addon'] = 'latest';
 
@@ -140,7 +143,7 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   it('addon N levels deep depending on preprocessor preprocesses that parent addon only', function() {
     return copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-3')
       .then(function() {
-        var packageJsonPath = path.join(__dirname, '..', '..', 'tmp', appName, 'package.json');
+        var packageJsonPath = path.join(appRoot, 'package.json');
         var packageJson = fs.readJsonSync(packageJsonPath);
         packageJson.devDependencies['ember-shallow-addon'] = 'latest';
 


### PR DESCRIPTION
This PR does a few things:

1. Makes all paths absolute. This is a first step toward enabling us to run tests outside of the Ember CLI folder.
2. Returns the location of the test fixture from the acceptance test helper to the acceptance test. This allows us to change the strategy without the test itself knowing how the helper functions. (Read: I plan to seamlessly swap in a faster fixture strategy.)
3. Makes the current tests pass using this new behavior changing as little as possible.