### PR TITLE
Use yarn if yarn.lock exists or `--yarn` is used

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -5,11 +5,15 @@ node_js:
 
 sudo: false
 
-cache:
+<% if (yarn) { %>cache:
+  yarn: true
+  directories:
+    - $HOME/.cache # includes bowers cache
+<% } else { %>cache:
   directories:
     - $HOME/.npm
     - $HOME/.cache # includes bowers cache
-
+<% } %>
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.4
@@ -24,7 +28,17 @@ matrix:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
-before_install:
+<% if (yarn) { %>before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
+
+install:
+  - yarn install
+  - bower install
+<% } else { %>before_install:
   - npm config set spin false
   - npm install -g bower phantomjs-prebuilt
   - bower --version
@@ -33,7 +47,7 @@ before_install:
 install:
   - npm install
   - bower install
-
+<% } %>
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -96,6 +96,7 @@ module.exports = {
       addonNamespace,
       emberCLIVersion: require('../../package').version,
       year: date.getFullYear(),
+      yarn: options.yarn,
     };
   },
 

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -4,7 +4,25 @@ node_js:
   - "6"
 
 sudo: false
+<% if (yarn) { %>
+cache:
+  yarn: true
+  directories:
+    - $HOME/.cache # includes bowers cache
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
+
+install:
+  - yarn install
+  - bower install
+
+script:
+  - yarn test<% } else { %>
 cache:
   directories:
     - $HOME/.npm
@@ -21,4 +39,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - npm test<% } %>

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -21,6 +21,7 @@ module.exports = {
       modulePrefix: name,
       namespace,
       emberCLIVersion: require('../../package').version,
+      yarn: options.yarn,
     };
   },
 };

