### PR TITLE
Interrupt command with an error if no _currentTask

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -186,6 +186,9 @@ let Command = CoreObject.extend({
   onInterrupt() {
     if (this._currentTask) {
       return this._currentTask.onInterrupt();
+    } else {
+      // interrupt all external commands which don't use `runTask()` with an error
+      process.exit(1);
     }
   },
 
@@ -197,6 +200,19 @@ let Command = CoreObject.extend({
     };
   },
 
+  /**
+   * Looks up for the task and runs
+   * It also keeps the reference for the current active task
+   * Keeping reference for the current task allows to cleanup task on interruption
+   *
+   * @private
+   * @method runTask
+   * @throws {Error} when no task found
+   * @throws {Error} on attempt to run concurrent task
+   * @param {string} name Task name from the tasks registry. Should be capitalized
+   * @param {object} options
+   * @return {Promise} Task run
+   */
   runTask(name, options) {
     if (this._currentTask) {
       throw new Error(`Concurrent tasks are not supported`);


### PR DESCRIPTION
I think we've slightly changed interruption behavior after #6615 for external commands like:

- https://github.com/isleofcode/ember-cordova/blob/master/lib/commands/build.js#L106
- https://github.com/ember-cli-deploy/ember-cli-deploy/blob/master/lib/commands/deploy.js#L53

Previously we've always thrown an `exit code 1` for the commands where the builder is involved. Now we've delegated decision about an exit code to the `_currentTask`.

The problem is that commands who don't use private `runTask` will always produce a zero exit code.

This change aims to solve it by producing an `exit code 1` if `_currentTask` is unknown.