### PR TITLE
Refactor addon tree cache to expose usable API

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -79,9 +79,38 @@ var DEFAULT_TREE_FOR_METHOD_METHODS = {
   vendor: ['treeForVendor']
 };
 
-var ADDON_TREE_CACHE = Object.create(null);
+var ADDON_TREE_CACHE = {
+  __cache: Object.create(null),
+
+  getItem: function(key) {
+    var addonTreeCacheStats = heimdall.statsFor('addon-tree-cache');
+    var cachedValue = this.__cache[key];
+
+    if (cachedValue) {
+      addonTreeCacheStats.hits++;
+      treeCacheLogger.info('Cache Hit: ' + key);
+      return cachedValue;
+    } else {
+      addonTreeCacheStats.misses++;
+      treeCacheLogger.info('Cache Miss: ' + key);
+      return null;
+    }
+  },
+
+  setItem: function(key, value) {
+    var hasValue = !!value;
+    heimdall.statsFor('addon-tree-cache').adds++;
+    treeCacheLogger.info('Cache Add: ' + key + ' - ' + hasValue);
+    this.__cache[key] = value;
+  },
+
+  clear: function() {
+    this.__cache = Object.create(null);
+  }
+};
+
 function _resetTreeCache() {
-  ADDON_TREE_CACHE = Object.create(null);
+  ADDON_TREE_CACHE.clear();
 }
 
 function warn(message) {
@@ -421,20 +450,14 @@ var addonProto = {
       treeFor: true
     });
 
-    var addonTreeCacheStats = heimdall.statsFor('addon-tree-cache');
-
     var cacheKeyForTreeType;
     if (experiments.ADDON_TREE_CACHING) {
       cacheKeyForTreeType = this[experiments.ADDON_TREE_CACHING](treeType);
 
-      if (ADDON_TREE_CACHE[cacheKeyForTreeType]) {
-        addonTreeCacheStats.hits++;
-        treeCacheLogger.info('Cache Hit: ' + cacheKeyForTreeType);
+      var cachedTree = ADDON_TREE_CACHE.getItem(cacheKeyForTreeType);
+      if (cachedTree) {
         node.stop();
-        return ADDON_TREE_CACHE[cacheKeyForTreeType];
-      } else {
-        addonTreeCacheStats.misses++;
-        treeCacheLogger.info('Cache Miss: ' + cacheKeyForTreeType);
+        return cachedTree;
       }
     }
 
@@ -455,10 +478,7 @@ var addonProto = {
     });
 
     if (cacheKeyForTreeType) {
-      var hasTree = !!tree;
-      addonTreeCacheStats.adds++;
-      treeCacheLogger.info('Cache Add: ' + cacheKeyForTreeType + ' - ' + hasTree);
-      ADDON_TREE_CACHE[cacheKeyForTreeType] = mergedTreesForType;
+      ADDON_TREE_CACHE.setItem(cacheKeyForTreeType, mergedTreesForType);
     }
 
     node.stop();
@@ -1565,3 +1585,7 @@ Addon.lookup = function(addon) {
 };
 module.exports = Addon;
 module.exports._resetTreeCache = _resetTreeCache;
+
+if (addonTreeCacheExperimentPresent) {
+  module.exports._treeCache = ADDON_TREE_CACHE;
+}


### PR DESCRIPTION
When using the `ADDON_TREE_CACHING` experiment, this adds `Addon.prototype.treeCache` so that consumers (such as ember-engines) can easily leverage the same cache with instrumentation available.

See https://github.com/ember-engines/ember-engines/pull/283 for an example of usage.