### PR TITLE
Remove link to transition guide when ember-cli-build.js file is missing

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -53,7 +53,7 @@ class Builder extends CoreObject {
     } else if (buildFile) {
       this.tree = buildFile({ project: this.project });
     } else {
-      throw new Error('No ember-cli-build.js found. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.');
+      throw new SilentError('No ember-cli-build.js found.');
     }
 
     this.builder = new broccoli.Builder(this.tree);


### PR DESCRIPTION
Resolves #6709 