### PR TITLE
Fix `BROCCOLI_VIZ=1 ember build`.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -16,8 +16,6 @@ var _resetTreeCache = require('./addon')._resetTreeCache;
 
 var Sync = require('tree-sync');
 
-var signalsTrapped = false;
-
 function _enableFSMonitorIfInstrumentationEnabled() {
   var monitor;
   if (_instrumentationEnabled()) {
@@ -132,6 +130,7 @@ module.exports = CoreObject.extend({
     this._buildCount = 0;
     this.setupBroccoliBuilder();
     this.trapSignals();
+    this._instantiationStack = (new Error).stack.replace(/[^\n]*\n/, '');
   },
 
   /**
@@ -163,17 +162,29 @@ module.exports = CoreObject.extend({
    * @method trapSignals
    */
   trapSignals: function() {
-    if (!signalsTrapped) {
-      process.on('SIGINT',  this.onSIGINT.bind(this));
-      process.on('SIGTERM', this.onSIGTERM.bind(this));
-      process.on('message', this.onMessage.bind(this));
-      exit.onExit(this.cleanup.bind(this));
+    this._boundOnSIGINT = this.onSIGINT.bind(this);
+    this._boundOnSIGTERM = this.onSIGTERM.bind(this);
+    this._boundOnMessage = this.onMessage.bind(this);
+    this._boundCleanup = this.cleanup.bind(this);
 
-      if (/^win/.test(process.platform)) {
-        this.trapWindowsSignals();
-      }
+    process.on('SIGINT',  this._boundOnSIGINT);
+    process.on('SIGTERM', this._boundOnSIGTERM);
+    process.on('message', this._boundOnMessage);
+    exit.onExit(this._boundCleanup);
 
-      signalsTrapped = true;
+    if (/^win/.test(process.platform)) {
+      this.trapWindowsSignals();
+    }
+  },
+
+  _cleanupSignals: function() {
+    process.removeListener('SIGINT',  this._boundOnSIGINT);
+    process.removeListener('SIGTERM', this._boundOnSIGTERM);
+    process.removeListener('message', this._boundOnMessage);
+    exit.offExit(this._boundCleanup);
+
+    if (/^win/.test(process.platform)) {
+      this._cleanupWindowsSignals();
     }
   },
 
@@ -185,11 +196,18 @@ module.exports = CoreObject.extend({
     // This is required to capture Ctrl + C on Windows
     if (process.stdin && process.stdin.isTTY) {
       process.stdin.setRawMode(true);
-      process.stdin.on('data', function (data) {
+      this._windowsCtrlCTrap = function (data) {
         if (data.length === 1 && data[0] === 0x03) {
           process.emit('SIGINT');
         }
-      });
+      };
+      process.stdin.on('data', this._windowsCtrlCTrap);
+    }
+  },
+
+  _cleanupWindowsSignals: function() {
+    if (this._windowsCtrlCTrap && process.stdin.removeListener) {
+      process.stdin.removeListener('data', this._windowsCtrlCTrap);
     }
   },
 
@@ -354,6 +372,8 @@ module.exports = CoreObject.extend({
     // ensure any addon treeFor caches are reset
     _resetTreeCache();
 
+    this._cleanupSignals();
+
     return this.builder.cleanup().finally(function() {
       ui.stopProgress();
     }).catch(function(err) {
@@ -406,8 +426,7 @@ module.exports = CoreObject.extend({
   /**
    * Handles the `message` event on the `process`.
    *
-   * Calls {{#crossLink "Builder/cleanupAndExit:method"}}{{/crossLink}} by default
-   * if the `kill` property on the `message` is set.
+   * Calls `process.exit` if the `kill` property on the `message` is set.
    *
    * @private
    * @method onMessage

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -17,7 +17,6 @@ var _resetTreeCache = require('./addon')._resetTreeCache;
 var Sync = require('tree-sync');
 
 var signalsTrapped = false;
-var buildCount = 0;
 
 function _enableFSMonitorIfInstrumentationEnabled() {
   var monitor;
@@ -130,6 +129,7 @@ module.exports = CoreObject.extend({
 
   init: function() {
     this._super.apply(this, arguments);
+    this._buildCount = 0;
     this.setupBroccoliBuilder();
     this.trapSignals();
   },
@@ -312,13 +312,13 @@ module.exports = CoreObject.extend({
         var vizJson;
 
         if (_instrumentationEnabled()) {
-          vizJson = self._computeVizInfo(buildCount, result, resultAnnotation);
+          vizJson = self._computeVizInfo(self._buildCount, result, resultAnnotation);
           self._reportVizInfo(vizJson);
         }
 
         if (_vizEnabled()) {
           vizJson.nodes = result.graph.__heimdall__.toJSONSubgraph();
-          writeVizInfo(buildCount,{
+          writeVizInfo(self._buildCount,{
             summary: vizJson.summary,
             // We want to change this to buildTree, to be consistent with the
             // hook, but first we must update broccoli-viz
@@ -327,7 +327,8 @@ module.exports = CoreObject.extend({
           });
         }
 
-        buildCount++;
+        self._buildCount++;
+
         return result;
       })
       .then(this.processAddonBuildSteps.bind(this, 'outputReady'))

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -19,7 +19,14 @@ module.exports = Task.extend({
       project: this.project
     });
 
-    return builder.build()
+    var annotation = {
+      type: 'initial',
+      reason: 'build',
+      primaryFile: null,
+      changedFiles: []
+    };
+
+    return builder.build(null, annotation)
       .then(function(results) {
         var totalTime = results.totalTime / 1e6;
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.2.0",
     "calculate-cache-key-for-tree": "^1.0.0",
-    "capture-exit": "^1.0.7",
+    "capture-exit": "^1.1.0",
     "chalk": "^1.1.3",
     "clean-base-url": "^1.0.0",
     "compression": "^1.4.4",

--- a/tests/fixtures/tasks/builder/ember-cli-build.js
+++ b/tests/fixtures/tasks/builder/ember-cli-build.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports = function() {
+  return path.join(__dirname, 'some-dir');
+};

--- a/tests/fixtures/tasks/builder/some-dir/foo.txt
+++ b/tests/fixtures/tasks/builder/some-dir/foo.txt
@@ -1,0 +1,1 @@
+Some file named foo.txt

--- a/tests/integration/tasks/build-test.js
+++ b/tests/integration/tasks/build-test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var fs = require('fs-extra');
+var path = require('path');
+var chai = require('../../chai');
+var expect = chai.expect;
+var file = chai.file;
+var walkSync = require('walk-sync');
+var assign = require('ember-cli-lodash-subset').assign;
+var BuildTask = require('../../../lib/tasks/build');
+var Promise = require('../../../lib/ext/promise');
+var MockProject = require('../../helpers/mock-project');
+var MockAnalytics = require('../../helpers/mock-analytics');
+var copyFixtureFiles = require('../../helpers/copy-fixture-files');
+var mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
+var remove = Promise.denodeify(fs.remove);
+var root = process.cwd();
+var tmproot = path.join(root, 'tmp');
+
+describe('build task test', function() {
+  var project, ui;
+
+  beforeEach(function() {
+    return mkTmpDirIn(tmproot)
+      .then(function(tmpdir) {
+        process.chdir(tmpdir);
+      })
+      .then(function() {
+        return copyFixtureFiles('tasks/builder');
+      })
+      .then(function() {
+        project = new MockProject();
+        ui = project.ui;
+      });
+  });
+
+  afterEach(function() {
+    process.chdir(root);
+    delete process.env.BROCCOLI_VIZ;
+
+    return remove(tmproot);
+  });
+
+  it('can build', function() {
+    var outputPath = 'dist';
+    var task = new BuildTask({
+      analytics: new MockAnalytics(),
+      project: project,
+      ui: ui
+    });
+
+    var runOptions = {
+      outputPath: outputPath,
+      environment: 'development'
+    };
+
+    return task.run(runOptions)
+      .then(function() {
+        var expected = [ 'foo.txt'];
+
+        expect(walkSync(outputPath)).to.eql(['foo.txt']);
+        expect(file('dist/foo.txt')).to.equal('Some file named foo.txt\n');
+      });
+  });
+
+  it('generates valid visualization output', function() {
+    process.env.BROCCOLI_VIZ = '1';
+
+    var outputPath = 'dist';
+    var task = new BuildTask({
+      analytics: new MockAnalytics(),
+      project: project,
+      ui: ui
+    });
+
+    var runOptions = {
+      outputPath: outputPath,
+      environment: 'development'
+    };
+
+    return task.run(runOptions)
+      .then(function() {
+        var vizOutputPath = 'broccoli-viz.0.json';
+        expect(file(vizOutputPath)).to.exist;
+
+        // confirm it is valid json
+        var output = fs.readJsonSync(vizOutputPath);
+        expect(output.summary.build.type).to.equal('initial');
+        expect(output.summary.buildSteps).to.equal(1);
+      });
+  });
+});

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -45,6 +45,24 @@ var mockBuildResultsWithHeimdallSubgraph = {
 describe('models/builder.js', function() {
   var addon, builder, buildResults, tmpdir;
 
+  function setupBroccoliBuilder() {
+    this.builder = {
+      build: function () {
+        return Promise.resolve('build results');
+      },
+
+      cleanup: function() {
+        return Promise.resolve('cleanup result');
+      }
+    };
+  }
+
+  afterEach(function() {
+    if (builder) {
+      return builder.cleanup();
+    }
+  });
+
   describe('._reportVizInfo', function() {
     var builder;
     var instrumentationWasCalled;
@@ -63,10 +81,10 @@ describe('models/builder.js', function() {
 
       builder = new Builder({
         project: {
-          addons: [ addon1, addon2 ]
+          addons: [ addon1, addon2 ],
+          ui: new MockUI()
         },
-        setupBroccoliBuilder: function() { },
-        trapSignals: function() { }
+        setupBroccoliBuilder: setupBroccoliBuilder
       })
     });
 
@@ -404,7 +422,7 @@ describe('models/builder.js', function() {
       var trapWindowsSignals = td.function();
 
       builder = new Builder({
-        setupBroccoliBuilder: function() { },
+        setupBroccoliBuilder: setupBroccoliBuilder,
         cleanup: function() { },
         trapWindowsSignals: trapWindowsSignals,
         project: new MockProject()
@@ -428,8 +446,7 @@ describe('models/builder.js', function() {
       var trapWindowsSignals = td.function();
 
       builder = new Builder({
-        setupBroccoliBuilder: function() { },
-        cleanupOnExit: function() { },
+        setupBroccoliBuilder: setupBroccoliBuilder,
         trapWindowsSignals: trapWindowsSignals,
         project: new MockProject()
       });
@@ -444,9 +461,7 @@ describe('models/builder.js', function() {
       return mkTmpDirIn(tmproot).then(function(dir) {
         tmpdir = dir;
         builder = new Builder({
-          setupBroccoliBuilder: function() { },
-          trapSignals: function() { },
-          cleanupOnExit: function() { },
+          setupBroccoliBuilder: setupBroccoliBuilder,
           project: new MockProject()
         });
       });
@@ -471,9 +486,7 @@ describe('models/builder.js', function() {
       command = new BuildCommand(commandOptions());
 
       builder = new Builder({
-        setupBroccoliBuilder: function() { },
-        trapSignals: function() { },
-        cleanupOnExit: function() { },
+        setupBroccoliBuilder: setupBroccoliBuilder,
         project: new MockProject()
       });
     });
@@ -518,15 +531,8 @@ describe('models/builder.js', function() {
       var command = new BuildCommand(commandOptions());
 
       builder = new Builder({
-        setupBroccoliBuilder: function() { },
-        trapSignals: function() { },
-        cleanupOnExit: function() { },
+        setupBroccoliBuilder: setupBroccoliBuilder,
         project: new MockProject(),
-        builder: {
-          build: function () {
-            return Promise.resolve('build results');
-          }
-        },
         processBuildResult: function(buildResults) { return Promise.resolve(buildResults); },
       });
     });
@@ -599,18 +605,20 @@ describe('models/builder.js', function() {
       project.addons = [addon];
 
       builder = new Builder({
-        setupBroccoliBuilder: function() { },
-        trapSignals:          function() { },
-        cleanupOnExit:        function() { },
+        setupBroccoliBuilder: function() {},
         builder: {
           build: function() {
             hooksCalled.push('build');
 
             return Promise.resolve(buildResults);
+          },
+
+          cleanup: function() {
+            return Promise.resolve('cleanup results');
           }
         },
         processBuildResult: function(buildResults) { return Promise.resolve(buildResults); },
-        project: project,
+        project: project
       });
 
       buildResults = 'build results';

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -24,6 +24,7 @@ var Heimdall = require('heimdalljs/heimdall');
 var walkSync = require('walk-sync');
 var itr2Array = require('../../helpers/itr2array');
 var EventEmitter = require('events');
+var captureExit = require('capture-exit');
 
 var mockBuildResultsWithHeimdallSubgraph = {
   graph: {
@@ -81,9 +82,7 @@ describe('models/builder.js', function() {
         SIGINT: getListenerCount(process, 'SIGINT'),
         SIGTERM: getListenerCount(process, 'SIGTERM'),
         message: getListenerCount(process, 'message'),
-
-        // enable when https://github.com/ember-cli/capture-exit/pull/17 lands
-        // exit: captureExit.listenerCount(),
+        exit: captureExit.listenerCount()
       };
     }
 
@@ -103,9 +102,7 @@ describe('models/builder.js', function() {
         SIGINT: originalListenerCounts.SIGINT + 1,
         SIGTERM: originalListenerCounts.SIGTERM + 1,
         message: originalListenerCounts.message + 1,
-
-        // enable when https://github.com/ember-cli/capture-exit/pull/17 lands
-        // exit: originalListenerCounts.exit + 1
+        exit: originalListenerCounts.exit + 1
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,8 +24,8 @@ acorn@^3.0.4, acorn@^3.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
 acorn@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.3.tgz#1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 after@0.8.1:
   version "0.8.1"
@@ -794,7 +794,7 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
-capture-exit@^1.0.7:
+capture-exit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.1.0.tgz#d931b32b11c2bd20ae57f34af0c1eb2c18781626"
   dependencies:
@@ -2486,7 +2486,7 @@ has-cors@1.1.0:
 
 has-flag@^1.0.0:
   version "1.0.0"
-  resolved "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-unicode@^2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
@@ -2822,7 +2822,7 @@ is-plain-obj@^1.0.0:
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
-  resolved "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
 
 is-primitive@^2.0.0:
   version "2.0.0"
@@ -3502,7 +3502,7 @@ minimatch@^2.0.1, minimatch@^2.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
@@ -3513,10 +3513,6 @@ minimist@^0.1.0:
 minimist@^1.1.0, minimist@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4853,7 +4849,7 @@ stringify-object@^2.4.0:
 
 stringmap@~0.2.2:
   version "0.2.2"
-  resolved "http://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz#556c137b258f942b8776f5b2ef582aa069d7d1b1"
+  resolved "https://registry.yarnpkg.com/stringmap/-/stringmap-0.2.2.tgz#556c137b258f942b8776f5b2ef582aa069d7d1b1"
 
 stringset@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Ensure an annotation is passed into `Builder.prototype.build` from the build task (even when not using the watcher).

Fixes https://github.com/ember-cli/ember-cli/issues/6579.