### PR TITLE
Remove missing init instrumentation warning

### DIFF
--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -71,13 +71,6 @@ class Instrumentation {
         node: null,
       };
       this.start('init');
-
-      this.ui.writeLine(chalk.yellow(
-        'No init instrumentation passed to CLI.  Please update your global ember or ' +
-        'invoke ember via the local executable within node_modules.  Init ' +
-        'instrumentation will still be recorded, but some bootstraping will be ' +
-        'omitted.'
-      ));
     }
   }
 

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -136,22 +136,6 @@ describe('models/instrumentation.js', function() {
         td.verify(heimdallStart(), { times: 0, ignoreExtraArgs: true });
       });
 
-      it('warns if no init instrumentation is included', function() {
-        td.when(heimdallStart('init'));
-
-        let ui = new MockUI();
-        let instrumentation = new Instrumentation({
-          ui,
-        });
-
-        expect(ui.output).to.eql(chalk.yellow(
-          'No init instrumentation passed to CLI.  Please update your global ember or ' +
-          'invoke ember via the local executable within node_modules.  Init ' +
-          'instrumentation will still be recorded, but some bootstraping will be ' +
-          'omitted.'
-        ) + EOL);
-      });
-
       it('does not warn if init instrumentation is included', function() {
         td.when(heimdallStart('init'));
 


### PR DESCRIPTION
This warning no longer makes sense after #6801.

The just-in-time creation of an init node is left in for testing convenience, but not anything else.