### PR TITLE
Use const/let in all blueprints

### DIFF
--- a/blueprints/addon/files/ember-cli-build.js
+++ b/blueprints/addon/files/ember-cli-build.js
@@ -1,8 +1,9 @@
+'use strict';
 /* eslint-env node */
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -1,7 +1,8 @@
+'use strict';
 /* eslint-env node */
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: '<%= modulePrefix %>',
     environment: environment,
     rootURL: '/',

--- a/blueprints/app/files/ember-cli-build.js
+++ b/blueprints/app/files/ember-cli-build.js
@@ -1,8 +1,9 @@
+'use strict';
 /* eslint-env node */
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
+  let app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/blueprints/http-mock/files/server/mocks/__name__.js
+++ b/blueprints/http-mock/files/server/mocks/__name__.js
@@ -1,7 +1,8 @@
+'use strict';
 /* eslint-env node */
 module.exports = function(app) {
-  var express = require('express');
-  var <%= camelizedModuleName %>Router = express.Router();
+  const express = require('express');
+  let <%= camelizedModuleName %>Router = express.Router();
 
   <%= camelizedModuleName %>Router.get('/', function(req, res) {
     res.send({

--- a/blueprints/http-proxy/files/server/proxies/__name__.js
+++ b/blueprints/http-proxy/files/server/proxies/__name__.js
@@ -1,10 +1,11 @@
+'use strict';
 /* eslint-env node */
-var proxyPath = '/<%=camelizedModuleName %>';
+const proxyPath = '/<%=camelizedModuleName %>';
 
 module.exports = function(app) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
-  var proxy = require('http-proxy').createProxyServer({});
+  let proxy = require('http-proxy').createProxyServer({});
 
   proxy.on('error', function(err, req) {
     console.error(err, req.url);

--- a/blueprints/server/files/server/index.js
+++ b/blueprints/server/files/server/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env node */
 
 // To use it create some files under `mocks/`
@@ -11,8 +12,8 @@
 
 module.exports = function(app) {
   const globSync   = require('glob').sync;
-  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
-  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
+  const mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
+  const proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
 
   // Log proxy requests
   const morgan  = require('morgan');

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "chai-as-promised": "^6.0.0",
     "chai-files": "^1.2.0",
     "co": "^4.6.0",
-    "ember-cli-blueprint-test-helpers": "^0.17.0",
+    "ember-cli-blueprint-test-helpers": "^0.17.1",
     "ember-cli-internal-test-helpers": "^0.9.0",
     "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-mocha": "^4.8.0",

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -123,8 +123,8 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
 
     expect(file('server/mocks/foo.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooRouter = express.Router();\n" +
                   "\n" +
                   "  fooRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -181,8 +181,8 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
 
     expect(file('server/mocks/foo-bar.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooBarRouter = express.Router();\n" +
                   "\n" +
                   "  fooBarRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -238,12 +238,12 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
       .to.contain("proxies.forEach(function(route) { route(app); });");
 
     expect(file('server/proxies/foo.js'))
-      .to.contain("var proxyPath = '/foo';\n" +
+      .to.contain("const proxyPath = '/foo';\n" +
                   "\n" +
                   "module.exports = function(app) {\n" +
                   "  // For options, see:\n" +
                   "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "  let proxy = require('http-proxy').createProxyServer({});\n" +
                   "\n" +
                   "  proxy.on('error', function(err, req) {\n" +
                   "    console.error(err, req.url);\n" +

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -154,8 +154,8 @@ describe('Acceptance: ember generate in-addon', function() {
 
     expect(file('server/mocks/foo.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooRouter = express.Router();\n" +
                   "\n" +
                   "  fooRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -212,8 +212,8 @@ describe('Acceptance: ember generate in-addon', function() {
 
     expect(file('server/mocks/foo-bar.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooBarRouter = express.Router();\n" +
                   "\n" +
                   "  fooBarRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -269,12 +269,12 @@ describe('Acceptance: ember generate in-addon', function() {
       .to.contain("proxies.forEach(function(route) { route(app); });");
 
     expect(file('server/proxies/foo.js'))
-      .to.contain("var proxyPath = '/foo';\n" +
+      .to.contain("const proxyPath = '/foo';\n" +
                   "\n" +
                   "module.exports = function(app) {\n" +
                   "  // For options, see:\n" +
                   "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "  let proxy = require('http-proxy').createProxyServer({});\n" +
                   "\n" +
                   "  proxy.on('error', function(err, req) {\n" +
                   "    console.error(err, req.url);\n" +

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -173,8 +173,8 @@ describe('Acceptance: ember generate', function() {
 
     expect(file('server/mocks/foo.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooRouter = express.Router();\n" +
                   "\n" +
                   "  fooRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -231,8 +231,8 @@ describe('Acceptance: ember generate', function() {
 
     expect(file('server/mocks/foo-bar.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooBarRouter = express.Router();\n" +
                   "\n" +
                   "  fooBarRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -288,12 +288,12 @@ describe('Acceptance: ember generate', function() {
       .to.contain("proxies.forEach(function(route) { route(app); });");
 
     expect(file('server/proxies/foo.js'))
-      .to.contain("var proxyPath = '/foo';\n" +
+      .to.contain("const proxyPath = '/foo';\n" +
                   "\n" +
                   "module.exports = function(app) {\n" +
                   "  // For options, see:\n" +
                   "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "  let proxy = require('http-proxy').createProxyServer({});\n" +
                   "\n" +
                   "  proxy.on('error', function(err, req) {\n" +
                   "    console.error(err, req.url);\n" +

--- a/tests/acceptance/pods-destroy-test.js
+++ b/tests/acceptance/pods-destroy-test.js
@@ -78,7 +78,7 @@ describe('Acceptance: ember destroy pod', function() {
   const assertDestroyAfterGenerate = co.wrap(function *(args, files) {
     yield initApp();
 
-    replaceFile('config/environment.js', "var ENV = {", "var ENV = {\npodModulePrefix: 'app/pods', \n");
+    replaceFile('config/environment.js', "(var|let|const) ENV = {", "$1 ENV = {\npodModulePrefix: 'app/pods', \n");
 
     yield generate(args);
     assertFilesExist(files);
@@ -104,7 +104,7 @@ describe('Acceptance: ember destroy pod', function() {
   const destroyAfterGenerateWithPodsByDefault = co.wrap(function *(args) {
     yield initApp();
 
-    replaceFile('config/environment.js', "var ENV = {", "var ENV = {\nusePodsByDefault: true, \n");
+    replaceFile('config/environment.js', "(var|let|const) ENV = {", "$1 ENV = {\nusePodsByDefault: true, \n");
 
     yield generate(args);
     return yield destroy(args);
@@ -113,7 +113,7 @@ describe('Acceptance: ember destroy pod', function() {
   const destroyAfterGenerate = co.wrap(function *(args) {
     yield initApp();
 
-    replaceFile('config/environment.js', "var ENV = {", "var ENV = {\npodModulePrefix: 'app/pods', \n");
+    replaceFile('config/environment.js', "(var|let|const) ENV = {", "$1 ENV = {\npodModulePrefix: 'app/pods', \n");
 
     yield generate(args);
     return yield destroy(args);

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -69,7 +69,7 @@ describe('Acceptance: ember generate pod', function() {
     let generateArgs = ['generate'].concat(args);
 
     return initApp().then(function() {
-      replaceFile('config/environment.js', "var ENV = {", "var ENV = {\npodModulePrefix: 'app/pods', \n");
+      replaceFile('config/environment.js', "(var|let|const) ENV = {", "$1 ENV = {\npodModulePrefix: 'app/pods', \n");
       return ember(generateArgs);
     });
   }
@@ -87,7 +87,7 @@ describe('Acceptance: ember generate pod', function() {
     let generateArgs = ['generate'].concat(args);
 
     return initApp().then(function() {
-      replaceFile('config/environment.js', "var ENV = {", "var ENV = {\nusePodsByDefault: true, \n");
+      replaceFile('config/environment.js', "(var|let|const) ENV = {", "$1 ENV = {\nusePodsByDefault: true, \n");
       return ember(generateArgs);
     });
   }
@@ -182,8 +182,8 @@ describe('Acceptance: ember generate pod', function() {
 
     expect(file('server/mocks/foo.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooRouter = express.Router();\n" +
                   "\n" +
                   "  fooRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -240,8 +240,8 @@ describe('Acceptance: ember generate pod', function() {
 
     expect(file('server/mocks/foo-bar.js'))
       .to.contain("module.exports = function(app) {\n" +
-                  "  var express = require('express');\n" +
-                  "  var fooBarRouter = express.Router();\n" +
+                  "  const express = require('express');\n" +
+                  "  let fooBarRouter = express.Router();\n" +
                   "\n" +
                   "  fooBarRouter.get('/', function(req, res) {\n" +
                   "    res.send({\n" +
@@ -297,12 +297,12 @@ describe('Acceptance: ember generate pod', function() {
       .to.contain("proxies.forEach(function(route) { route(app); });");
 
     expect(file('server/proxies/foo.js'))
-      .to.contain("var proxyPath = '/foo';\n" +
+      .to.contain("const proxyPath = '/foo';\n" +
                   "\n" +
                   "module.exports = function(app) {\n" +
                   "  // For options, see:\n" +
                   "  // https://github.com/nodejitsu/node-http-proxy\n" +
-                  "  var proxy = require('http-proxy').createProxyServer({});\n" +
+                  "  let proxy = require('http-proxy').createProxyServer({});\n" +
                   "\n" +
                   "  proxy.on('error', function(err, req) {\n" +
                   "    console.error(err, req.url);\n" +

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ ember-cli-babel@^5.1.3:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-blueprint-test-helpers@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.17.0.tgz#fa984b6b7ba616d959b6a14c3a9ba3e242b51023"
+ember-cli-blueprint-test-helpers@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.17.1.tgz#37b5ace0d828bb4da3d319adc70cc6d5ca81bc50"
   dependencies:
     chai "^3.3.0"
     chai-as-promised "^6.0.0"
@@ -1465,7 +1465,7 @@ ember-cli-blueprint-test-helpers@^0.17.0:
     ember-cli-internal-test-helpers "^0.9.1"
     exists-sync "0.0.3"
     findup "^0.1.5"
-    fs-extra "^0.30.0"
+    fs-extra "^2.1.0"
     lodash.merge "^4.4.0"
     rsvp "^3.0.17"
     tmp-sync "^1.0.0"
@@ -2207,7 +2207,7 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^2.1.2:
+fs-extra@^2.1.0, fs-extra@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
   dependencies:


### PR DESCRIPTION
This will remove all left over usage of `var` off the blueprints.

When to use `const` vs. `let` is a matter of opinions obviously. After checking with @Turbo87 on Slack, I was assuming the `ember-suave`-like rules of `const` in module root, `let` otherwise would be appropriate. Although in some cases we have `require` statements in a function body, so used `const` there as well. Hope that makes sense...

There will be some test failures, as this is relying on https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/104 to be merged and released. So don't merge yet! 