### PR TITLE
Make findHost public

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -566,10 +566,10 @@ let addonProto = {
     This prevents previous addons (prior to `this.import`, ca 2.7.0)
     to break at importing assets when they are used nested in other addons.
 
-    @private
+    @public
     @method _findHost
   */
-  _findHost() {
+  findHost() {
     let current = this;
     let app;
 
@@ -580,6 +580,18 @@ let addonProto = {
     } while (current.parent.parent && (current = current.parent));
 
     return app;
+  },
+
+  /**
+    findHost() used to be the private _findHost().
+    Leaving _findHost() for backwards compatibility since it's
+    an intimate API.
+
+    @private
+    @method _findHost
+  */
+  _findHost() {
+    return this.findHost();
   },
 
   /**


### PR DESCRIPTION
Seems reasonable for an addon to want access to the host app. Also, this method doesn't seem to be used internally at all.