### PR TITLE
Add new `search` command

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -347,6 +347,7 @@ class Project {
     let internalMiddlewarePath = path.join(__dirname, '../tasks/server/middleware');
     let legacyBlueprintsPath = require.resolve('ember-cli-legacy-blueprints');
     let emberTryPath = require.resolve('ember-try');
+    let emberSearchPath = require.resolve('ember-cli-search');
     return [
       path.join(internalMiddlewarePath, 'testem-url-rewriter'),
       path.join(internalMiddlewarePath, 'tests-server'),
@@ -356,6 +357,7 @@ class Project {
       path.join(internalMiddlewarePath, 'proxy-server'),
       path.dirname(legacyBlueprintsPath),
       path.dirname(emberTryPath),
+      path.dirname(emberSearchPath),
     ];
   }
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-cli-lodash-subset": "^1.0.11",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.0.0",
+    "ember-cli-search": "^0.1.2",
     "ember-cli-string-utils": "^1.0.0",
     "ember-try": "^0.2.9",
     "ensure-posix-path": "^1.0.2",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -634,7 +634,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = app;
             expect(app._addonEnabled(emberFooEnvAddonFixture)).to.be.false;
 
-            expect(app.project.addons.length).to.equal(9);
+            expect(app.project.addons.length).to.equal(10);
           });
 
           it('foo', function() {
@@ -644,7 +644,7 @@ describe('broccoli/ember-app', function() {
             emberFooEnvAddonFixture.app = app;
             expect(app._addonEnabled(emberFooEnvAddonFixture)).to.be.true;
 
-            expect(app.project.addons.length).to.equal(10);
+            expect(app.project.addons.length).to.equal(11);
           });
         });
       });
