### PR TITLE
Support npm packages as `ember new` blueprints

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -4,6 +4,7 @@ const symbol = require('../utilities/symbol');
 let experiments = {
   BUILD_INSTRUMENTATION: symbol('build-instrumentation'),
   INSTRUMENTATION: 'instrumentation',
+  NPM_BLUEPRINTS: symbol('npm-blueprints'),
 };
 
 Object.freeze(experiments);

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -8,8 +8,14 @@ const temp = require('temp');
 const path = require('path');
 const merge = require('ember-cli-lodash-subset').merge;
 const execa = require('execa');
+const SilentError = require('silent-error');
+const validateNpmPackageName = require('validate-npm-package-name');
+
+const experiments = require('../experiments');
 
 const logger = require('heimdalljs-logger')('ember-cli:tasks:install-blueprint');
+
+const NOT_FOUND_REGEXP = /npm ERR! 404 {2}'(\S+)' is not in the npm registry/;
 
 // Automatically track and cleanup temp files at exit
 temp.track();
@@ -50,7 +56,8 @@ class InstallBlueprintTask extends Task {
     logger.info(`Resolving blueprint "${name}" ...`);
 
     if (!isGitRepo(name)) {
-      return this._lookupBlueprint(name);
+      return this._lookupBlueprint(name)
+        .catch(error => this._handleLookupFailure(name, error));
     }
 
     return this._createTempFolder()
@@ -66,6 +73,32 @@ class InstallBlueprintTask extends Task {
     }));
   }
 
+  _handleLookupFailure(name, error) {
+    logger.info(`Blueprint lookup for "${name}" failed`);
+    if (!experiments.NPM_BLUEPRINTS) {
+      logger.info(`"NPM_BLUEPRINTS experiment disabled -> rethrowing original error`);
+      throw error;
+    }
+
+    if (!validateNpmPackageName(name).validForNewPackages) {
+      logger.info(`"${name} is not a valid npm package name -> rethrowing original error`);
+      throw error;
+    }
+
+    logger.info(`"${name} is a valid npm package name -> trying npm`);
+    return this._tryNpmBlueprint(name);
+  }
+
+  _tryNpmBlueprint(name) {
+    return this._createTempFolder()
+      .then(pathName => this._npmInstallModule(name, pathName)
+        .catch(error => this._handleNpmInstallModuleError(error)))
+      .then(modulePath => {
+        this._validateNpmModule(modulePath, name);
+        return this._loadBlueprintFromPath(modulePath);
+      });
+  }
+
   _createTempFolder() {
     return mkdirTemp('ember-cli');
   }
