### PR TITLE
print the `serving on http://host:port/basePath` after each rebuild

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 let logger = require('heimdalljs-logger')('ember-cli:watcher');
 const CoreObject = require('core-object');
+const cleanBaseURL = require('clean-base-url');
 
 class Watcher extends CoreObject {
   constructor(_options) {
@@ -14,6 +15,7 @@ class Watcher extends CoreObject {
 
     logger.info('initialize %o', options);
 
+    this.serving = _options.serving;
     this.watcher = this.watcher || this.constructWatcher(options);
 
     this.watcher.on('error', this.didError.bind(this));
@@ -40,9 +42,16 @@ class Watcher extends CoreObject {
     logger.info('didChange %o', results);
 
     let totalTime = results.totalTime / 1e6;
+    let message = chalk.green(`Build successful (${Math.round(totalTime)}ms)`);
 
     this.ui.writeLine('');
-    this.ui.writeLine(chalk.green(`Build successful - ${Math.round(totalTime)}ms.`));
+
+    if (this.serving) {
+      let options = this.options;
+      let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+      message += ` – Serving on http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
+    }
+    this.ui.writeLine(message);
 
     this.analytics.track({
       name: 'ember rebuild',

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -33,6 +33,7 @@ class ServeTask extends Task {
       builder,
       analytics: this.analytics,
       options,
+      serving: true,
     });
 
     let serverRoot = './server';

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -11,8 +11,6 @@ const Promise = require('rsvp').Promise;
 const Task = require('../../models/task');
 const SilentError = require('silent-error');
 
-const cleanBaseURL = require('clean-base-url');
-
 class ExpressServerTask extends Task {
   constructor(options) {
     super(options);
@@ -140,11 +138,7 @@ class ExpressServerTask extends Task {
       this.serverWatcher.on('delete', this.serverWatcherDidChange.bind(this));
     }
 
-    return this.startHttpServer().then(() => {
-      let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
-
-      options.ui.writeLine(`Serving on http${options.ssl ? 's' : ''}://${this.displayHost(options.host)}:${options.port}${baseURL}`);
-    });
+    return this.startHttpServer();
   }
 
   serverWatcherDidChange() {

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -93,7 +93,112 @@ describe('Watcher', function() {
     });
 
     it('logs that the build was successful', function() {
-      expect(ui.output).to.equal(EOL + chalk.green('Build successful - 12344ms.') + EOL);
+      expect(ui.output).to.equal(EOL + chalk.green('Build successful (12344ms)') + EOL);
+    });
+  });
+
+  describe('output', function() {
+    this.timeout(40000);
+
+    beforeEach(function() {
+      ui = new MockUI();
+      analytics = new MockAnalytics();
+      watcher = new MockWatcher();
+    });
+
+    it('with ssl', function() {
+      let subject = new Watcher({
+        ui,
+        analytics,
+        builder,
+        watcher,
+        serving: true,
+        options: {
+          host: undefined,
+          port: '1337',
+          ssl: true,
+          sslCert: 'tests/fixtures/ssl/server.crt',
+          sslKey: 'tests/fixtures/ssl/server.key',
+          rootURL: '/',
+        },
+      });
+
+      subject.didChange({
+        totalTime: 12344000000,
+      });
+
+      let output = ui.output.trim().split(EOL);
+      expect(output[0]).to.equal(`${chalk.green('Build successful (12344ms)')} – Serving on https://localhost:1337/`);
+    });
+
+    it('with baseURL', function() {
+      let subject = new Watcher({
+        ui,
+        analytics,
+        builder,
+        watcher,
+        serving: true,
+        options: {
+          host: undefined,
+          port: '1337',
+          baseURL: '/foo',
+        },
+      });
+
+      subject.didChange({
+        totalTime: 12344000000,
+      });
+
+      let output = ui.output.trim().split(EOL);
+      expect(output[0]).to.equal(`${chalk.green('Build successful (12344ms)')} – Serving on http://localhost:1337/foo/`);
+      expect(output.length).to.equal(1, 'expected only one line of output');
+    });
+
+    it('with rootURL', function() {
+      let subject = new Watcher({
+        ui,
+        analytics,
+        builder,
+        watcher,
+        serving: true,
+        options: {
+          host: undefined,
+          port: '1337',
+          rootURL: '/foo',
+        },
+      });
+
+      subject.didChange({
+        totalTime: 12344000000,
+      });
+
+      let output = ui.output.trim().split(EOL);
+
+      expect(output[0]).to.equal(`${chalk.green('Build successful (12344ms)')} – Serving on http://localhost:1337/foo/`);
+      expect(output.length).to.equal(1, 'expected only one line of output');
+    });
+
+    it('with empty rootURL', function() {
+      let subject = new Watcher({
+        ui,
+        analytics,
+        builder,
+        watcher,
+        serving: true,
+        options: {
+          host: undefined,
+          port: '1337',
+          rootURL: '',
+        },
+      });
+
+      subject.didChange({
+        totalTime: 12344000000,
+      });
+
+      let output = ui.output.trim().split(EOL);
+      expect(output[0]).to.equal(`${chalk.green('Build successful (12344ms)')} – Serving on http://localhost:1337/`);
+      expect(output.length).to.equal(1, 'expected only one line of output');
     });
   });
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -44,6 +44,26 @@ describe('express-server', function() {
     } catch (err) { /* ignore */ }
   });
 
