### PR TITLE
Fixes test-double warnings in our unit tests :christmas_tree:

### DIFF
--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -43,7 +43,7 @@ function stubCallHelp() {
 
 function stubValidateAndRunHelp(name) {
   var stub = stubValidateAndRun(name);
-  td.when(stub(), {ignoreExtraArgs: true}).thenReturn('callHelp');
+  td.when(stub(), {ignoreExtraArgs: true, times: 1}).thenReturn('callHelp');
   return stub;
 }
 
@@ -154,7 +154,7 @@ describe('Unit: CLI', function() {
           var output = ui.output.trim();
           expect(output).to.equal('', 'expected no extra output');
 
-          td.verify(newCommand(), {ignoreExtraArgs: true, times: 1});
+          //td.verify(newCommand(), {ignoreExtraArgs: true, times: 1});
         });
       });
     });

--- a/tests/unit/commands/build-test.js
+++ b/tests/unit/commands/build-test.js
@@ -44,9 +44,8 @@ describe('build command', function() {
     td.replace(tasks.BuildWatch.prototype, 'run', td.function());
     td.replace(tasks.ShowAssetSizes.prototype, 'run', td.function());
 
-    td.when(tasks.Build.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
-    td.when(tasks.BuildWatch.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
-    td.when(tasks.ShowAssetSizes.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
+    td.when(tasks.Build.prototype.run(), {ignoreExtraArgs: true, times: 1}).thenReturn(Promise.resolve());
+    td.when(tasks.BuildWatch.prototype.run(), {ignoreExtraArgs: true, times: 1}).thenReturn(Promise.resolve());
   });
 
   afterEach(function() {
@@ -57,7 +56,6 @@ describe('build command', function() {
     return command.validateAndRun([]).then(function() {
       var buildRun = tasks.Build.prototype.run;
 
-      td.verify(buildRun(), {ignoreExtraArgs: true, times: 1});
       expect(buildTaskInstance.project).to.equal(options.project, 'has correct project instance');
     });
   });
@@ -66,7 +64,6 @@ describe('build command', function() {
     return command.validateAndRun(['--watch']).then(function() {
       var buildWatchRun = tasks.BuildWatch.prototype.run;
 
-      td.verify(buildWatchRun(), {ignoreExtraArgs: true, times: 1});
       expect(buildWatchTaskInstance.project).to.equal(options.project, 'has correct project instance');
     });
   });
@@ -86,7 +83,6 @@ describe('build command', function() {
       var buildRun = tasks.Build.prototype.run;
       var showSizesRun = tasks.ShowAssetSizes.prototype.run;
 
-      td.verify(buildRun(), {ignoreExtraArgs: true, times: 1});
       td.verify(showSizesRun(), {ignoreExtraArgs: true, times: 0});
     });
   });
@@ -96,7 +92,6 @@ describe('build command', function() {
       var buildRun = tasks.Build.prototype.run;
       var showSizesRun = tasks.ShowAssetSizes.prototype.run;
 
-      td.verify(buildRun(), {ignoreExtraArgs: true, times: 1});
       td.verify(showSizesRun(), {ignoreExtraArgs: true, times: 1});
     });
   });
@@ -106,7 +101,6 @@ describe('build command', function() {
       var buildRun = tasks.Build.prototype.run;
       var showSizesRun = tasks.ShowAssetSizes.prototype.run;
 
-      td.verify(buildRun(), {ignoreExtraArgs: true, times: 1});
       td.verify(showSizesRun(), {ignoreExtraArgs: true, times: 0});
     });
   });

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -71,7 +71,6 @@ describe('install command', function() {
     td.replace(tasks.NpmInstall.prototype, 'run', td.function());
     td.when(tasks.NpmInstall.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
     td.replace(tasks.GenerateFromBlueprint.prototype, 'run', td.function());
-    td.when(tasks.GenerateFromBlueprint.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
 
     command = new InstallCommand(options);
   });

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -2,7 +2,7 @@
 
 var path           = require('path');
 var CoreObject     = require('core-object');
-var expect         = require('chai').expect;
+var expect         = require('../../chai').expect;
 var MockProject    = require('../../helpers/mock-project');
 var commandOptions = require('../../factories/command-options');
 var Promise        = require('../../../lib/ext/promise');
@@ -35,9 +35,13 @@ describe('test command', function() {
     td.replace(tasks.Test.prototype, 'run', td.function());
     td.replace(tasks.Build.prototype, 'run', td.function());
     td.replace(tasks.TestServer.prototype, 'run', td.function());
-    td.when(tasks.Test.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
-    td.when(tasks.Build.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
+    td.when(tasks.Test.prototype.run(), {ignoreExtraArgs: true, times: 1}).thenReturn(Promise.resolve());
+    td.when(tasks.Build.prototype.run(), {ignoreExtraArgs: true, times: 1}).thenReturn(Promise.resolve());
     td.when(tasks.TestServer.prototype.run(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
+  });
+
+  afterEach(function() {
+    td.reset();
   });
 
   function buildCommand() {
@@ -50,10 +54,7 @@ describe('test command', function() {
     });
 
     it('builds and runs test', function() {
-      return command.validateAndRun([]).then(function() {
-        td.verify(tasks.Build.prototype.run(), {ignoreExtraArgs: true});
-        td.verify(tasks.Test.prototype.run(), {ignoreExtraArgs: true});
-      });
+      return command.validateAndRun([]);
     });
 
     it('has the correct options', function() {
@@ -146,7 +147,7 @@ describe('test command', function() {
       return command.validateAndRun(['--path=tests']).then(function() {
         var captor = td.matchers.captor();
 
-        td.verify(tasks.Build.prototype.run(), {ignoreExtraArgs: true, times: 0});
+        td.verify(tasks.Build.prototype.run(td.matchers.anything()), { times: 0 });
         td.verify(tasks.Test.prototype.run(captor.capture()));
 
         expect(captor.value.outputPath).to.equal(path.resolve('tests'), 'has outputPath');

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -348,7 +348,6 @@ describe('Blueprint', function() {
     describe('printBasicHelp', function() {
       beforeEach(function() {
         td.replace(blueprint, '_printCommand', td.function());
-        td.when(blueprint._printCommand(), {ignoreExtraArgs: true}).thenReturn(' command printed');
         td.replace(blueprint, 'printDetailedHelp', td.function());
         td.when(blueprint.printDetailedHelp(), {ignoreExtraArgs: true}).thenReturn('help in detail');
       });
@@ -365,20 +364,23 @@ describe('Blueprint', function() {
 
         expect(output).to.equal(testString);
 
-        td.verify(blueprint._printCommand(), {ignoreExtraArgs: true, times: 0});
+        td.verify(blueprint._printCommand(), {times: 0});
       });
 
       it('calls printCommand', function() {
+        td.when(blueprint._printCommand(), {ignoreExtraArgs: true}).thenReturn(' command printed');
+
         var output = blueprint.printBasicHelp();
 
         var testString = processHelpString('\
       my-blueprint command printed');
 
         expect(output).to.equal(testString);
-        td.verify(blueprint._printCommand('      ', true), {times: 1});
       });
 
       it('prints detailed help if verbose', function() {
+        td.when(blueprint._printCommand(), {ignoreExtraArgs: true}).thenReturn(' command printed');
+
         var availableOptions = [];
         assign(blueprint, {
           availableOptions: availableOptions
@@ -391,7 +393,6 @@ describe('Blueprint', function() {
 help in detail');
 
         expect(output).to.equal(testString);
-        td.verify(blueprint.printDetailedHelp(availableOptions));
       });
     });
 
@@ -726,8 +727,6 @@ help in detail');
           return blueprintNew.install(options);
         })
         .then(function() {
-
-          td.verify(ui.prompt(), {ignoreExtraArgs: true});
 
           var actualFiles = walkSync(tmpdir).sort();
           // Prompts contain \n EOL

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -312,6 +312,7 @@ describe('models/builder.js', function() {
     });
 
     afterEach(function() {
+      td.reset();
       delete process.env.BROCCOLI_VIZ;
       delete process.env.EMBER_CLI_INSTRUMENTATION;
     });
@@ -690,11 +691,9 @@ describe('models/builder.js', function() {
 
     it('allows addons to add promises preBuild', function() {
       var preBuild = td.replace(addon, 'preBuild', td.function());
-      td.when(preBuild(), {ignoreExtraArgs: true}).thenReturn(Promise.resolve());
+      td.when(preBuild(), {ignoreExtraArgs: true, times: 1}).thenReturn(Promise.resolve());
 
-      return builder.build().then(function() {
-        td.verify(preBuild(), {ignoreExtraArgs: true});
-      });
+      return builder.build();
     });
 
     it('allows addons to add promises postBuild', function() {

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -100,6 +100,10 @@ describe('models/command.js', function() {
     ui = options.ui;
   });
 
+  afterEach(function() {
+    td.reset();
+  });
+
   it('parseArgs() should parse the command options.', function() {
     expect(new ServeCommand(options).parseArgs(['--port', '80'])).to.have.deep.property('options.port', 80);
   });
@@ -568,13 +572,16 @@ describe('models/command.js', function() {
         td.when(command._printCommand(), {ignoreExtraArgs: true}).thenReturn(' command printed');
       });
 
+      afterEach(function() {
+        td.reset();
+      });
+
       it('calls printCommand', function() {
         var output = command.printBasicHelp();
 
         var testString = processHelpString('ember serve command printed' + EOL);
 
         expect(output).to.equal(testString);
-        td.verify(command._printCommand(), {times: 1});
       });
 
       it('is root', function() {


### PR DESCRIPTION
Warnings I was referring to:

```
Warning: testdouble.js - td.verify - test double was both stubbed and verified with arguments (), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double
```

[Why shouldn't we use `verify` and `when` at the same time?](https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double)

We were abusing `test-double` assertion a little bit. Of course, there's always [an option to turn warning off](https://github.com/testdouble/testdouble.js/blob/master/docs/C-configuration.md#tdconfig) but I feel like it's just hiding the problem. Besides, cleaning things up never hurts! 

cc @Turbo87 