### PR TITLE
Refactor `capture-exit` usage to avoid releasing exit.

### DIFF
--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -6,6 +6,7 @@
 // The process finishes after the last interruption handler is settled.
 
 let exit = require('capture-exit');
+exit.captureExit();
 
 let windowsCtrlCTrap;
 let handlers = [];
@@ -83,8 +84,6 @@ function setupSignalsTrap() {
   if (/^win/.test(process.platform)) {
     trapWindowsSignals();
   }
-
-  exit.captureExit();
 }
 
 /**
@@ -99,8 +98,6 @@ function teardownSignalsTrap() {
   if (/^win/.test(process.platform)) {
     cleanupWindowsSignals();
   }
-
-  exit.releaseExit();
 }
 
 /**


### PR DESCRIPTION
Calling `exit.releaseExit()` (possibly _while exiting_) will lead to very difficult to track down bugs.

We should capture exit very early in our processing, and simply not release. There are no downsides to this, and calling `captureExit.releaseExit()` during exit will soon throw an error (see https://github.com/ember-cli/capture-exit/pull/22#issuecomment-281412875).

Fixes #6779