### PR TITLE
Use `_shouldCompileJS` to guard precompilation of addon JS.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -821,9 +821,23 @@ let addonProto = {
     return this._fileSystemInfo().hasPodTemplates;
   },
 
+  /**
+     Looks in the addon/ folder to determine if JS files exist that need to be
+     precompiled.
+
+     This is executed once during initial build but not on rebuilds.
+
+     @private
+     @method _shouldCompileJS
+     @return {Boolean} indicates if JS files exist and need to be compiled for this addon
+  */
+  _shouldCompileJS() {
+    return this._fileSystemInfo().hasJSFiles;
+  },
+
   _fileSystemInfo() {
-    if (this._cachedTemplateInfo) {
-      return this._cachedTemplateInfo;
+    if (this._cachedFileSystemInfo) {
+      return this._cachedFileSystemInfo;
     }
 
     let jsExtensions = this.registry.extensionsForType('js');
@@ -857,13 +871,13 @@ let addonProto = {
     let extensionMatcher = new RegExp(`(${templateExtensions.join('|')})$`);
     let hasTemplates = files.some(file => file.match(extensionMatcher));
 
-    this._cachedTemplateInfo = {
+    this._cachedFileSystemInfo = {
       hasJSFiles,
       hasTemplates,
       hasPodTemplates,
     };
 
-    return this._cachedTemplateInfo;
+    return this._cachedFileSystemInfo;
   },
 
   _getAddonTreeFiles() {
@@ -1093,7 +1107,7 @@ let addonProto = {
     @return {Tree} Processed javascript file tree
   */
   processedAddonJsFiles(addonTree) {
-    if (this._fileSystemInfo().hasJSFiles) {
+    if (this._shouldCompileJS()) {
       let preprocessedAddonJS = this._addonPreprocessTree('js', this.addonJsFiles(addonTree));
 
       let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {


### PR DESCRIPTION
This makes it simpler to reason about when reviewing the `processedAddonJSFiles` method, and adds an extension point (still private) allowing addons that rely on processing addon JS files but do not have `addon/**/*.js` files (where they are generally shifting things from a node module into their addon path).