### PR TITLE
Allow `ember new -b <blueprint> foo` to opt-in to yarn by default.

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -25,7 +25,7 @@ module.exports = Command.extend({
     { name: 'skip-npm',   type: Boolean, default: false, aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false, aliases: ['sb'] },
     { name: 'skip-git',   type: Boolean, default: false, aliases: ['sg'] },
-    { name: 'yarn',       type: Boolean, default: false },
+    { name: 'yarn',       type: Boolean },
     { name: 'directory',  type: String,                  aliases: ['dir'] },
   ],
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -233,6 +233,23 @@ describe('Acceptance: ember new', function() {
     });
   });
 
+  it('ember new uses yarn when blueprint has yarn.lock', function() {
+    fs.mkdirsSync('my_blueprint/files');
+    fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
+    fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "fs-extra": "*" }}');
+    fs.writeFileSync('my_blueprint/files/yarn.lock', '');
+
+    return ember([
+      'new',
+      'foo',
+      '--skip-git',
+      '--blueprint=./my_blueprint',
+    ]).then(function() {
+      expect(file('yarn.lock')).to.not.be.empty;
+      expect(dir('node_modules/fs-extra')).to.not.be.empty;
+    });
+  });
+
   it('ember new without skip-git flag creates .git dir', function() {
     return ember([
       'new',

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -117,7 +117,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
-  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -479,7 +479,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -117,7 +117,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
-  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -511,7 +511,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -479,7 +479,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },


### PR DESCRIPTION
This change removes the hardcoded default of `--yarn=false`, but does not change the way `ember new foo` or `ember addon foo` work with regards to `npm` vs `yarn`. The change simply allows a blueprint to include a `yarn.lock` to "hint" to our `NPMTask` that yarn should be used if possible.