### PR TITLE
Fix dirty git state

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -69,7 +69,7 @@ module.exports = {
     let bowerPath = path.join(this.path, 'files', 'bower.json');
 
     [packagePath, bowerPath].forEach(filePath => {
-      fs.remove(filePath);
+      fs.removeSync(filePath);
     });
   },
 


### PR DESCRIPTION
This fixes #6909. Inside of the `afterInstall` hook, we were using the async methods of fs-extra (`.remove()`) but not actually waiting for them to resolve. Instead, we use the sync variant to resolve the issue, as this ensures the file has been removed before we proceed.