### PR TITLE
Command interruption

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -7,10 +7,10 @@ const getOptionArgs = require('../utilities/get-option-args');
 let logger = require('heimdalljs-logger')('ember-cli:cli');
 let loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
 const Instrumentation = require('../models/instrumentation');
-const exit = require('capture-exit');
 const heimdall = require('heimdalljs');
 
 const Promise = RSVP.Promise;
+const onProcessInterrupt = require('../utilities/will-interrupt-process');
 
 class CLI {
   /**
@@ -145,6 +145,7 @@ class CLI {
         }
       }
 
+      let onCommandInterrupt = command.onInterrupt.bind(command);
       let instrumentation = this.instrumentation;
       let initCompleted = false;
 
@@ -154,6 +155,7 @@ class CLI {
         instrumentation.start('command');
 
         loggerTesting.info('cli: command.beforeRun');
+        onProcessInterrupt.addHandler(onCommandInterrupt);
 
         return command.beforeRun(commandArgs);
 
@@ -167,14 +169,14 @@ class CLI {
         }
         instrumentation.start('shutdown');
 
+        onProcessInterrupt.removeHandler(onCommandInterrupt);
         shutdownOnExit = function() {
           instrumentation.stopAndReport('shutdown');
         };
 
-        // schedule this with `capture-exit` to ensure that
-        // the shutdown instrumentation hook is invoked properly even if
-        // we exit before hitting the `finally` below
-        exit.onExit(shutdownOnExit);
+        // Ensure that the shutdown instrumentation hook is invoked properly
+        // even if we exit before hitting the `finally` below
+        onProcessInterrupt.addHandler(shutdownOnExit);
       }).then(result => {
         // if the help option was passed, call the help command
         if (result === 'callHelp') {
@@ -205,15 +207,15 @@ class CLI {
         });
       });
     })
-      .finally(() => {
-        if (shutdownOnExit) {
-          // invoke instrumentation shutdown and
-          // remove from `capture-exit` callbacks
-          shutdownOnExit();
-          exit.offExit(shutdownOnExit);
-        }
-      })
-      .catch(this.logError.bind(this));
+    .finally(() => {
+      if (shutdownOnExit) {
+        // invoke instrumentation shutdown and
+        // remove instrumentation interruption handlers
+        shutdownOnExit();
+        onProcessInterrupt.removeHandler(shutdownOnExit);
+      }
+    })
+    .catch(this.logError.bind(this));
   }
 
   /**

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-// work around misbehaving libraries, so we can correctly cleanup before
-// actually exiting.
-require('capture-exit').captureExit();
-
 // Main entry point
 const requireAsHash = require('../utilities/require-as-hash');
 const packageConfig = require('../../package.json');

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -17,33 +17,20 @@ module.exports = Command.extend({
   ],
 
   run(commandOptions) {
-    let BuildTask = this.taskFor(commandOptions);
-    let buildTask = new BuildTask({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-    });
     let ShowAssetSizesTask = this.tasks.ShowAssetSizes;
     let showTask = new ShowAssetSizesTask({
       ui: this.ui,
     });
 
-    return Win.checkIfSymlinksNeedToBeEnabled(this.ui)
-      .then(() => buildTask.run(commandOptions))
-      .then(() => {
+    return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(() => {
+      let buildTaskName = commandOptions.watch ? 'BuildWatch' : 'Build';
+      return this.runTask(buildTaskName, commandOptions).then(() => {
         if (!commandOptions.suppressSizes && commandOptions.environment === 'production') {
           return showTask.run({
             outputPath: commandOptions.outputPath,
           });
         }
       });
-  },
-
-  taskFor(options) {
-    if (options.watch) {
-      return this.tasks.BuildWatch;
-    } else {
-      return this.tasks.Build;
-    }
+    });
   },
 });

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -128,12 +128,6 @@ module.exports = Command.extend({
       port: this._generateTestPortNumber(commandOptions),
     }, this._generateCustomConfigs(commandOptions));
 
-    let options = {
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-    };
-
     return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(() => {
       let session;
 
@@ -142,39 +136,32 @@ module.exports = Command.extend({
           throw new SilentError('Specifying a build is not allowed with the `--server` option.');
         }
 
-        let TestServerTask = this.tasks.TestServer;
-        let testServer = new TestServerTask(options);
         let builder = new this.Builder(testOptions);
 
-        testOptions.watcher = new this.Watcher(assign(options, {
+        testOptions.watcher = new this.Watcher(assign(this._env(), {
           builder,
           verbose: false,
           options: commandOptions,
         }));
 
-        session = testServer.run(testOptions)
-          .finally(() => builder.cleanup());
-
+        session = this.runTask('TestServer', testOptions).finally(() => builder.cleanup());
+      } else if (hasBuild) {
+        session = this.runTask('Test', testOptions);
       } else {
-        let TestTask = this.tasks.Test;
-        let test = new TestTask(options);
-
-
-        if (hasBuild) {
-          session = test.run(testOptions);
-        } else {
-          let BuildTask = this.tasks.Build;
-          let build = new BuildTask(options);
-
-          session = build.run({
-            environment: commandOptions.environment,
-            outputPath,
-          })
-          .then(() => test.run(testOptions));
-        }
+        session = this.runTask('Build', {
+          environment: commandOptions.environment,
+          outputPath,
+        })
+        .then(() => this.runTask('Test', testOptions));
       }
 
       return session.finally(this.rmTmp.bind(this));
     });
+  },
+
+  onInterrupt() {
+    this.rmTmp();
+
+    return this._super.onInterrupt.apply(this, arguments);
   },
 });

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -1,7 +1,5 @@
 'use strict';
-const exit = require('capture-exit');
-exit.captureExit();
-
+const onProcessInterrupt = require('../utilities/will-interrupt-process');
 const fs = require('fs-extra');
 const existsSync = require('exists-sync');
 const path = require('path');
@@ -12,7 +10,6 @@ const chalk = require('chalk');
 const attemptNeverIndex = require('../utilities/attempt-never-index');
 const findBuildFile = require('../utilities/find-build-file');
 const _resetTreeCache = require('./addon')._resetTreeCache;
-
 const Sync = require('tree-sync');
 const heimdall = require('heimdalljs');
 
@@ -31,8 +28,10 @@ class Builder extends CoreObject {
     super(options);
 
     this.setupBroccoliBuilder();
-    this.trapSignals();
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
+    this._cleanup = this.cleanup.bind(this);
+
+    onProcessInterrupt.addHandler(this._cleanup);
   }
 
   /**
@@ -57,60 +56,6 @@ class Builder extends CoreObject {
     }
 
     this.builder = new broccoli.Builder(this.tree);
-  }
-
-  /**
-   * @private
-   * @method trapSignals
-   */
-  trapSignals() {
-    this._boundOnSIGINT = this.onSIGINT.bind(this);
-    this._boundOnSIGTERM = this.onSIGTERM.bind(this);
-    this._boundOnMessage = this.onMessage.bind(this);
-    this._boundCleanup = this.cleanup.bind(this);
-
-    process.on('SIGINT', this._boundOnSIGINT);
-    process.on('SIGTERM', this._boundOnSIGTERM);
-    process.on('message', this._boundOnMessage);
-    exit.onExit(this._boundCleanup);
-
-    if (/^win/.test(process.platform)) {
-      this.trapWindowsSignals();
-    }
-  }
-
-  _cleanupSignals() {
-    process.removeListener('SIGINT', this._boundOnSIGINT);
-    process.removeListener('SIGTERM', this._boundOnSIGTERM);
-    process.removeListener('message', this._boundOnMessage);
-    exit.offExit(this._boundCleanup);
-
-    if (/^win/.test(process.platform)) {
-      this._cleanupWindowsSignals();
-    }
-  }
-
-  /**
-   * @private
-   * @method trapWindowsSignals
-   */
-  trapWindowsSignals() {
-    // This is required to capture Ctrl + C on Windows
-    if (process.stdin && process.stdin.isTTY) {
-      process.stdin.setRawMode(true);
-      this._windowsCtrlCTrap = function(data) {
-        if (data.length === 1 && data[0] === 0x03) {
-          process.emit('SIGINT');
-        }
-      };
-      process.stdin.on('data', this._windowsCtrlCTrap);
-    }
-  }
-
-  _cleanupWindowsSignals() {
-    if (this._windowsCtrlCTrap && process.stdin.removeListener) {
-      process.stdin.removeListener('data', this._windowsCtrlCTrap);
-    }
   }
 
   /**
@@ -241,7 +186,7 @@ class Builder extends CoreObject {
     // ensure any addon treeFor caches are reset
     _resetTreeCache();
 
-    this._cleanupSignals();
+    onProcessInterrupt.removeHandler(this._cleanup);
 
     let node = heimdall.start({ name: 'Builder Cleanup' });
 
@@ -269,44 +214,6 @@ class Builder extends CoreObject {
     this.project.ui.writeDeprecateLine('Heimdalljs < 0.1.4 found.  Please remove old versions of heimdalljs and reinstall (you can find them with `npm ls heimdalljs` as long as you have nothing `npm link`d).  Performance instrumentation data will be incomplete until then.', !process._heimdall);
 
     return value;
-  }
-
-  /**
-   * Handles the `SIGINT` signal.
-   *
-   * Calls {{#crossLink "Builder/cleanupAndExit:method"}}{{/crossLink}} by default.
-   *
-   * @private
-   * @method onSIGINT
-   */
-  onSIGINT() {
-    process.exit(1);
-  }
-
-  /**
-   * Handles the `SIGTERM` signal.
-   *
-   * Calls {{#crossLink "Builder/cleanupAndExit:method"}}{{/crossLink}} by default.
-   *
-   * @private
-   * @method onSIGTERM
-   */
-  onSIGTERM() {
-    process.exit(1);
-  }
-
-  /**
-   * Handles the `message` event on the `process`.
-   *
-   * Calls `process.exit` if the `kill` property on the `message` is set.
-   *
-   * @private
-   * @method onMessage
-   */
-  onMessage(message) {
-    if (message.kill) {
-      process.exit(1);
-    }
   }
 }
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -177,6 +177,46 @@ let Command = CoreObject.extend({
   },
 
   /**
+   * Called when command is interrupted from outside, e.g. ctrl+C or process kill
+   * Can be used to cleanup artifacts produced by command and control process exit code
+   *
+   * @method onInterrupt
+   * @return {Promise|undefined} if rejected promise then result of promise will be used as an exit code
+   */
+  onInterrupt() {
+    if (this._currentTask) {
+      return this._currentTask.onInterrupt();
+    }
+  },
+
+  _env() {
+    return {
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project,
+    };
+  },
+
+  runTask(name, options) {
+    if (this._currentTask) {
+      throw new Error(`Concurrent tasks are not supported`);
+    }
+
+    let Task = this.tasks[name];
+    if (!Task) {
+      throw new Error(`Unknown task "${name}"`);
+    }
+
+    let task = new Task(this._env());
+
+    this._currentTask = task;
+
+    return Promise.resolve(task.run(options)).finally(() => {
+      delete this._currentTask;
+    });
+  },
+
+  /**
     Hook for extending a command before it is run in the cli.run command.
     Most common use case would be to extend availableOptions.
     @method beforeRun

--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -6,6 +6,17 @@ class Task extends CoreObject {
   run(/*options*/) {
     throw new Error('Task needs to have run() defined.');
   }
