### PR TITLE
Make in-repo-addon blueprint 'use strict'.

### DIFF
--- a/blueprints/in-repo-addon/files/lib/__name__/index.js
+++ b/blueprints/in-repo-addon/files/lib/__name__/index.js
@@ -1,4 +1,6 @@
 /*jshint node:true*/
+'use strict';
+
 module.exports = {
   name: '<%= dasherizedModuleName %>',
 


### PR DESCRIPTION
Matches [other](https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/files/index.js#L2) places.