### PR TITLE
Do not use `chalk.white` when displaying asset sizes

### DIFF
--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -23,7 +23,7 @@ class AssetPrinterSize {
             sizeOutput += ` (${filesize(file.gzipSize)} gzipped)`;
           }
 
-          ui.writeLine(chalk.blue(` - ${file.name}: `) + chalk.white(sizeOutput));
+          ui.writeLine(chalk.blue(` - ${file.name}: `) + sizeOutput);
         });
       } else {
         ui.writeLine(chalk.red(`No asset files found in the path provided: ${this.outputPath}`));


### PR DESCRIPTION
White text is not readable on white/light terminals.

Before:

![before](https://cloud.githubusercontent.com/assets/80978/24433613/5aa2f5a6-1400-11e7-96a4-4c1731574c37.png)

After:

![after](https://cloud.githubusercontent.com/assets/80978/24433628/668f2466-1400-11e7-97bf-a856feb6838d.png)
