### PR TITLE
Remove support for Node 0.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "7"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ We love pull requests. Here's a quick guide:
 
 2. Ensure you have the development requirements:
 
-   * node (0.12 recommended) or io.js (1.x) -- *do not install node using sudo*
-   * npm (2.x)
+   * node (latest LTS recommended) -- *do not install node using sudo*
+   * npm (3.x)
    * phantomjs
 
 3. Run the tests. We only take pull requests with passing tests, and it's great

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -37,7 +37,7 @@
     "loader.js": "^4.1.0"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 4"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "yuidocjs": "0.10.2"
   },
   "engines": {
-    "node": "0.12.* || ^4.5 || 6.* || 7.*"
+    "node": "^4.5 || 6.* || 7.*"
   },
   "trackingCode": "UA-49225444-1",
   "greenkeeper": {

--- a/tests/helpers/package-cache.js
+++ b/tests/helpers/package-cache.js
@@ -99,21 +99,6 @@ var lookups = {
 function translate(type, lookup) { return lookups[lookup][type]; }
 
 /**
- * The `checkDowngrade` command is used to turn a request for `yarn` into `npm`
- * if it is unsupported on that platform.
- *
- * @method checkDowngrade
- * @param {String} type Either 'bower', 'npm', or 'yarn'.
- */
-function checkDowngrade(type) {
-  // The only thing we support that doesn't support `yarn` is v0.12
-  if (type === 'yarn' && process.version.indexOf('v0.12') === 0) {
-    type = 'npm';
-  }
-  return type;
-}
-
-/**
  * The PackageCache wraps all package management functions. It also
  * handles initial global state setup.
  *
@@ -528,8 +513,6 @@ PackageCache.prototype = {
    * @param {String} type The type of package cache.
    */
   _install: function(label, type) {
-    type = checkDowngrade(type);
-
     this._removeLinks(label, type);
     commands[type].invoke('install', { cwd: this.dirs[label] });
     this._restoreLinks(label, type);
@@ -548,8 +531,6 @@ PackageCache.prototype = {
    * @param {String} type The type of package cache.
    */
   _upgrade: function(label, type) {
-    type = checkDowngrade(type);
-
     // Lock out upgrade calls after the first time upgrading the cache.
     if (upgraded[label]) { return; }
 
@@ -580,7 +561,6 @@ PackageCache.prototype = {
    * @return {String} The directory on disk which contains the cache.
    */
   create: function(label, type, manifest, links) {
-    type = checkDowngrade(type);
     links = links || [];
 
     // Save metadata about the PackageCache invocation in the manifest.

--- a/tests/unit/utilities/package-cache-test.js
+++ b/tests/unit/utilities/package-cache-test.js
@@ -446,9 +446,6 @@ describe('PackageCache', function() {
 
   describe('_upgrade (yarn)', function() {
 
-    // This test doesn't apply to Node.js 0.12.
-    if (process.version.indexOf('v0.12') === 0) { return; }
-
     // We're only going to test the invocation pattern boundary.
     // Don't want to wait for the install to execute.
     var testCounter = 0;
@@ -645,25 +642,6 @@ describe('PackageCache', function() {
     // Clean up.
     testPackageCache.destroy('from');
     testPackageCache.destroy('to');
-  });
-
-  it('downgrades on 0.12', function() {
-    td.when(yarn('--version')).thenReturn({stdout: '1.0.0'});
-    td.when(npm('--version')).thenReturn({stdout: '1.0.0'});
-
-    testPackageCache.create('one', 'yarn', '{}');
-    testPackageCache.create('two', 'yarn', '{}');
-    testPackageCache.create('three', 'yarn', '{}');
-
-    if (process.version.indexOf('v0.12') === 0) {
-      td.verify(npm(), { times: 6, ignoreExtraArgs: true });
-    } else {
-      td.verify(yarn(), { times: 6, ignoreExtraArgs: true });
-    }
-
-    testPackageCache.destroy('one');
-    testPackageCache.destroy('two');
-    testPackageCache.destroy('three');
   });
 
   it('succeeds at a clean install', function() {


### PR DESCRIPTION
* Remove 0.12 from `.travis.yml`
* Update `engines` in `package.json` to indicate `4.5` is minimum version.
* Tweak language in `CONTRIBUTING.md` to suggest using "latest LTS" (instead of specific version).

---

Node 0.12 has already exited maintenance mode in a large percentage of the globe (Oceana, much of Asia, etc). Taking advantage of the one time timezones have worked in our favor...