### PR TITLE
`ember new` with blueprints from npm

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -5,6 +5,7 @@ let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
   INSTRUMENTATION: symbol('instrumentation'),
   ADDON_TREE_CACHING: symbol('addon-tree-caching'),
+  NPM_BLUEPRINTS: symbol('npm-blueprints'),
 };
 
 Object.freeze(experiments);

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Blueprint = require('../models/blueprint');
-const Task = require('../models/task');
 const RSVP = require('rsvp');
 const SilentError = require('silent-error');
 const isGitRepo = require('is-git-url');
@@ -10,6 +8,10 @@ const temp = require('temp');
 const execa = require('execa');
 const path = require('path');
 const merge = require('ember-cli-lodash-subset').merge;
+
+const Blueprint = require('../models/blueprint');
+const Task = require('../models/task');
+const experiments = require('../experiments');
 
 // Automatically track and cleanup temp files at exit
 temp.track();
@@ -73,15 +75,17 @@ function lookupBlueprint(blueprintName, paths) {
   try {
     blueprint = Blueprint.lookup(blueprintName, { paths });
   } catch (err) {
-    // If we didn't find it locally, we'll see if it's a valid npm package name
-    // and install it from npm if so.
-    if (maybeNpmPackage(blueprintName)) {
-      return downloadBlueprint(blueprintName, fromNpm);
+
+    if (experiments.NPM_BLUEPRINTS) {
+      // If we didn't find it locally, we'll see if it's a valid npm package name
+      // and install it from npm if so.
+      if (maybeNpmPackage(blueprintName)) {
+        return downloadBlueprint(blueprintName, fromNpm);
+      }
     }
 
     // Blueprint wasn't found and it couldn't be an npm package, so re-throw the
     // original exception.
-
     return Promise.reject(err);
   }
 

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -7,7 +7,7 @@ const SilentError = require('silent-error');
 const isGitRepo = require('is-git-url');
 const validateNpmPackageName = require('validate-npm-package-name');
 const temp = require('temp');
-const childProcess = require('child_process');
+const execa = require('execa');
 const path = require('path');
 const merge = require('ember-cli-lodash-subset').merge;
 
@@ -15,7 +15,6 @@ const merge = require('ember-cli-lodash-subset').merge;
 temp.track();
 
 const mkdir = RSVP.denodeify(temp.mkdir);
-const exec = RSVP.denodeify(childProcess.exec);
 const Promise = RSVP.Promise;
 
 const DEFAULT_BLUEPRINT_NAME = 'app';
@@ -103,25 +102,24 @@ function downloadBlueprint(blueprintName, download) {
     // provided callback.
     .then(tempPath => download(blueprintName, tempPath))
     // The download callback returns a promise that resolves to the final path
-    // of the downloaded blueprint. Run `npm install` inside of it and then load
-    // it.
-    .then(blueprintPath =>
-      exec('npm install', { cwd: blueprintPath })
-        .then(() => Blueprint.load(blueprintPath))
-    );
+    // of the downloaded blueprint, so we load it and resolve with it.
+    .then(blueprintPath => Blueprint.load(blueprintPath));
 }
 
+// Clone the blueprint with git, then run npm install inside the cloned
+// repository so it has all of its dependencies.
 function fromGit(blueprintName, tempPath) {
-  let execArgs = ['git', 'clone', blueprintName, tempPath].join(' ');
-  return exec(execArgs)
+  return execa('git', ['clone', blueprintName, tempPath])
+    .then(() => execa('npm', ['install'], { cwd: tempPath }))
     .then(() => tempPath);
 }
 
+// Install the blueprint with npm. We skip running `npm install` inside like the
+// git version because npm handles this for us automatically.
 function fromNpm(blueprintName, tempPath) {
-  let execArgs = ['npm', 'install', blueprintName].join(' ');
   let pkgPath = path.join(tempPath, 'node_modules', blueprintName);
 
-  return exec(execArgs, { cwd: tempPath })
+  return execa('npm', ['install', blueprintName], { cwd: tempPath })
     .catch(err => throwNpmError(err))
     .then(() => pkgPath);
 }

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -3,7 +3,9 @@
 const Blueprint = require('../models/blueprint');
 const Task = require('../models/task');
 const RSVP = require('rsvp');
+const SilentError = require('silent-error');
 const isGitRepo = require('is-git-url');
+const validateNpmPackageName = require('validate-npm-package-name');
 const temp = require('temp');
 const childProcess = require('child_process');
 const path = require('path');
@@ -12,14 +14,19 @@ const merge = require('ember-cli-lodash-subset').merge;
 // Automatically track and cleanup temp files at exit
 temp.track();
 
-let mkdir = RSVP.denodeify(temp.mkdir);
-let exec = RSVP.denodeify(childProcess.exec);
+const mkdir = RSVP.denodeify(temp.mkdir);
+const exec = RSVP.denodeify(childProcess.exec);
+const Promise = RSVP.Promise;
+
+const DEFAULT_BLUEPRINT_NAME = 'app';
 
 class InstallBlueprintTask extends Task {
   run(options) {
     let cwd = process.cwd();
     let name = options.rawName;
-    let blueprintOption = options.blueprint;
+    let blueprintName = options.blueprint;
+    let blueprintPaths = this.project.blueprintLookupPaths();
+
     // If we're in a dry run, pretend we changed directories.
     // Pretending we cd'd avoids prompts in the actual current directory.
     let fakeCwd = path.join(cwd, name);
@@ -38,22 +45,99 @@ class InstallBlueprintTask extends Task {
 
     installOptions = merge(installOptions, options || {});
 
-    if (isGitRepo(blueprintOption)) {
-      return mkdir('ember-cli').then(pathName => {
-        let execArgs = ['git', 'clone', blueprintOption, pathName].join(' ');
-        return exec(execArgs).then(() => exec('npm install', { cwd: pathName }).then(() => {
-          let blueprint = Blueprint.load(pathName);
-          return blueprint.install(installOptions);
-        }));
-      });
-    } else {
-      let blueprintName = blueprintOption || 'app';
-      let blueprint = Blueprint.lookup(blueprintName, {
-        paths: this.project.blueprintLookupPaths(),
-      });
-      return blueprint.install(installOptions);
-    }
+    return lookupBlueprint(blueprintName, blueprintPaths)
+      .then(blueprint => blueprint.install(installOptions));
   }
+}
+
+// Given a blueprint name and set of paths to search, looks up the specified
+// blueprint. If it detects a git repository URL, it will clone the repository
+// and use that as the blueprint. If it detects an npm package name, it will
+// install the package and use that as the blueprint.
+function lookupBlueprint(blueprintName, paths) {
+  // Fast path: if no blueprint is defined, we can fall back to the default app
+  // blueprint which we know is available locally.
+  if (blueprintName === undefined) {
+    return Blueprint.lookup(DEFAULT_BLUEPRINT_NAME, { paths });
+  }
+
+  let blueprint;
+
+  // Git URLs are unambiguous, so we can detect and install it now.
+  if (isGitRepo(blueprintName)) {
+    return downloadBlueprint(blueprintName, fromGit);
+  }
+
+  // npm package names, however, are *not* unambiguous because they could also
+  // be describing a path on disk. First, we will search the blueprint paths and
+  // prefer anything that we find locally.
+  try {
+    blueprint = Blueprint.lookup(blueprintName, { paths });
+  } catch (err) {
+    // If we didn't find it locally, we'll see if it's a valid npm package name
+    // and install it from npm if so.
+    if (maybeNpmPackage(blueprintName)) {
+      return downloadBlueprint(blueprintName, fromNpm);
+    }
+
+    // Blueprint wasn't found and it couldn't be an npm package, so re-throw the
+    // original exception.
+
+    return Promise.reject(err);
+  }
+
+  return Promise.resolve(blueprint);
+}
+
+function maybeNpmPackage(packageName) {
+  return validateNpmPackageName(packageName).validForNewPackages;
+}
+
+// Creates a temporary directory, runs a passed callback to install a blueprint
+// into that directory, then returns a blueprint loaded from the downloaded
+// directory.
+function downloadBlueprint(blueprintName, download) {
+  // Create a temporary directory
+  return mkdir('ember-cli')
+    // Download the blueprint into the temporary directory by calling the
+    // provided callback.
+    .then(tempPath => download(blueprintName, tempPath))
+    // The download callback returns a promise that resolves to the final path
+    // of the downloaded blueprint. Run `npm install` inside of it and then load
+    // it.
+    .then(blueprintPath =>
+      exec('npm install', { cwd: blueprintPath })
+        .then(() => Blueprint.load(blueprintPath))
+    );
+}
+
+function fromGit(blueprintName, tempPath) {
+  let execArgs = ['git', 'clone', blueprintName, tempPath].join(' ');
+  return exec(execArgs)
+    .then(() => tempPath);
+}
+
+function fromNpm(blueprintName, tempPath) {
+  let execArgs = ['npm', 'install', blueprintName].join(' ');
+  let pkgPath = path.join(tempPath, 'node_modules', blueprintName);
+
+  return exec(execArgs, { cwd: tempPath })
+    .catch(err => throwNpmError(err))
+    .then(() => pkgPath);
+}
+
+const NOT_FOUND_REGEXP = /npm ERR! 404 {2}'(\S+)' is not in the npm registry/;
+
+function throwNpmError(err) {
+  let match = err.message && err.message.match(NOT_FOUND_REGEXP);
+
+  if (match) {
+    let packageName = match[1];
+
+    throw new SilentError(`The package '${packageName}' was not found in the npm registry.`);
+  }
+
+  throw err;
 }
 
 module.exports = InstallBlueprintTask;

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "tiny-lr": "^1.0.3",
     "tree-sync": "^1.2.1",
     "uuid": "^3.0.0",
+    "validate-npm-package-name": "^2.2.2",
     "walk-sync": "^0.3.0",
     "yam": "0.0.22"
   },

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra');
 const ember = require('../helpers/ember');
+const experiments = require('../experiments');
 const walkSync = require('walk-sync');
 const Blueprint = require('../../lib/models/blueprint');
 const path = require('path');
@@ -206,20 +207,23 @@ describe('Acceptance: ember new', function() {
     });
   });
 
