### PR TITLE
Resolve path when calling UnwatchedDir for Bower

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -195,7 +195,7 @@ class EmberApp {
     let templatesTree = existsSync(templatesPath) ? new UnwatchedDir(templatesPath) : null;
 
     // do not watch bower's default directory by default
-    let bowerTree = this.project._watchmanInfo.enabled ? this.bowerDirectory : new UnwatchedDir(this.bowerDirectory);
+    let bowerTree = this.project._watchmanInfo.enabled ? this.bowerDirectory : new UnwatchedDir(this._resolveLocal(this.bowerDirectory));
 
     let vendorPath = this._resolveLocal('vendor');
     let vendorTree = existsSync(vendorPath) ? new WatchedDir(vendorPath) : null;

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -195,7 +195,8 @@ class EmberApp {
     let templatesTree = existsSync(templatesPath) ? new UnwatchedDir(templatesPath) : null;
 
     // do not watch bower's default directory by default
-    let bowerTree = this.project._watchmanInfo.enabled ? this.bowerDirectory : new UnwatchedDir(this._resolveLocal(this.bowerDirectory));
+    let bowerDirectory = this._resolveLocal(this.bowerDirectory);
+    let bowerTree = this.project._watchmanInfo.enabled ? bowerDirectory : new UnwatchedDir(bowerDirectory);
 
     let vendorPath = this._resolveLocal('vendor');
     let vendorTree = existsSync(vendorPath) ? new WatchedDir(vendorPath) : null;


### PR DESCRIPTION
The path passed to UnWatchedDir for Bower directory case was not resolved. Fixing that in this commit.