### PR TITLE
[BUGFIX] - Fixes blueprints noop log removals

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1546,8 +1546,10 @@ function finishProcessingForInstall(infos) {
 }
 
 function finishProcessingForUninstall(infos) {
-  infos.forEach(markToBeRemoved);
-  return infos;
+  let validInfos = infos.filter(info => existsSync(info.outputPath));
+  validInfos.forEach(markToBeRemoved);
+
+  return validInfos;
 }
 
 module.exports = Blueprint;

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -621,6 +621,19 @@ describe('Blueprint', function() {
         expect(actualFiles).to.contain('app/basics/mock-project.txt');
       });
     });
+
+    it('uninstall doesn\'t log remove messages when file does not exist', function() {
+      options.entity = { name: 'does-not-exist' };
+
+      return blueprint.uninstall(options)
+      .then(function() {
+        let output = ui.output.trim().split(EOL);
+        expect(output.shift()).to.match(/^uninstalling/);
+        expect(output.shift()).to.match(/remove.* .ember-cli/);
+        expect(output.shift()).to.match(/remove.* .gitignore/);
+        expect(output.shift()).to.not.match(/remove.* app[/\\]basics[/\\]does-not-exist.txt/);
+      });
+    });
   });
 
   describe('instrumented blueprint uninstallation', function() {


### PR DESCRIPTION
This fixes a bug where blueprint removals were always logging as successful regardless if the designated file(s) for removal didn't exist.  I changed the `cleanRemove` utility to accept an optional callback function that runs when an `ENOENT` error occurs.  

I added a callback function to `remove` in the blueprint model which results in the ui indicating the`file does not exist` for each missing file. 

Not sure if this is the right approach and appreciate any feedback!

```
$ ember d route nothing-here
uninstalling route
  remove app/routes/nothing-here.js
  remove app/templates/nothing-here.hbs
  does not exist app/routes/nothing-here.js
  does not exist app/templates/nothing-here.hbs
updating router
  remove route nothing-here
uninstalling route-test
  remove tests/unit/routes/nothing-here-test.js
  does not exist tests/unit/routes/nothing-here-test.js
```

Resolves #6744