--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -13,6 +13,7 @@ module.exports = NewCommand.extend({
     { name: 'skip-npm',   type: Boolean, default: false,   aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false,   aliases: ['sb'] },
     { name: 'skip-git',   type: Boolean, default: false,   aliases: ['sg'] },
+    { name: 'yarn',       type: Boolean, default: false },
     { name: 'directory',  type: String,                    aliases: ['dir'] },
   ],
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const path = require('path');
 const clone = require('ember-cli-lodash-subset').clone;
 const merge = require('ember-cli-lodash-subset').merge;
 const Command = require('../models/command');
 const Promise = require('rsvp').Promise;
 const SilentError = require('silent-error');
+const existsSync = require('exists-sync');
 const validProjectName = require('../utilities/valid-project-name');
 const normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
@@ -57,6 +59,11 @@ module.exports = Command.extend({
     }
 
     let blueprintOpts = clone(commandOptions);
+
+    if (blueprintOpts.yarn === undefined) {
+      blueprintOpts.yarn = existsSync(path.join(project.root, 'yarn.lock'));
+    }
+
     merge(blueprintOpts, {
       rawName: packageName,
       targetFiles: rawArgs || '',

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -21,6 +21,7 @@ module.exports = Command.extend({
     { name: 'blueprint',  type: String,                  aliases: ['b'] },
     { name: 'skip-npm',   type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
+    { name: 'yarn',       type: Boolean },
     { name: 'name',       type: String,  default: '',    aliases: ['n'] },
   ],
 
@@ -74,6 +75,7 @@ module.exports = Command.extend({
         if (!commandOptions.skipNpm) {
           return this.runTask('NpmInstall', {
             verbose: commandOptions.verbose,
+            useYarn: commandOptions.yarn,
             optional: false,
           }).then(() => {
             project.setupNodeModulesPath();

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -14,6 +14,7 @@ module.exports = Command.extend({
     { name: 'save', type: Boolean, default: false, aliases: ['S'] },
     { name: 'save-dev', type: Boolean, default: true, aliases: ['D'] },
     { name: 'save-exact', type: Boolean, default: false, aliases: ['E', 'exact'] },
+    { name: 'yarn', type: Boolean, description: 'Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM' },
   ],
 
   anonymousOptions: [

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -25,6 +25,7 @@ module.exports = Command.extend({
     { name: 'skip-npm',   type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'skip-git',   type: Boolean, default: false, aliases: ['sg'] },
+    { name: 'yarn',       type: Boolean, default: false },
     { name: 'directory',  type: String,                  aliases: ['dir'] },
   ],
 

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -25,6 +25,7 @@ class AddonInstallTask extends Task {
       ui: this.ui,
       analytics: this.analytics,
       project: this.project,
+      useYarn: commandOptions.yarn,
     });
 
     let blueprintInstall = new this.BlueprintTask({

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -27,11 +27,11 @@ class NpmInstallTask extends NpmTask {
   }
 
   formatStartMessage(packages) {
-    return `NPM: Installing ${formatPackageList(packages)} ...`;
+    return `${this.useYarn ? 'Yarn' : 'NPM'}: Installing ${formatPackageList(packages)} ...`;
   }
 
   formatCompleteMessage(packages) {
-    return `NPM: Installed ${formatPackageList(packages)}`;
+    return `${this.useYarn ? 'Yarn' : 'NPM'}: Installed ${formatPackageList(packages)}`;
   }
 }
 

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -82,24 +82,43 @@ class NpmTask extends Task {
   }
 
   findPackageManager() {
-    if (!this.hasYarnLock()) {
-      logger.info('yarn.lock not found -> using npm');
+    if (this.useYarn === undefined) {
+      if (!this.hasYarnLock()) {
+        logger.info('yarn.lock not found -> using npm');
+        return this.checkNpmVersion();
+      }
+
+      logger.info('yarn.lock found -> trying yarn');
+      return this.checkYarn()
+        .then(() => {
+          logger.info('yarn found -> using yarn');
+          this.useYarn = true;
+        })
+        .catch(() => {
+          logger.info('yarn not found -> using npm');
+          return this.checkNpmVersion();
+        });
+
+    } else if (this.useYarn) {
+      logger.info('yarn requested -> trying yarn');
+
+      return this.checkYarn().catch(error => {
+        if (error.code === 'ENOENT') {
+          throw new SilentError('Yarn could not be found.');
+        }
+
+        throw error;
+      });
+
+    } else {
+      logger.info('npm requested -> using npm');
       return this.checkNpmVersion();
     }
-
-    logger.info('yarn.lock found -> trying yarn');
-    return this.checkYarn()
-      .then(() => {
-        logger.info('yarn found -> using yarn');
-        this.useYarn = true;
-      })
-      .catch(() => {
-        logger.info('yarn not found -> using npm');
-        return this.checkNpmVersion();
-      });
   }
 
   run(options) {
+    this.useYarn = options.useYarn;
+
     return this.findPackageManager().then(() => {
 
       let ui = this.ui;

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -68,38 +68,44 @@ class NpmTask extends Task {
 
       ui.startProgress(chalk.green(startMessage));
 
-      let args = [this.command];
-
-      if (options.save) {
-        args.push('--save');
-      }
-
-      if (options['save-dev']) {
-        args.push('--save-dev');
-      }
-
-      if (options['save-exact']) {
-        args.push('--save-exact');
-      }
-
-      if ('optional' in options && !options.optional) {
-        args.push('--no-optional');
-      }
-
-      if (options.verbose) {
-        args.push('--loglevel verbose');
-      } else {
-        args.push('--loglevel error');
-      }
-
-      if (options.packages) {
-        args = args.concat(options.packages);
-      }
+      let args = this.toNpmArgs(this.command, options);
 
       return this.npm(args)
         .finally(() => ui.stopProgress())
         .then(() => ui.writeLine(chalk.green(completeMessage)));
     });
+  }
+
+  toNpmArgs(command, options) {
+    let args = [command];
+
+    if (options.save) {
+      args.push('--save');
+    }
+
+    if (options['save-dev']) {
+      args.push('--save-dev');
+    }
+
+    if (options['save-exact']) {
+      args.push('--save-exact');
+    }
+
+    if ('optional' in options && !options.optional) {
+      args.push('--no-optional');
+    }
+
+    if (options.verbose) {
+      args.push('--loglevel verbose');
+    } else {
+      args.push('--loglevel error');
+    }
+
+    if (options.packages) {
+      args = args.concat(options.packages);
+    }
+
+    return args;
   }
 
   formatStartMessage(/* packages */) {

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -28,7 +28,7 @@ class NpmTask extends Task {
     return RSVP.resolve(execa('npm', args, { preferLocal: false }));
   }
 
-  checkVersion() {
+  checkNpmVersion() {
     return this.npm(['--version']).then(result => {
       let version = result.stdout;
       logger.info('npm --version: %s', version);
@@ -60,7 +60,7 @@ class NpmTask extends Task {
   }
 
   run(options) {
-    return this.checkVersion().then(() => {
+    return this.checkNpmVersion().then(() => {
 
       let ui = this.ui;
       let startMessage = this.formatStartMessage(options.packages);

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -102,24 +102,7 @@ class NpmTask extends Task {
    * @return {Promise}
    */
   findPackageManager() {
-    if (this.useYarn === undefined) {
-      if (!this.hasYarnLock()) {
-        logger.info('yarn.lock not found -> using npm');
-        return this.checkNpmVersion();
-      }
-
-      logger.info('yarn.lock found -> trying yarn');
-      return this.checkYarn()
-        .then(() => {
-          logger.info('yarn found -> using yarn');
-          this.useYarn = true;
-        })
-        .catch(() => {
-          logger.info('yarn not found -> using npm');
-          return this.checkNpmVersion();
-        });
-
-    } else if (this.useYarn) {
+    if (this.useYarn === true) {
       logger.info('yarn requested -> trying yarn');
 
       return this.checkYarn().catch(error => {
@@ -129,11 +112,28 @@ class NpmTask extends Task {
 
         throw error;
       });
+    }
 
-    } else {
+    if (this.useYarn === false) {
       logger.info('npm requested -> using npm');
       return this.checkNpmVersion();
     }
+
+    if (!this.hasYarnLock()) {
+      logger.info('yarn.lock not found -> using npm');
+      return this.checkNpmVersion();
+    }
+
+    logger.info('yarn.lock found -> trying yarn');
+    return this.checkYarn()
+      .then(() => {
+        logger.info('yarn found -> using yarn');
+        this.useYarn = true;
+      })
+      .catch(() => {
+        logger.info('yarn not found -> using npm');
+        return this.checkNpmVersion();
+      });
   }
 
   run(options) {

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -2,11 +2,13 @@
 
 // Runs `npm install` in cwd
 
+const path = require('path');
 const chalk = require('chalk');
 const execa = require('execa');
 const semver = require('semver');
 const RSVP = require('rsvp');
 const SilentError = require('silent-error');
+const existsSync = require('exists-sync');
 
 const logger = require('heimdalljs-logger')('ember-cli:npm-task');
 
@@ -26,6 +28,26 @@ class NpmTask extends Task {
   npm(args) {
     logger.info('npm: %j', args);
     return RSVP.resolve(execa('npm', args, { preferLocal: false }));
+  }
+
+  yarn(args) {
+    logger.info('yarn: %j', args);
+    return RSVP.resolve(execa('yarn', args, { preferLocal: false }));
+  }
+
+  hasYarnLock() {
+    return existsSync(path.join(this.project.root, 'yarn.lock'));
+  }
+
+  checkYarn() {
+    return this.yarn(['--version']).then(result => {
+      let version = result.stdout;
+      logger.info('yarn --version: %s', version);
+
+    }).catch(error => {
+      logger.error('yarn --version failed: %s', error);
+      throw error;
+    });
   }
 
   checkNpmVersion() {
@@ -59,8 +81,26 @@ class NpmTask extends Task {
     });
   }
 
+  findPackageManager() {
+    if (!this.hasYarnLock()) {
+      logger.info('yarn.lock not found -> using npm');
+      return this.checkNpmVersion();
+    }
+
+    logger.info('yarn.lock found -> trying yarn');
+    return this.checkYarn()
+      .then(() => {
+        logger.info('yarn found -> using yarn');
+        this.useYarn = true;
+      })
+      .catch(() => {
+        logger.info('yarn not found -> using npm');
+        return this.checkNpmVersion();
+      });
+  }
+
   run(options) {
-    return this.checkNpmVersion().then(() => {
+    return this.findPackageManager().then(() => {
 
       let ui = this.ui;
       let startMessage = this.formatStartMessage(options.packages);
@@ -68,9 +108,16 @@ class NpmTask extends Task {
 
       ui.startProgress(chalk.green(startMessage));
 
-      let args = this.toNpmArgs(this.command, options);
+      let promise;
+      if (this.useYarn) {
+        let args = this.toYarnArgs(this.command, options);
+        promise = this.yarn(args);
+      } else {
+        let args = this.toNpmArgs(this.command, options);
+        promise = this.npm(args);
+      }
 
-      return this.npm(args)
+      return promise
         .finally(() => ui.stopProgress())
         .then(() => ui.writeLine(chalk.green(completeMessage)));
     });
@@ -99,6 +146,43 @@ class NpmTask extends Task {
       args.push('--loglevel verbose');
     } else {
       args.push('--loglevel error');
+    }
+
+    if (options.packages) {
+      args = args.concat(options.packages);
+    }
+
+    return args;
+  }
+
+  toYarnArgs(command, options) {
+    let args = [];
+    if (command === 'install') {
+      if (options.save) {
+        args.push('add');
+      } else if (options['save-dev']) {
+        args.push('add', '--dev');
+      } else {
+        args.push('install');
+      }
+
+      if (options['save-exact']) {
+        args.push('--exact');
+      }
+
+      if ('optional' in options && !options.optional) {
+        args.push('--ignore-optional');
+      }
+
+    } else if (command === 'uninstall') {
+      args.push('remove');
+
+    } else {
+      throw new Error(`NPM command "${command}" can not be translated to Yarn command`);
+    }
+
+    if (options.verbose) {
+      args.push('--verbose');
     }
 
     if (options.packages) {

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -16,6 +16,12 @@ const Task = require('../models/task');
 
 class NpmTask extends Task {
 
+  /**
+   * @private
+   * @class NpmTask
+   * @constructor
+   * @param {Object} options
+   */
   constructor(options) {
     super(options);
 
@@ -81,6 +87,20 @@ class NpmTask extends Task {
     });
   }
 
+  /**
+   * This method will determine what package manager (npm or yarn) should be
+   * used to install the npm dependencies.
+   *
+   * Setting `this.useYarn` to `true` or `false` will force the use of yarn
+   * or npm respectively.
+   *
+   * If `this.useYarn` is not set we check if `yarn.lock` exists and if
+   * `yarn` is available and in that case set `useYarn` to `true`.
+   *
+   * @private
+   * @method findPackageManager
+   * @return {Promise}
+   */
   findPackageManager() {
     if (this.useYarn === undefined) {
       if (!this.hasYarnLock()) {

--- a/lib/tasks/npm-uninstall.js
+++ b/lib/tasks/npm-uninstall.js
@@ -13,11 +13,11 @@ class NpmUninstallTask extends NpmTask {
   }
 
   formatStartMessage(packages) {
-    return `NPM: Uninstalling ${formatPackageList(packages)} ...`;
+    return `${this.useYarn ? 'Yarn' : 'NPM'}: Uninstalling ${formatPackageList(packages)} ...`;
   }
 
   formatCompleteMessage(packages) {
-    return `NPM: Uninstalled ${formatPackageList(packages)}`;
+    return `${this.useYarn ? 'Yarn' : 'NPM'}: Uninstalled ${formatPackageList(packages)}`;
   }
 }
 

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -16,6 +16,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 
@@ -87,6 +88,7 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sn\u001b[39m
   \u001b[36m--skip-bower\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: )\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
 
@@ -114,6 +116,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -101,6 +101,7 @@ ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -D\u001b[39m
   \u001b[36m--save-exact\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -E, --exact\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -419,7 +419,13 @@ module.exports = {
           aliases: ['E', 'exact'],
           key: 'saveExact',
           required: false
-        }
+        },
+        {
+          name: 'yarn',
+          key: 'yarn',
+          required: false,
+          description: 'Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM'
+        },
       ],
       anonymousOptions: ['<addon-name>']
     },

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -60,6 +60,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'directory',
           aliases: ['dir'],
           key: 'directory',
@@ -373,6 +379,11 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'name',
           default: '',
           aliases: ['n'],
@@ -458,6 +469,12 @@ module.exports = {
           default: false,
           aliases: ['sg'],
           key: 'skipGit',
+          required: false
+        },
+        {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
           required: false
         },
         {

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -16,6 +16,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 
@@ -87,6 +88,7 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sn\u001b[39m
   \u001b[36m--skip-bower\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: )\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
 
@@ -114,6 +116,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -101,6 +101,7 @@ ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -D\u001b[39m
   \u001b[36m--save-exact\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -E, --exact\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM
 
 ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   Creates a new directory and runs \u001b[32member init\u001b[39m in it.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -60,6 +60,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'directory',
           aliases: ['dir'],
           key: 'directory',
@@ -405,6 +411,11 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'name',
           default: '',
           aliases: ['n'],
@@ -490,6 +501,12 @@ module.exports = {
           default: false,
           aliases: ['sg'],
           key: 'skipGit',
+          required: false
+        },
+        {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
           required: false
         },
         {

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -451,6 +451,12 @@ module.exports = {
           aliases: ['E', 'exact'],
           key: 'saveExact',
           required: false
+        },
+        {
+          name: 'yarn',
+          key: 'yarn',
+          required: false,
+          description: 'Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM'
         }
       ],
       anonymousOptions: ['<addon-name>']

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -419,6 +419,12 @@ module.exports = {
           aliases: ['E', 'exact'],
           key: 'saveExact',
           required: false
+        },
+        {
+          name: 'yarn',
+          key: 'yarn',
+          required: false,
+          description: 'Use --yarn to enforce yarn usage, or --no-yarn to enforce NPM'
         }
       ],
       anonymousOptions: ['<addon-name>']

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -60,6 +60,12 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'directory',
           aliases: ['dir'],
           key: 'directory',
@@ -373,6 +379,11 @@ module.exports = {
           required: false
         },
         {
+          name: 'yarn',
+          key: 'yarn',
+          required: false
+        },
+        {
           name: 'name',
           default: '',
           aliases: ['n'],
@@ -458,6 +469,12 @@ module.exports = {
           default: false,
           aliases: ['sg'],
           key: 'skipGit',
+          required: false
+        },
+        {
+          name: 'yarn',
+          default: false,
+          key: 'yarn',
           required: false
         },
         {

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -222,4 +222,40 @@ describe('NpmTask', function() {
       return expect(task.findPackageManager()).to.be.rejected;
     });
   });
+
+  describe('toYarnArgs', function() {
+    let task;
+
+    beforeEach(function() {
+      task = new NpmTask();
+    });
+
+    it('converts "npm install --no-optional" to "yarn install --ignore-optional"', function() {
+      let args = task.toYarnArgs('install', { optional: false });
+
+      return expect(args).to.deep.equal(['install', '--ignore-optional']);
+    });
+
+    it('converts "npm install --save foobar" to "yarn add foobar"', function() {
+      let args = task.toYarnArgs('install', { save: true, packages: ['foobar'] });
+
+      return expect(args).to.deep.equal(['add', 'foobar']);
+    });
+
+    it('converts "npm install --save-dev --save-exact foo" to "yarn add --dev --exact foo"', function() {
+      let args = task.toYarnArgs('install', {
+        'save-dev': true,
+        'save-exact': true,
+        packages: ['foo'],
+      });
+
+      return expect(args).to.deep.equal(['add', '--dev', '--exact', 'foo']);
+    });
+
+    it('converts "npm uninstall bar" to "yarn remove bar"', function() {
+      let args = task.toYarnArgs('uninstall', { packages: ['bar'] });
+
+      return expect(args).to.deep.equal(['remove', 'bar']);
+    });
+  });
 });

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -73,4 +73,35 @@ describe('NpmTask', function() {
       });
     });
   });
+
+  describe('checkYarn', function() {
+    let task, ui, yarn;
+
+    beforeEach(function() {
+      ui = new MockUI();
+      yarn = td.function();
+      task = new NpmTask({ ui, yarn });
+    });
+
+    it('resolves when yarn is found', function() {
+      td.when(yarn(['--version'])).thenResolve({ stdout: '0.22.1' });
+
+      return expect(task.checkYarn()).to.be.fulfilled;
+    });
+
+    it('rejects when yarn is not found', function() {
+      let error = new Error('yarn not found');
+      error.code = 'ENOENT';
+
+      td.when(yarn(['--version'])).thenReject(error);
+
+      return expect(task.checkYarn()).to.be.rejectedWith('yarn not found');
+    });
+
+    it('rejects when an unknown error is thrown', function() {
+      td.when(yarn(['--version'])).thenReject(new Error('foobar?'));
+
+      return expect(task.checkYarn()).to.be.rejectedWith('foobar?');
+    });
+  });
 });

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -7,17 +7,17 @@ const td = require('testdouble');
 const SilentError = require('silent-error');
 
 describe('NpmTask', function() {
-  describe('checkNpmVersion()', function() {
-    let task, ui, npmFn;
+  describe('checkNpmVersion', function() {
+    let task, ui, npm;
 
     beforeEach(function() {
       ui = new MockUI();
-      npmFn = td.function();
-      task = new NpmTask({ ui, npm: npmFn });
+      npm = td.function();
+      task = new NpmTask({ ui, npm });
     });
 
     it('resolves when a compatible version is found', function() {
-      td.when(npmFn(['--version'])).thenResolve({ stdout: '3.2.1' });
+      td.when(npm(['--version'])).thenResolve({ stdout: '3.2.1' });
 
       return expect(task.checkNpmVersion()).to.be.fulfilled.then(() => {
         expect(ui.output).to.be.empty;
@@ -26,7 +26,7 @@ describe('NpmTask', function() {
     });
 
     it('resolves with warning when a newer version is found', function() {
-      td.when(npmFn(['--version'])).thenResolve({ stdout: '5.0.0' });
+      td.when(npm(['--version'])).thenResolve({ stdout: '5.0.0' });
 
       return expect(task.checkNpmVersion()).to.be.fulfilled.then(() => {
         expect(ui.output).to.contain('WARNING');
@@ -35,7 +35,7 @@ describe('NpmTask', function() {
     });
 
     it('rejects when an older version is found', function() {
-      td.when(npmFn(['--version'])).thenResolve({ stdout: '2.9.9' });
+      td.when(npm(['--version'])).thenResolve({ stdout: '2.9.9' });
 
       return expect(task.checkNpmVersion()).to.be.rejectedWith(SilentError, /npm install -g npm/).then(() => {
         expect(ui.output).to.be.empty;
@@ -47,7 +47,7 @@ describe('NpmTask', function() {
       let error = new Error('npm not found');
       error.code = 'ENOENT';
 
-      td.when(npmFn(['--version'])).thenReject(error);
+      td.when(npm(['--version'])).thenReject(error);
 
       return expect(task.checkNpmVersion()).to.be.rejectedWith(SilentError, /instructions at https:\/\/github.com\/npm\/npm/).then(() => {
         expect(ui.output).to.be.empty;
@@ -56,7 +56,7 @@ describe('NpmTask', function() {
     });
 
     it('rejects when npm returns an unreadable version', function() {
-      td.when(npmFn(['--version'])).thenResolve({ stdout: '5' });
+      td.when(npm(['--version'])).thenResolve({ stdout: '5' });
 
       return expect(task.checkNpmVersion()).to.be.rejectedWith(TypeError, /Invalid Version/).then(() => {
         expect(ui.output).to.be.empty;
@@ -65,7 +65,7 @@ describe('NpmTask', function() {
     });
 
     it('rejects when an unknown error is thrown', function() {
-      td.when(npmFn(['--version'])).thenReject(new Error('foobar?'));
+      td.when(npm(['--version'])).thenReject(new Error('foobar?'));
 
       return expect(task.checkNpmVersion()).to.be.rejectedWith('foobar?').then(() => {
         expect(ui.output).to.be.empty;

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -7,7 +7,7 @@ const td = require('testdouble');
 const SilentError = require('silent-error');
 
 describe('NpmTask', function() {
-  describe('checkVersion()', function() {
+  describe('checkNpmVersion()', function() {
     let task, ui, npmFn;
 
     beforeEach(function() {
@@ -19,7 +19,7 @@ describe('NpmTask', function() {
     it('resolves when a compatible version is found', function() {
       td.when(npmFn(['--version'])).thenResolve({ stdout: '3.2.1' });
 
-      return expect(task.checkVersion()).to.be.fulfilled.then(() => {
+      return expect(task.checkNpmVersion()).to.be.fulfilled.then(() => {
         expect(ui.output).to.be.empty;
         expect(ui.errors).to.be.empty;
       });
@@ -28,7 +28,7 @@ describe('NpmTask', function() {
     it('resolves with warning when a newer version is found', function() {
       td.when(npmFn(['--version'])).thenResolve({ stdout: '5.0.0' });
 
-      return expect(task.checkVersion()).to.be.fulfilled.then(() => {
+      return expect(task.checkNpmVersion()).to.be.fulfilled.then(() => {
         expect(ui.output).to.contain('WARNING');
         expect(ui.errors).to.be.empty;
       });
@@ -37,7 +37,7 @@ describe('NpmTask', function() {
     it('rejects when an older version is found', function() {
       td.when(npmFn(['--version'])).thenResolve({ stdout: '2.9.9' });
 
-      return expect(task.checkVersion()).to.be.rejectedWith(SilentError, /npm install -g npm/).then(() => {
+      return expect(task.checkNpmVersion()).to.be.rejectedWith(SilentError, /npm install -g npm/).then(() => {
         expect(ui.output).to.be.empty;
         expect(ui.errors).to.be.empty;
       });
@@ -49,7 +49,7 @@ describe('NpmTask', function() {
 
       td.when(npmFn(['--version'])).thenReject(error);
 
-      return expect(task.checkVersion()).to.be.rejectedWith(SilentError, /instructions at https:\/\/github.com\/npm\/npm/).then(() => {
+      return expect(task.checkNpmVersion()).to.be.rejectedWith(SilentError, /instructions at https:\/\/github.com\/npm\/npm/).then(() => {
         expect(ui.output).to.be.empty;
         expect(ui.errors).to.be.empty;
       });
@@ -58,7 +58,7 @@ describe('NpmTask', function() {
     it('rejects when npm returns an unreadable version', function() {
       td.when(npmFn(['--version'])).thenResolve({ stdout: '5' });
 
-      return expect(task.checkVersion()).to.be.rejectedWith(TypeError, /Invalid Version/).then(() => {
+      return expect(task.checkNpmVersion()).to.be.rejectedWith(TypeError, /Invalid Version/).then(() => {
         expect(ui.output).to.be.empty;
         expect(ui.errors).to.be.empty;
       });
@@ -67,7 +67,7 @@ describe('NpmTask', function() {
     it('rejects when an unknown error is thrown', function() {
       td.when(npmFn(['--version'])).thenReject(new Error('foobar?'));
 
-      return expect(task.checkVersion()).to.be.rejectedWith('foobar?').then(() => {
+      return expect(task.checkNpmVersion()).to.be.rejectedWith('foobar?').then(() => {
         expect(ui.output).to.be.empty;
         expect(ui.errors).to.be.empty;
       });


### PR DESCRIPTION
Resolves #6341 

- [x] rewrite `ember install` to use yarn if `yarn.lock` exists
- [x] rewrite `ember init/new/addon` to use yarn if `--yarn` is used
- [x] add `--yarn` (enforce yarn usage) and `--no-yarn` (enforce NPM usage) options to `ember install` 
- [x] write tests
- [x] rebase on top of https://github.com/ember-cli/ember-cli/pull/6745 to resolve conflict
- [x] remove `--no-yarn` default for `ember init` command (`yarn.lock` should be detected for project upgrades)
- [x] adjust `.travis.yml` files to use `yarn` if requested