@@ -78,6 +111,30 @@ class InstallBlueprintTask extends Task {
   _npmInstall(cwd) {
     logger.info(`Running "npm install" in "${cwd}" ...`);
     return execa('npm', ['install'], { cwd });
+  }
+
+  _npmInstallModule(module, cwd) {
+    logger.info(`Running "npm install ${module}" in "${cwd}" ...`);
+    return execa('npm', ['install', module], { cwd })
+      .then(() => path.join(cwd, 'node_modules', module));
+  }
+
+  _handleNpmInstallModuleError(error) {
+    let match = error.stderr && error.stderr.match(NOT_FOUND_REGEXP);
+    if (match) {
+      let packageName = match[1];
+      throw new SilentError(`The package '${packageName}' was not found in the npm registry.`);
+    }
+
+    throw error;
+  }
+
+  _validateNpmModule(modulePath, packageName) {
+    logger.info(`Checking for "ember-blueprint" keyword in "${packageName}" module ...`);
+    let pkg = require(path.join(modulePath, 'package.json'));
+    if (!pkg || !pkg.keywords || pkg.keywords.indexOf('ember-blueprint') === -1) {
+      throw new SilentError(`The package '${packageName}' is not a valid Ember CLI blueprint.`);
+    }
   }
 
   _loadBlueprintFromPath(path) {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "tiny-lr": "^1.0.3",
     "tree-sync": "^1.2.1",
     "uuid": "^3.0.0",
+    "validate-npm-package-name": "^3.0.0",
     "walk-sync": "^0.3.0",
     "yam": "0.0.22"
   },

--- a/tests/unit/tasks/install-blueprint-test.js
+++ b/tests/unit/tasks/install-blueprint-test.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const InstallBlueprintTask = require('../../../lib/tasks/install-blueprint');
+const experiments = require('../../../lib/experiments');
 const td = require('testdouble');
+const SilentError = require('silent-error');
 const expect = require('../../chai').expect;
 
 describe('InstallBlueprintTask', function() {
@@ -13,6 +15,7 @@ describe('InstallBlueprintTask', function() {
   describe('_resolveBlueprint', function() {
     beforeEach(function() {
       task._lookupBlueprint = td.function();
+      task._tryNpmBlueprint = td.function();
       task._createTempFolder = td.function();
       task._gitClone = td.function();
       task._npmInstall = td.function();
@@ -30,13 +33,46 @@ describe('InstallBlueprintTask', function() {
         .to.eventually.equal(foobarBlueprint);
     });
 
-    it('rejects if the "foobar" blueprint was not found locally', function() {
-      let error = new Error('foobar not found');
-      td.when(task._lookupBlueprint('foobar')).thenReject(error);
+    if (!experiments.NPM_BLUEPRINTS) {
+      it('rejects if the "foobar" blueprint was not found locally', function() {
+        let error = new Error('foobar not found');
+        td.when(task._lookupBlueprint('foobar')).thenReject(error);
 
-      return expect(task._resolveBlueprint('foobar'))
-        .to.be.rejectedWith(error);
-    });
+        return expect(task._resolveBlueprint('foobar'))
+          .to.be.rejectedWith(error);
+      });
+
+    } else {
+      it('rejects invalid npm package name "foo:bar"', function() {
+        let error = new Error('foobar not found');
+        td.when(task._lookupBlueprint('foo:bar')).thenReject(error);
+
+        return expect(task._resolveBlueprint('foo:bar'))
+          .to.be.rejectedWith(error);
+      });
+
+      it('tries to resolve "foobar" as npm package as a fallback', function() {
+        let error = new Error('foobar not found');
+        td.when(task._lookupBlueprint('foobar')).thenReject(error);
+
+        let foobarBlueprint = { name: 'foobar npm blueprint' };
+        td.when(task._tryNpmBlueprint('foobar')).thenResolve(foobarBlueprint);
+
+        return expect(task._resolveBlueprint('foobar'))
+          .to.eventually.equal(foobarBlueprint);
+      });
+
+      it('rejects if npm module resolution failed', function() {
+        let error = new Error('foobar not found');
+        td.when(task._lookupBlueprint('foobar')).thenReject(error);
+
+        let npmError = new Error('npm failure');
+        td.when(task._tryNpmBlueprint('foobar')).thenReject(npmError);
+
+        return expect(task._resolveBlueprint('foobar'))
+          .to.be.rejectedWith(npmError);
+      });
+    }
 
     it('resolves "https://github.com/ember-cli/app-blueprint-test.git" blueprint by cloning, ' +
       'installing dependencies and loading the blueprint', function() {
@@ -86,6 +122,76 @@ describe('InstallBlueprintTask', function() {
       td.when(task._loadBlueprintFromPath(task._tempPath)).thenReject(error);
 
       return expect(task._resolveBlueprint(url))
+        .to.be.rejectedWith(error);
+    });
+  });
+
+  describe('_tryNpmBlueprint', function() {
+    beforeEach(function() {
+      task._createTempFolder = td.function();
+      task._npmInstallModule = td.function();
+      task._validateNpmModule = td.function();
+      task._loadBlueprintFromPath = td.function();
+
+      task._tempPath = '/tmp/foobar';
+      td.when(task._createTempFolder()).thenResolve(task._tempPath);
+    });
+
+    it('resolves with blueprint after successful "npm install"', function() {
+      let modulePath = '/path/to/foobar';
+      td.when(task._npmInstallModule('foobar', task._tempPath)).thenResolve(modulePath);
+
+      let foobarBlueprint = { name: 'foobar blueprint' };
+      td.when(task._loadBlueprintFromPath(modulePath)).thenResolve(foobarBlueprint);
+
+      return expect(task._tryNpmBlueprint('foobar'))
+        .to.eventually.equal(foobarBlueprint);
+    });
+
+    it('rejects with SilentError if npm module "foobar" could not be found', function() {
+      let error = new Error();
+      error.stderr = `
+          npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/ember-cli-app-blueprint-tes
+          npm ERR! 404
+          npm ERR! 404  'foobar' is not in the npm registry.
+          npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
+          npm ERR! 404
+          npm ERR! 404 Note that you can also install from a
+          npm ERR! 404 tarball, folder, http url, or git url.`;
+
+      td.when(task._npmInstallModule('foobar', task._tempPath)).thenReject(error);
+
+      return expect(task._tryNpmBlueprint('foobar'))
+        .to.be.rejectedWith(SilentError, `The package 'foobar' was not found in the npm registry.`);
+    });
+
+    it('rejects if "npm install" fails', function() {
+      let error = new Error('npm install failed');
+      td.when(task._npmInstallModule('foobar', task._tempPath)).thenReject(error);
+
+      return expect(task._tryNpmBlueprint('foobar'))
+        .to.be.rejectedWith(error);
+    });
+
+    it('rejects if npm module validation fails', function() {
+      let modulePath = '/path/to/foobar';
+      td.when(task._npmInstallModule('foobar', task._tempPath)).thenResolve(modulePath);
+
+      let error = new Error('module validation failed');
+      td.when(task._validateNpmModule(modulePath, 'foobar')).thenThrow(error);
+
+      return expect(task._tryNpmBlueprint('foobar'))
+        .to.be.rejectedWith(error);
+    });
+
+    it('rejects if loading blueprint fails', function() {
+      let modulePath = '/path/to/foobar';
+      td.when(task._npmInstallModule('foobar', task._tempPath)).thenResolve(modulePath);
+
+      let error = new Error('loading blueprint failed');
+      td.when(task._loadBlueprintFromPath(modulePath)).thenReject(error);
+
+      return expect(task._tryNpmBlueprint('foobar'))
         .to.be.rejectedWith(error);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,10 +191,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
@@ -685,6 +681,10 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+
 bytes@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-1.0.0.tgz#3569ede8ba34315fab99c3e92cb04c7220de1fa8"
@@ -1002,6 +1002,17 @@ configstore@^2.0.0:
     write-file-atomic "^1.1.2"
     xdg-basedir "^2.0.0"
 
+configstore@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.0.0.tgz#e1b8669c1803ccc50b545e92f8e6e79aa80e0196"
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^1.1.2"
+    xdg-basedir "^3.0.0"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -1088,6 +1099,10 @@ cryptiles@0.2.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
   dependencies:
     boom "0.4.x"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
 ctype@0.5.3:
   version "0.5.3"
@@ -1221,6 +1236,12 @@ doctrine@^1.2.2:
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  dependencies:
+    is-obj "^1.0.0"
+
+dot-prop@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.1.0.tgz#eb29eac57dfa31fda1edef50ea462ee3d38ff3ab"
   dependencies:
     is-obj "^1.0.0"
 
@@ -3656,13 +3677,21 @@ quibble@^0.4.0:
   dependencies:
     lodash "^4.17.2"
 
-quick-temp@0.1.6, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
+quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/quick-temp/-/quick-temp-0.1.6.tgz#a6242a15cba9f9cdbd341287b5c569e318eec307"
   dependencies:
     mktemp "~0.4.0"
     rimraf "~2.2.6"
     underscore.string "~2.3.3"
+
+quick-temp@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/quick-temp/-/quick-temp-0.1.8.tgz#bab02a242ab8fb0dd758a3c9776b32f9a5d94408"
+  dependencies:
+    mktemp "~0.4.0"
+    rimraf "^2.5.4"
+    underscore.string "~3.3.4"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -3711,20 +3740,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -3882,7 +3902,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3:
+rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -4144,7 +4164,7 @@ spawn-sync@^1.0.15:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
-sprintf-js@~1.0.2:
+sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
@@ -4501,9 +4521,22 @@ underscore.string@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.3.3.tgz#71c08bf6b428b1133f37e78fa3a21c82f7329b0d"
 
+underscore.string@~3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
+  dependencies:
+    sprintf-js "^1.0.3"
+    util-deprecate "^1.0.2"
+
 underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -4525,7 +4558,7 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -4540,6 +4573,12 @@ uuid@^2.0.1:
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  dependencies:
+    builtins "^1.0.3"
 
 vary@~1.1.0:
   version "1.1.0"
@@ -4645,6 +4684,10 @@ xdg-basedir@^2.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
   dependencies:
     os-homedir "^1.0.0"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 xmldom@^0.1.19:
   version "0.1.27"


### PR DESCRIPTION
Closes #6772 

- [x] tries to install from NPM if a blueprint with a matching name is not found
- [x] only works for `ember new` and `ember addon`
- [x] fails if the npm package does not have the `ember-blueprint` keyword
- [x] hidden behind `NPM_BLUEPRINTS` experiment flag
- [x] has tests 😉 
