### PR TITLE
AppVeyor: Use cache buster for NPM cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - npm install
 
 cache:
-  - '%APPDATA%\npm-cache'
+  - '%APPDATA%\npm-cache -> package.json'
   - '%APPDATA%\Roaming\bower'
 
 


### PR DESCRIPTION
This should hopefully reduce our NPM issues on AppVeyor as long as we're not using yarn there (aka `master` doesn't care, but `release` and `beta` currently do)