### PR TITLE
Add stats and logging for addon tree caching opt out

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -11,6 +11,7 @@ const SilentError = require('silent-error');
 const heimdallLogger = require('heimdalljs-logger');
 let logger = heimdallLogger('ember-cli:addon');
 let treeCacheLogger = heimdallLogger('ember-cli:addon:tree-cache');
+let cacheKeyLogger = heimdallLogger('ember-cli:addon:cache-key-for-tree');
 
 const nodeModulesPath = require('node-modules-path');
 
@@ -39,6 +40,11 @@ heimdall.registerMonitor('addon-tree-cache', function AddonTreeCacheSchema() {
   this.hits = 0;
   this.misses = 0;
   this.adds = 0;
+});
+
+heimdall.registerMonitor('cache-key-for-tree', function CacheKeyForTreeSchema() {
+  this.modifiedMethods = 0;
+  this.treeForMethodsOverride = 0;
 });
 
 let DEFAULT_BABEL_CONFIG = {
@@ -1509,16 +1515,21 @@ if (addonTreeCacheExperimentPresent) {
   addonProto[experiments.ADDON_TREE_CACHING] = function cacheKeyForTree(treeType) {
     let self = this;
     let methodsToValidate = methodsForTreeType(treeType);
+    let cacheKeyStats = heimdall.statsFor('cache-key-for-tree');
 
     // determine if treeFor* (or other methods for tree type) overrides for the given tree
-    let anyMethodsModified = methodsToValidate.some(methodName => self[methodName] !== addonProto[methodName]);
+    let modifiedMethods = methodsToValidate.filter(methodName => self[methodName] !== addonProto[methodName]);
 
-    if (anyMethodsModified) {
+    if (modifiedMethods.length) {
+      cacheKeyStats.modifiedMethods++;
+      cacheKeyLogger.info(`Opting out due to: modified methods: ${modifiedMethods.join(', ')}`);
       return null; // uncacheable
     }
 
-    // determine if treeMethodsFor overrides for given tree
+    // determine if treeForMethods overrides for given tree
     if (self.treeForMethods[treeType] !== DEFAULT_TREE_FOR_METHODS[treeType]) {
+      cacheKeyStats.treeForMethodsOverride++;
+      cacheKeyLogger.info('Opting out due to: treeForMethods override');
       return null; // uncacheable
     }
 


### PR DESCRIPTION
This will make it easier to identify addons that are opting out of tree caching. This won't catch addons that define their own `cacheKeyForTree` method, but we should assume that means those addons are handling caching on their own.