### PR TITLE
WIP: remove ember-cli-legacy-blueprints

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "ember-cli-broccoli-sane-watcher": "^2.0.3",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cli-legacy-blueprints": "^0.1.2",
     "ember-cli-lodash-subset": "^1.0.11",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.0.0",


### PR DESCRIPTION
now that ember-source provides our blueprints