### PR TITLE
Ensure `beforeRun` is included in `command` instrumentation.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -136,18 +136,21 @@ CLI.prototype.run = function(environment) {
       }
     }
 
-    command.beforeRun(commandArgs);
-
     var instrumentation = this.instrumentation;
     shutdownOnExit = function() {
       instrumentation.stopAndReport('shutdown');
     };
 
     return Promise.resolve().then(function() {
-      loggerTesting.info('cli: command.validateAndRun');
-
       instrumentation.stopAndReport('init');
       instrumentation.start('command');
+
+      loggerTesting.info('cli: command.beforeRun');
+
+      return command.beforeRun(commandArgs);
+    }).then(function() {
+      loggerTesting.info('cli: command.validateAndRun');
+
       return command.validateAndRun(commandArgs);
     }).then(function (result) {
       instrumentation.stopAndReport('command', commandName, commandArgs);

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -70,22 +70,22 @@ function stubRun(name) {
   return td.replace(commands[name].prototype, 'run', td.function());
 }
 
-beforeEach(function() {
-  ui = new MockUI();
-  analytics = new MockAnalytics();
-  argv = [];
-  commands = { };
-  isWithinProject = true;
-});
-
-afterEach(function() {
-  td.reset();
-
-  delete process.env.EMBER_ENV;
-  commands = argv = ui = undefined;
-});
-
 describe('Unit: CLI', function() {
+  beforeEach(function() {
+    ui = new MockUI();
+    analytics = new MockAnalytics();
+    argv = [];
+    commands = { };
+    isWithinProject = true;
+  });
+
+  afterEach(function() {
+    td.reset();
+
+    delete process.env.EMBER_ENV;
+    commands = argv = ui = undefined;
+  });
+
   this.timeout(10000);
   it('exists', function() {
     expect(CLI).to.be.ok;


### PR DESCRIPTION
Prior to this change `command.beforeRun` was being included in `init` instrumentation. This change fixes that by moving `.beforeRun` into `command` instrumentation.

This change also ensures that `beforeRun` can return a promise (which we had previously documented in the API docs but was not actually supported until this commit) and adds a test.