### PR TITLE
Fix minifyCss options (incorrect CSS includes paths)

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -65,7 +65,7 @@ let DEFAULT_CONFIG = {
     },
   },
   minifyCSS: {
-    options: { relativeTo: 'assets' },
+    options: { rebaseTo: 'assets' },
   },
   sourcemaps: {},
   trees: {},
@@ -83,7 +83,7 @@ class EmberApp {
    - storeConfigInMeta, defaults to `true`
    - autoRun, defaults to `true`
    - outputPaths, defaults to `{}`
-   - minifyCSS, defaults to `{enabled: !!isProduction,options: { relativeTo: 'assets' }}
+   - minifyCSS, defaults to `{enabled: !!isProduction,options: { rebaseTo: 'assets' }}
    - minifyJS, defaults to `{enabled: !!isProduction}
    - sourcemaps, defaults to `{}`
    - trees, defaults to `{}`


### PR DESCRIPTION
Hi,
I just noticed a bug according to importing fonts from css files.
I had sth like:
```sass
@font-face
  src: url('fonts/myfont-light.woff2') format('woff2')
```

and `ember-cli` with `minifyCSS` options generated a path `/assets/assets/fonts/myfont-light.woff2` which was inncorect.

I debug this problem it was caused by the latest update of https://github.com/shinnn/broccoli-clean-css where `relativeTo` option was changed to `rebaseTo`.

So, here is a fix for that :)