### PR TITLE
test node 4 instead of 6

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "4"
 
 sudo: false
 

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "4"
 
 sudo: false
 <% if (yarn) { %>

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 <% if (yarn) { %>


### PR DESCRIPTION
Scenario: I'm changing my addon's index.js. I've introduced node 6 syntax unknowingly. Since I'm running node 6 locally and our Travis blueprints test node 6 only, it remains broken until someone starts using the addon in node 4.

Downside: It slows down Travis runs. (We could manually install npm 3/4 in Travis to speed it up again)

Thoughts?