### PR TITLE
Preserve header key case when serving with proxy

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -17,6 +17,7 @@ class ProxyServerAddon {
         secure: options.secureProxy,
         changeOrigin: true,
         xfwd: options.transparentProxy,
+        preserveHeaderKeyCase: true,
       });
 
       proxy.on('error', e => {


### PR DESCRIPTION
Still missing a test for this but not entirely sure where.

---

Fixes #6960

Recap: When running `ember server` with the `--proxy` option [http-proxy](https://github.com/nodejitsu/node-http-proxy) is used as a middleware for those requests. By default `http-proxy` lower cases all header keys. Ran into issue where I was expecting `X-REQUEST-ID` sent in uppercase from the API, but when developing using `--proxy` it introduced that header has `x-request-id` instead.