### PR TITLE
Promote cacheKeyForTree to public API

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -4,7 +4,6 @@ const symbol = require('../utilities/symbol');
 let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
   INSTRUMENTATION: symbol('instrumentation'),
-  ADDON_TREE_CACHING: symbol('addon-tree-caching'),
 };
 
 Object.freeze(experiments);

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -31,7 +31,6 @@ const walkSync = require('walk-sync');
 const ensurePosixPath = require('ensure-posix-path');
 const defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
 const findAddonByName = require('../utilities/find-addon-by-name');
-const experiments = require('../experiments');
 const heimdall = require('heimdalljs');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const addonProcessTree = require('../utilities/addon-process-tree');
@@ -462,15 +461,12 @@ let addonProto = {
       treeFor: true,
     });
 
-    let cacheKeyForTreeType;
-    if (experiments.ADDON_TREE_CACHING) {
-      cacheKeyForTreeType = this[experiments.ADDON_TREE_CACHING](treeType);
+    let cacheKeyForTreeType = this.cacheKeyForTree(treeType);
 
-      let cachedTree = ADDON_TREE_CACHE.getItem(cacheKeyForTreeType);
-      if (cachedTree) {
-        node.stop();
-        return cachedTree;
-      }
+    let cachedTree = ADDON_TREE_CACHE.getItem(cacheKeyForTreeType);
+    if (cachedTree) {
+      node.stop();
+      return cachedTree;
     }
 
     let trees = this.eachAddonInvoke('treeFor', [treeType]);
@@ -518,6 +514,49 @@ let addonProto = {
     }
 
     return tree;
+  },
+
+  /**
+    Calculates a cacheKey for the given treeType. It is expected to return a
+    cache key allowing multiple builds of the same tree to simply return the
+    original tree (preventing duplicate work). If it returns null / undefined
+    the tree in question will opt out of this caching system.
+
+    This method is invoked prior to calling treeFor with the same tree name.
+
+    You should override this method if you implement custom treeFor or treeFor*
+    methods, which cause addons to opt-out of this caching.
+
+    @public
+    @method cacheKeyForTree
+    @param {String} treeType
+    @return {String} cacheKey
+  */
+  cacheKeyForTree: function cacheKeyForTree(treeType) {
+    let self = this;
+    let methodsToValidate = methodsForTreeType(treeType);
+    let cacheKeyStats = heimdall.statsFor('cache-key-for-tree');
+
+    // determine if treeFor* (or other methods for tree type) overrides for the given tree
+    let modifiedMethods = methodsToValidate.filter(methodName => self[methodName] !== addonProto[methodName]);
+
+    if (modifiedMethods.length) {
+      cacheKeyStats.modifiedMethods++;
+      cacheKeyLogger.info(`Opting out due to: modified methods: ${modifiedMethods.join(', ')}`);
+      return null; // uncacheable
+    }
+
+    // determine if treeForMethods overrides for given tree
+    if (self.treeForMethods[treeType] !== DEFAULT_TREE_FOR_METHODS[treeType]) {
+      cacheKeyStats.treeForMethodsOverride++;
+      cacheKeyLogger.info('Opting out due to: treeForMethods override');
+      return null; // uncacheable
+    }
+
+    // compute cache key
+    let cacheKey = calculateCacheKeyForTree(treeType, self);
+
+    return cacheKey; // profit?
   },
 
   /**
@@ -1502,48 +1541,6 @@ function methodsForTreeType(treeType) {
   return GLOBAL_TREE_FOR_METHOD_METHODS.concat(treeMethods);
 }
 
-/*
-  `cacheKeyForTree` is currently hidden behind an experiment (pending review
-  and landing of https://github.com/ember-cli/rfcs/pull/90).
-
-  Once that RFC is accepted, a few things need to happen:
-
-  * Remove `ADDON_TREE_CACHING` from `lib/experiments/index.js`.
-  * Remove this guard.
-  * Remove guard around tests in `tests/unit/models/addon-test.js`.
-  * Move this code back up into the `addonProto` directly
-
-*/
-let addonTreeCacheExperimentPresent = !!experiments.ADDON_TREE_CACHING;
-if (addonTreeCacheExperimentPresent) {
-  addonProto[experiments.ADDON_TREE_CACHING] = function cacheKeyForTree(treeType) {
-    let self = this;
-    let methodsToValidate = methodsForTreeType(treeType);
-    let cacheKeyStats = heimdall.statsFor('cache-key-for-tree');
-
-    // determine if treeFor* (or other methods for tree type) overrides for the given tree
-    let modifiedMethods = methodsToValidate.filter(methodName => self[methodName] !== addonProto[methodName]);
-
-    if (modifiedMethods.length) {
-      cacheKeyStats.modifiedMethods++;
-      cacheKeyLogger.info(`Opting out due to: modified methods: ${modifiedMethods.join(', ')}`);
-      return null; // uncacheable
-    }
-
-    // determine if treeForMethods overrides for given tree
-    if (self.treeForMethods[treeType] !== DEFAULT_TREE_FOR_METHODS[treeType]) {
-      cacheKeyStats.treeForMethodsOverride++;
-      cacheKeyLogger.info('Opting out due to: treeForMethods override');
-      return null; // uncacheable
-    }
-
-    // compute cache key
-    let cacheKey = calculateCacheKeyForTree(treeType, self);
-
-    return cacheKey; // profit?
-  };
-}
-
 let Addon = CoreObject.extend(addonProto);
 
 /**
@@ -1621,7 +1618,4 @@ Addon.lookup = function(addon) {
 };
 module.exports = Addon;
 module.exports._resetTreeCache = _resetTreeCache;
-
-if (addonTreeCacheExperimentPresent) {
-  module.exports._treeCache = ADDON_TREE_CACHE;
-}
+module.exports._treeCache = ADDON_TREE_CACHE;


### PR DESCRIPTION
As discussed in ember-cli/rfcs#90. Should be good to go once the RFC is merged.

Pro tip: use `?w=1` when viewing the changes to tidy up the large amount of whitespace changes in the tests.