### PR TITLE
Run YUIDoc on single `it`

### DIFF
--- a/tests/unit/docs-lint-test.js
+++ b/tests/unit/docs-lint-test.js
@@ -9,37 +9,37 @@ describe('YUIDoc', function() {
   });
   let yuiDoc = new Y.YUIDoc(options);
 
-  let json = yuiDoc.run();
+  it('parses without warnings', function() {
+    let json = yuiDoc.run();
 
-  let warnings = {};
-  json.warnings.forEach(function(warning) {
-    let tmp = warning.line.split(':');
-    let file = tmp[0].trim();
-    let line = tmp[1];
+    let warnings = {};
+    json.warnings.forEach(function(warning) {
+      let tmp = warning.line.split(':');
+      let file = tmp[0].trim();
+      let line = tmp[1];
 
-    if (!warnings[file]) {
-      warnings[file] = [];
-    }
-
-    warnings[file].push({
-      line,
-      message: warning.message,
-    });
-  });
-
-  Object.keys(json.files).forEach(function(file) {
-    it(file, function() {
-      let fileWarnings = warnings[file];
-      if (fileWarnings) {
-        let message = `YUIDoc issues found:${EOL}${EOL}`;
-        fileWarnings.forEach(function(warning) {
-          message += `line ${warning.line}: ${warning.message}${EOL}`;
-        });
-
-        let error = new Error(message);
-        delete error.stack;
-        throw error;
+      if (!warnings[file]) {
+        warnings[file] = [];
       }
+
+      warnings[file].push({
+        line,
+        message: warning.message,
+      });
     });
+
+    let message = '';
+    Object.keys(warnings).forEach(function(file) {
+      message += `\t${file} – YUIDoc issues found:${EOL}${EOL}`;
+      warnings[file].forEach(function(warning) {
+        message += `\t\tline ${warning.line}: ${warning.message}${EOL}`;
+      });
+    });
+
+    if (message.length) {
+      let error = new Error(message);
+      delete error.stack;
+      throw error;
+    }
   });
 });


### PR DESCRIPTION
Second part of https://github.com/ember-cli/ember-cli/issues/6565
Currently we lint docs even when explicitly passing a glob for specific files. This PR changes that behaviour, skipping doc linting in that case and keeping it for the `all` and `lint` options