### PR TITLE
Ignore files created by Ember-Try

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -15,3 +15,8 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try


### PR DESCRIPTION
Ember-Try creates a number of temporary files within a project during its test runs. This can cause IDEs & Version Control Tools to try and scan the files, which uses unnecessary resources on the system. Additionally, if Ember-Try exits unexpectedly, some of these files may not be cleaned up correctly, leaving them around to be accidentally committed.

Adding these files to `.gitignore` will alleviate both problems, given the intentional temporary nature of the files.