### PR TITLE
ENHANCEMENT: throw when converting `npm install foo` to `yarn install foo`

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -196,11 +196,14 @@ class NpmTask extends Task {
 
   toYarnArgs(command, options) {
     let args = [];
+
     if (command === 'install') {
       if (options.save) {
         args.push('add');
       } else if (options['save-dev']) {
         args.push('add', '--dev');
+      } else if (options.packages) {
+        throw new Error(`NPM command "${command} ${options.packages.join(' ')}" can not be translated to Yarn command`);
       } else {
         args.push('install');
       }
@@ -212,7 +215,6 @@ class NpmTask extends Task {
       if ('optional' in options && !options.optional) {
         args.push('--ignore-optional');
       }
-
     } else if (command === 'uninstall') {
       args.push('remove');
 

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -236,5 +236,9 @@ describe('NpmTask', function() {
 
       return expect(args).to.deep.equal(['remove', 'bar']);
     });
+
+    it('throws when "yarn install" is called with packages', function() {
+      return expect(() => task.toYarnArgs('install', { packages: ['foo'] })).to.throw(Error, /install foo/);
+    });
   });
 });


### PR DESCRIPTION
This was found while debugging a yarn related issue in Ember Electron. This was not very visible as most authors would probably include either the save or the save-dev flag, but as we had a typo in there in lead to an interesting bug hunt.

`npm install foo` installs a package without saving it to package.json which is not an option in yarn (at least none that I know of). Therefore `yarn install foo` is no longer an equivalent command. 

This changed rather recently as `yarn` printed a deprecation warning pointing to `yarn add` before, but this is no longer the case in 0.23.2.