### PR TITLE
Ensure `lintTree` results cannot clobber tests.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1148,13 +1148,11 @@ class EmberApp {
     @method appTests
   */
   appTests(coreTestTree) {
-    let appTestTrees = [coreTestTree];
-
-    if (this.hinting) {
-      Array.prototype.push.apply(appTestTrees, this.lintTestTrees());
-    }
-
-    appTestTrees.push(this._processedEmberCLITree());
+    let appTestTrees = [].concat(
+      this.hinting && this.lintTestTrees(),
+      this._processedEmberCLITree(),
+      coreTestTree
+    ).filter(Boolean);
 
     appTestTrees = this._mergeTrees(appTestTrees, {
       overwrite: true,

--- a/tests/unit/broccoli/ember-app/test-test.js
+++ b/tests/unit/broccoli/ember-app/test-test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const co = require('co');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+
+const EmberApp = require('../../../../lib/broccoli/ember-app');
+const MockCLI = require('../../../helpers/mock-cli');
+const Project = require('../../../../lib/models/project');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+const walkSync = require('walk-sync');
+const stew = require('broccoli-stew');
+
+describe('EmberApp#test', function() {
+  let input;
+
+  beforeEach(co.wrap(function *() {
+    input = yield createTempDir();
+
+    input.write({
+      'config': {
+        'environment.js': `module.exports = function() { return { modulePrefix: 'test-app' }; };`,
+      },
+    });
+  }));
+
+  afterEach(function() {
+    return input.dispose();
+  });
+
+  function createApp(options) {
+    options = options || {};
+
+    let pkg = { name: 'ember-app-test' };
+
+    let cli = new MockCLI();
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+
+    return new EmberApp({
+      project,
+      name: pkg.name,
+      _ignoreMissingLoader: true,
+      sourcemaps: { enabled: false },
+    }, options);
+  }
+
+  it('emits dist/assets/tests.js by default', co.wrap(function *() {
+    input.write({
+      'tests': {
+        'test-helper.js': '// test-helper.js',
+      },
+    });
+
+    let app = createApp();
+    let output = yield buildOutput(app.test());
+
+    let files = walkSync(output.path(), { directories: false });
+    expect(files).to.deep.equal([
+      'assets/test-support.js',
+      'assets/tests.js',
+      'testem.js',
+    ]);
+  }));
+
+  it('lintTree results do not "win" over app tests', co.wrap(function *() {
+    input.write({
+      'app': { },
+      'tests': {
+        'integration': {
+          'components': {
+            'foo-bar-test.js': '// foo-bar-test.js',
+          },
+        },
+      },
+    });
+
+    let app = createApp();
+
+    // create a fake addon that has a `lintTree`
+    app.project.addons.push({
+      // this lintTree implementation will return the same
+      // files as the input tree, but the contents will be
+      // different
+      lintTree(type, tree) {
+        return stew.map(tree, string => string.toUpperCase());
+      },
+    });
+
+    let output = yield buildOutput(app.test());
+
+    // confirm this contains the original value
+    // unmodified by the `lintTree` added above
+    expect(output.read().assets['tests.js']).to.include('// foo-bar-test.js');
+  }));
+});


### PR DESCRIPTION
The prior logic resulted in the result of `lintTree` being **after** the actual processed `tests/` tree. When those trees were then passed to `MergeTrees` the `lintTree` result would clobber the normal processed `tests/` tree. In general, when a linter is actually emitting linting tests, this is fine because the files that it emits are not the same names as the original (e.g. `tests/test-helper.js` becomes `tests/test-helper.lint-test.js`), but when the `lintTree` implementation does not emit different names than the input tree the `lintTree` versions "win".

In Ember CLI < 2.13, this setup still worked properly because we would fully process the result of `lintTree` through the consuming applications JS processor pipeline (e.g. babel). This _sounds_ neat but actually means that we were transpiling all of `tests/` twice.

In Ember CLI 2.13 and above, we only process the result of `lintTree` for modules (not a full "transpile down to ES5"). This means that any babel processing that would have been done for `tests/` normally is thrown away when the transpiled versions are clobbered by the untranspiled `lintTree`.

This change corrects the ordering of trees, so that the correctly proccessed `tests/` tree "wins" when the `lintTree` tree emits files with the same names.