### PR TITLE
Discover dependencies of npm-linked addons

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -9,6 +9,7 @@ const existsSync = require('exists-sync');
 const path = require('path');
 const resolve = require('resolve');
 const heimdall = require('heimdalljs');
+const fs = require('fs');
 
 /**
   AddonDiscovery is responsible for collecting information about all of the
@@ -198,7 +199,7 @@ class AddonDiscovery {
         logger.info(' - is addon, adding...');
         let addonInfo = {
           name: addonPkg.name,
-          path: addonPath,
+          path: fs.realpathSync(addonPath),
           pkg: addonPkg,
         };
         return addonInfo;

--- a/tests/fixtures/addon/simple/node_modules/.gitignore
+++ b/tests/fixtures/addon/simple/node_modules/.gitignore
@@ -1,0 +1,1 @@
+symlinked-addon


### PR DESCRIPTION
This alters our addon resolution strategy to match node's behavior. Node always resolves symlinks.

This fixes the case where you have an npm-linked dependency with its own dependencies. Today those grandchild dependencies are silently dropped.

I can do a test too. Does it make sense to extend nested-addons-smoke-test-slow so it includes a symlinked addon?