### PR TITLE
package.json: Remove "npm" from greenkeeper ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,8 +149,7 @@
   "trackingCode": "UA-49225444-1",
   "greenkeeper": {
     "ignore": [
-      "diff",
-      "npm"
+      "diff"
     ]
   }
 }


### PR DESCRIPTION
This is no longer needed since https://github.com/ember-cli/ember-cli/pull/6680 removed the `npm` dependency