### PR TITLE
Flesh out `init` instrumentation.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -7,6 +7,7 @@ var logger        = require('heimdalljs-logger')('ember-cli:cli');
 var loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
 var Instrumentation = require('../models/instrumentation');
 var exit = require('capture-exit');
+var heimdall = require('heimdalljs');
 
 /**
  * @private
@@ -89,6 +90,8 @@ CLI.prototype.run = function(environment) {
     var commandArgs = args;
     var helpOptions;
 
+    var commandLookupCreationtoken = heimdall.start('lookup-command');
+
     var CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
       project: environment.project,
       ui: this.ui
@@ -105,9 +108,13 @@ CLI.prototype.run = function(environment) {
       cli: this
     });
 
+    commandLookupCreationtoken.stop();
+
     getOptionArgs('--verbose', commandArgs).forEach(function(arg) {
       process.env['EMBER_VERBOSE_' + arg.toUpperCase()] = 'true';
     });
+
+    var platformCheckerToken = heimdall.start('platform-checker');
 
     var PlatformChecker = require('../utilities/platform-checker');
     var platform = new PlatformChecker(process.version);
@@ -124,6 +131,8 @@ CLI.prototype.run = function(environment) {
                               ' is not tested against Ember CLI on your platform.' + recommendation);
       }
     }
+
+    platformCheckerToken.stop();
 
     logger.info('command: %s', commandName);
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -10,6 +10,7 @@ var packageConfig = require('../../package.json');
 var logger        = require('heimdalljs-logger')('ember-cli:cli/index');
 var merge         = require('ember-cli-lodash-subset').merge;
 var path          = require('path');
+var heimdall = require('heimdalljs');
 
 // ember-cli and user apps have many dependencies, many of which require
 // process.addListener('exit', ....) for cleanup, by default this limit for
@@ -25,13 +26,19 @@ var name         = packageConfig.name;
 var trackingCode = packageConfig.trackingCode;
 
 function loadCommands() {
+  var token = heimdall.start('load-commands');
   var Command = require('../models/command');
-  return requireAsHash('../commands/*.js', Command);
+  var hash = requireAsHash('../commands/*.js', Command);
+  token.stop();
+  return hash;
 }
 
 function loadTasks() {
+  var token = heimdall.start('load-tasks');
   var Task = require('../models/task');
-  return requireAsHash('../tasks/*.js', Task);
+  var hash = requireAsHash('../tasks/*.js', Task);
+  token.stop();
+  return hash;
 }
 
 function clientId() {

--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -11,6 +11,7 @@ var path       = require('path');
 var CoreObject = require('core-object');
 var resolve    = require('resolve');
 var findup     = require('find-up');
+var heimdall = require('heimdalljs');
 
 /**
   AddonDiscovery is responsible for collecting information about all of the
@@ -37,6 +38,10 @@ var AddonDiscovery = CoreObject.extend({
     @method discoverProjectAddons
    */
   discoverProjectAddons: function(project) {
+    var token = heimdall.start({
+      name: project.name() + ': addon-discovery',
+      addonDiscoveryNode: true
+    });
     var projectAsAddon = this.discoverFromProjectItself(project);
     var internalAddons = this.discoverFromInternalProjectAddons(project);
     var cliAddons = this.discoverFromCli(project.cli);
@@ -51,6 +56,7 @@ var AddonDiscovery = CoreObject.extend({
     var inRepoAddons = this.discoverInRepoAddons(project.root, project.pkg);
     var addons = projectAsAddon.concat(cliAddons, internalAddons, dependencyAddons, inRepoAddons);
 
+    token.stop();
     return addons;
   },
 
@@ -65,6 +71,10 @@ var AddonDiscovery = CoreObject.extend({
     @method discoverProjectAddons
   */
   discoverChildAddons: function(addon) {
+    var token = heimdall.start({
+      name: addon.name + ': addon-discovery',
+      addonDiscoveryNode: true
+    });
     logger.info('discoverChildAddons: %s(%s)', addon.name, addon.root);
     var dependencyAddons = this.discoverFromDependencies(addon.root, addon.nodeModulesPath, addon.pkg, true);
     var inRepoAddons = this.discoverInRepoAddons(addon.root, addon.pkg);
@@ -74,6 +84,7 @@ var AddonDiscovery = CoreObject.extend({
       return !addon.shouldIncludeChildAddon || addon.shouldIncludeChildAddon(childAddon);
     });
 
+    token.stop();
     return addons;
   },
 

--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -7,6 +7,7 @@
 var CoreObject = require('core-object');
 var DAG        = require('../utilities/DAG');
 var logger     = require('heimdalljs-logger')('ember-cli:addons-factory');
+var heimdall = require('heimdalljs');
 
 /**
   AddonsFactory is responsible for instantiating a collection of addons, in the right order.
@@ -26,11 +27,14 @@ var AddonsFactory = CoreObject.extend({
   initializeAddons: function(addonPackages) {
     var addonParent = this.addonParent;
     var project     = this.project;
+    var addonParentName = typeof addonParent.name === 'function' ? addonParent.name() : addonParent.name;
+
+    var initializeAddonsToken = heimdall.start(addonParentName + ': initializeAddons');
     var graph       = new DAG();
     var Addon       = require('../models/addon');
     var addonInfo, emberAddonConfig;
 
-    logger.info('initializeAddons for: ', typeof addonParent.name === 'function' ? addonParent.name() : addonParent.name);
+    logger.info('initializeAddons for: ', addonParentName);
     logger.info('     addon names are:', Object.keys(addonPackages));
 
     for (var name in addonPackages) {
@@ -44,6 +48,11 @@ var AddonsFactory = CoreObject.extend({
     graph.topsort(function (vertex) {
       var addonInfo = vertex.value;
       if (addonInfo) {
+        var initializeAddonToken = heimdall.start({
+          name: 'initialize ' + addonInfo.name,
+          addonName: addonInfo.name,
+          addonInitializationNode: true
+        });
         var start = Date.now();
         var AddonConstructor = Addon.lookup(addonInfo);
         var addon = new AddonConstructor(addonParent, project);
@@ -54,6 +63,7 @@ var AddonsFactory = CoreObject.extend({
         }
         AddonConstructor._meta_.initializeIn = Date.now() - start;
         addon.constructor = AddonConstructor;
+        initializeAddonToken.stop();
         addons.push(addon);
       }
     });
@@ -67,6 +77,8 @@ var AddonsFactory = CoreObject.extend({
         }
       };
     }));
+
+    initializeAddonsToken.stop();
 
     return addons;
   }

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -16,6 +16,7 @@ var versionUtils    = require('../utilities/version-utils');
 var emberCLIVersion = versionUtils.emberCLIVersion;
 var findAddonByName = require('../utilities/find-addon-by-name');
 var Instrumentation = require('./instrumentation');
+var heimdall = require('heimdalljs');
 
 /**
   The Project model is tied to your package.json. It is instantiated
@@ -402,7 +403,15 @@ Project.prototype.addonCommands = function() {
   var Command = require('../models/command');
   var commands = {};
   this.addons.forEach(function(addon) {
-    var includedCommands = (addon.includedCommands && addon.includedCommands()) || {};
+    if (!addon.includedCommands) { return; }
+
+    var token = heimdall.start({
+      name: 'lookup-commands: ' + addon.name,
+      addonName: addon.name,
+      addonCommandInitialization: true
+    });
+
+    var includedCommands = addon.includedCommands();
     var addonCommands = {};
 
     for (var key in includedCommands) {
@@ -415,6 +424,8 @@ Project.prototype.addonCommands = function() {
     if (Object.keys(addonCommands).length) {
       commands[addon.name] = addonCommands;
     }
+
+    token.stop();
   });
   return commands;
 };

--- a/tests/helpers/mock-cli.js
+++ b/tests/helpers/mock-cli.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var MockUI          = require('console-ui/mock');
+var path = require('path');
+var MockUI = require('console-ui/mock');
 var Instrumentation = require('../../lib/models/instrumentation');
 
 module.exports = MockCLI;
@@ -8,6 +9,7 @@ function MockCLI(options) {
   options = options || {};
 
   this.ui = options.ui || new MockUI();
+  this.root = path.join(__dirname, '..', '..');
   this.npmPackage = options.npmPackage || 'ember-cli';
   this.instrumentation = options.instrumentation || new Instrumentation({});
 }

--- a/tests/unit/models/addon-discovery-test.js
+++ b/tests/unit/models/addon-discovery-test.js
@@ -398,23 +398,19 @@ describe('models/addon-discovery.js', function() {
     var addon, discovery, discoverFromProjectItselfCalled, discoverFromInternalProjectAddonsCalled, discoverFromDependenciesCalled, discoverInRepoAddonsCalled;
 
     beforeEach(function() {
-      addon = {
-        name: 'awesome-sauce',
-        root: fixturePath,
-        pkg: {
-          dependencies: {
-            'foo-bar': 'latest'
-          },
-          devDependencies: {
-            'dev-dep-bar': 'latest'
-          }
+      var cli = new MockCLI();
+      var packageContents = {
+        dependencies: {
+          'foo-bar': 'latest'
         },
-        hasDependencies: function() {
-          return true;
+        devDependencies: {
+          'dev-dep-bar': 'latest'
         }
       };
 
-      discovery = new AddonDiscovery(ui);
+      project = new Project(fixturePath, packageContents, cli.ui, cli);
+
+      discovery = new AddonDiscovery(cli.ui);
 
       discovery.discoverFromProjectItself = function() {
         discoverFromProjectItselfCalled = true;
@@ -442,7 +438,7 @@ describe('models/addon-discovery.js', function() {
     });
 
     it('delegates to internal methods', function() {
-      discovery.discoverProjectAddons(addon);
+      discovery.discoverProjectAddons(project);
 
       expect(discoverFromProjectItselfCalled).to.equal(true);
       expect(discoverFromInternalProjectAddonsCalled).to.equal(true);
@@ -451,9 +447,15 @@ describe('models/addon-discovery.js', function() {
     });
 
     it('concats  discoverInRepoAddons and discoverFromDependencies results', function() {
-      var result = discovery.discoverProjectAddons(addon);
+      var result = discovery.discoverProjectAddons(project);
 
-      expect(result).to.deep.equal([ 'discoverFromProjectItself', 'discoverFromInternalProjectAddons', 'discoverFromDependencies', 'discoverInRepoAddons' ]);
+      expect(result).to.deep.equal([
+        'discoverFromProjectItself',
+        'discoverInRepoAddons', // ember-cli's own in-repo addons
+        'discoverFromInternalProjectAddons',
+        'discoverFromDependencies',
+        'discoverInRepoAddons' // apps in-repo addons
+      ]);
     });
   });
 


### PR DESCRIPTION
Adds instrumentation for:

* Addon initialization
* Command initialization (e.g. `addon.includedCommands()`)