### PR TITLE
add description to build environment option

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -9,7 +9,7 @@ module.exports = Command.extend({
   aliases: ['b'],
 
   availableOptions: [
-    { name: 'environment',    type: String,  default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
+    { name: 'environment',    type: String,  default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }], description: 'Possible values are "development", "production", and "test".' },
     { name: 'output-path',    type: 'Path',  default: 'dist/',       aliases: ['o'] },
     { name: 'watch',          type: Boolean, default: false,         aliases: ['w'] },
     { name: 'watcher',        type: String },

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -27,7 +27,7 @@ ember asset-sizes \u001b[36m<options...>\u001b[39m
 ember build \u001b[36m<options...>\u001b[39m
   Builds your app and places it into the output path (dist/ by default).
   \u001b[90maliases: b\u001b[39m
-  \u001b[36m--environment\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: development)\u001b[39m
+  \u001b[36m--environment\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: development)\u001b[39m Possible values are "development", "production", and "test".
     \u001b[90maliases: -e <value>, -dev (--environment=development), -prod (--environment=production)\u001b[39m
   \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m \u001b[36m(Default: dist/)\u001b[39m
     \u001b[90maliases: -o <value>\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -93,6 +93,7 @@ module.exports = {
       availableOptions: [
         {
           name: 'environment',
+          description: 'Possible values are "development", "production", and "test".',
           default: 'development',
           aliases: [
             'e',

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -27,7 +27,7 @@ ember asset-sizes \u001b[36m<options...>\u001b[39m
 ember build \u001b[36m<options...>\u001b[39m
   Builds your app and places it into the output path (dist/ by default).
   \u001b[90maliases: b\u001b[39m
-  \u001b[36m--environment\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: development)\u001b[39m
+  \u001b[36m--environment\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: development)\u001b[39m Possible values are "development", "production", and "test".
     \u001b[90maliases: -e <value>, -dev (--environment=development), -prod (--environment=production)\u001b[39m
   \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m \u001b[36m(Default: dist/)\u001b[39m
     \u001b[90maliases: -o <value>\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -93,6 +93,7 @@ module.exports = {
       availableOptions: [
         {
           name: 'environment',
+          description: 'Possible values are "development", "production", and "test".',
           default: 'development',
           aliases: [
             'e',

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -93,6 +93,7 @@ module.exports = {
       availableOptions: [
         {
           name: 'environment',
+          description: 'Possible values are "development", "production", and "test".',
           default: 'development',
           aliases: [
             'e',


### PR DESCRIPTION
I was trying to make a build `ember b` to run tests on later `ember t --path dist`, but an `app.import` under `EmberApp.env() === 'test'` wasn't getting included.

Turns out `ember b -e test` works for this scenario, but the help text doesn't make it clear.

I will fix tests if others like this addition.