### PR TITLE
Pass only packages to npm uninstall task that exist

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -948,14 +948,14 @@ let Blueprint = CoreObject.extend({
     let task = this.taskFor('npm-uninstall');
     let installText = (packages.length > 1) ? 'uninstall packages' : 'uninstall package';
     let packageNames = [];
-    let packageArray = [];
+
+    let projectDependencies = this.project.dependencies();
 
     for (let i = 0; i < packages.length; i++) {
-      packageNames.push(packages[i].name);
-
-      let packageNameAndVersion = packages[i].name;
-
-      packageArray.push(packageNameAndVersion);
+      let packageName = packages[i].name;
+      if (packageName in projectDependencies) {
+        packageNames.push(packageName);
+      }
     }
 
     this._writeStatusToUI(chalk.green, installText, packageNames.join(', '));
@@ -963,7 +963,7 @@ let Blueprint = CoreObject.extend({
     return task.run({
       'save-dev': true,
       verbose: false,
-      packages: packageArray,
+      packages: packageNames,
     });
   },
 


### PR DESCRIPTION
This is a PR for issue #6999.

`Blueprint.removePackagesFromProject` now checks if package actually exists in project dependencies, if not then does not include it for uninstall procedure.