### PR TITLE
Preserve user errors in instrumentation hook

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -143,9 +143,11 @@ class CLI {
       }
 
       let instrumentation = this.instrumentation;
+      let initCompleted = false;
 
       return Promise.resolve().then(() => {
         instrumentation.stopAndReport('init');
+        initCompleted = true;
         instrumentation.start('command');
 
         loggerTesting.info('cli: command.beforeRun');
@@ -156,9 +158,10 @@ class CLI {
         loggerTesting.info('cli: command.validateAndRun');
 
         return command.validateAndRun(commandArgs);
-
       }).finally(() => {
-        instrumentation.stopAndReport('command', commandName, commandArgs);
+        if (initCompleted) {
+          instrumentation.stopAndReport('command', commandName, commandArgs);
+        }
         instrumentation.start('shutdown');
 
         shutdownOnExit = function() {

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -215,6 +215,9 @@ class Builder extends CoreObject {
       .then(result => {
         self.project._instrumentation.stopAndReport('build', result, resultAnnotation);
         return result;
+      }, reason => {
+        self.project._instrumentation.stopAndReport('build', null, resultAnnotation);
+        throw reason;
       })
       .then(this.checkForPostBuildEnvironmentIssues.bind(this))
       .catch(error => {

--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -119,15 +119,20 @@ class Instrumentation {
       build: {
         type: resultAnnotation.type,
         count: this.instrumentations.build.count,
-        outputChangedFiles: result.outputChanges,
+        outputChangedFiles: null,
       },
       platform: {
         name: process.platform,
       },
-      output: result.directory,
+      output: null,
       totalTime,
       buildSteps,
     };
+
+    if (result) {
+      summary.build.outputChangedFiles = result.outputChanges;
+      summary.output = result.directory;
+    }
 
     if (resultAnnotation.type === 'rebuild') {
       summary.build.primaryFile = resultAnnotation.primaryFile;


### PR DESCRIPTION
When we run `stopAndReport('init')` we invoke user hooks.  These might
error.  If they do the instrumentation start/stops will be unbalanced
and we will report the following unhelpful error instead of the actual
error in the user hook.

`Error: Cannot stop instrumentation "command".  It has not started.`

This commit fixes this issue.