### PR TITLE
make blueprint files public

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -231,6 +231,7 @@ let Blueprint = CoreObject.extend({
   /**
     Used to retrieve files for blueprint.
 
+    @public
     @method files
     @return {Array} Contents of the blueprint's files directory
   */


### PR DESCRIPTION
We use it ([here](https://github.com/ember-cli/ember-cli/blob/master/blueprints/server/index.js#L30)), and is more useful now that we have good support for choices in linting and testing (different config files).