### PR TITLE
Use `encode/decodeURIComponent()` for `meta` tag config

### DIFF
--- a/lib/broccoli/app-config-from-meta.js
+++ b/lib/broccoli/app-config-from-meta.js
@@ -1,7 +1,7 @@
 try {
   var metaName = prefix + '/config/environment';
   var rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');
-  var config = JSON.parse(unescape(rawConfig));
+  var config = JSON.parse(decodeURIComponent(rawConfig));
 
   var exports = { 'default': config };
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1,4 +1,4 @@
-/* global require, module, escape */
+/* global require, module */
 'use strict';
 
 /**

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -95,7 +95,7 @@ function contentFor(config, match, type, options) {
       content.push(calculateBaseTag(config.baseURL, config.locationType));
 
       if (options.storeConfigInMeta) {
-        content.push(`<meta name="${config.modulePrefix}/config/environment" content="${escape(JSON.stringify(config))}" />`);
+        content.push(`<meta name="${config.modulePrefix}/config/environment" content="${encodeURIComponent(JSON.stringify(config))}" />`);
       }
 
       break;

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -163,7 +163,7 @@ describe('Default Packager: Ember CLI Internal', function() {
     let appConfigFileContent = emberCliFiles['app-config.js'].trim();
 
     expect(appConfigFileContent).to.contain(`var rawConfig = document.querySelector(`);
-    expect(appConfigFileContent).to.contain(`var config = JSON.parse(unescape(rawConfig));`);
+    expect(appConfigFileContent).to.contain(`var config = JSON.parse(decodeURIComponent(rawConfig));`);
   }));
 
   it('populates the contents of internal files correctly, including content from add-ons', co.wrap(function *() {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1,5 +1,3 @@
-/* global escape */
-
 'use strict';
 
 const co = require('co');

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -51,7 +51,7 @@ describe('ember-app-utils', function() {
 
         expect(
           actual,
-          '`<meta>` tag was included by default'
+          '`<meta>` tag was included with multibyte characters'
         ).to.contain(expected);
       });
 

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -18,7 +18,7 @@ describe('ember-app-utils', function() {
     };
 
     let defaultMatch = '{{content-for \'head\'}}';
-    let escapedConfig = escape(JSON.stringify(config));
+    let escapedConfig = encodeURIComponent(JSON.stringify(config));
     let defaultOptions = {
       storeConfigInMeta: true,
       autoRun: true,
@@ -36,6 +36,18 @@ describe('ember-app-utils', function() {
       it('returns `<meta>` tag by default', function() {
         let actual = contentFor(config, defaultMatch, 'head', defaultOptions);
         let expected = `<meta name="cool-foo/config/environment" content="${escapedConfig}" />`;
+
+        expect(
+          actual,
+          '`<meta>` tag was included by default'
+        ).to.contain(expected);
+      });
+
+      it('handles multibyte characters in `<meta>` tag', function() {
+        let configWithMultibyteChars = { modulePrefix: 'cool-å' };
+        let actual = contentFor(configWithMultibyteChars, defaultMatch, 'head', defaultOptions);
+        let escapedConfig = encodeURIComponent(JSON.stringify(configWithMultibyteChars));
+        let expected = `<meta name="cool-å/config/environment" content="${escapedConfig}" />`;
 
         expect(
           actual,


### PR DESCRIPTION
Issue: #6598