### PR TITLE
Updated npm version for ember-data to use ~ instead of ^

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.13.0",
+    "ember-data": "~2.13.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",


### PR DESCRIPTION
Users should explicitly move from minor version to minor version, rather than automatically jumping to whatever is newest.