### PR TITLE
Use `yarn install --no-lockfile` in travis for addons

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -32,7 +32,7 @@ matrix:
   - phantomjs --version
 
 install:
-  - yarn install
+  - yarn install --no-lockfile
 <% } else { %>before_install:
   - npm config set spin false
   - npm install -g phantomjs-prebuilt


### PR DESCRIPTION
I'm not sure if this was as simple as the issue description made it sound, but it sounded like just changing the one line from `yarn install` to `yarn install --no-lockfile`, so I did that. Let me know if extra work is required and I'll be happy to update the PR.

Fixes #6844