### PR TITLE
Handle addon constructor errors gracefully

### DIFF
--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -52,7 +52,16 @@ class AddonsFactory {
         });
         let start = Date.now();
         let AddonConstructor = Addon.lookup(addonInfo);
-        let addon = new AddonConstructor(addonParent, project);
+        let addon;
+
+        try {
+          addon = new AddonConstructor(addonParent, project);
+        } catch (e) {
+          project.ui.writeError(e);
+          const SilentError = require('silent-error');
+          throw new SilentError(`An error occured in the constructor for ${addonInfo.name} at ${addonInfo.path}`);
+        }
+
         if (addon.initializeAddons) {
           addon.initializeAddons();
         } else {

--- a/tests/fixtures/addon/invalid-constructor/lib/ember-invalid-addon/index.js
+++ b/tests/fixtures/addon/invalid-constructor/lib/ember-invalid-addon/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function() {
+  throw new Error('invalid');
+};

--- a/tests/fixtures/addon/invalid-constructor/lib/ember-invalid-addon/package.json
+++ b/tests/fixtures/addon/invalid-constructor/lib/ember-invalid-addon/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ember-invalid-addon",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/tests/fixtures/addon/invalid-constructor/package.json
+++ b/tests/fixtures/addon/invalid-constructor/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-project",
+  "private": true,
+  "ember-addon": {
+    "paths": ["./lib/ember-invalid-addon"]
+  }
+}

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -388,6 +388,21 @@ describe('models/project.js', function() {
 
       expect(added).to.be.ok;
     });
+
+    it('should catch addon constructor errors', function() {
+      projectPath = path.resolve(__dirname, '../../fixtures/addon/invalid-constructor');
+      packageContents = require(path.join(projectPath, 'package.json'));
+
+      makeProject();
+
+      const invalidAddonName = 'ember-invalid-addon';
+      const expectedPath = path.join(projectPath, '/lib/', invalidAddonName);
+      const expectedError = `SilentError: An error occured in the constructor for ${invalidAddonName} at ${expectedPath}`;
+
+      expect(function() {
+        project.initializeAddons();
+      }).to.throw(expectedError);
+    });
   });
 
   describe('reloadAddon', function() {


### PR DESCRIPTION
This change adds a user friendly error message when an addon constructor
function throws an error during addon initialization.

Fixes #6820 