### PR TITLE
Lazily require `broccoli-babel-transpiler`.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -29,7 +29,6 @@ var Funnel     = require('broccoli-funnel');
 var walkSync   = require('walk-sync');
 var ensurePosixPath = require('ensure-posix-path');
 var defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
-var Babel = require('broccoli-babel-transpiler');
 var findAddonByName = require('../utilities/find-addon-by-name');
 var experiments = require('../experiments');
 var heimdall = require('heimdalljs');
@@ -137,6 +136,7 @@ function processModulesOnly(tree) {
   var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
   options.whitelist = ['es6.modules'];
 
+  var Babel = require('broccoli-babel-transpiler');
   return new Babel(tree, options);
 }
 
@@ -748,6 +748,7 @@ var addonProto = {
 
       var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
 
+      var Babel = require('broccoli-babel-transpiler');
       return new Babel(namespacedTree, options);
     }
   },
@@ -1081,6 +1082,7 @@ var addonProto = {
 
         var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
 
+        var Babel = require('broccoli-babel-transpiler');
         processedJsFiles = new Babel(processedJsFiles, options);
       }
 


### PR DESCRIPTION
`broccoli-babel-transpiler` is only used during build related commands (and only in fallback scenarios), moving this to be a bit lazier shaves about 450ms from every `ember *` command invocation.

---

Before:

```
% \time node -e "require('./lib/models/addon');"
        0.61 real         0.51 user         0.10 sys
% cd empty-app
% \time ember v
        1.25 real         0.89 user         0.26 sys
```

After:

```
% \time node -e "require('./lib/models/addon');"
        0.16 real         0.14 user         0.03 sys
% cd empty-app
% \time ember v
        0.79 real         0.60 user         0.16 sys
```