### PR TITLE
Update ember-ajax to v3.0.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "^2.4.1",
+    "ember-ajax": "^3.0.0",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.0.0",


### PR DESCRIPTION
This version of ember-ajax brings Babel 6 along with a breaking change around `normalizeErrorResponse`.

See https://github.com/ember-cli/ember-ajax/releases/tag/v3.0.0 for more details.