### PR TITLE
BUGFIX #6679 - workaround for tiny-lr not reloading on empty files arguments

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -137,7 +137,13 @@ class LiveReloadServerTask extends Task {
     let previousTree = this.tree;
     let files;
 
-    if (results.directory) {
+    if (results.stack) {
+      this._hasCompileError = true;
+      files = ['LiveReload due to compile error'];
+    } else if (this._hasCompileError) {
+      this._hasCompileError = false;
+      files = ['LiveReload due to resolved compile error'];
+    } else if (results.directory) {
       this.tree = new FSTree.fromEntries(this.getDirectoryEntries(results.directory), { sortAndExpand: true });
       files = previousTree.calculatePatch(this.tree)
         .filter(isNotRemoved)


### PR DESCRIPTION
In a situation when you revert failed compile attempt in `broccoli-persistent-filter`'s `processString`, 

```
// lib/tasks/server/livereload-server.js

didChange(results) {
...
      this.tree = new FSTree.fromEntries(this.getDirectoryEntries(results.directory), {sortAndExpand: true});
      files = previousTree.calculatePatch(this.tree)
        .filter(isNotRemoved)
        .filter(isNotDirectory)
        .map(relativePath)
        .filter(isNotSourceMapFile);
```
the result of `files` is `[]`.

This gets passed to `this.liveReloadServer().changed({` which doesn't trigger new websocket push, because there's nothing to notify clients about.

This PR works around this by catching the fact that there was a compilation error and forcing reload on next `didChange`.

I'm not sure if it's possible to write test for this as `tiny-lr`'s [`changed`](https://github.com/mklabs/tiny-lr/blob/master/lib/server.js#L220) doesn't return. I've got test written for the Error handling portion of the functionality.

This might be a too complicated approach, but I'm not familiar with whole system enough to see any other options. Because it doesn't different between reasons for errors, it also fixes #6242.