### PR TITLE
Update version of ember-cli-eslint used in new applications.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -131,7 +131,7 @@ module.exports = Command.extend({
         if (!commandOptions.skipNpm) {
           return addonInstall.run({
             verbose: commandOptions.verbose,
-            packages: ['ember-cli-eslint@2']
+            packages: ['ember-cli-eslint@3']
           });
         }
       })


### PR DESCRIPTION
New applications will now get ember-cli-eslint@3 which uses the latest version of eslint (we previously could not do this update due to eslint@3 dropping support for Node 0.12).