+
+  /**
+   * Interrupt comamd with an exit code
+   * Called when the process is interrupted from outside, e.g. CTRL+C or `process.kill()`
+   *
+   * @private
+   * @method onInterrupt
+   */
+  onInterrupt() {
+    process.exit(1);
+  }
 }
 
 module.exports = Task;

--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -24,6 +24,14 @@ class BuildWatchTask extends Task {
       options,
     }).then(() => new Promise(() => {}) /* Run until failure or signal to exit */);
   }
+
+  /**
+   * Exit silently
+   *
+   * @private
+   * @method onInterrupt
+   */
+  onInterrupt() {}
 }
 
 module.exports = BuildWatchTask;

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -58,6 +58,14 @@ class ServeTask extends Task {
       expressServer.start(options),
     ]).then(() => new Promise(() => {}) /* hang until the user exits. */);
   }
+
+  /**
+   * Exit silently
+   *
+   * @private
+   * @method onInterrupt
+   */
+  onInterrupt() {}
 }
 
 module.exports = ServeTask;

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -52,6 +52,14 @@ class TestServerTask extends TestTask {
       });
     });
   }
+
+  /**
+   * Exit silently
+   *
+   * @private
+   * @method onInterrupt
+   */
+  onInterrupt() {}
 }
 
 module.exports = TestServerTask;

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// (un)Register process interruption signals(SIGINT, SIGTERM, process.kill()) handlers.
+//
+// When the process interrupted("CTR+C") all the registered handlers are being invoked via `capture-exit`.
+// The process finishes after the last interruption handler is settled.
+
+let exit = require('capture-exit');
+
+let windowsCtrlCTrap;
+let handlers = [];
+
+module.exports = {
+  /**
+   * Add process interruption handler
+   *
+   * When the first handler is added then automatically
+   * sets up process interruption signals listeners
+   *
+   * @private
+   * @method addHandler
+   * @param {function} cb   Callback to be called when process interruption fired
+   */
+  addHandler(cb) {
+    let index = handlers.indexOf(cb);
+    if (index > -1) { return; }
+
+    if (handlers.length === 0) {
+      setupSignalsTrap();
+    }
+
+    handlers.push(cb);
+    exit.onExit(cb);
+  },
+
+  /**
+   * Remove process interruption handler
+   *
+   * If there are no remaining handlers after removal
+   * then clean up all the process interruption signal listeners
+   *
+   * @private
+   * @method removeHandler
+   * @param {function} cb   Callback to be removed
+   */
+  removeHandler(cb) {
+    let index = handlers.indexOf(cb);
+    if (index < 0) { return; }
+
+    handlers.splice(index, 1);
+    exit.offExit(cb);
+
+    if (handlers.length === 0) {
+      teardownSignalsTrap();
+    }
+  },
+
+  /**
+   * Tears down all the handlers and cleans up all signal listeners
+   *
+   * @private
+   * @method teardown
+   */
+  teardown() {
+    while (handlers.length > 0) {
+      this.removeHandler(handlers[0]);
+    }
+  },
+};
+
+/**
+ * Sets up listeners for interruption signals
+ *
+ * When one of these signals is caught than raise process.exit()
+ * which enforces `capture-exit` to run registered interruption handlers
+ *
+ * @method setupSignalsTrap
+ */
+function setupSignalsTrap() {
+  process.on('SIGINT', _exit);
+  process.on('SIGTERM', _exit);
+  process.on('message', onMessage);
+  if (/^win/.test(process.platform)) {
+    trapWindowsSignals();
+  }
+
+  exit.captureExit();
+}
+
+/**
+ * Removes interruption signal listeners and tears down capture-exit
+ *
+ * @method teardownSignalsTrap
+ */
+function teardownSignalsTrap() {
+  process.removeListener('SIGINT', _exit);
+  process.removeListener('SIGTERM', _exit);
+  process.removeListener('message', onMessage);
+  if (/^win/.test(process.platform)) {
+    cleanupWindowsSignals();
+  }
+
+  exit.releaseExit();
+}
+
+/**
+ * Supresses "Terminate batch job (Y/N)" confirmation on Windows
+ *
+ * @method trapWindowsSignals
+ */
+function trapWindowsSignals() {
+  // This is required to capture Ctrl + C on Windows
+  if (process.stdin && process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    windowsCtrlCTrap = function(data) {
+      if (data.length === 1 && data[0] === 0x03) {
+        process.emit('SIGINT');
+      }
+    };
+    process.stdin.on('data', windowsCtrlCTrap);
+  }
+}
+
+function cleanupWindowsSignals() {
+  if (windowsCtrlCTrap && process.stdin.removeListener) {
+    process.stdin.removeListener('data', windowsCtrlCTrap);
+  }
+}
+
+/**
+ * Handles the `message` event on the `process`.
+ *
+ * Calls `process.exit` if the `kill` property on the `message` is set.
+ *
+ * @method onMessage
+ */
+function onMessage(message) {
+  if (message.kill) {
+    _exit();
+  }
+}
+
+function _exit() {
+  process.exit();
+}

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -319,8 +319,35 @@ describe('Acceptance: smoke-test', function() {
           killCliProcess(child);
         }
       },
