### PR TITLE
Make project.config() public

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -193,7 +193,7 @@ Project.prototype.configPath = function() {
 /**
   Loads the configuration for this project and its addons.
 
-  @private
+  @public
   @method config
   @param  {String} env Environment name
   @return {Object}     Merged confiration object


### PR DESCRIPTION
There are use cases like the one discussed in #6637 that require access to `project.config()`. Should it be made public therefore?