### PR TITLE
Add --test-port 0 for random port

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -20,7 +20,7 @@ module.exports = Command.extend({
     { name: 'config-file', type: String,                            aliases: ['c', 'cf'] },
     { name: 'server',      type: Boolean, default: false,           aliases: ['s'] },
     { name: 'host',        type: String,                            aliases: ['H'] },
-    { name: 'test-port',   type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running with --server.' },
+    { name: 'test-port',   type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running with --server. Pass 0 to automatically pick an available port' },
     { name: 'filter',      type: String,                            aliases: ['f'],  description: 'A string to filter tests to run' },
     { name: 'module',      type: String,                            aliases: ['m'],  description: 'The name of a test module to run' },
     { name: 'watcher',     type: String,  default: 'events',        aliases: ['w'] },

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -159,7 +159,7 @@ ember test \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -s\u001b[39m
   \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
-  \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server.
+  \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server. Pass 0 to automatically pick an available port
     \u001b[90maliases: -tp <value>\u001b[39m
   \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run
     \u001b[90maliases: -f <value>\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -621,7 +621,7 @@ module.exports = {
         {
           name: 'test-port',
           default: 7357,
-          description: 'The test port to use when running with --server.',
+          description: 'The test port to use when running with --server. Pass 0 to automatically pick an available port',
           aliases: ['tp'],
           key: 'testPort',
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -159,7 +159,7 @@ ember test \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -s\u001b[39m
   \u001b[36m--host\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -H <value>\u001b[39m
-  \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server.
+  \u001b[36m--test-port\u001b[39m \u001b[36m(Number)\u001b[39m \u001b[36m(Default: 7357)\u001b[39m The test port to use when running with --server. Pass 0 to automatically pick an available port
     \u001b[90maliases: -tp <value>\u001b[39m
   \u001b[36m--filter\u001b[39m \u001b[36m(String)\u001b[39m A string to filter tests to run
     \u001b[90maliases: -f <value>\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -653,7 +653,7 @@ module.exports = {
         {
           name: 'test-port',
           default: 7357,
-          description: 'The test port to use when running with --server.',
+          description: 'The test port to use when running with --server. Pass 0 to automatically pick an available port',
           aliases: ['tp'],
           key: 'testPort',
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -621,7 +621,7 @@ module.exports = {
         {
           name: 'test-port',
           default: 7357,
-          description: 'The test port to use when running with --server.',
+          description: 'The test port to use when running with --server. Pass 0 to automatically pick an available port',
           aliases: ['tp'],
           key: 'testPort',
           required: false


### PR DESCRIPTION
Using `--test-port 0` finds a random port. Adding documentation for it (just like the one with `ember serve --port 0`)