-    }).catch(function() {
-      // just eat the rejection as we are testing what happens
+    })
+    .then(result => {
+      let dirPath = path.join(appRoot, 'tmp');
+      let dir = fs.readdirSync(dirPath);
+
+      expect(result.code, 'should be zero exit code').to.equal(0);
+      expect(dir.length, '/tmp should be empty').to.equal(0);
+    })
+    .catch(function(result) {
+      expect(false, 'should not be rejected').to.equal(true);
+    });
+  });
+
+  it('ember new foo, test, SIGINT exits with error and clears tmp/', function() {
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--test-port=25522', {
+      onOutput(string, child) {
+        // wait for the first passed test and then exit
+        if (string.match(/^ok\ /)) {
+          killCliProcess(child);
+        }
+      },
+    }).then(() => {
+      expect(false, 'should not be resolved').to.equal(true);
+    }).catch(result => {
+      let dirPath = path.join(appRoot, 'tmp');
+      let dir = fs.readdirSync(dirPath);
+
+      expect(result.code, 'should be error exit code').to.not.equal(0);
+      expect(dir.length, '/tmp should be empty').to.equal(0);
     });
   });
 

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+let willInterruptProcess;
+let captureExit;
+
+let td = require('testdouble');
+let chai = require('../../chai');
+let expect = chai.expect;
+let EventEmitter = require('events');
+
+function getSignalListenersCount(emitter, event) {
+  if (emitter.listenerCount) { // Present in Node >= 4.0
+    return emitter.listenerCount(event);
+  } else {
+    // deprecated in Node 4.0
+    return EventEmitter.listenerCount(emitter, event);
+  }
+}
+
+function getListenerCounts() {
+  return {
+    SIGINT: getSignalListenersCount(process, 'SIGINT'),
+    SIGTERM: getSignalListenersCount(process, 'SIGTERM'),
+    message: getSignalListenersCount(process, 'message'),
+    exit: captureExit.listenerCount(),
+  };
+}
+
+function getSignalListenerCounts() {
+  return {
+    SIGINT: getSignalListenersCount(process, 'SIGINT'),
+    SIGTERM: getSignalListenersCount(process, 'SIGTERM'),
+    message: getSignalListenersCount(process, 'message'),
+  };
+}
+
+describe('will interrupt process', function() {
+  let cb;
+  beforeEach(function() {
+    willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
+    captureExit = require('capture-exit');
+    cb = td.function();
+  });
+
+  afterEach(function() {
+    willInterruptProcess.teardown();
+  });
+
+  describe('capture-exit integration', function() {
+    let originalExitHandlersCount;
+
+    beforeEach(function() {
+      originalExitHandlersCount = captureExit.listenerCount();
+    });
+
+    it('adds exit handler', function() {
+      willInterruptProcess.addHandler(cb);
+
+      expect(captureExit.listenerCount()).to.equal(originalExitHandlersCount + 1);
+    });
+
+    it('removes exit handler', function() {
+      willInterruptProcess.addHandler(cb);
+      willInterruptProcess.addHandler(function() {});
+
+      willInterruptProcess.removeHandler(cb);
+
+      expect(captureExit.listenerCount()).to.equal(originalExitHandlersCount + 1);
+    });
+
+    it('removes all exit handlers', function() {
+      willInterruptProcess.addHandler(cb);
+      willInterruptProcess.addHandler(function() {});
+
+      willInterruptProcess.teardown();
+
+      expect(captureExit.listenerCount()).to.equal(originalExitHandlersCount);
+    });
+  });
+
+  describe('process interruption signal listeners', function() {
+    let originalSignalListenersCounts;
+
+    beforeEach(function() {
+      originalSignalListenersCounts = getSignalListenerCounts();
+    });
+
+    it('sets up interruption signal listeners when then first handler added', function() {
+      willInterruptProcess.addHandler(cb);
+
+      expect(getSignalListenerCounts()).to.eql({
+        SIGINT: originalSignalListenersCounts.SIGINT + 1,
+        SIGTERM: originalSignalListenersCounts.SIGTERM + 1,
+        message: originalSignalListenersCounts.message + 1,
+      });
+    });
+
+    it('sets up interruption signal listeners only once', function() {
+      willInterruptProcess.addHandler(cb);
+      willInterruptProcess.addHandler(function() {});
+
+      expect(getSignalListenerCounts()).to.eql({
+        SIGINT: originalSignalListenersCounts.SIGINT + 1,
+        SIGTERM: originalSignalListenersCounts.SIGTERM + 1,
+        message: originalSignalListenersCounts.message + 1,
+      });
+    });
+
+    it('cleans up interruption signal listeners', function() {
+      willInterruptProcess.addHandler(cb);
+      // will-interrupt-process doesn't have any public API to get actual handlers count
+      // so here we make a side test to ensure that we don't add the same callback twice
+      willInterruptProcess.addHandler(cb);
+
+      willInterruptProcess.removeHandler(cb);
+
+      expect(getSignalListenerCounts()).to.eql(originalSignalListenersCounts);
+    });
+
+    it(`doesn't clean up interruption signal listeners if there are remaining handlers`, function() {
+      willInterruptProcess.addHandler(cb);
+      willInterruptProcess.addHandler(() => cb());
+
+      willInterruptProcess.removeHandler(cb);
+
+      expect(getSignalListenerCounts()).to.eql({
+        SIGINT: originalSignalListenersCounts.SIGINT + 1,
+        SIGTERM: originalSignalListenersCounts.SIGTERM + 1,
+        message: originalSignalListenersCounts.message + 1,
+      });
+    });
+
+    it('cleans up all interruption signal listeners', function() {
+      willInterruptProcess.addHandler(cb);
+      willInterruptProcess.addHandler(function() {});
+      willInterruptProcess.addHandler(() => cb);
+
+      willInterruptProcess.teardown();
+
+      expect(getSignalListenerCounts()).to.eql(originalSignalListenersCounts);
+    });
+  });
+
+  describe('Windows CTRL + C Capture', function() {
+    let originalPlatform, originalStdin;
+
+    before(function() {
+      originalPlatform = process.platform;
+      originalStdin = process.platform;
+    });
+
+    after(function() {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: originalStdin,
+      });
+    });
+
+    it('enables raw capture on Windows', function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'win',
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: {
+          isTTY: true,
+          on: td.function(),
+          setRawMode: td.function(),
+        },
+      });
+
+      let trapWindowsSignals = td.function();
+      let windowsCtrlCTrap = td.matchers.isA(Function);
+
+      willInterruptProcess.addHandler(cb);
+      td.verify(process.stdin.setRawMode(true));
+      td.verify(process.stdin.on('data', windowsCtrlCTrap));
+    });
+
+    it('does not enable raw capture on non-Windows', function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'mockOS',
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: {
+          isTTY: true,
+          on: td.function(),
+          setRawMode: td.function(),
+        },
+      });
+
+      let trapWindowsSignals = td.function();
+      let windowsCtrlCTrap = td.matchers.isA(Function);
+
+      willInterruptProcess.addHandler(cb);
+
+      td.verify(process.stdin.setRawMode(true), {
+        times: 0,
+      });
+
+      td.verify(process.stdin.on('data', windowsCtrlCTrap), {
+        times: 0,
+      });
+    });
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -733,7 +733,7 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
-capture-exit@^1.1.0:
+capture-exit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
   dependencies:


