### PR TITLE
Stop creating recursive symlink (addon requiring itself)

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -7,7 +7,6 @@ const fs = require('fs-extra');
 const spawn = require('child_process').spawn;
 const chalk = require('chalk');
 
-const symlinkOrCopySync = require('symlink-or-copy').sync;
 const runCommand = require('../helpers/run-command');
 const ember = require('../helpers/ember');
 const copyFixtureFiles = require('../helpers/copy-fixture-files');

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -71,12 +71,7 @@ describe('Acceptance: addon-smoke-test', function() {
     // add HTMLBars for templates (generators do this automatically when components/templates are added)
     packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
-    // build with addon deps being developed
-    packageJson.dependencies['developing-addon'] = 'latest';
-
     fs.writeJsonSync(packageJsonPath, packageJson);
-
-    symlinkOrCopySync(path.resolve('../../tests/fixtures/addon/developing-addon'), path.join(addonRoot, 'node_modules', 'developing-addon'));
 
     let result = yield runCommand('node_modules/ember-cli/bin/ember', 'build');
 


### PR DESCRIPTION
When running the `addon/smoke-test-slow` test in isolation, I was getting an `EEXIST` error that the `node_modules/developing-addon` symlink that we were creating manually in this test is already present. Deleting the extra test setup resolved the issue.

This just impacts the test suite and was a precursor to #6911.  

Many thanks to @Turbo87 for helping to track this down :heart: 