### PR TITLE
Revert changes removing `bower.json` from default blueprints.

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -54,6 +54,14 @@ module.exports = {
     this._writeContentsToFile(sortPackageJson(contents), 'package.json');
   },
 
+  generateBowerJson() {
+    let contents = this._readContentsFromFile('bower.json');
+
+    contents.name = '<%= addonName %>';
+
+    this._writeContentsToFile(contents, 'bower.json');
+  },
+
   afterInstall() {
     let packagePath = path.join(this.path, 'files', 'package.json');
     let bowerPath = path.join(this.path, 'files', 'bower.json');
@@ -93,6 +101,7 @@ module.exports = {
     let appFiles = this._appBlueprint.files();
 
     this.generatePackageJson();
+    this.generateBowerJson();
 
     let addonFiles = walkSync(path.join(this.path, 'files'));
 

--- a/blueprints/app/files/bower.json
+++ b/blueprints/app/files/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "<%= name %>",
+  "dependencies": {
+  }
+}

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -48,13 +48,17 @@ describe('Acceptance: addon-smoke-test', function() {
     expect(dir(addonRoot)).to.not.exist;
   });
 
-  it('generates package.json with proper metadata', function() {
+  it('generates package.json and bower.json with proper metadata', function() {
     let packageContents = fs.readJsonSync('package.json');
 
     expect(packageContents.name).to.equal(addonName);
     expect(packageContents.private).to.be.an('undefined');
     expect(packageContents.keywords).to.deep.equal(['ember-addon']);
     expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
+
+    let bowerContents = fs.readJsonSync('bower.json');
+
+    expect(bowerContents.name).to.equal(addonName);
   });
 
   it('ember addon foo, clean from scratch', function() {

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -270,5 +270,22 @@ describe('blueprint - addon', function() {
         expect(json.devDependencies).to.deep.equal({ a: "1", b: "1" });
       });
     });
+
+    describe('generateBowerJson', function() {
+      it('works', function() {
+        blueprint.generateBowerJson();
+
+        let captor = td.matchers.captor();
+
+        td.verify(readJsonSync(path.normalize('test-app-blueprint-path/files/bower.json')));
+        td.verify(writeFileSync(path.normalize('test-blueprint-path/files/bower.json'), captor.capture()));
+
+        // string to test ordering
+        expect(captor.value).to.equal('\
+{\n\
+  "name": "<%= addonName %>"\n\
+}\n');
+      });
+    });
   });
 });


### PR DESCRIPTION
This reverts commit be142aaf7801bf64f4322583c7d82ae7c7066c52, reversing changes made to b90f8602eff3e71e9f7ff61541a740bfd25ea503.

This is being reverted due to user experience issues when the `bower.json` file is no longer part of the blueprint.

As things exist prior to a revert, any user upgrading from a version of ember-cli prior to 2.11 would never be instructed to update their `bower.json` to remove entries for `ember`, `ember-cli-shims`, etc.

To bring the changes being reverted back, we need to land the ability for a blueprint to indicate that a file should be deleted as part of the `ember init` process.  This was RFC'ed in ember-cli/rfcs#92 and the implementation is pending in https://github.com/ember-cli/ember-cli/pull/6472 and should hopefully land in 2.13 (current ember-cli#master branch).

This was discussed at the ember-cli meeting on 2017-01-26.