### PR TITLE
Remove flagging for `experiments.INSTRUMENTATION`.

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -4,7 +4,6 @@ const getCallerFile = require('get-caller-file');
 const deprecate = require('../utilities/deprecate');
 
 let experiments = {
-  BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
   NPM_BLUEPRINTS: symbol('npm-blueprints'),
   BROWSER_TARGETS: symbol('browser-targets'),
   get INSTRUMENTATION() {

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -1,12 +1,19 @@
 'use strict';
 const symbol = require('../utilities/symbol');
+const getCallerFile = require('get-caller-file');
+const deprecate = require('../utilities/deprecate');
 
 let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
-  INSTRUMENTATION: 'instrumentation',
   NPM_BLUEPRINTS: symbol('npm-blueprints'),
   BROWSER_TARGETS: symbol('browser-targets'),
+  get INSTRUMENTATION() {
+    deprecate(`\`experiments.INSTRUMENTATION\` is deprecated now that the feature has landed, use \`instrumentation\` method on your addon instead. Required from: \n${getCallerFile()}`, true);
+
+    return 'instrumentation';
+  },
 };
+
 
 Object.freeze(experiments);
 

--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -187,12 +187,6 @@ class Instrumentation {
   _invokeAddonHook(name, instrumentationInfo) {
     if (this.project && this.project.addons.length) {
       this.project.addons.forEach(addon => {
-        if (experiments.BUILD_INSTRUMENTATION && addon[experiments.BUILD_INSTRUMENTATION]) {
-          throw new TypeError(
-            `${addon.name} defines experiments.BUILD_INSTRUMENTATION. Update to use experiments.INSTRUMENTATION`
-          );
-        }
-
         if (typeof addon.instrumentation === 'function') {
           addon.instrumentation(name, instrumentationInfo);
         }

--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs-extra');
 const chalk = require('chalk');
-const experiments = require('../experiments/');
 const heimdallGraph = require('heimdalljs-graph');
 const utilsInstrumentation = require('../utilities/instrumentation');
 const logger = require('heimdalljs-logger')('ember-cli:instrumentation');
@@ -186,8 +185,6 @@ class Instrumentation {
   }
 
   _invokeAddonHook(name, instrumentationInfo) {
-    if (!experiments.INSTRUMENTATION) { return; }
-
     if (this.project && this.project.addons.length) {
       this.project.addons.forEach(addon => {
         if (experiments.BUILD_INSTRUMENTATION && addon[experiments.BUILD_INSTRUMENTATION]) {
@@ -196,9 +193,8 @@ class Instrumentation {
           );
         }
 
-        let hook = addon[experiments.INSTRUMENTATION];
-        if (typeof hook === 'function') {
-          hook.call(addon, name, instrumentationInfo);
+        if (typeof addon.instrumentation === 'function') {
+          addon.instrumentation(name, instrumentationInfo);
         }
       });
     }

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -214,36 +214,34 @@ describe('Acceptance: smoke-test', function() {
   });
 
 
-  if (experiments.INSTRUMENTATION) {
-    it('ember build generates instrumentation files when viz is enabled', function() {
-      process.env.BROCCOLI_VIZ = '1';
+  it('ember build generates instrumentation files when viz is enabled', function() {
+    process.env.BROCCOLI_VIZ = '1';
 
-      return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
-        env: {
-          BROCCOLI_VIZ: '1',
-        },
-      }).then(function() {
-        [
-          'instrumentation.build.0.json',
-          'instrumentation.command.json',
-          'instrumentation.init.json',
-          'instrumentation.shutdown.json',
-        ].forEach(function(instrumentationFile) {
-          expect(fs.existsSync(instrumentationFile)).to.equal(true);
+    return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
+      env: {
+        BROCCOLI_VIZ: '1',
+      },
+    }).then(function() {
+      [
+        'instrumentation.build.0.json',
+        'instrumentation.command.json',
+        'instrumentation.init.json',
+        'instrumentation.shutdown.json',
+      ].forEach(function(instrumentationFile) {
+        expect(fs.existsSync(instrumentationFile)).to.equal(true);
 
-          let json = fs.readJsonSync(instrumentationFile);
-          expect(Object.keys(json)).to.eql([
-            'summary', 'nodes',
-          ]);
+        let json = fs.readJsonSync(instrumentationFile);
+        expect(Object.keys(json)).to.eql([
+          'summary', 'nodes',
+        ]);
 
-          expect(Array.isArray(json.nodes)).to.equal(true);
-        });
-      })
-        .finally(function() {
-          delete process.env.BROCCOLI_VIZ;
-        });
-    });
-  }
+        expect(Array.isArray(json.nodes)).to.equal(true);
+      });
+    })
+      .finally(function() {
+        delete process.env.BROCCOLI_VIZ;
+      });
+  });
 
   it('ember new foo, build --watch development, and verify rebuilt after change', function() {
     let touched = false;

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -293,21 +293,6 @@ describe('models/builder.js', function() {
           expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'postBuild', 'outputReady', 'instrumentation']);
         });
       });
-
-      if (experiments.BUILD_INSTRUMENTATION) {
-        it('throws if [BUILD_INSTRUMENTATION] is set', function() {
-          addon[experiments.BUILD_INSTRUMENTATION] = function() { };
-
-          return builder.build(null, {}).then(function() {
-            throw new Error('Expected build to reject from thrown error');
-          }, function(reason) {
-            expect(reason.message).to.eql(oneLine`
-              TestAddon defines experiments.BUILD_INSTRUMENTATION. Update to use
-              experiments.INSTRUMENTATION
-            `);
-          });
-        });
-      }
     });
 
     it('hooks are called in the right order without visualization', function() {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -283,18 +283,16 @@ describe('models/builder.js', function() {
         process.env.EMBER_CLI_INSTRUMENTATION = '1';
       });
 
-      if (experiments.INSTRUMENTATION) {
-        it('invokes the instrumentation hook if it is preset', function() {
-          addon[experiments.INSTRUMENTATION] = function(instrumentation) {
-            hooksCalled.push('instrumentation');
-            instrumentationArg = instrumentation;
-          };
+      it('invokes the instrumentation hook if it is preset', function() {
+        addon.instrumentation = function(instrumentation) {
+          hooksCalled.push('instrumentation');
+          instrumentationArg = instrumentation;
+        };
 
-          return builder.build(null, {}).then(function() {
-            expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'postBuild', 'outputReady', 'instrumentation']);
-          });
+        return builder.build(null, {}).then(function() {
+          expect(hooksCalled).to.deep.equal(['preBuild', 'build', 'postBuild', 'outputReady', 'instrumentation']);
         });
-      }
+      });
 
       if (experiments.BUILD_INSTRUMENTATION) {
         it('throws if [BUILD_INSTRUMENTATION] is set', function() {

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -609,24 +609,6 @@ describe('models/instrumentation.js', function() {
 
         td.verify(hook(), { ignoreExtraArgs: true, times: 0 });
       });
-
-      describe('(build)', function() {
-        if (experiments.BUILD_INSTRUMENTATION) {
-          it('throws if an addon specifies [BUILD_INSTRUMENTATION]', function() {
-            process.env.EMBER_CLI_INSTRUMENTATION = '1';
-
-            addon[experiments.BUILD_INSTRUMENTATION] = function() {};
-
-            instrumentation.start('build');
-
-            expect(function() {
-              instrumentation.stopAndReport('build', 'a', 'b');
-            }).to.throw(
-              'Test Addon defines experiments.BUILD_INSTRUMENTATION. Update to use experiments.INSTRUMENTATION'
-            );
-          });
-        }
-      });
     });
   });
 

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -574,43 +574,41 @@ describe('models/instrumentation.js', function() {
       });
 
 
-      if (experiments.INSTRUMENTATION) {
-        it('invokes addons that have [INSTRUMENTATION] for init', function() {
-          process.env.EMBER_CLI_INSTRUMENTATION = '1';
+      it('invokes addons that have [INSTRUMENTATION] for init', function() {
+        process.env.EMBER_CLI_INSTRUMENTATION = '1';
 
-          let hook = td.function();
-          addon[experiments.INSTRUMENTATION] = hook;
+        let hook = td.function();
+        addon.instrumentation = hook;
 
-          instrumentation.start('init');
-          instrumentation.stopAndReport('init', 'a', 'b');
+        instrumentation.start('init');
+        instrumentation.stopAndReport('init', 'a', 'b');
 
-          td.verify(hook('init', { summary: mockInitSummary, tree: mockInitTree }));
-        });
+        td.verify(hook('init', { summary: mockInitSummary, tree: mockInitTree }));
+      });
 
-        it('invokes addons that have [INSTRUMENTATION] for build', function() {
-          process.env.EMBER_CLI_INSTRUMENTATION = '1';
+      it('invokes addons that have [INSTRUMENTATION] for build', function() {
+        process.env.EMBER_CLI_INSTRUMENTATION = '1';
 
-          let hook = td.function();
-          addon[experiments.INSTRUMENTATION] = hook;
+        let hook = td.function();
+        addon.instrumentation = hook;
 
-          instrumentation.start('build');
-          instrumentation.stopAndReport('build', 'a', 'b');
+        instrumentation.start('build');
+        instrumentation.stopAndReport('build', 'a', 'b');
 
-          td.verify(hook('build', { summary: mockBuildSummary, tree: mockBuildTree }));
-        });
+        td.verify(hook('build', { summary: mockBuildSummary, tree: mockBuildTree }));
+      });
 
-        it('does not invoke addons if instrumentation is disabled', function() {
-          process.env.EMBER_CLI_INSTRUMENTATION = 'not right now thanks';
+      it('does not invoke addons if instrumentation is disabled', function() {
+        process.env.EMBER_CLI_INSTRUMENTATION = 'not right now thanks';
 
-          let hook = td.function();
-          addon[experiments.INSTRUMENTATION] = hook;
+        let hook = td.function();
+        addon.instrumentation = hook;
 
-          instrumentation.start('build');
-          instrumentation.stopAndReport('build', 'a', 'b');
+        instrumentation.start('build');
+        instrumentation.stopAndReport('build', 'a', 'b');
 
-          td.verify(hook(), { ignoreExtraArgs: true, times: 0 });
-        });
-      }
+        td.verify(hook(), { ignoreExtraArgs: true, times: 0 });
+      });
 
       describe('(build)', function() {
         if (experiments.BUILD_INSTRUMENTATION) {


### PR DESCRIPTION
Now that the instrumentation hook is public API, this removes the
internal code guards and cleans things up a bit.

This PR likely should wait until after we branch 2.13 into the beta branch...