### PR TITLE
Add stableCacheKeyForTree utility

### DIFF
--- a/lib/utilities/stable-cache-key-for-tree.js
+++ b/lib/utilities/stable-cache-key-for-tree.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+
+/**
+ * An implementation of Addon#cacheKeyForTree that assumes the return values of
+ * all trees is stable. This makes it easy to opt-back-in to tree caching for
+ * addons that implement stable overrides of treeFor hooks.
+ *
+ * @public
+ * @param {String} treeType
+ * @return {String} cacheKey
+ */
+module.exports = function stableCacheKeyForTree(treeType) {
+  let addon = this;
+  let cacheKey = calculateCacheKeyForTree(treeType, addon);
+  return cacheKey;
+};


### PR DESCRIPTION
This utility makes it easy for addon developers to opt back into addon
tree caching if they need to do simple overrides of some hooks.

Will be used liked:

```js
const cacheKeyForTree = require('ember-cli/lib/utilities/stable-cache-key-for-tree');

module.exports = {
  name: 'some-addon',
  treeForApp() { return someStableTree; },
  cacheKeyForTree
};
```

@rwjblue: if this seems good, should likely be added to the [RFC](https://github.com/ember-cli/rfcs/pull/90).