### PR TITLE
tasks/bower-install: Fix "bower" lookup

### DIFF
--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -9,6 +9,8 @@ const Task = require('../models/task');
 const formatPackageList = require('../utilities/format-package-list');
 let resolve = Promise.denodeify(require('resolve'));
 
+const cliPath = path.resolve(`${__dirname}/../..`);
+
 class BowerInstallTask extends Task {
 
   ensureBower() {
@@ -16,9 +18,9 @@ class BowerInstallTask extends Task {
       return Promise.resolve(this.bower);
     }
 
-    return resolve('bower')
+    return resolve('bower', { basedir: cliPath })
       .catch(() => this.installBower()
-        .then(() => resolve('bower')))
+        .then(() => resolve('bower', { basedir: cliPath })))
       .then(bowerPath => require(bowerPath));
   }
 
@@ -28,9 +30,7 @@ class BowerInstallTask extends Task {
 
     ui.startProgress(chalk.green('NPM: Installing bower ...'));
 
-    return Promise.resolve(execa('npm', ['install', 'bower@^1.3.12'], {
-      cwd: path.resolve(`${__dirname}/../..`),
-    }))
+    return Promise.resolve(execa('npm', ['install', 'bower@^1.3.12'], { cwd: cliPath }))
       .finally(() => ui.stopProgress())
       .then(() => ui.writeLine(chalk.green('NPM: Installed bower')));
   }


### PR DESCRIPTION
tl;dr we are lazily installing `bower` into the `ember-cli` package folder to avoid conflicts with other bower dependencies, and our `resolve()` call was not looking in the right base directory.

Resolves #6666 