### PR TITLE
ensure SIGINT ember serve produces instrumentation

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -145,10 +145,10 @@ class CLI {
         }
       }
 
-      let onCommandInterrupt = command.onInterrupt.bind(command);
       let instrumentation = this.instrumentation;
+      let onCommandInterrupt;
 
-      return Promise.resolve().then(() => {
+      let runPromise = Promise.resolve().then(() => {
         instrumentation.stopAndReport('init');
         instrumentation.start('command');
 
@@ -156,7 +156,6 @@ class CLI {
         onProcessInterrupt.addHandler(onCommandInterrupt);
 
         return command.beforeRun(commandArgs);
-
       }).then(() => {
         loggerTesting.info('cli: command.validateAndRun');
 
@@ -172,9 +171,6 @@ class CLI {
         shutdownOnExit = function() {
           instrumentation.stopAndReport('shutdown');
         };
-        // Ensure that the shutdown instrumentation hook is invoked properly
-        // even if we exit before hitting the `finally` below
-        onProcessInterrupt.addHandler(shutdownOnExit);
       }).then(result => {
         // if the help option was passed, call the help command
         if (result === 'callHelp') {
@@ -203,13 +199,16 @@ class CLI {
           }
         });
       });
+
+      onCommandInterrupt = () =>
+        Promise.resolve(command.onInterrupt())
+          .then(() => runPromise);
+
+      return runPromise;
     })
     .finally(() => {
       if (shutdownOnExit) {
-        // invoke instrumentation shutdown and
-        // remove instrumentation interruption handlers
         shutdownOnExit();
-        onProcessInterrupt.removeHandler(shutdownOnExit);
       }
     })
     .catch(this.logError.bind(this));

--- a/lib/commands/asset-sizes.js
+++ b/lib/commands/asset-sizes.js
@@ -11,9 +11,6 @@ module.exports = Command.extend({
   ],
 
   run(commandOptions) {
-    let task = new this.tasks.ShowAssetSizes({
-      ui: this.ui,
-    });
-    return task.run(commandOptions);
+    return this.runTask('ShowAssetSizes', commandOptions);
   },
 });

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -17,17 +17,12 @@ module.exports = Command.extend({
   ],
 
   run(commandOptions) {
-    let ShowAssetSizesTask = this.tasks.ShowAssetSizes;
-    let showTask = new ShowAssetSizesTask({
-      ui: this.ui,
-    });
-
     return Win.checkIfSymlinksNeedToBeEnabled(this.ui).then(() => {
       let buildTaskName = commandOptions.watch ? 'BuildWatch' : 'Build';
       return this.runTask(buildTaskName, commandOptions).then(() => {
         let isProduction = commandOptions.environment === 'production' || process.env.EMBER_ENV === 'production';
         if (!commandOptions.suppressSizes && isProduction) {
-          return showTask.run({
+          return this.runTask('ShowAssetSizes', {
             outputPath: commandOptions.outputPath,
           });
         }

--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -43,14 +43,6 @@ module.exports = Command.extend({
                                             'For more details, use `ember help`.'));
     }
 
-    let Task = this.tasks.DestroyFromBlueprint;
-    let task = new Task({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-      settings: this.settings,
-    });
-
     let taskArgs = {
       args: rawArgs,
     };
@@ -65,7 +57,7 @@ module.exports = Command.extend({
       this.project.initializeAddons();
     }
 
-    return task.run(taskOptions);
+    return this.runTask('DestroyFromBlueprint', taskOptions);
   },
 
   printDetailedHelp() {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -38,14 +38,6 @@ module.exports = Command.extend({
                                             'blueprint name to be specified. ' +
                                             'For more details, use `ember help`.'));
     }
-    let Task = this.tasks.GenerateFromBlueprint;
-    let task = new Task({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-      testing: this.testing,
-      settings: this.settings,
-    });
 
     let taskArgs = {
       args: rawArgs,
@@ -61,7 +53,7 @@ module.exports = Command.extend({
       this.project.initializeAddons();
     }
 
-    return task.run(taskOptions);
+    return this.runTask('GenerateFromBlueprint', taskOptions);
   },
 
   printDetailedHelp(options) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -44,46 +44,6 @@ module.exports = Command.extend({
       commandOptions.skipBower = true;
     }
 
-    let installBlueprint = new this.tasks.InstallBlueprint({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-    });
-
-    let gitInit, npmInstall, generate, bowerInstall;
-
-    // needs an explicit check in case it's just 'undefined'
-    // due to passing of options from 'new' and 'addon'
-    if (commandOptions.skipGit === false) {
-      gitInit = new this.tasks.GitInit({
-        ui: this.ui,
-        project: this.project,
-      });
-    }
-
-    if (!commandOptions.skipNpm) {
-      npmInstall = new this.tasks.NpmInstall({
-        ui: this.ui,
-        analytics: this.analytics,
-        project: this.project,
-      });
-
-      generate = new this.tasks.GenerateFromBlueprint({
-        ui: this.ui,
-        analytics: this.analytics,
-        project: this.project,
-        testing: this.testing,
-      });
-    }
-
-    if (!commandOptions.skipBower) {
-      bowerInstall = new this.tasks.BowerInstall({
-        ui: this.ui,
-        analytics: this.analytics,
-        project: this.project,
-      });
-    }
-
     let project = this.project;
     let packageName = (commandOptions.name !== '.' && commandOptions.name) || project.name();
 
@@ -108,11 +68,11 @@ module.exports = Command.extend({
     }
 
     logger.info('before:installblueprint');
-    return installBlueprint.run(blueprintOpts)
+    return this.runTask('InstallBlueprint', blueprintOpts)
       .then(() => {
         logger.info('after:installblueprint');
         if (!commandOptions.skipNpm) {
-          return npmInstall.run({
+          return this.runTask('NpmInstall', {
             verbose: commandOptions.verbose,
             optional: false,
           }).then(() => {
@@ -122,7 +82,7 @@ module.exports = Command.extend({
       })
       .then(() => {
         if (!commandOptions.skipBower) {
-          return bowerInstall.run({
+          return this.runTask('BowerInstall', {
             verbose: commandOptions.verbose,
           });
         }
@@ -132,7 +92,7 @@ module.exports = Command.extend({
         if (!commandOptions.skipNpm) {
           this.project.reloadAddons();
 
-          return generate.run({
+          return this.runTask('GenerateFromBlueprint', {
             verbose: commandOptions.verbose,
             args: ['ember-cli-eslint'],
             ignoreMissingMain: true,
@@ -141,7 +101,7 @@ module.exports = Command.extend({
       })
       .then(() => {
         if (commandOptions.skipGit === false) {
-          return gitInit.run(commandOptions, rawArgs);
+          return this.runTask('GitInit', commandOptions, rawArgs);
         }
       });
   },

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -28,18 +28,19 @@ module.exports = Command.extend({
       return Promise.reject(new SilentError(msg));
     }
 
-    let AddonInstallTask = this.tasks.AddonInstall;
-    let addonInstall = new AddonInstallTask({
+    return this.runTask('AddonInstall', {
+      'packages': addonNames,
+      blueprintOptions: commandOptions,
+    });
+  },
+
+  _env() {
+    return {
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
       NpmInstallTask: this.tasks.NpmInstall,
       BlueprintTask: this.tasks.GenerateFromBlueprint,
-    });
-
-    return addonInstall.run({
-      'packages': addonNames,
-      blueprintOptions: commandOptions,
-    });
+    };
   },
 });

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -69,10 +69,6 @@ module.exports = Command.extend({
       commandOptions.directory = packageName;
     }
 
-    let createAndStepIntoDirectory = new this.tasks.CreateAndStepIntoDirectory({
-      ui: this.ui,
-      analytics: this.analytics,
-    });
     let InitCommand = this.commands.Init;
 
     let initCommand = new InitCommand({
@@ -82,24 +78,23 @@ module.exports = Command.extend({
       project: Project.nullProject(this.ui, this.cli),
     });
 
-    return createAndStepIntoDirectory
-      .run({
-        directoryName: commandOptions.directory,
-        dryRun: commandOptions.dryRun,
-      })
-      .then(opts => {
-        initCommand.project.root = process.cwd();
+    return this.runTask('CreateAndStepIntoDirectory', {
+      directoryName: commandOptions.directory,
+      dryRun: commandOptions.dryRun,
+    })
+    .then(opts => {
+      initCommand.project.root = process.cwd();
 
-        return initCommand
-          .run(commandOptions, rawArgs)
-          .catch(err => {
-            let dirName = commandOptions.directory;
-            process.chdir(opts.initialDirectory);
-            return rmdir(dirName).then(() => {
-              console.log(chalk.red(`Error creating new application. Removing generated directory \`./${dirName}\``));
-              throw err;
-            });
+      return initCommand
+        .run(commandOptions, rawArgs)
+        .catch(err => {
+          let dirName = commandOptions.directory;
+          process.chdir(opts.initialDirectory);
+          return rmdir(dirName).then(() => {
+            console.log(chalk.red(`Error creating new application. Removing generated directory \`./${dirName}\``));
+            throw err;
           });
-      });
+        });
+    });
   },
 });

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -67,15 +67,8 @@ module.exports = Command.extend({
           }
         }
 
-        let ServeTask = this.tasks.Serve;
-        let serve = new ServeTask({
-          ui: this.ui,
-          analytics: this.analytics,
-          project: this.project,
-        });
-
         return Win.checkIfSymlinksNeedToBeEnabled(this.ui)
-          .then(() => serve.run(commandOptions));
+          .then(() => this.runTask('Serve', commandOptions));
       });
   },
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -31,7 +31,10 @@ class Builder extends CoreObject {
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
     this._cleanup = this.cleanup.bind(this);
 
-    onProcessInterrupt.addHandler(this._cleanup);
+    this._cleanupPromise = null;
+    this._onProcessInterrupt = options.onProcessInterrupt || onProcessInterrupt;
+
+    this._onProcessInterrupt.addHandler(this._cleanup);
   }
 
   /**
@@ -179,24 +182,28 @@ class Builder extends CoreObject {
    * @return {Promise}
    */
   cleanup() {
-    let ui = this.project.ui;
-    ui.startProgress('cleaning up');
-    ui.writeLine('cleaning up...');
+    if (!this._cleanupPromise) {
+      let ui = this.project.ui;
+      ui.startProgress('cleaning up');
+      ui.writeLine('cleaning up...');
 
-    // ensure any addon treeFor caches are reset
-    _resetTreeCache();
+      // ensure any addon treeFor caches are reset
+      _resetTreeCache();
 
-    onProcessInterrupt.removeHandler(this._cleanup);
+      this._onProcessInterrupt.removeHandler(this._cleanup);
 
-    let node = heimdall.start({ name: 'Builder Cleanup' });
+      let node = heimdall.start({ name: 'Builder Cleanup' });
 
-    return this.builder.cleanup().finally(() => {
-      ui.stopProgress();
-      node.stop();
-    }).catch(err => {
-      ui.writeLine(chalk.red('Cleanup error.'));
-      ui.writeError(err);
-    });
+      this._cleanupPromise = this.builder.cleanup().finally(() => {
+        ui.stopProgress();
+        node.stop();
+      }).catch(err => {
+        ui.writeLine(chalk.red('Cleanup error.'));
+        ui.writeError(err);
+      });
+    }
+
+    return this._cleanupPromise;
   }
 
   /**

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -189,11 +189,13 @@ let Command = CoreObject.extend({
     }
   },
 
-  _env() {
+  _env(/* name */) {
     return {
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
+      testing: this.testing,
+      settings: this.settings,
     };
   },
 
@@ -207,7 +209,7 @@ let Command = CoreObject.extend({
       throw new Error(`Unknown task "${name}"`);
     }
 
-    let task = new Task(this._env());
+    let task = new Task(this._env(name));
 
     this._currentTask = task;
 

--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -4,25 +4,38 @@ const chalk = require('chalk');
 const Task = require('../models/task');
 const Watcher = require('../models/watcher');
 const Builder = require('../models/builder');
-const Promise = require('rsvp').Promise;
+const RSVP = require('rsvp');
 
 class BuildWatchTask extends Task {
+  constructor(options) {
+    super(options);
+
+    this._builder = null;
+    this._runDeferred = null;
+  }
+
   run(options) {
     this.ui.startProgress(
       chalk.green('Building'), chalk.green('.')
     );
 
-    return new Watcher({
+    this._runDeferred = RSVP.defer();
+
+    let builder = this._builder = options._builder || new Builder({
       ui: this.ui,
-      builder: new Builder({
-        ui: this.ui,
-        outputPath: options.outputPath,
-        environment: options.environment,
-        project: this.project,
-      }),
+      outputPath: options.outputPath,
+      environment: options.environment,
+      project: this.project,
+    });
+
+    let watcher = options._watcher || new Watcher({
+      ui: this.ui,
+      builder,
       analytics: this.analytics,
       options,
-    }).then(() => new Promise(() => {}) /* Run until failure or signal to exit */);
+    });
+
+    return watcher.then(() => this._runDeferred.promise /* Run until failure or signal to exit */);
   }
 
   /**
@@ -31,7 +44,9 @@ class BuildWatchTask extends Task {
    * @private
    * @method onInterrupt
    */
-  onInterrupt() {}
+  onInterrupt() {
+    return this._builder.cleanup().then(() => this._runDeferred.resolve());
+  }
 }
 
 module.exports = BuildWatchTask;

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -4,22 +4,31 @@ const existsSync = require('exists-sync');
 const path = require('path');
 const LiveReloadServer = require('./server/livereload-server');
 const ExpressServer = require('./server/express-server');
-const Promise = require('rsvp').Promise;
+const RSVP = require('rsvp');
 const Task = require('../models/task');
 const Watcher = require('../models/watcher');
 const ServerWatcher = require('../models/server-watcher');
 const Builder = require('../models/builder');
 
+const Promise = RSVP.Promise;
+
 class ServeTask extends Task {
+  constructor(options) {
+    super(options);
+
+    this._runDeferred = null;
+    this._builder = null;
+  }
+
   run(options) {
-    let builder = new Builder({
+    let builder = this._builder = options._builder || new Builder({
       ui: this.ui,
       outputPath: options.outputPath,
       project: this.project,
       environment: options.environment,
     });
 
-    let watcher = new Watcher({
+    let watcher = options._watcher || new Watcher({
       ui: this.ui,
       builder,
       analytics: this.analytics,
@@ -37,7 +46,7 @@ class ServeTask extends Task {
       });
     }
 
-    let expressServer = new ExpressServer({
+    let expressServer = options._expressServer || new ExpressServer({
       ui: this.ui,
       project: this.project,
       watcher,
@@ -45,7 +54,7 @@ class ServeTask extends Task {
       serverWatcher,
     });
 
-    let liveReloadServer = new LiveReloadServer({
+    let liveReloadServer = options._liveReloadServer || new LiveReloadServer({
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
@@ -53,10 +62,13 @@ class ServeTask extends Task {
       expressServer,
     });
 
+    /* hang until the user exits */
+    this._runDeferred = RSVP.defer();
+
     return Promise.all([
       liveReloadServer.start(options),
       expressServer.start(options),
-    ]).then(() => new Promise(() => {}) /* hang until the user exits. */);
+    ]).then(() => this._runDeferred.promise);
   }
 
   /**
@@ -65,7 +77,9 @@ class ServeTask extends Task {
    * @private
    * @method onInterrupt
    */
-  onInterrupt() {}
+  onInterrupt() {
+    return this._builder.cleanup().then(() => this._runDeferred.resolve());
+  }
 }
 
 module.exports = ServeTask;

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -59,7 +59,10 @@ class TestServerTask extends TestTask {
    * @private
    * @method onInterrupt
    */
-  onInterrupt() {}
+  onInterrupt() {
+    // We don't have any hanging promise to resolve here because the SIGINT is
+    // captured and handled by testem
+  }
 }
 
 module.exports = TestServerTask;

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -127,8 +127,6 @@ describe('models/builder.js', function() {
     let instrumentationStop;
 
     beforeEach(function() {
-      let command = new BuildCommand(commandOptions());
-
       builder = new Builder({
         setupBroccoliBuilder,
         project: new MockProject(),

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -179,6 +179,23 @@ describe('models/builder.js', function() {
     });
   });
 
+  describe('cleanup', function() {
+    beforeEach(function() {
+      builder = new Builder({
+        setupBroccoliBuilder,
+        project: new MockProject(),
+        processBuildResult(buildResults) { return Promise.resolve(buildResults); },
+      });
+    });
+
+    it('is idempotent', function() {
+      let firstCleanupPromise = builder.cleanup();
+      expect(builder.cleanup()).to.equal(firstCleanupPromise);
+
+      return firstCleanupPromise;
+    });
+  });
+
   describe('addons', function() {
     let hooksCalled;
     let instrumentationArg;

--- a/tests/unit/tasks/build-watch-test.js
+++ b/tests/unit/tasks/build-watch-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const RSVP = require('rsvp');
+const MockUI = require('console-ui/mock');
+const BuildWatchTask = require('../../../lib/tasks/build-watch');
+const Builder = require('../../../lib/models/builder');
+const MockProject = require('../../helpers/mock-project');
+const expect = require('chai').expect;
+
+const Promise = RSVP.Promise;
+
+describe('build-watch task', function() {
+  let task, ui;
+
+  function setupBroccoliBuilder() {
+    this.builder = {
+      build() {
+        return Promise.resolve('build results');
+      },
+
+      cleanup() {
+        return Promise.resolve('cleanup result');
+      },
+
+      processBuildResult(results) {
+        return Promise.resolve(results);
+      },
+    };
+  }
+
+  function runBuildWatchTask() {
+    let project = new MockProject();
+
+    ui = project.ui;
+    let _builder = new Builder({
+      ui,
+      project,
+      setupBroccoliBuilder,
+      onProcessInterrupt: {
+        addHandler() {},
+        removeHandler() {},
+      },
+    });
+
+    let _watcher = {
+      then(fulfillmentHandler, rejectionHandler) {
+        return Promise.resolve().then(fulfillmentHandler, rejectionHandler);
+      },
+    };
+
+    task = new BuildWatchTask({
+      ui,
+      project,
+    });
+
+    let options = {
+      outputPath: 'tmp/build-watch-task-test',
+      environment: 'test',
+      _builder,
+      _watcher,
+    };
+    return task.run(options);
+  }
+
+  describe('onInterrupt', function() {
+    it('fulfills the run promise and cleans up the builder', function() {
+      let runPromise = runBuildWatchTask();
+
+      RSVP.resolve().then(() => task.onInterrupt());
+
+      return runPromise.then(() => {
+        expect(ui.output).to.include('cleaning up...');
+      });
+    });
+  });
+});
+

--- a/tests/unit/tasks/serve-test.js
+++ b/tests/unit/tasks/serve-test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const RSVP = require('rsvp');
+const MockUI = require('console-ui/mock');
+const ServeTask = require('../../../lib/tasks/serve');
+const Builder = require('../../../lib/models/builder');
+const MockProject = require('../../helpers/mock-project');
+const expect = require('chai').expect;
+
+const Promise = RSVP.Promise;
+
+describe('serve task', function() {
+  let task, ui;
+
+  function setupBroccoliBuilder() {
+    this.builder = {
+      build() {
+        return Promise.resolve('build results');
+      },
+
+      cleanup() {
+        return Promise.resolve('cleanup result');
+      },
+
+      processBuildResult(results) {
+        return Promise.resolve(results);
+      },
+    };
+  }
+
+  function runServeTask() {
+    let project = new MockProject();
+
+    ui = project.ui;
+    let _builder = new Builder({
+      ui,
+      project,
+      setupBroccoliBuilder,
+      onProcessInterrupt: {
+        addHandler() {},
+        removeHandler() {},
+      },
+    });
+
+    let _watcher = {};
+    let _expressServer = {
+      start() { return Promise.resolve(); },
+    };
+    let _liveReloadServer = _expressServer;
+
+    task = new ServeTask({
+      ui,
+      project,
+    });
+
+    let options = {
+      outputPath: 'tmp/serve-task-test',
+      environment: 'test',
+      _builder,
+      _watcher,
+      _expressServer,
+      _liveReloadServer,
+    };
+    return task.run(options);
+  }
+
+  describe('onInterrupt', function() {
+    it('fulfills the run promise and cleans up the builder', function() {
+      let servePromise = runServeTask();
+
+      RSVP.resolve().then(() => task.onInterrupt());
+
+      return servePromise.then(() => {
+        expect(ui.output).to.include('cleaning up...');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Previously the command's run promise would not resolve, and subsequent then handlers responsible for producing instrumentation would never run.

Cleanup occurred due to capture-exit.

Now our exit handler not only cleans up, but also finishes the run promise chain.


Also ensure ServeCommand.run invokes its task via runTask so our onInterrupt hook works.