### PR TITLE
Make instrumentation more resilient to errors

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -147,11 +147,9 @@ class CLI {
 
       let onCommandInterrupt = command.onInterrupt.bind(command);
       let instrumentation = this.instrumentation;
-      let initCompleted = false;
 
       return Promise.resolve().then(() => {
         instrumentation.stopAndReport('init');
-        initCompleted = true;
         instrumentation.start('command');
 
         loggerTesting.info('cli: command.beforeRun');
@@ -163,17 +161,17 @@ class CLI {
         loggerTesting.info('cli: command.validateAndRun');
 
         return command.validateAndRun(commandArgs);
-      }).finally(() => {
-        if (initCompleted) {
-          instrumentation.stopAndReport('command', commandName, commandArgs);
-        }
-        instrumentation.start('shutdown');
+      }).then(result => {
+        instrumentation.stopAndReport('command', commandName, commandArgs);
 
         onProcessInterrupt.removeHandler(onCommandInterrupt);
+
+        return result;
+      }).finally(() => {
+        instrumentation.start('shutdown');
         shutdownOnExit = function() {
           instrumentation.stopAndReport('shutdown');
         };
-
         // Ensure that the shutdown instrumentation hook is invoked properly
         // even if we exit before hitting the `finally` below
         onProcessInterrupt.addHandler(shutdownOnExit);
@@ -190,7 +188,6 @@ class CLI {
         }
 
         return result;
-
       }).then(exitCode => {
         loggerTesting.info(`cli: command run complete. exitCode: ${exitCode}`);
         // TODO: fix this

--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const experiments = require('../experiments/');
 const heimdallGraph = require('heimdalljs-graph');
 const utilsInstrumentation = require('../utilities/instrumentation');
+const logger = require('heimdalljs-logger')('ember-cli:instrumentation');
 
 let vizEnabled = utilsInstrumentation.vizEnabled;
 let instrumentationEnabled = utilsInstrumentation.instrumentationEnabled;
@@ -244,7 +245,13 @@ class Instrumentation {
     if (!instr.token) {
       throw new Error(`Cannot stop instrumentation "${name}".  It has not started.`);
     }
-    instr.token.stop();
+    try {
+      instr.token.stop();
+    } catch (e) {
+      this.ui.writeLine(chalk.red(`Error reporting instrumentation '${name}'.  Stack: ${this._heimdall.stack}`));
+      logger.error(e.stack);
+      return;
+    }
 
     let instrSummaryName = `_${name}Summary`;
     if (!this[instrSummaryName]) {

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -364,10 +364,12 @@ describe('models/instrumentation.js', function() {
     let instrumentation;
     let heimdall;
     let addon;
+    let ui;
 
     beforeEach(function() {
       project = new MockProject();
       instrumentation = project._instrumentation;
+      ui = instrumentation.ui;
       heimdall = instrumentation._heimdall = new Heimdall();
       process.env.EMBER_CLI_INSTRUMENTATION = '1';
 
@@ -389,6 +391,17 @@ describe('models/instrumentation.js', function() {
       expect(function() {
         instrumentation.stopAndReport('init');
       }).to.throw('Cannot stop instrumentation "init".  It has not started.');
+    });
+
+    it('warns if heimdall stop throws (eg when unbalanced)', function() {
+      instrumentation.start('init');
+      heimdall.start('a ruckus');
+
+      expect(function() {
+        instrumentation.stopAndReport('init');
+      }).to.not.throw();
+
+      expect(ui.output).to.eql(`${chalk.red('Error reporting instrumentation \'init\'.  Stack: init,a ruckus')}\n`);
     });
 
     it('computes summary for name', function() {


### PR DESCRIPTION
1. if `stopAndReport` is unable to `token.stop()` because the heimdall stack is unbalanced, log an error but do not throw.  This case is most likely due to some other error and we want the root cause to surface rather than masking it with an error from the instrumentation.

2. Don't try to report command instrumentation when the command promise has rejected.  This is error prone (although less so due to the change listed above) and in any case build timing is far more relevant for regular builds than builds which error (eg b/c we can't grab the port for `ember serve`).