### PR TITLE
Revert "Use `amd` for transpiling modules with babel@5."

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -209,7 +209,7 @@ EmberApp.prototype._initOptions = function(options) {
 
   let detectedDefaultOptions = {
     babel: {
-      modules: 'amd',
+      modules: 'amdStrict',
       moduleIds: true,
       resolveModuleSource: require('amd-name-resolver').moduleResolve,
     },

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -52,7 +52,7 @@ if (!heimdall.hasMonitor('cache-key-for-tree')) {
 }
 
 let DEFAULT_BABEL_CONFIG = {
-  modules: 'amd',
+  modules: 'amdStrict',
   moduleIds: true,
   resolveModuleSource: require('amd-name-resolver').moduleResolve,
 };


### PR DESCRIPTION
This reverts commit 24bd49638f43bda9a7e33c8a692d2e734cc3d1c5.

Revertting this change in favor of fixing the babel@6 transpilation in https://github.com/babel/babel/pull/5422.