### PR TITLE
Remove "ember-cli-app-version" from "addon" blueprint

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -30,7 +30,7 @@ module.exports = {
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];
     delete contents.devDependencies['ember-cli-babel'];
 
-    // 99% of blueprints don't need ember-data, make it opt-in instead
+    // 99% of addons don't need ember-data, make it opt-in instead
     delete contents.devDependencies['ember-data'];
 
     if (contents.keywords.indexOf('ember-addon') === -1) {

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -33,6 +33,9 @@ module.exports = {
     // 99% of addons don't need ember-data, make it opt-in instead
     delete contents.devDependencies['ember-data'];
 
+    // 100% of addons don't need ember-cli-app-version, make it opt-in instead
+    delete contents.devDependencies['ember-cli-app-version'];
+
     if (contents.keywords.indexOf('ember-addon') === -1) {
       contents.keywords.push('ember-addon');
     }


### PR DESCRIPTION
[ember-cli-app-version](https://github.com/EmberSherpa/ember-cli-app-version) only seems useful for apps, but I don't see any advantage for addons.