### PR TITLE
[BUGFIX] Revert "Remove arbitrary *.js filtering for addon tree."

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1052,7 +1052,11 @@ let addonProto = {
   addonJsFiles(tree) {
     this._requireBuildPackages();
 
+    let includePatterns = this.registry.extensionsForType('js')
+      .map(extension => new RegExp(`${extension}$`));
+
     return new Funnel(tree, {
+      include: includePatterns,
       destDir: this.moduleName(),
       annotation: 'Funnel: Addon JS',
     });


### PR DESCRIPTION
This reverts commit 541dfe98b3c116c9c50663d61f6859a928be61ad. The change introduced a regression where CSS assets in addons would be duplicated. [Conversation thread on 6524.](https://github.com/ember-cli/ember-cli/pull/6524#discussion_r90800977) @rwjblue apparently has a fix-forward in mind, but I want to make sure that we have this cataloged and an optional fix for Monday's branch point.

<details>
<summary>Before #6524 (correct)</summary>

```
.child-addon { content: "addon/styles/_import.css"; }
.child-addon { content: "addon/styles/alpha.css"; }
.child-addon { content: "addon/styles/app.css"; }
.child-addon { content: "addon/styles/child-addon.css"; }
.grandchild-addon { content: "addon/styles/grandchild-addon.css"; }
.child-addon { content: "addon/styles/zeta.css"; }
```

</details>

<details>
<summary>After #6524</summary>

```
.child-addon { content: "addon/styles/_import.css"; }
.child-addon { content: "addon/styles/alpha.css"; }
.child-addon { content: "addon/styles/app.css"; }
.child-addon { content: "addon/styles/child-addon.css"; }
.grandchild-addon { content: "addon/styles/grandchild-addon.css"; }
.child-addon { content: "addon/styles/_import.css"; }
.child-addon { content: "addon/styles/addon.css"; }
.child-addon { content: "addon/styles/alpha.css"; }
.child-addon { content: "addon/styles/app.css"; }
.child-addon { content: "addon/styles/child-addon.css"; }
.child-addon { content: "addon/styles/zeta.css"; }
.grandchild-addon { content: "addon/styles/_import.css"; }
.grandchild-addon { content: "addon/styles/addon.css"; }
.grandchild-addon { content: "addon/styles/alpha.css"; }
.grandchild-addon { content: "addon/styles/app.css"; }
.grandchild-addon { content: "addon/styles/grandchild-addon.css"; }
.grandchild-addon { content: "addon/styles/zeta.css"; }
.child-addon { content: "addon/styles/zeta.css"; }
```

</details>