### PR TITLE
BUGFIX Scoped package names

### DIFF
--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const getPackageBaseName = require('../utilities/get-package-base-name');
 const find = require('ember-cli-lodash-subset').find;
 
 module.exports = function findAddonByName(addons, name) {
   function matchAddon(name, addon) {
-    return name === addon.name || (addon.pkg && name === addon.pkg.name);
+    return name === addon.name || (addon.pkg && name === getPackageBaseName(addon.pkg.name));
   }
 
   return find(addons, addon => matchAddon(name, addon));

--- a/tests/unit/utilities/find-addon-by-name-test.js
+++ b/tests/unit/utilities/find-addon-by-name-test.js
@@ -14,7 +14,15 @@ describe('findAddonByName', function() {
     }, {
       name: 'foo-bar',
       pkg: { name: 'foo-bar' },
+    }, {
+      name: 'foo-bar-baz',
+      pkg: { name: '@foo/bar-baz' },
     }];
+  });
+
+  it('should return the foo-bar-baz addon when the unscoped package name is supplied', function() {
+    let addon = findAddonByName(addons, 'bar-baz');
+    expect(addon.name).to.equal('foo-bar-baz', 'should have found the foo-bar-baz addon');
   });
 
   it('should return the foo addon from name', function() {


### PR DESCRIPTION
In the function `findDefaultBlueprintName`, the package name passed to `findAddonByName` has been processed by `getPackageBaseName`, which removes the scope (@scope/my-pkg-name becomes my-pkg-name). In `findAddonByName` a comparison is done:
```
function matchAddon(name, addon) {
    return name === addon.name || (addon.pkg && name === addon.pkg.name);
  }
```
In the case where you are using scoped names, addon.pkg.name will be the fully scoped package name and that second comparison can never be true. If your package name in package.json and index.js are the same, you would never notice this. We are transitioning from a naming standard like "prefix-my-package-name" to "@prefix2/my-package-name". To make it easier for users, we decided to update the package name in package.json, but leave the index.js name unchanged (so that users of our library can update their package.json but not have to update import and require statements.) Under ember-cli 2.5.1 this worked fine, but when we went to try an upgrade we found this issue.  The logic in the `matchAddon` function appears to support the notion of the names being different. Processing addon.pkg.name with `getPackageBaseName` alleviates the problem.

