### PR TITLE
Use `tap` reporter in CI.

### DIFF
--- a/tests/runner.js
+++ b/tests/runner.js
@@ -18,9 +18,11 @@ fs.removeSync('.deps-tmp');
 var root = 'tests/{unit,integration,acceptance}';
 var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test,-slow}.js'));
 var optionOrFile = process.argv[2];
+// default to `tap` reporter in CI otherwise default to `spec`
+var reporter = process.env.MOCHA_REPORTER || (process.env.CI ? 'tap' : 'spec');
 var mocha = new Mocha({
   timeout: 5000,
-  reporter: process.env.MOCHA_REPORTER || 'spec',
+  reporter: reporter,
   retries: 2
 });
 var testFiles = glob.sync(root + '/**/*-test.js');


### PR DESCRIPTION
This makes finding failed tests in CI output much much easier:

* you can search for `not ok` and jump directly to the failure
* all stdout / stderr is grouped in the reporter output
* the count of pass / fail / skip is emitted at the end

I still find `spec` to be much nicer to look at while running local tests, so I left that as the default for non-CI tests.

Compare the following CI builds:

* [spec output](https://travis-ci.org/ember-cli/ember-cli/jobs/184977601)
* [tap output](https://travis-ci.org/ember-cli/ember-cli/jobs/184987946)