### PR TITLE
Change usage of shims for ember-source@2.11.0 final.

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -5,8 +5,7 @@ module.exports = {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-4',
-          'ember-cli-shims': '0.1.3'
+          'ember': 'components/ember#lts-2-4'
         },
         resolutions: {
           'ember': 'lts-2-4'
@@ -22,8 +21,7 @@ module.exports = {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-8',
-          'ember-cli-shims': '0.1.3'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
           'ember': 'lts-2-8'
@@ -39,8 +37,7 @@ module.exports = {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release',
-          'ember-cli-shims': '0.1.3'
+          'ember': 'components/ember#release'
         },
         resolutions: {
           'ember': 'release'
@@ -56,8 +53,7 @@ module.exports = {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta',
-          'ember-cli-shims': '0.1.3'
+          'ember': 'components/ember#beta'
         },
         resolutions: {
           'ember': 'beta'
@@ -73,8 +69,7 @@ module.exports = {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary',
-          'ember-cli-shims': '0.1.3'
+          'ember': 'components/ember#canary'
         },
         resolutions: {
           'ember': 'canary'

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,6 +27,7 @@
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-shims": "^1.0.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -278,10 +278,13 @@ EmberApp.prototype._resolveLocal = function(to) {
   @method _initVendorFiles
 */
 EmberApp.prototype._initVendorFiles = function() {
+  var bowerDeps = this.project.bowerDependencies();
   var ember = this.project.findAddonByName('ember-source');
+  var addonEmberCliShims = this.project.findAddonByName('ember-cli-shims');
+  var bowerEmberCliShims = bowerDeps['ember-cli-shims'];
   var developmentEmber;
   var productionEmber;
-  var emberShims;
+  var emberShims = null;
   var jquery;
 
   if (ember) {
@@ -291,7 +294,11 @@ EmberApp.prototype._initVendorFiles = function() {
     jquery           = ember.paths.jquery;
   } else {
     jquery = this.bowerDirectory + '/jquery/dist/jquery.js';
-    emberShims = this.bowerDirectory + '/ember-cli-shims/app-shims.js';
+
+    if (bowerEmberCliShims) {
+      emberShims = this.bowerDirectory + '/ember-cli-shims/app-shims.js';
+    }
+
     // in Ember 1.10 and higher `ember.js` is deprecated in favor of
     // the more aptly named `ember.debug.js`.
     productionEmber = this.bowerDirectory + '/ember/ember.prod.js';
@@ -302,7 +309,6 @@ EmberApp.prototype._initVendorFiles = function() {
   }
 
   var handlebarsVendorFiles;
-  var bowerDeps = this.project.bowerDependencies();
   if ('handlebars' in bowerDeps) {
     handlebarsVendorFiles = {
       development: this.bowerDirectory + '/handlebars/handlebars.js',
@@ -341,10 +347,11 @@ EmberApp.prototype._initVendorFiles = function() {
   }
 
   // Warn if ember-cli-shims is not included.
-  // `ember-source` bundles them by default, so we must check if that is the
-  // load mechanism of ember before checking `bower`.
-  if (!ember && !bowerDeps['ember-cli-shims']) {
-    this.project.ui.writeWarnLine('You have not included `ember-cli-shims` in your project\'s `bower.json`. This only works if you provide an alternative yourself and unset `app.vendorFiles[\'app-shims.js\']`.');
+  // certain versions of `ember-source` bundle them by default,
+  // so we must check if that is the load mechanism of ember
+  // before checking `bower`.
+  if (!emberShims && !addonEmberCliShims && !bowerEmberCliShims) {
+    this.project.ui.writeWarnLine('You have not included `ember-cli-shims` in your project\'s `bower.json` or `package.json`. This only works if you provide an alternative yourself and unset `app.vendorFiles[\'app-shims.js\']`.');
   }
 
   // this is needed to support versions of Ember older than


### PR DESCRIPTION
See:

* https://github.com/ember-cli/ember-cli-shims/pull/82
* https://github.com/emberjs/ember.js/pull/14808

ember-source@2.11.0 will not have shims, this prepares us for that.