### PR TITLE
Move instrumentation out of `bin/ember`.

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -4,21 +4,6 @@
 // Provide a title to the process in `ps`
 process.title = 'ember';
 
-var instrumentation = require('../lib/utilities/instrumentation');
-
-var instrumentationEnabled = instrumentation.instrumentationEnabled;
-
-var initInstrumentation;
-
-if (instrumentationEnabled()) {
-  var heimdall = require('heimdalljs');
-  var initInstrumentationToken = heimdall.start('init');
-  initInstrumentation = {
-    token: initInstrumentationToken,
-    node: heimdall.current,
-  };
-}
-
 // require('time-require');
 var resolve = require('resolve');
 var exit = require('exit');
@@ -43,8 +28,7 @@ resolve('ember-cli', {
     cliArgs: process.argv.slice(2),
     inputStream: process.stdin,
     outputStream: process.stdout,
-    errorStream: process.stderr,
-    initInstrumentation: initInstrumentation,
+    errorStream: process.stderr
   }).then(function(result) {
     var exitCode = typeof result === 'object' ? result.exitCode : result;
     exit(exitCode);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,5 +1,17 @@
 'use strict';
 
+const instrumentation = require('../utilities/instrumentation');
+
+let initInstrumentation;
+if (instrumentation.instrumentationEnabled()) {
+  const heimdall = require('heimdalljs');
+  let initInstrumentationToken = heimdall.start('init');
+  initInstrumentation = {
+    token: initInstrumentationToken,
+    node: heimdall.current,
+  };
+}
+
 // work around misbehaving libraries, so we can correctly cleanup before
 // actually exiting.
 require('capture-exit').captureExit();
@@ -125,6 +137,7 @@ module.exports = function(options) {
     disableDependencyChecker: options.disableDependencyChecker,
     root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
     npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli',
+    initInstrumentation,
   });
 
   let project = Project.projectOrnullProject(ui, cli);


### PR DESCRIPTION
As has generally been our preference, we try very very hard to avoid changing things in `bin/ember` that may negatively impact users using it as a launcher for many different ember-cli versions.

This moves the recent changes out of `bin/ember` into `lib/cli/index.js`. The downside is that it is _slightly_ later in the boot process, but the upside is that we get to keep `bin/ember` backwards and forwards compatible for a little while longer...

Fixes https://github.com/ember-cli/ember-cli/issues/6769.