### PR TITLE
Adds yarn-error.log to gitignore in the app blueprint

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -14,6 +14,7 @@
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
+yarn-error.log
 testem.log
 
 # ember-try


### PR DESCRIPTION
While updating an app to ember-cli@2.13.0-beta.4 I noticed all/most of the blueprint files prefer yarn over npm now, however, the gitignore was missing this. 