### PR TITLE
Remove wasted work around addon's addon trees.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -911,32 +911,17 @@ EmberApp.prototype._addonTree = function _addonTree() {
     return this._cachedAddonTree;
   }
 
-  let addonTrees = mergeTrees(this.addonTreesFor('addon'), {
+  let addonTrees = this.addonTreesFor('addon');
+
+  let combinedAddonTree = mergeTrees(addonTrees, {
     overwrite: true,
-    annotation: 'TreeMerger (addons)',
+    annotation: 'TreeMerger: `addon/` trees',
   });
 
-  let addonTranspiledModules = new Funnel(addonTrees, {
-    srcDir: 'modules',
-    allowEmpty: true,
-    annotation: 'Funnel: Addon JS',
+  return this._cachedAddonTree = new Funnel(combinedAddonTree, {
+    destDir: 'addon-tree-output',
+    annotation: 'Funnel: addon-tree-output',
   });
-
-  return this._cachedAddonTree = [
-    this._concatFiles(addonTrees, {
-      inputFiles: ['**/*.css'],
-      outputFile: '/addons.css',
-      allowNone: true,
-      annotation: 'Concat: Addon CSS',
-    }),
-
-    this._concatFiles(addonTranspiledModules, {
-      inputFiles: ['**/*.js'],
-      outputFile: '/addons.js',
-      allowNone: true,
-      annotation: 'Concat: Addon JS',
-    }),
-  ];
 };
 
 /**
@@ -949,8 +934,7 @@ EmberApp.prototype._processedVendorTree = function() {
     return this._cachedVendorTree;
   }
 
-  let trees = this._addonTree();
-  trees = trees.concat(this.addonTreesFor('vendor'));
+  let trees = this.addonTreesFor('vendor');
 
   if (this.trees.vendor) {
     trees.push(this.trees.vendor);
@@ -982,14 +966,16 @@ EmberApp.prototype._processedExternalTree = function() {
 
   let vendor = this._processedVendorTree();
   let bower = this._processedBowerTree();
+  let addons = this._addonTree();
 
-  let trees = [vendor];
+  let trees = [vendor].concat(addons);
   if (bower) {
     trees.unshift(bower);
   }
 
   let externalTree = mergeTrees(trees, {
     annotation: 'TreeMerger (ExternalTree)',
+    overwrite: true,
   });
 
   if (this.amdModuleNames) {
@@ -1266,17 +1252,21 @@ EmberApp.prototype.javascript = function() {
   }
 
   this.import('vendor/ember-cli/vendor-prefix.js', { prepend: true });
-  this.import('vendor/addons.js');
-  this.import('vendor/ember-cli/vendor-suffix.js');
 
   let vendorFiles = [];
   for (let outputFile in this._scriptOutputFiles) {
+    let isMainVendorFile = outputFile === this.options.outputPaths.vendor.js;
     let headerFiles = this._scriptOutputFiles[outputFile];
+    let inputFiles = isMainVendorFile ? ['addon-tree-output/**/*.js'] : [];
+    let footerFiles = isMainVendorFile ? ['vendor/ember-cli/vendor-suffix.js'] : [];
 
     vendorFiles.push(
       this._concatFiles(applicationJs, {
         headerFiles,
+        inputFiles,
+        footerFiles,
         outputFile,
+        allowNone: true,
         separator: '\n;',
         annotation: `Concat: Vendor ${outputFile}`,
       })
@@ -1332,15 +1322,17 @@ EmberApp.prototype.styles = function() {
     });
   }
 
-  this.import('vendor/addons.css');
-
   let vendorStyles = [];
   for (let outputFile in this._styleOutputFiles) {
+    let isMainVendorFile = outputFile === this.options.outputPaths.vendor.css;
     let headerFiles = this._styleOutputFiles[outputFile];
+    let inputFiles = isMainVendorFile ? ['addon-tree-output/**/*.css'] : [];
 
     vendorStyles.push(this._concatFiles(stylesAndVendor, {
       headerFiles,
+      inputFiles,
       outputFile,
+      allowNone: true,
       annotation: `Concat: Vendor Styles${outputFile}`,
     }));
   }

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -992,14 +992,9 @@ let addonProto = {
 
     let trees = [addonJs, templatesTree].filter(Boolean);
 
-    let combinedJSAndTemplates = mergeTrees(trees, {
+    return mergeTrees(trees, {
       overwrite: true,
       annotation: `Addon#compileAddon(${this.name}) `,
-    });
-
-    return new Funnel(combinedJSAndTemplates, {
-      destDir: 'modules/',
-      annotation: 'Funnel: compileAddon',
     });
   },
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -500,7 +500,7 @@ describe('broccoli/ember-app', function() {
 
           let args = td.explain(app.addonTreesFor).calls.map(function(call) { return call.args[0]; });
 
-          expect(args).to.deep.equal(['addon', 'vendor']);
+          expect(args).to.deep.equal(['vendor']);
         });
 
         it('_processedAppTree calls addonTreesFor', function() {
@@ -523,13 +523,10 @@ describe('broccoli/ember-app', function() {
         td.when(app.addonPostprocessTree(), { ignoreExtraArgs: true }).thenReturn(['batman']);
       });
 
-      it('styles calls addonTreesFor', function() {
-        app.styles();
+      it('from .styles()', function() {
+        let stylesOutput = app.styles();
 
-        let captor = td.matchers.captor();
-        td.verify(app.addonPostprocessTree('css', captor.capture()));
-
-        expect(captor.value.description).to.equal('styles', 'should be called with consolidated tree');
+        expect(stylesOutput).to.eql(['batman']);
       });
 
       it('template type is called', function() {
@@ -1074,18 +1071,19 @@ describe('broccoli/ember-app', function() {
 
         app.styles(); // run
 
-        expect(count).to.eql(3);
+        expect(count).to.eql(1);
 
-        expect(args[2]).to.deep.eql({
+        expect(args[0]).to.deep.eql({
           annotation: 'Concat: Vendor Styles/assets/vendor.css',
+          allowNone: true,
           headerFiles: [
             'files/a.css',
             'files/b.css',
             'files/c.css',
             'files/d.css',
             'files/e.css',
-            'vendor/addons.css',
           ],
+          inputFiles: ['addon-tree-output/**/*.css'],
           outputFile: '/assets/vendor.css',
         });
       });
@@ -1098,40 +1096,23 @@ describe('broccoli/ember-app', function() {
 
         app.styles(); // run
 
-        expect(count).to.eql(3);
+        expect(count).to.eql(1);
 
         expect(args[0]).to.deep.eql({
-          allowNone: true,
-          annotation: 'Concat: Addon CSS',
-          inputFiles: [
-            '**/*.css',
-          ],
-          outputFile: '/addons.css',
-        });
-
-        expect(args[1]).to.deep.eql({
-          allowNone: true,
-          annotation: 'Concat: Addon JS',
-          inputFiles: [
-            '**/*.js',
-          ],
-          outputFile: '/addons.js',
-        });
-
-        expect(args[2]).to.deep.eql({
           annotation: 'Concat: Vendor Styles/assets/vendor.css',
+          allowNone: true,
           headerFiles: [
             'files/a.css',
             'files/b.css',
             'files/c.css',
             'files/d.css',
-            'vendor/addons.css',
           ],
+          inputFiles: ['addon-tree-output/**/*.css'],
           outputFile: '/assets/vendor.css',
         });
       });
 
-      it('correctly orders concats from app.javacsript()', function() {
+      it('correctly orders concats from app.javascript()', function() {
         app.import('files/b.js');
         app.import('files/c.js');
         app.import('files/a.js');
@@ -1163,6 +1144,7 @@ describe('broccoli/ember-app', function() {
         // should be: a,b,c,d in output
         expect(args[1]).to.deep.eql({
           annotation: "Concat: Vendor /assets/vendor.js",
+          allowNone: true,
           headerFiles: [
             "vendor/ember-cli/vendor-prefix.js",
             "files/d.js",
@@ -1172,9 +1154,9 @@ describe('broccoli/ember-app', function() {
             "bower_components/ember-cli-shims/app-shims.js",
             "files/b.js",
             "files/c.js",
-            "vendor/addons.js",
-            "vendor/ember-cli/vendor-suffix.js",
           ],
+          inputFiles: ['addon-tree-output/**/*.js'],
+          footerFiles: ['vendor/ember-cli/vendor-suffix.js'],
           outputFile: "/assets/vendor.js",
           separator: '\n;',
         });
@@ -1197,23 +1179,9 @@ describe('broccoli/ember-app', function() {
 
         app.testFiles('some-tree'); // run
 
-        expect(count).to.eql(4);
+        expect(count).to.eql(2);
 
         expect(args[0]).to.deep.eql({
-          allowNone: true,
-          annotation: 'Concat: Addon CSS',
-          inputFiles: ['**/*.css'],
-          outputFile: '/addons.css',
-        });
-
-        expect(args[1]).to.deep.eql({
-          allowNone: true,
-          annotation: 'Concat: Addon JS',
-          inputFiles: ['**/*.js'],
-          outputFile: '/addons.js',
-        });
-
-        expect(args[2]).to.deep.eql({
           allowNone: true,
           annotation: 'Concat: Test Support JS',
           footerFiles: [
@@ -1232,7 +1200,7 @@ describe('broccoli/ember-app', function() {
           outputFile: '/assets/test-support.js',
         });
 
-        expect(args[3]).to.deep.eql({
+        expect(args[1]).to.deep.eql({
           annotation: 'Concat: Test Support CSS',
           headerFiles: [
             'files/a.css',
@@ -1246,4 +1214,3 @@ describe('broccoli/ember-app', function() {
     });
   });
 });
-


### PR DESCRIPTION
Prior to this change, after retrieving the `addon` trees for all addons we then immediately concat the assets down into a single `addons.{js,css}` file (after merging and funneling to a different location).

The long term objective is to keep "loose modules" throughout the entire pipeline and eventually replace the final concat stages that we are currently using with a higher level "packager". This takes a very small step towards that future...

The good news is that this is actually a win regardless of that future state (we reduced the number of build steps by around 4 with this change).