### PR TITLE
Avoid extra build steps for `app/` with only `.gitkeep` file.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -34,6 +34,7 @@ var findAddonByName = require('../utilities/find-addon-by-name');
 var experiments = require('../experiments');
 var heimdall = require('heimdalljs');
 var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+var fs = require('fs');
 
 heimdall.registerMonitor('addon-tree-cache', function AddonTreeCacheSchema() {
   this.hits = 0;
@@ -588,7 +589,9 @@ var addonProto = {
     @return {Tree} App file tree
   */
   treeForApp: function(tree) {
-    return tree;
+    if (this._shouldProcessAppTree()) {
+      return tree;
+    }
   },
 
   /**
@@ -799,6 +802,17 @@ var addonProto = {
     return this._fileSystemInfo().hasPodTemplates;
   },
 
+  /**
+     Looks in the addon's `app/` directory to determine if any files exist other than `.gitkeep`.
+
+     @private
+     @method _shouldProcessAppTree
+     @return {Boolean}
+   */
+  _shouldProcessAppTree: function() {
+    return this._fileSystemInfo().hasAppTreeFiles;
+  },
+
   _fileSystemInfo: function() {
     if (this._cachedTemplateInfo) {
       return this._cachedTemplateInfo;
@@ -839,10 +853,17 @@ var addonProto = {
       return file.match(extensionMatcher);
     });
 
+    var appTreeEntries = this._getAppTreeRootEntries()
+        .filter(function(entry) {
+          return entry !== '.gitkeep';
+        });
+    var appTreeHasNonGitkeepFiles = appTreeEntries.length !== 0;
+
     this._cachedTemplateInfo = {
       hasJSFiles: hasJSFiles,
       hasTemplates: hasTemplates,
-      hasPodTemplates: hasPodTemplates
+      hasPodTemplates: hasPodTemplates,
+      hasAppTreeFiles: appTreeHasNonGitkeepFiles
     };
 
     return this._cachedTemplateInfo;
@@ -853,6 +874,16 @@ var addonProto = {
 
     if (existsSync(addonTreePath)) {
       return walkSync(addonTreePath);
+    }
+
+    return [];
+  },
+
+  _getAppTreeRootEntries: function() {
+    var appTreePath = this._treePathFor('app');
+
+    if (existsSync(appTreePath)) {
+      return fs.readdirSync(appTreePath);
     }
 
     return [];

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -679,7 +679,8 @@ describe('models/addon.js', function() {
       expect(addon._fileSystemInfo()).to.deep.equal({
         hasJSFiles: true,
         hasTemplates: true,
-        hasPodTemplates: true
+        hasPodTemplates: true,
+        hasAppTreeFiles: false
       });
     });
 
@@ -695,7 +696,8 @@ describe('models/addon.js', function() {
       expect(addon._fileSystemInfo()).to.deep.equal({
         hasJSFiles: false,
         hasTemplates: true,
-        hasPodTemplates: false
+        hasPodTemplates: false,
+        hasAppTreeFiles: false
       });
     });
 
@@ -712,7 +714,8 @@ describe('models/addon.js', function() {
       expect(addon._fileSystemInfo()).to.deep.equal({
         hasJSFiles: false,
         hasTemplates: true,
-        hasPodTemplates: false
+        hasPodTemplates: false,
+        hasAppTreeFiles: false
       });
     });
 
@@ -729,7 +732,8 @@ describe('models/addon.js', function() {
       expect(addon._fileSystemInfo()).to.deep.equal({
         hasJSFiles: true,
         hasTemplates: false,
-        hasPodTemplates: false
+        hasPodTemplates: false,
+        hasAppTreeFiles: false
       });
     });
 
@@ -746,7 +750,39 @@ describe('models/addon.js', function() {
       expect(addon._fileSystemInfo()).to.deep.equal({
         hasJSFiles: false,
         hasTemplates: false,
-        hasPodTemplates: false
+        hasPodTemplates: false,
+        hasAppTreeFiles: false
+      });
+    });
+
+    it('does not hasAppTreeFiles when none found', function() {
+      addon._getAppTreeRootEntries = function() {
+        return [
+          '.gitkeep'
+        ];
+      };
+
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: true,
+        hasTemplates: false,
+        hasPodTemplates: false,
+        hasAppTreeFiles: false
+      });
+    });
+
+    it('has hasAppTreeFiles when found', function() {
+      addon._getAppTreeRootEntries = function() {
+        return [
+          '.gitkeep',
+          'components'
+        ];
+      };
+
+      expect(addon._fileSystemInfo()).to.deep.equal({
+        hasJSFiles: true,
+        hasTemplates: false,
+        hasPodTemplates: false,
+        hasAppTreeFiles: true
       });
     });
   });


### PR DESCRIPTION
The app tree's of each addon are gathered and then merged down into a single tree. The default addon blueprint includes writing to `app/.gitkeep`, which forces every addon to "have" an app tree (even though they may not have any files other than `.gitkeep`).

This change adds a detection for `app/.gitkeep` only (by using `fs.readdirSync`), and if only a `.gitkeep` is found we do not return the app tree.  We are mostly specializing this guard to check against what our default blueprint creates (which is a single `.gitkeep` based `app` tree).