### PR TITLE
[BUGFIX] Do not set committer for the initial git commit

### DIFF
--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -12,7 +12,6 @@ const Promise = RSVP.Promise;
 class GitInitTask extends Task {
   run(_commandOptions) {
     let commandOptions = _commandOptions || {};
-    const template = require('lodash.template');
     const chalk = require('chalk');
     let ui = this.ui;
 
@@ -26,11 +25,7 @@ class GitInitTask extends Task {
 
       return this._gitInit()
         .then(() => this._gitAdd())
-        .then(() => {
-          let commitTemplate = fs.readFileSync(path.join(__dirname, '../utilities/COMMIT_MESSAGE.txt'));
-          let commitMessage = template(commitTemplate)(pkg);
-          return this._gitCommit(commitMessage);
-        })
+        .then(() => this._gitCommit())
         .then(() => ui.writeLine(chalk.green('Successfully initialized git.')));
     })
       .catch(error => {
@@ -53,8 +48,19 @@ class GitInitTask extends Task {
     return execa('git', ['add', '.']);
   }
 
-  _gitCommit(commitMessage) {
-    return execa('git', ['commit', '-m', commitMessage], { env: this.buildGitEnvironment() });
+  _gitCommit() {
+    const template = require('lodash.template');
+    let commitTemplate = fs.readFileSync(path.join(__dirname, '../utilities/COMMIT_MESSAGE.txt'));
+    let commitMessage = template(commitTemplate)(pkg);
+    let env = this.buildGitEnvironment();
+    return execa('git', ['commit', '-m', commitMessage], { env })
+      .catch(error => {
+        if (error.message.indexOf('git config --global user') > -1) {
+          env.GIT_COMMITTER_NAME = 'Tomster';
+          env.GIT_COMMITTER_EMAIL = 'tomster@emberjs.com';
+          return execa('git', ['commit', '-m', commitMessage], { env });
+        }
+      });
   }
 
   buildGitEnvironment() {
@@ -63,8 +69,6 @@ class GitInitTask extends Task {
     return Object.assign({}, process.env, {
       GIT_AUTHOR_NAME: 'Tomster',
       GIT_AUTHOR_EMAIL: 'tomster@emberjs.com',
-      GIT_COMMITTER_NAME: 'Tomster',
-      GIT_COMMITTER_EMAIL: 'tomster@emberjs.com',
     });
   }
 }

--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -55,7 +55,7 @@ class GitInitTask extends Task {
     let env = this.buildGitEnvironment();
     return execa('git', ['commit', '-m', commitMessage], { env })
       .catch(error => {
-        if (error.message.indexOf('git config --global user') > -1) {
+        if (error && error.message && error.message.indexOf('git config --global user') > -1) {
           env.GIT_COMMITTER_NAME = 'Tomster';
           env.GIT_COMMITTER_EMAIL = 'tomster@emberjs.com';
           return execa('git', ['commit', '-m', commitMessage], { env });

--- a/tests/unit/tasks/git-init-test.js
+++ b/tests/unit/tasks/git-init-test.js
@@ -52,13 +52,13 @@ describe('git-init', function() {
     td.when(task._gitVersion()).thenResolve();
     td.when(task._gitInit()).thenResolve();
     td.when(task._gitAdd()).thenResolve();
-    td.when(task._gitCommit(td.matchers.anything())).thenResolve();
+    td.when(task._gitCommit()).thenResolve();
 
     return task.run().then(function() {
       td.verify(task._gitVersion());
       td.verify(task._gitInit());
       td.verify(task._gitAdd());
-      td.verify(task._gitCommit(td.matchers.anything()));
+      td.verify(task._gitCommit());
 
       expect(task.ui.output).to.contain('Successfully initialized git.');
       expect(task.ui.errors).to.equal('');


### PR DESCRIPTION
As discussed in #6920, setting the git committer for the initial commit can trigger a gpg error which prevents the project from being created.
Setting only the git author and not the git committer should fix this issue and is also semantically more correct as the first commit is authored by emberjs-cli but is committed by the user.

Resolves #6920