### PR TITLE
Implement targets RFC

### DIFF
--- a/blueprints/addon/files/addon-config/targets.js
+++ b/blueprints/addon/files/addon-config/targets.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+
+module.exports = {
+  browsers: [
+    'ie 9',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
+  ]
+};

--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+
+module.exports = {
+  browsers: [
+    'ie 9',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
+  ]
+};

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -5,6 +5,7 @@ let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
   INSTRUMENTATION: 'instrumentation',
   NPM_BLUEPRINTS: symbol('npm-blueprints'),
+  BROWSER_TARGETS: symbol('browser-targets'),
 };
 
 Object.freeze(experiments);

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -17,6 +17,7 @@ let emberCLIVersion = versionUtils.emberCLIVersion;
 const findAddonByName = require('../utilities/find-addon-by-name');
 const Instrumentation = require('./instrumentation');
 const heimdall = require('heimdalljs');
+const experiments = require('../experiments');
 
 let processCwd = process.cwd();
 // ensure NULL_PROJECT is a singleton
@@ -213,6 +214,43 @@ class Project {
     } else {
       return this.getAddonsConfig(env, {});
     }
+  }
+
+  /**
+    Returns the targets of this project, or the default targets if not present.
+
+    @public
+    @property targets
+    @return {Object}  Targets object
+  */
+  get targets() {
+    if (!experiments.BROWSER_TARGETS) {
+      return;
+    }
+    if (this._targets) {
+      return this._targets;
+    }
+    let configPath = 'config';
+
+    if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
+      configPath = this.pkg['ember-addon']['configPath'];
+    }
+
+    let targetsPath = path.join(this.root, configPath, 'targets');
+
+    if (existsSync(`${targetsPath}.js`)) {
+      this._targets = this.require(targetsPath);
+    } else {
+      this._targets = {
+        browsers: [
+          'ie 9',
+          'last 1 Chrome versions',
+          'last 1 Firefox versions',
+          'last 1 Safari versions',
+        ],
+      };
+    }
+    return this._targets;
   }
 
   /**


### PR DESCRIPTION
This PR implements https://github.com/ember-cli/rfcs/pull/95 (still unmerged).

API example

```js
app.project.targets; // { browsers: [...], node: '6.6.0' };
```