### PR TITLE
[FIXES #6970]: Revert nopt dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "minimatch": "^3.0.0",
     "morgan": "^1.5.2",
     "node-modules-path": "^1.0.0",
-    "nopt": "^4.0.0",
+    "nopt": "^3.0.6",
     "npm-package-arg": "^4.1.1",
     "portfinder": "^1.0.7",
     "promise-map-series": "^0.2.1",

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -83,7 +83,7 @@ let OptionsAliasCommand = Command.extend({
   run(options) { return options; },
 });
 
-describe('models/command.js', function() {
+describe.only('models/command.js', function() {
   let ui;
   let config;
   let options;
@@ -157,6 +157,19 @@ describe('models/command.js', function() {
 
   it('parseArgs() should parse shorthand dasherized options.', function() {
     expect(new ServeCommand(options).parseArgs(['-lr', 'false'])).to.have.deep.property('options.liveReload', false);
+  });
+
+  it('parseArgs() should parse string options.', function() {
+    let CustomAliasCommand = Command.extend({
+      name: 'custom-alias',
+      availableOptions: [{
+        name: 'options',
+        type: String,
+      }],
+      run(options) { return options; },
+    });
+    const command = new CustomAliasCommand(options).parseArgs(['1', '--options', '--split 2 --random']);
+    expect(command).to.have.deep.property('options.options', '--split 2 --random');
   });
 
   describe('#validateAndRun', function() {

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -83,7 +83,7 @@ let OptionsAliasCommand = Command.extend({
   run(options) { return options; },
 });
 
-describe.only('models/command.js', function() {
+describe('models/command.js', function() {
   let ui;
   let config;
   let options;

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,10 +191,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
@@ -612,9 +608,9 @@ broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.3:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-broccoli-middleware@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-0.18.1.tgz#bf525581c2deb652c425942b18580f76d3748122"
+broccoli-middleware@^1.0.0-beta.8:
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0-beta.8.tgz#89cb6a9950ff0cf5bd75071d83d7cd6f6a11a95b"
   dependencies:
     handlebars "^4.0.4"
     mime "^1.2.11"
@@ -3329,18 +3325,11 @@ node-uuid@~1.4.0:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
 
-nopt@3.x:
+nopt@3.x, nopt@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
     abbrev "1"
-
-nopt@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-path@^2.0.1:
   version "2.0.1"
@@ -3464,7 +3453,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@^0.1.0, osenv@^0.1.3, osenv@^0.1.4:
+osenv@^0.1.0, osenv@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   dependencies:
@@ -3649,13 +3638,9 @@ q@^1.1.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
 
-qs@6.2.0:
+qs@6.2.0, qs@^6.0.2, qs@^6.1.0, qs@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
-
-qs@^6.0.2, qs@^6.1.0, qs@^6.2.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
 qs@~1.0.0:
   version "1.0.2"
@@ -3722,20 +3707,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
Revert ```nopt``` dependency update.
Adds a unit test to prevent updating to 4.x before it's fixed upstream.

Currently, 4.0.1 will fail
```
1) models/command.js parseArgs() should parse string options.:
   AssertionError: expected { Object (options, args) } to have a deep property 'options.options' of '--split 2 --random', but got ''
    at Context.<anonymous> (tests/unit/models/command-test.js:165:34)
```
Fixes #6970

