### PR TITLE
update from npm 2 when using node 4

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -35,7 +35,8 @@ install:
   - yarn install --no-lockfile
 <% } else { %>before_install:
   - npm config set spin false
-  - npm install -g phantomjs-prebuilt
+  - npm install -g npm phantomjs-prebuilt
+  - npm --version
   - phantomjs --version
 
 install:


### PR DESCRIPTION
Addresses https://github.com/ember-cli/ember-cli/pull/6930#issuecomment-298063946

Only thing worth debating is this will skip npm 3 and go straight to 4. This seems like a good thing, since we also get Travis's latest yarn if we go the alternate route.

cc @Turbo87 