### PR TITLE
remove ember-cli-sri and ember-cli-uglify from addons

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -38,6 +38,10 @@ module.exports = {
     // 100% of addons don't need ember-cli-app-version, make it opt-in instead
     delete contents.devDependencies['ember-cli-app-version'];
 
+    // 100% of addons don't need these, make it opt-in instead
+    delete contents.devDependencies['ember-cli-sri'];
+    delete contents.devDependencies['ember-cli-uglify'];
+
     if (contents.keywords.indexOf('ember-addon') === -1) {
       contents.keywords.push('ember-addon');
     }


### PR DESCRIPTION
I'd like to start the conversation on whether these are useful as defaults to addons. The only way I can think of is if they are deploying the dummy app to production.