### PR TITLE
Add logging for `this.runTask` within commands.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -75,16 +75,15 @@ module.exports = Command.extend({
       return Promise.reject(new SilentError(`We currently do not support a name of \`${packageName}\`.`));
     }
 
-    logger.info('before:installblueprint');
     return this.runTask('InstallBlueprint', blueprintOpts)
       .then(() => {
-        logger.info('after:installblueprint');
         if (!commandOptions.skipNpm) {
           return this.runTask('NpmInstall', {
             verbose: commandOptions.verbose,
             useYarn: commandOptions.yarn,
             optional: false,
           }).then(() => {
+            logger.info('setting up node_modules path for project');
             project.setupNodeModulesPath();
           });
         }
@@ -99,6 +98,7 @@ module.exports = Command.extend({
       .then(() => {
         // skip `ember generate ember-cli-eslint` if the plugin hasn't been installed
         if (!commandOptions.skipNpm) {
+          logger.info('reloading project addons');
           this.project.reloadAddons();
 
           return this.runTask('GenerateFromBlueprint', {

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -228,6 +228,8 @@ let Command = CoreObject.extend({
       throw new Error(`Concurrent tasks are not supported`);
     }
 
+    logger.info(`\`${this.name}\` command running \`${name}\` task`);
+
     let Task = this.tasks[name];
     if (!Task) {
       throw new Error(`Unknown task "${name}"`);
@@ -237,9 +239,15 @@ let Command = CoreObject.extend({
 
     this._currentTask = task;
 
-    return Promise.resolve(task.run(options)).finally(() => {
-      delete this._currentTask;
-    });
+    return Promise.resolve(task.run(options))
+      .catch(error => {
+        logger.info(`An error occurred running \`${name}\` from the \`${this.name}\` command.`, error.stack);
+
+        throw error;
+      })
+      .finally(() => {
+        delete this._currentTask;
+      });
   },
 
   /**


### PR DESCRIPTION
This makes tracking down errors thrown from commands that manage multiple tasks much easier.