### PR TITLE
[BUGFIX release] Revert rawMode to original value during windows signals cleanup

### DIFF
--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -8,7 +8,7 @@
 let exit = require('capture-exit');
 exit.captureExit();
 
-let windowsCtrlCTrap;
+let windowsCtrlCTrap, originalIsRaw;
 let handlers = [];
 
 module.exports = {
@@ -81,7 +81,8 @@ function setupSignalsTrap() {
   process.on('SIGINT', _exit);
   process.on('SIGTERM', _exit);
   process.on('message', onMessage);
-  if (/^win/.test(process.platform)) {
+
+  if (isWindowsTTY()) {
     trapWindowsSignals();
   }
 }
@@ -95,7 +96,8 @@ function teardownSignalsTrap() {
   process.removeListener('SIGINT', _exit);
   process.removeListener('SIGTERM', _exit);
   process.removeListener('message', onMessage);
-  if (/^win/.test(process.platform)) {
+
+  if (isWindowsTTY()) {
     cleanupWindowsSignals();
   }
 }
@@ -106,22 +108,31 @@ function teardownSignalsTrap() {
  * @method trapWindowsSignals
  */
 function trapWindowsSignals() {
+  const stdin = process.stdin;
+
+  originalIsRaw = stdin.isRaw;
+
   // This is required to capture Ctrl + C on Windows
-  if (process.stdin && process.stdin.isTTY) {
-    process.stdin.setRawMode(true);
-    windowsCtrlCTrap = function(data) {
-      if (data.length === 1 && data[0] === 0x03) {
-        process.emit('SIGINT');
-      }
-    };
-    process.stdin.on('data', windowsCtrlCTrap);
-  }
+  stdin.setRawMode(true);
+
+  windowsCtrlCTrap = function(data) {
+    if (data.length === 1 && data[0] === 0x03) {
+      process.emit('SIGINT');
+    }
+  };
+  stdin.on('data', windowsCtrlCTrap);
 }
 
 function cleanupWindowsSignals() {
-  if (windowsCtrlCTrap && process.stdin.removeListener) {
-    process.stdin.removeListener('data', windowsCtrlCTrap);
-  }
+  const stdin = process.stdin;
+
+  stdin.setRawMode(originalIsRaw);
+
+  stdin.removeListener('data', windowsCtrlCTrap);
+}
+
+function isWindowsTTY() {
+  return (/^win/).test(process.platform) && process.stdin && process.stdin.isTTY;
 }
 
 /**

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -60,8 +60,8 @@ function createTestTargets(projectName, options) {
     .then(() => {
       if (options.createESLintConfig) {
         let eslintConfig = `module.exports = {
-          root: true, 
-          parserOptions: { 
+          root: true,
+          parserOptions: {
             sourceType: 'module'
           },
         };`;

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -160,14 +160,41 @@ describe('will interrupt process', function() {
           isTTY: true,
           on: td.function(),
           setRawMode: td.function(),
+          removeListener: td.function(),
         },
       });
 
       let windowsCtrlCTrap = td.matchers.isA(Function);
 
       willInterruptProcess.addHandler(cb);
-      td.verify(process.stdin.setRawMode(true));
       td.verify(process.stdin.on('data', windowsCtrlCTrap));
+    });
+
+    it('adds and reverts rawMode on Windows', function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'win',
+      });
+
+      Object.defineProperty(process, 'stdin', {
+        value: {
+          isRaw: false,
+          isTTY: true,
+          on: td.function(),
+          setRawMode: td.function(),
+          removeListener: td.function(),
+        },
+      });
+
+      willInterruptProcess.addHandler(cb);
+      td.verify(process.stdin.setRawMode(true));
+
+      willInterruptProcess.removeHandler(cb);
+      td.verify(process.stdin.setRawMode(false));
+
+      td.verify(process.stdin.setRawMode(), {
+        ignoreExtraArgs: true,
+        times: 2,
+      });
     });
 
     it('does not enable raw capture on non-Windows', function() {
@@ -180,6 +207,7 @@ describe('will interrupt process', function() {
           isTTY: true,
           on: td.function(),
           setRawMode: td.function(),
+          removeListener: td.function(),
         },
       });
 
@@ -196,5 +224,4 @@ describe('will interrupt process', function() {
       });
     });
   });
-
 });


### PR DESCRIPTION
I've noticed `ember-data` node-tests hangs forever without an ability to _CTRL+C_ while running on Windows.

The reason for this is that `will-interrupt-process` doesn't revert original `isRaw`. This pr includes reverting of the `rawMode` to its original value which allows you to kill the process with _CTRL+C_

**How to test**:
First you need Windows. 
Put this script in the root of any ember app or addon:
```js
// win-hang.js
const ember = require('ember-cli/tests/helpers/ember');

// this ends up with an exception in `ember` test helper
ember(['g', 'ember']);
```
And then run it `node win-hang.js`.

**Expected**: the process finishes
**Actual**: the process hangs. Unable to kill the process even by pressing _CTRL+C_

tested on win10. 