### PR DESCRIPTION
Fixes #6421 
During implementation I've also noticed that we don't clean [tests tmp](https://github.com/ember-cli/ember-cli/blob/master/lib/commands/test.js#L53) when the process is interrupted. This pr [fixes](https://github.com/ember-cli/ember-cli/compare/master...ro0gr:command-interruption?expand=1#diff-39de54119935553ddd431dac09b49eafR161) it as well.

Depends on https://github.com/ember-cli/capture-exit/pull/18

The problem was that the process interruption was handled in the `model/builder`. It always sent an **exit code 1** when the process has been stopped from outside. 
Actually it's not a case for `server` commands like `ember s` or `ember t -s`. Interrupting of these commands should not produce an error code. 

Unfortunately builder has not enough knowledge which exit code to produce. It should be responsible only for clean up of self produced artifacts on unexpected exits.

That's the reason why I moved handling of interruption to the [`lib/cli/cli.js`](https://github.com/ember-cli/ember-cli/compare/master...ro0gr:command-interruption?expand=1#diff-16a41bfbe414387d773df099f941217eR138). 
If something has sent an interruption signal to a cli while the command is active then the [command's interrupt method is called](https://github.com/ember-cli/ember-cli/compare/master...ro0gr:command-interruption?expand=1#diff-16a41bfbe414387d773df099f941217eR139). It [calls the current task's interrupt method](https://github.com/ember-cli/ember-cli/compare/master...ro0gr:command-interruption?expand=1#diff-5346944aa3595cbf8116950d83f80cfeR188).
Return value of `interrupt()` is handled by the `capture-exit`. It allows us to reject interruption promise with a given exit code.

I've tested basic flows against windows and linux with these changes included. Couldn't find any issues.
`/tmp` is cleaned-up after successful/failed builds and interruption. 
exit code 1 produced only when the build and test commands are interrupted in a single(not server) run mode.

There is still some work left to be done:
  - [x] land capture-exit 
  - [x] fix current tests
  - [x] `ember t -s` acceptance test([nice starting point](https://github.com/ember-cli/ember-cli/blob/49479996571cfd838bd0c403cd08358d6591a344/tests/acceptance/smoke-test-slow.js#L284)) for `/tmp` cleanup and **exit code 0** when command interrupted 
 - [ ] ~~`interrupt()` unit tests~~
 - [x] unit tests for `Command.runTask()` 
 - [x] tests for `will-interrupt-process`
 - [x] rebase
 - [x] change interrupt exit code management to use process.exit(1) rather than a rejecting promise.
 - [x] change interrupt semantics so default is to exit 1 and the long-running commands explicitly opt-in to a zero exit code
 - [x] improve the handler setup test if it's feasible
 - [x] cleanup from inline comments eg
   - this._super in test command rather than copy super impl
   - a couple of comments are out of place from copying
   - super minor linting things