### PR TITLE
Pass init instrumentation to CLI if we have it

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -121,6 +121,7 @@ module.exports = function(options) {
     disableDependencyChecker: options.disableDependencyChecker,
     root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
     npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli',
+    initInstrumentation: options.initInstrumentation,
   });
 
   let project = Project.projectOrnullProject(ui, cli);


### PR DESCRIPTION
We correctly warn that we didn't get an init instrumentation from bin in the case where eg we are invoked from a 2.10 global ember bin.  However, we were failing to pass in the bin init instrumentation and therefore were not able to init bootstrapping even when the global ember was up to date.


@rwjblue i'm not sure it's worth adding a smoke test for this and it's not clear where we can fit in a useful unit test but happy to entertain feedback on this point