### PR TITLE
Add changelog to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 /*.*
 !.travis.yml
 !appveyor.yml
+/CHANGELOG.md


### PR DESCRIPTION
While searching for large files in a default Ember project, I'd noticed a few in `ember-cli`:

```
➜  ember_test git:(master) ✗ find ./node_modules/ember-cli -type f | xargs du -sh | grep '^\d*[KM]' | sort -rn       
296K    ./node_modules/ember-cli/CHANGELOG.md
248K    ./node_modules/ember-cli/node_modules/underscore.string/test/test_underscore/vendor/jquery.js
```

Would it be possible to add the changelog to the NPM Ignore, or a similar globbing pattern to catch it?

I'll file a separate issue for `underscore.string`.

Thanks for your time!