### PR TITLE
Enable instrumentation experiment with public `instrument` method.

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -3,7 +3,7 @@ const symbol = require('../utilities/symbol');
 
 let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
-  INSTRUMENTATION: symbol('instrumentation'),
+  INSTRUMENTATION: 'instrumentation',
 };
 
 Object.freeze(experiments);


### PR DESCRIPTION
https://github.com/ember-cli/rfcs/pull/91 was merged a little under a month ago, the work has gradually landed (behind this experiment flag), and now all known issues (from https://github.com/ember-cli/ember-cli/issues/6623) have been addressed.

This enables the feature by default (while still supporting any users relying on the experiment flag).  A follow-up PR will be submitted soon, making accessing this property isssue a deprecation and removing ember-cli internal usage of the experiment flag.

Closes #6623.