### PR TITLE
[BUGFIX release] Include ember-testing.js when using ember-source

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -289,12 +289,14 @@ EmberApp.prototype._initVendorFiles = function() {
   let bowerEmberCliShims = bowerDeps['ember-cli-shims'];
   let developmentEmber;
   let productionEmber;
+  let emberTesting;
   let emberShims = null;
   let jquery;
 
   if (ember) {
     developmentEmber = ember.paths.debug;
     productionEmber = ember.paths.prod;
+    emberTesting = ember.paths.testing;
     emberShims = ember.paths.shims;
     jquery = ember.paths.jquery;
   } else {
@@ -311,6 +313,8 @@ EmberApp.prototype._initVendorFiles = function() {
     if (!existsSync(this._resolveLocal(developmentEmber))) {
       developmentEmber = `${this.bowerDirectory}/ember/ember.js`;
     }
+
+    emberTesting = `${this.bowerDirectory}/ember/ember-testing.js`;
   }
 
   let handlebarsVendorFiles;
@@ -331,7 +335,7 @@ EmberApp.prototype._initVendorFiles = function() {
       production: productionEmber,
     },
     'ember-testing.js': [
-      `${this.bowerDirectory}/ember/ember-testing.js`,
+      emberTesting,
       { type: 'test' },
     ],
     'app-shims.js': emberShims,
@@ -359,9 +363,10 @@ EmberApp.prototype._initVendorFiles = function() {
     this.project.ui.writeWarnLine('You have not included `ember-cli-shims` in your project\'s `bower.json` or `package.json`. This only works if you provide an alternative yourself and unset `app.vendorFiles[\'app-shims.js\']`.');
   }
 
-  // this is needed to support versions of Ember older than
-  // 1.8.0 (when ember-testing.js was added to the deployment)
-  if (this.vendorFiles['ember-testing.js'] && !existsSync(this.vendorFiles['ember-testing.js'][0])) {
+  // If ember-testing.js is coming from Bower (not ember-source) and it does not
+  // exist, then we remove it from vendor files. This is needed to support versions
+  // of Ember older than 1.8.0 (when ember-testing.js was incldued in ember.js itself)
+  if (!ember && this.vendorFiles['ember-testing.js'] && !existsSync(this.vendorFiles['ember-testing.js'][0])) {
     delete this.vendorFiles['ember-testing.js'];
   }
 };


### PR DESCRIPTION
This is dependent on https://github.com/emberjs/ember.js/pull/15112 to expose `ember.paths.testing`.