### PR TITLE
Ensure addon blueprint calls `this.filesPath`

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -125,7 +125,9 @@ module.exports = {
 
   files() {
     let appFiles = this.lookupBlueprint('app').files();
-    let addonFiles = walkSync(path.join(this.path, 'files'));
+
+    let addonFilesPath = this.filesPath(this.options);
+    let addonFiles = walkSync(addonFilesPath);
 
     return uniq(appFiles.concat(addonFiles));
   },


### PR DESCRIPTION
Ensures that the default `addon` blueprint honours the `filesPath()` method that was introduced in #4837