### PR TITLE
Prevent duplicate AddonDiscovery work

### DIFF
--- a/lib/models/addon-discovery.js
+++ b/lib/models/addon-discovery.js
@@ -11,7 +11,10 @@ const path = require('path');
 const resolve = require('resolve');
 const findup = require('find-up');
 const heimdall = require('heimdalljs');
-
+const PACKAGE_CACHE = Object.create(null);
+const AT_PATH_CACHE = Object.create(null);
+const FROM_DEPS_CACHE = Object.create(null);
+const FROM_IN_REPO_DEPS_CACHE = Object.create(null);
 /**
   AddonDiscovery is responsible for collecting information about all of the
   addons that will be used with a project.
@@ -20,7 +23,7 @@ const heimdall = require('heimdalljs');
   @extends CoreObject
   @constructor
 */
-class AddonDiscovery {
+module.exports = class AddonDiscovery {
   constructor(ui) {
     this.ui = ui;
   }
@@ -110,8 +113,15 @@ class AddonDiscovery {
     @method discoverFromDependencies
    */
   discoverFromDependencies(root, nodeModulesPath, pkg, excludeDevDeps) {
+    let key = `${root}|${nodeModulesPath}|${pkg.name}|${excludeDevDeps}`;
+    let entry = FROM_DEPS_CACHE[key];
+
+    if (entry !== undefined) {
+      return entry;
+    }
+
     let discovery = this;
-    let addons = Object.keys(this.dependencies(pkg, excludeDevDeps)).map(function(name) {
+    let addons = Object.freeze(Object.keys(this.dependencies(pkg, excludeDevDeps)).map(function(name) {
       if (name !== 'ember-cli') {
         let addonPath = this.resolvePackage(root, name);
 
@@ -131,18 +141,25 @@ class AddonDiscovery {
           return addon;
         }
       }
-    }, this).filter(Boolean);
-    return addons;
+    }, this).filter(Boolean));
+
+    return (FROM_DEPS_CACHE[key] = addons);
   }
 
   resolvePackage(root, packageName) {
-    try {
+    let cacheKey = `${packageName}|${root}`;
+    let cacheEntry = PACKAGE_CACHE[cacheKey];
+    if (cacheEntry) {
+      return cacheEntry.path;
+    }
+    cacheEntry = PACKAGE_CACHE[cacheKey] = { path: null };
 
+    try {
       let entryModulePath = resolve.sync(packageName, { basedir: root });
 
       let pkgPath = findup.sync('package.json', { cwd: entryModulePath });
       if (pkgPath) {
-        return path.dirname(pkgPath);
+        return (cacheEntry.path = path.dirname(pkgPath));
       }
 
     } catch (e) {
@@ -162,13 +179,21 @@ class AddonDiscovery {
     @method discoverInRepoAddons
    */
   discoverInRepoAddons(root, pkg) {
-    if (!pkg || !pkg['ember-addon'] || !pkg['ember-addon'].paths) {
-      return [];
+    let key = `${root}|${pkg.name}`;
+    let entry = FROM_IN_REPO_DEPS_CACHE[key];
+    if (entry !== undefined) {
+      return entry;
     }
 
-    return pkg['ember-addon'].paths
+    if (!pkg || !pkg['ember-addon'] || !pkg['ember-addon'].paths) {
+      return (FROM_IN_REPO_DEPS_CACHE[key] = Object.freeze([]));
+    }
+
+    let result = Object.freeze(pkg['ember-addon'].paths
       .map(addonPath => this.discoverAtPath(path.join(root, addonPath)))
-      .filter(Boolean);
+      .filter(Boolean));
+
+    return (FROM_IN_REPO_DEPS_CACHE[key] = result);
   }
 
   /**
@@ -201,10 +226,14 @@ class AddonDiscovery {
    */
   discoverAtPath(addonPath) {
     let pkgPath = path.join(addonPath, 'package.json');
+    let info = AT_PATH_CACHE[pkgPath];
+    if (info !== undefined) {
+      return info;
+    }
     logger.info('attemping to add: %s', addonPath);
 
     if (existsSync(pkgPath)) {
-      const addonPkg = require(pkgPath);
+      let addonPkg = require(pkgPath);
       let keywords = addonPkg.keywords || [];
       logger.info(' - module found: %s', addonPkg.name);
 
@@ -212,12 +241,12 @@ class AddonDiscovery {
 
       if (keywords.indexOf('ember-addon') > -1) {
         logger.info(' - is addon, adding...');
-        let addonInfo = {
+        let addonInfo = Object.freeze({
           name: addonPkg.name,
           path: addonPath,
           pkg: addonPkg,
-        };
-        return addonInfo;
+        });
+        return (AT_PATH_CACHE[pkgPath] = addonInfo);
       } else {
         logger.info(' - no ember-addon keyword, not including.');
       }
@@ -256,6 +285,4 @@ class AddonDiscovery {
 
     return addonPackages;
   }
-}
-
-module.exports = AddonDiscovery;
+};

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -394,6 +394,10 @@ class Project {
     @method discoverAddons
    */
   discoverAddons() {
+    if (this.addonPackages) {
+      return
+    }
+
     let addonsList = this.addonDiscovery.discoverProjectAddons(this);
 
     this.addonPackages = this.addonDiscovery.addonPackages(addonsList);


### PR DESCRIPTION
Apps with nested add-ons and many engines are negatively affected by duplicate add-on discovery work.

This freezes + caches the return values, preventing much duplicate work.