### PR TITLE
Fallback for toYarnArgs in npm-task.js produces invalid yarn command

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -196,7 +196,8 @@ class NpmTask extends Task {
 
   toYarnArgs(command, options) {
     let args = [];
-    if (command === 'install') {
+
+    if (command === 'install' && ) {
       if (options.save) {
         args.push('add');
       } else if (options['save-dev']) {
@@ -212,7 +213,6 @@ class NpmTask extends Task {
       if ('optional' in options && !options.optional) {
         args.push('--ignore-optional');
       }
-
     } else if (command === 'uninstall') {
       args.push('remove');
 


### PR DESCRIPTION
This was found while debugging a yarn related issue in Ember Electron. This was not very visible as most authors would probably include either the save or the save-dev flag, but as we had a typo in there in lead to an interesting bug hunt.

The else clause produced a no longer valid yarn invocation as `yarn install` is no longer deprecated but removed.