### PR TITLE
Apply clean-base-url to config.rootURL

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1714,6 +1714,12 @@ EmberApp.prototype.contentFor = function(config, match, type) {
   var deprecatedHooks = ['app-prefix', 'app-suffix', 'vendor-prefix', 'vendor-suffix'];
   var deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
 
+  // This normalizes `rootURL` to the value which we use everywhere inside of Ember CLI.
+  // This makes sure that the user doesn't have to account for it in application code.
+  if ('rootURL' in config) {
+    config.rootURL = calculateRootURL(config);
+  }
+
   switch (type) {
     case 'head':             this._contentForHead(content, config);           break;
     case 'config-module':    this._contentForConfigModule(content, config);   break;


### PR DESCRIPTION
So here's the deal: this is an improvement but it is actually a change. This method has not changed:
- [In 2.4, before all `baseURL` changes.](https://github.com/ember-cli/ember-cli/blob/v2.4.3/lib/broccoli/ember-app.js#L1656-L1663)
- [In `master` after changes.](https://github.com/ember-cli/ember-cli/blob/9e674547c82fa6747895e2b5b7f6a53e73d0226f/lib/broccoli/ember-app.js#L1752-L1759)

We would populate the `base` tag with `/` if the provided value was falsey, but the config value would always be the original as specified by the user.

[Flipping through the switchover commit you can see that we didn't adjust what appears in the config module in any way.](https://github.com/ember-cli/ember-cli/pull/5792)

I'm in favor of this change since this is what we do internally for all usages. Exposing it to the user in the "canonical" format is probably a better decision. However it _is_ a change and could be considered breaking. I require a +1 from @rwjblue and @Turbo87 to ship.

Closes #6599. Discarding this also should close #6599.