### PR TITLE
remove the implied npm install and test from travis

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -43,9 +43,6 @@ before_install:
   - npm install -g npm phantomjs-prebuilt
   - npm --version
   - phantomjs --version
-
-install:
-  - npm install
 <% } %>
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -26,10 +26,4 @@ cache:
 before_install:
   - npm config set spin false
   - npm install -g phantomjs-prebuilt
-  - phantomjs --version
-
-install:
-  - npm install
-
-script:
-  - npm test<% } %>
+  - phantomjs --version<% } %>


### PR DESCRIPTION
It makes it cleaner, and makes it easier to deal with the evolving `<% if (yarn) { %>` logic.