+
+  it('address in use', function() {
+    let preexistingServer = net.createServer();
+    preexistingServer.listen(1337);
+
+    return subject.start({
+      host: undefined,
+      port: '1337',
+    })
+      .then(function() {
+        expect(false, 'should have rejected').to.be.ok;
+      })
+      .catch(function(reason) {
+        expect(reason.message).to.equal('Could not serve on http://localhost:1337. It is either in use or you do not have permission.');
+      })
+      .finally(function() {
+        preexistingServer.close();
+      });
+  });
+
   describe('displayHost', function() {
     it('should use the specified host if specified', function() {
       expect(subject.displayHost('1.2.3.4')).to.equal('1.2.3.4');
@@ -80,82 +100,6 @@ describe('express-server', function() {
 
   describe('output', function() {
     this.timeout(40000);
-
-    it('with ssl', function() {
-      return subject.start({
-        host: undefined,
-        port: '1337',
-        ssl: true,
-        sslCert: 'tests/fixtures/ssl/server.crt',
-        sslKey: 'tests/fixtures/ssl/server.key',
-        rootURL: '/',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[0]).to.equal('Serving on https://localhost:1337/');
-      });
-    });
-
-    it('with proxy', function() {
-      return subject.start({
-        proxy: 'http://localhost:3001/',
-        host: undefined,
-        port: '1337',
-        rootURL: '/',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[1]).to.equal('Serving on http://localhost:1337/');
-        expect(output[0]).to.equal('Proxying to http://localhost:3001/');
-        expect(output.length).to.equal(2, 'expected only two lines of output');
-      });
-    });
-
-    it('without proxy', function() {
-      return subject.start({
-        host: undefined,
-        port: '1337',
-        rootURL: '/',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[0]).to.equal('Serving on http://localhost:1337/');
-        expect(output.length).to.equal(1, 'expected only one line of output');
-      });
-    });
-
-    it('with baseURL', function() {
-      return subject.start({
-        host: undefined,
-        port: '1337',
-        baseURL: '/foo',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[0]).to.equal('Serving on http://localhost:1337/foo/');
-        expect(output.length).to.equal(1, 'expected only one line of output');
-      });
-    });
-
-    it('with rootURL', function() {
-      return subject.start({
-        host: undefined,
-        port: '1337',
-        rootURL: '/foo',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[0]).to.equal('Serving on http://localhost:1337/foo/');
-        expect(output.length).to.equal(1, 'expected only one line of output');
-      });
-    });
-
-    it('with empty rootURL', function() {
-      return subject.start({
-        host: undefined,
-        port: '1337',
-        rootURL: '',
-      }).then(function() {
-        let output = ui.output.trim().split(EOL);
-        expect(output[0]).to.equal('Serving on http://localhost:1337/');
-        expect(output.length).to.equal(1, 'expected only one line of output');
-      });
-    });
 
     it('address in use', function() {
       let preexistingServer = net.createServer();


### PR DESCRIPTION
this has literally been killing me since the start of time.

- [x] fix tests