### PR TITLE
Use `amd` for transpiling modules with babel@5.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -35,7 +35,7 @@
     "ember-resolver": "^2.0.3",
     "ember-source": "~2.12.0-beta.1",
     "ember-welcome-page": "^2.0.2",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.2.3"
   },
   "engines": {
     "node": ">= 4"

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -209,7 +209,7 @@ EmberApp.prototype._initOptions = function(options) {
 
   let detectedDefaultOptions = {
     babel: {
-      modules: 'amdStrict',
+      modules: 'amd',
       moduleIds: true,
       resolveModuleSource: require('amd-name-resolver').moduleResolve,
     },

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -52,7 +52,7 @@ if (!heimdall.hasMonitor('cache-key-for-tree')) {
 }
 
 let DEFAULT_BABEL_CONFIG = {
-  modules: 'amdStrict',
+  modules: 'amd',
   moduleIds: true,
   resolveModuleSource: require('amd-name-resolver').moduleResolve,
 };


### PR DESCRIPTION
In order to allow gradual migration from babel@5 to babel@6 we must be able update addons on a case by case basis to ember-cli-babel@6. This means that at any given time we will have both babel@5 and babel@6 transpiled modules present in the system. Unfortunately, our prior default module transpilation target (`amdStrict`) is not compatible with babel@6 transpiled modules. The issue is best illustrated with an example.

Given the following input content:

```js
import defaultThingy from './a';
import { namedThingy } from './b';

export default function() {
  defaultThingy();
}

export function namedExport() {
  namedThingy();
}
```

Babel 5 with `amdStrict` will emit:

```js
define('some/file/name', ['exports', './a', './b'], function (exports, _a, _b) {
  'use strict';

  exports.namedExport = namedExport;

  exports['default'] = function () {
    (0, _a['default'])();
  };

  function namedExport() {
    (0, _b.namedThingy)();
  }
});
```

And Babel 6 with `transform-es2015-modules-amd` will emit:

```js
define('some/file/here', ['exports', './a', './b'], function (exports, _a, _b) {
  'use strict';

  Object.defineProperty(exports, "__esModule", {
    value: true
  });

  exports.default = function () {
    (0, _a2.default)();
  };

  exports.namedExport = namedExport;

  var _a2 = _interopRequireDefault(_a);

  function _interopRequireDefault(obj) {
    return obj && obj.__esModule ? obj : {
      default: obj
    };
  }

  function namedExport() {
    (0, _b.namedThingy)();
  }
});
```

The issue is not immediately obvious, but the babel@5 module does not define `__esModule` on the `exports` object which means that when the babel@6 module attempts to import the default export from the babel@5 module it will result in getting the raw `exports` object (not `exports.default`).

Switching our default transpilation while still using babel@5 from `amdStrict` to `amd` will emit interoperable modules:

```js
define('some/file/name', ['exports', './a', './b'], function (exports, _a, _b) {
  'use strict';

  Object.defineProperty(exports, '__esModule', {
    value: true
  });
  exports.namedExport = namedExport;

  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }

  var _defaultThingy = _interopRequireDefault(_a);

  exports['default'] = function () {
    (0, _defaultThingy['default'])();
  };

  function namedExport() {
    (0, _b.namedThingy)();
  }
});
```