### PR TITLE
Remove guard in `treeForAddon` around `addon/**/*.js` files.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -822,20 +822,6 @@ let addonProto = {
     return this._fileSystemInfo().hasPodTemplates;
   },
 
-  /**
-     Looks in the addon/ folder to determine if JS files exist that need to be
-     precompiled.
-
-     This is executed once during initial build but not on rebuilds.
-
-     @private
-     @method _shouldCompileJS
-     @return {Boolean} indicates if JS files exist and need to be compiled for this addon
-  */
-  _shouldCompileJS() {
-    return this._fileSystemInfo().hasJSFiles;
-  },
-
   _fileSystemInfo() {
     if (this._cachedFileSystemInfo) {
       return this._cachedFileSystemInfo;
@@ -1108,32 +1094,30 @@ let addonProto = {
     @return {Tree} Processed javascript file tree
   */
   processedAddonJsFiles(addonTree) {
-    if (this._shouldCompileJS()) {
-      let preprocessedAddonJS = this._addonPreprocessTree('js', this.addonJsFiles(addonTree));
+    let preprocessedAddonJS = this._addonPreprocessTree('js', this.addonJsFiles(addonTree));
 
-      let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
-        annotation: `processedAddonJsFiles(${this.name})`,
-        registry: this.registry,
+    let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
+      annotation: `processedAddonJsFiles(${this.name})`,
+      registry: this.registry,
+    });
+
+    let postprocessedAddonJs = this._addonPostprocessTree('js', processedAddonJS);
+
+    if (!registryHasPreprocessor(this.registry, 'js')) {
+      this._warn(`Addon files were detected in \`${this._treePathFor('addon')}\`, but no JavaScript ` +
+                 `preprocessors were found for \`${this.name}\`. Please make sure to add a preprocessor ` +
+                 '(most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in ' +
+                 `\`${this.name}\`'s \`package.json\`.`);
+
+      let options = defaultsDeep({}, DEFAULT_BABEL_CONFIG, {
+        annotation: `Babel Fallback - Addon#processedAddonJsFiles(${this.name})`,
       });
 
-      let postprocessedAddonJs = this._addonPostprocessTree('js', processedAddonJS);
-
-      if (!registryHasPreprocessor(this.registry, 'js')) {
-        this._warn(`Addon files were detected in \`${this._treePathFor('addon')}\`, but no JavaScript ` +
-                   `preprocessors were found for \`${this.name}\`. Please make sure to add a preprocessor ` +
-                   '(most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in ' +
-                   `\`${this.name}\`'s \`package.json\`.`);
-
-        let options = defaultsDeep({}, DEFAULT_BABEL_CONFIG, {
-          annotation: `Babel Fallback - Addon#processedAddonJsFiles(${this.name})`,
-        });
-
-        const Babel = require('broccoli-babel-transpiler');
-        postprocessedAddonJs = new Babel(postprocessedAddonJs, options);
-      }
-
-      return postprocessedAddonJs;
+      const Babel = require('broccoli-babel-transpiler');
+      postprocessedAddonJs = new Babel(postprocessedAddonJs, options);
     }
+
+    return postprocessedAddonJs;
   },
 
   /**


### PR DESCRIPTION
This guard was added to avoid wasted effort when preprocessing the `addon/` directory when it only contains a single `.gitkeep` file (or is non-existent). The assumption I made was that if there are no `*.js` files inside the `addon/` directory, then we didn't need to attempt to transpile it.

Unfortunately, "back in reality" there are a number of addons that wrap existing libraries, that have no `addon/**/*.js` files but still need the `this._super.treeForAddon` invocation to process the provided tree.

This change, reverts the guard (it was only a relatively small savings anyways).

The diff is best viewed [without whitespace changes](https://github.com/ember-cli/ember-cli/pull/6884/files?w=1)...

Related issues:

* https://github.com/ember-redux/ember-redux/issues/105
* https://github.com/mike-north/ember-lodash/issues/89
* https://github.com/ciena-blueplanet/ember-dagre/issues/77