### PR TITLE
Use beta ember-cli-shims

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,7 +26,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
-    "ember-cli-shims": "^1.1.0",
+    "ember-cli-shims": "^1.2.0-beta.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "~2.13.0",


### PR DESCRIPTION
This beta brings https://github.com/emberjs/rfcs/blob/master/text/0176-javascript-module-api.md support, and deprecates the current shims.