@@ -662,7 +662,7 @@ describe('broccoli/ember-app', function() {
 
           expect(app._addonDisabledByBlacklist({ name: 'ember-foo-env-addon' })).to.be.true;
           expect(app._addonDisabledByBlacklist({ name: 'Ember Random Addon' })).to.be.false;
-          expect(app.project.addons.length).to.equal(9);
+          expect(app.project.addons.length).to.equal(10);
         });
 
         it('throws if unavailable addon is specified', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -221,7 +221,7 @@ describe('models/project.js', function() {
         'tests-server-middleware',
         'history-support-middleware',
         'broccoli-watcher', 'broccoli-serve-files',
-        'proxy-server-middleware', 'ember-cli-legacy-blueprints', 'ember-try',
+        'proxy-server-middleware', 'ember-cli-legacy-blueprints', 'ember-try', 'ember-cli-search',
         'ember-random-addon', 'ember-non-root-addon',
         'ember-generated-with-export-addon',
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
@@ -233,10 +233,10 @@ describe('models/project.js', function() {
     it('returns instances of the addons', function() {
       let addons = project.addons;
 
-      expect(addons[9].name).to.equal('Ember Non Root Addon');
-      expect(addons[15].name).to.equal('Ember Super Button');
-      expect(addons[15].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[15].addons[1].name).to.equal('Ember Ng');
+      expect(addons[10].name).to.equal('Ember Non Root Addon');
+      expect(addons[16].name).to.equal('Ember Super Button');
+      expect(addons[16].addons[0].name).to.equal('Ember Yagni');
+      expect(addons[16].addons[1].name).to.equal('Ember Ng');
     });
 
     it('addons get passed the project instance', function() {
@@ -248,7 +248,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       let addons = project.addons;
 
-      expect(addons[11].name).to.equal('Ember Random Addon');
+      expect(addons[12].name).to.equal('Ember Random Addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -311,8 +311,8 @@ describe('models/project.js', function() {
     it('returns an instance of an addon with an object export', function() {
       let addons = project.addons;
 
-      expect(addons[8] instanceof Addon).to.equal(true);
-      expect(addons[8].name).to.equal('Ember CLI Generated with export');
+      expect(addons[9] instanceof Addon).to.equal(true);
+      expect(addons[9].name).to.equal('Ember CLI Generated with export');
     });
 
     it('adds the project itself if it is an addon', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,10 +191,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
@@ -459,7 +455,7 @@ breakable@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/breakable/-/breakable-1.0.0.tgz#784a797915a38ead27bad456b5572cb4bbaa78c1"
 
-broccoli-babel-transpiler@^5.6.2:
+broccoli-babel-transpiler@^5.6.0, broccoli-babel-transpiler@^5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.6.2.tgz#958c72e43575b2f0a862a5096dba1ce1ebc7d74d"
   dependencies:
@@ -1065,6 +1061,12 @@ core-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-1.1.0.tgz#86d63918733cf9da1a5aae729e62c0a88e66ad0a"
 
+core-object@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/core-object/-/core-object-2.1.1.tgz#4b7a5f1edefcb1e6d0dcb58eab1b9f90bfc666a8"
+  dependencies:
+    chalk "^1.1.3"
+
 core-object@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-3.0.0.tgz#da758c8933f1c857878c344463b5121b00ad12c4"
@@ -1098,6 +1100,10 @@ d@^0.1.1, d@~0.1.1:
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
   dependencies:
     es5-ext "~0.10.2"
+
+date-fns@^1.22.0:
+  version "1.27.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.27.2.tgz#ce82f420bc028356cc661fc55c0494a56a990c9c"
 
 debug@2, debug@2.6.0, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.0"
@@ -1232,11 +1238,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ember-cli-babel@^5.1.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.3.tgz#63770469ea4778fb8ab69be9daa464e6427170e9"
+ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.7:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.1.tgz#14a1a7b3ae9e9f1284f7bcdb142eb53bd0b1b5bd"
   dependencies:
-    broccoli-babel-transpiler "^5.6.2"
+    broccoli-babel-transpiler "^5.6.0"
     broccoli-funnel "^1.0.0"
     clone "^2.0.0"
     ember-cli-version-checker "^1.0.2"
@@ -1363,6 +1369,17 @@ ember-cli-preprocess-registry@^3.0.0:
     lodash "^4.5.0"
     process-relative-require "^1.0.0"
     silent-error "^1.0.0"
+
+ember-cli-search@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-search/-/ember-cli-search-0.1.2.tgz#ae886dbc920816feaa55196a24c76bbc3bd8c236"
+  dependencies:
+    chalk "^1.1.3"
+    core-object "^2.1.1"
+    date-fns "^1.22.0"
+    ember-cli-babel "^5.1.7"
+    node-fetch "^1.6.3"
+    rsvp "^3.3.3"
 
 ember-cli-string-utils@^1.0.0:
   version "1.1.0"
@@ -3291,7 +3308,7 @@ node-emoji@^1.4.1:
   dependencies:
     string.prototype.codepointat "^0.2.0"
 
-node-fetch@^1.3.3:
+node-fetch@^1.3.3, node-fetch@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:
@@ -3711,20 +3728,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
Adds a new command called `search`. It currently supports 3 search modes: addon discovery, code discovery, and code exploration which are explained below.

### Addon Discovery

The addon discovery mode allows you to search for addons based on a given keyword. This is a great way to discovery addons within the community:

```
ember search --addon 'i18n'
```

<img src="http://i.imgur.com/h9cl9K0.gif" />


### Code Discovery

The code discovery mode allows you to search all addons that contain a given code snippet. This is great to find other addons that are using a method or hook that you would like to learn more about. As an example, hooks within your index.js file such as: `included`, `treeForApp`, `treeForPublic`, etc. are not well documented. Here we can search to find other addons which are using one of these hooks:

```
ember search --code 'treeForPublic'
```

<img src="http://i.imgur.com/MmDHeOn.gif" />


### Code Exploration

The last mode is code exploration. This allows you to see actual code diffs based on that code snippet. Note that we must supply the exact addon name via --addon.

```
ember search --addon 'ember-intl' --code 'treeForPublic'
```

<img src="http://i.imgur.com/N74G40q.gif" />

Slightly unrelated note: It would be interesting to explore (if the cli-core team hasn't already) a way to install global commands like this one via addons without having to add code to ember-cli's code base.