### PR TITLE
Add yarn to ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ it will make it easier for us to track down the issue you're having.
 
 ---
 
-Output from `ember version --verbose && npm --version`:
+Output from `ember version --verbose && npm --version && yarn --version`:
 ```
 [Replace this line with the output.]
 ```


### PR DESCRIPTION
Now that ember-cli supports using yarn, it is likely that more issues will come through with regards to yarn usage and integration with ember-cli. Because of that, we should ask users to include their yarn version number in issue reports. If they are not using yarn, we'll simply see a "command not found" message as the last line in the output.

## yarn installed
```
ember version --verbose && npm --version && yarn --version
ember-cli: 2.13.0
http_parser: 2.7.0
node: 6.10.2
v8: 5.1.281.98
uv: 1.9.1
zlib: 1.2.11
ares: 1.10.1-DEV
icu: 58.2
modules: 48
openssl: 1.0.2k
os: darwin x64
3.10.10
0.23.3
```

## yarn not installed
```
ember version --verbose && npm --version && yarn --version
ember-cli: 2.13.0
http_parser: 2.7.0
node: 6.10.2
v8: 5.1.281.98
uv: 1.9.1
zlib: 1.2.11
ares: 1.10.1-DEV
icu: 58.2
modules: 48
openssl: 1.0.2k
os: darwin x64
3.10.10
zsh: command not found: yarn
```