### PR TITLE
produce error code only if build is not finished

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -162,13 +162,12 @@ module.exports = CoreObject.extend({
    * @method trapSignals
    */
   trapSignals: function() {
-    this._boundOnSIGINT = this.onSIGINT.bind(this);
-    this._boundOnSIGTERM = this.onSIGTERM.bind(this);
+    this._boundExit = this._exit.bind(this);
     this._boundOnMessage = this.onMessage.bind(this);
     this._boundCleanup = this.cleanup.bind(this);
 
-    process.on('SIGINT',  this._boundOnSIGINT);
-    process.on('SIGTERM', this._boundOnSIGTERM);
+    process.on('SIGINT',  this._boundExit);
+    process.on('SIGTERM', this._boundExit);
     process.on('message', this._boundOnMessage);
     exit.onExit(this._boundCleanup);
 
@@ -178,8 +177,8 @@ module.exports = CoreObject.extend({
   },
 
   _cleanupSignals: function() {
-    process.removeListener('SIGINT',  this._boundOnSIGINT);
-    process.removeListener('SIGTERM', this._boundOnSIGTERM);
+    process.removeListener('SIGINT',  this._boundExit);
+    process.removeListener('SIGTERM', this._boundExit);
     process.removeListener('message', this._boundOnMessage);
     exit.offExit(this._boundCleanup);
 
@@ -320,7 +319,7 @@ module.exports = CoreObject.extend({
     var self = this;
     attemptNeverIndex('tmp');
 
-    return this.processAddonBuildSteps('preBuild')
+    return this._build = this.processAddonBuildSteps('preBuild')
       .then(function() {
         return self.builder.build(willReadStringDir);
       })
@@ -354,6 +353,9 @@ module.exports = CoreObject.extend({
       .catch(function(error) {
         this.processAddonBuildSteps('buildError', error);
         throw error;
+      }.bind(this))
+      .finally(function() {
+        delete this._build;
       }.bind(this));
   },
 
@@ -400,30 +402,6 @@ module.exports = CoreObject.extend({
   },
 
   /**
-   * Handles the `SIGINT` signal.
-   *
-   * Calls {{#crossLink "Builder/cleanupAndExit:method"}}{{/crossLink}} by default.
-   *
-   * @private
-   * @method onSIGINT
-   */
-  onSIGINT: function() {
-    process.exit(1);
-  },
-
-  /**
-   * Handles the `SIGTERM` signal.
-   *
-   * Calls {{#crossLink "Builder/cleanupAndExit:method"}}{{/crossLink}} by default.
-   *
-   * @private
-   * @method onSIGTERM
-   */
-  onSIGTERM: function() {
-    process.exit(1);
-  },
-
-  /**
    * Handles the `message` event on the `process`.
    *
    * Calls `process.exit` if the `kill` property on the `message` is set.
@@ -433,8 +411,12 @@ module.exports = CoreObject.extend({
    */
   onMessage: function(message) {
     if (message.kill) {
-      process.exit(1);
+      this._exit();
     }
+  },
+
+  _exit: function() {
+    process.exit(this._build ? 1 : 0);
   },
 
   _computeVizInfo: _computeVizInfo,


### PR DESCRIPTION
An attempt to fix #6421. 
Instead of always throwing an error code we do it only if `Builder.build` is in progress.

Needs:
- [ ] tests
- [ ] testing under windows
- [ ] go/no-go feedback