-  it('ember new with package blueprint installs the package and uses it', function() {
-    this.timeout(20000); // relies on npm over the network
+  if (experiments.NPM_BLUEPRINTS) {
+    it('ember new with package blueprint installs the package and uses it', function() {
+      this.timeout(20000); // relies on npm over the network
 
-    return ember([
-      'new',
-      'app-from-npm',
-      '--skip-npm',
-      '--skip-bower',
-      '--skip-git',
-      '--blueprint=ember-cli-app-blueprint-test',
-    ]).then(function() {
-      expect(file('.ember-cli')).to.exist;
+      return ember([
+        'new',
+        'app-from-npm',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git',
+        '--blueprint=ember-cli-app-blueprint-test',
+      ]).then(function() {
+        expect(file('.ember-cli')).to.exist;
+        expect(file('package.json')).to.contain('"name": "app-from-npm"');
+      });
     });
-  });
+  }
 
   it('ember new passes blueprint options through to blueprint', function() {
     fs.mkdirsSync('my_blueprint/files');

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -206,6 +206,21 @@ describe('Acceptance: ember new', function() {
     });
   });
 
+  it('ember new with package blueprint installs the package and uses it', function() {
+    this.timeout(20000); // relies on GH network stuff
+
+    return ember([
+      'new',
+      'app-from-npm',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--blueprint=ember-cli-app-blueprint-test',
+    ]).then(function() {
+      expect(file('.ember-cli')).to.exist;
+    });
+  });
+
   it('ember new passes blueprint options through to blueprint', function() {
     fs.mkdirsSync('my_blueprint/files');
     fs.writeFileSync('my_blueprint/index.js', [

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -207,7 +207,7 @@ describe('Acceptance: ember new', function() {
   });
 
   it('ember new with package blueprint installs the package and uses it', function() {
-    this.timeout(20000); // relies on GH network stuff
+    this.timeout(20000); // relies on npm over the network
 
     return ember([
       'new',


### PR DESCRIPTION
This PR adds support for installing blueprints from npm. Previously, we supported installing blueprints from the local filesystem or via an explicit `.git` URL.

This feature works by looking at the blueprint name and only attempting to install the blueprint from npm if:

1. The blueprint is a valid npm package name.
2. No blueprint with that name was found locally.

This ends up being nicer from a developer ergonomics perspective because I can just say something like "Type `ember new my-app -b pwa-blueprint`" instead of "Type `ember new my-app -b https://github.com/tomdale/pwa-blueprint.git`".

The feature is wrapped in the `NPM_BLUEPRINTS` experiment flag so hopefully it can be iterated on without too much risk if people think this is a good overall direction.