### PR TITLE
[BUGFIX release] Update `ember-cli-htmlbars-inline-precompile` requirement

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -22,7 +22,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",


### PR DESCRIPTION
This fixes an error that would occur if a version <0.3.6 were installed in an app with the `ember-source` NPM package rather than the bower package, recently introduced in Ember v2.11.0:

```
$ ember s
Cannot find module 'MyApp/bower_components/ember/ember-template-compiler'
Error: Cannot find module 'MyApp/bower_components/ember/ember-template-compiler'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Class.included (MyApp/node_modules/ember-cli-htmlbars-inline-precompile/index.js:48:20)
    at Class.superWrapper [as included] (MyApp/node_modules/core-object/lib/assign-properties.js:32:18)
    at EmberApp.<anonymous> (MyApp/node_modules/ember-cli/lib/broccoli/ember-app.js:492:15)
    at Array.filter (native)
    at EmberApp._notifyAddonIncluded (MyApp/node_modules/ember-cli/lib/broccoli/ember-app.js:487:45)
    at new EmberApp (MyApp/node_modules/ember-cli/lib/broccoli/ember-app.js:138:8)
```

See: https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/blob/master/CHANGELOG.md#036-2016-11-04