### PR TITLE
remove travis sudo check

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.npm

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.npm


### PR DESCRIPTION
I ran a travis build without this sudo check, and it still uses the new container system, so I think this override is no longer necessary as it's the default now.