### PR TITLE
Fix incomplete API docs for Blueprint.lookupBlueprint

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1218,7 +1218,8 @@ var Blueprint = CoreObject.extend({
     Used to retrieve a blueprint with the given name.
 
     @method lookupBlueprint
-    @param dasherizedName
+    @param {String} dasherizedName
+    @return {Blueprint}
     @public
   */
   lookupBlueprint: function(dasherizedName) {


### PR DESCRIPTION
https://ember-cli.com/api/classes/Blueprint.html#method_lookupBlueprint describes the dasherizedName param as an `Object` and does not specify the return value.