### PR TITLE
Avoid error upon registering a heimdall monitor twice.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -36,16 +36,20 @@ const heimdall = require('heimdalljs');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const addonProcessTree = require('../utilities/addon-process-tree');
 
-heimdall.registerMonitor('addon-tree-cache', function AddonTreeCacheSchema() {
-  this.hits = 0;
-  this.misses = 0;
-  this.adds = 0;
-});
+if (!heimdall.hasMonitor('addon-tree-cache')) {
+  heimdall.registerMonitor('addon-tree-cache', function AddonTreeCacheSchema() {
+    this.hits = 0;
+    this.misses = 0;
+    this.adds = 0;
+  });
+}
 
-heimdall.registerMonitor('cache-key-for-tree', function CacheKeyForTreeSchema() {
-  this.modifiedMethods = 0;
-  this.treeForMethodsOverride = 0;
-});
+if (!heimdall.hasMonitor('cache-key-for-tree')) {
+  heimdall.registerMonitor('cache-key-for-tree', function CacheKeyForTreeSchema() {
+    this.modifiedMethods = 0;
+    this.treeForMethodsOverride = 0;
+  });
+}
 
 let DEFAULT_BABEL_CONFIG = {
   modules: 'amdStrict',


### PR DESCRIPTION
`heimdall` throws an error if the same monitor name is registered twice. In normal operations with npm@3 / yarn this is not an issue (because only one version of this file is required). However, when working in a libary where you are `npm link ember-cli` it is possible to actually end up with this file being evaluated twice (once from the `npm link` and another from the source location).

This change simply checks if a monitor has already been registered with a given name, and does nothing.