### PR TITLE
Don't print heimdall stack on errors

### DIFF
--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -248,7 +248,7 @@ class Instrumentation {
     try {
       instr.token.stop();
     } catch (e) {
-      this.ui.writeLine(chalk.red(`Error reporting instrumentation '${name}'.  Stack: ${this._heimdall.stack}`));
+      this.ui.writeLine(chalk.red(`Error reporting instrumentation '${name}'.`));
       logger.error(e.stack);
       return;
     }

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -401,7 +401,14 @@ describe('models/instrumentation.js', function() {
         instrumentation.stopAndReport('init');
       }).to.not.throw();
 
-      expect(ui.output).to.eql(`${chalk.red('Error reporting instrumentation \'init\'.  Stack: init,a ruckus')}${EOL}`);
+      expect(ui.output).to.eql(`${chalk.red('Error reporting instrumentation \'init\'.')}${EOL}`);
+
+      instrumentation.start('init');
+      heimdall.start('trouble');
+
+      expect(function() {
+        instrumentation.stopAndReport('init');
+      }).to.not.throw();
     });
 
     it('computes summary for name', function() {


### PR DESCRIPTION
Currently this is error-prone.  The stack is useful for understanding error cases but it needs to be made more resilient first.

The error case is as follows

1. build_1
  a.  something in build adds to the stack and then errors, leaving the stack unbalanced.
  b.  stopAndReport(build_1) fails to stop the node.
2. build_2
  a.  start(build_2) now detachs a node it thought was not active, but because of the prior stop failure, it is still active.  When the new build node is added, it is a descendant of the build_1 node.
  b.  something in the build adds to the stacka nd then errors, leaving the stack unbalanced.
  c.  now the stack is detached, an error case.

The better solution here is for stop in 1b. to work even when unbalanced.  What should be done

  1.  stopping nodes autocloses the stack to the current node.
  2.  analysis tools (eg rob's visualizer) check for autoclosed nodes and highlight the nearest un-autoclosed ancestor