### PR TITLE
Better error message when addon doesn't define a name property

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -221,7 +221,7 @@ let addonProto = {
     p.setupRegistry(this);
 
     if (!this.name) {
-      throw new SilentError('An addon must define a `name` property.');
+      throw new SilentError(`An addon must define a \`name\` property (found at ${this.root}).`);
     }
 
     this.__originalOptions = this.options = defaultsDeep(this.options, {


### PR DESCRIPTION
Spent a good while trying to figure out which addon was failing. PR'ing this in for the next developer ;)