### PR TITLE
Work around broken bower installation for old npm versions

### DIFF
--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -77,6 +77,17 @@ class BowerInstallTask extends Task {
     return existsSync(this.bowerJsonPath);
   }
 
+  hasBowerDependencies() {
+    if (!this.hasBowerJson()) {
+      return false;
+    }
+
+    let json = fs.readJsonSync(this.bowerJsonPath);
+    let deps = Object.keys(json.dependencies || {});
+    let devDeps = Object.keys(json.devDependencies || {});
+    return deps.length || devDeps.length;
+  }
+
   ensureBowerJson() {
     if (this.hasBowerJson()) {
       return Promise.resolve();
@@ -100,8 +111,8 @@ class BowerInstallTask extends Task {
 
     // if we are running "bower install" from "ember init" and there is
     // no "bower.json" we return early
-    if (!this.hasBowerJson() && !savePackages) {
-      logger.info('Skipping "bower install" since "bower.json" does not exist');
+    if (!savePackages && !this.hasBowerDependencies()) {
+      logger.info('Skipping "bower install" since "bower.json" does not exist or is empty');
       return Promise.resolve();
     }
 

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -6,6 +6,7 @@ const path = require('path');
 const existsSync = require('exists-sync');
 const execa = require('execa');
 const RSVP = require('rsvp');
+const SilentError = require('silent-error');
 const Task = require('../models/task');
 const formatPackageList = require('../utilities/format-package-list');
 
@@ -55,7 +56,17 @@ class BowerInstallTask extends Task {
 
     return Promise.resolve(execa('npm', ['install', 'bower@^1.3.12'], { cwd: cliPath }))
       .finally(() => ui.stopProgress())
+      .catch(error => this.handleInstallBowerError(error))
       .then(() => ui.writeLine(chalk.green('NPM: Installed bower')));
+  }
+
+  handleInstallBowerError(error) {
+    if (error.message.indexOf('Cannot read property \'target\' of null') !== -1) {
+      throw new SilentError('Bower could not be installed due to a bug in your npm installation.\n' +
+        'Please update your npm version by running: npm install -g npm');
+    }
+
+    throw error;
   }
 
   get bowerJsonPath() {


### PR DESCRIPTION
This PR:

- checks the error message returned from `npm install bower` and displays a helpful error message if the known bug was hit

- checks if the `bower.json` actually has any dependencies before trying to `npm install bower` so that the first case should become a rare edge case when used with a custom app blueprint that still includes bower dependencies

Resolves https://github.com/ember-cli/ember-cli/issues/6863