### PR TITLE
Don't invoke preprocessTree('css') after preprocessors.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1347,10 +1347,10 @@ EmberApp.prototype.styles = function() {
     }));
   }
 
-  vendorStyles = this.addonPreprocessTree('css', mergeTrees(vendorStyles, {
+  vendorStyles = mergeTrees(vendorStyles, {
     annotation: 'TreeMerger (vendorStyles)',
     overwrite: true,
-  }));
+  });
 
   if (this.options.minifyCSS.enabled === true) {
     options = this.options.minifyCSS.options || {};


### PR DESCRIPTION
Closes #6512.