### PR TITLE
[ENHANCEMENT] Ignore jetbrains files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ npm-debug.log
 .deps-tmp
 /coverage
 *.pem
+
+# JetBrains files
+.idea/
+*.iml

--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -15,3 +15,7 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+# JetBrains files
+.idea/
+*.iml


### PR DESCRIPTION
I constantly finding myself adding JetBrains entries to `.gitignore` files in new and existing Ember projects. I know I'm not the only person using IntelliJ or WebStorm for Ember. This won't fix existing projects, but it will help eliminate this bit of recurring overhead for future individual and public projects.

I added it both to the project `.gitignore` and the `gitignore` in the app blueprint.