### PR TITLE
tests/acceptance/generate: Fix flaky tests

### DIFF
--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -348,10 +348,12 @@ describe('Acceptance: ember generate', function() {
   it('passes custom cli arguments to blueprint options', function() {
     return initApp()
       .then(function() {
-        outputFile(
+        return outputFile(
           'blueprints/customblue/files/app/__name__.js',
           "Q: Can I has custom command? A: <%= hasCustomCommand %>"
         );
+      })
+      .then(function() {
         return outputFile(
           'blueprints/customblue/index.js',
           "module.exports = {\n" +


### PR DESCRIPTION
We have to wait for the first outputFile() too before we can continue.

/cc @stefanpenner @rwjblue @nathanhammond  