### PR TITLE
Set the basePort for livereload from 49153 -> 7020

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -9,7 +9,7 @@ const EOL = require('os').EOL;
 
 const Promise = RSVP.Promise;
 
-PortFinder.basePort = 49153;
+PortFinder.basePort = 7020;
 
 let getPort = RSVP.denodeify(PortFinder.getPort);
 let defaultPort = process.env.PORT || 4200;

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -8,8 +8,6 @@ const RSVP = require('rsvp');
 const td = require('testdouble');
 const PortFinder = require('portfinder');
 
-PortFinder.basePort = 32768;
-
 const Promise = RSVP.Promise;
 const getPort = RSVP.denodeify(PortFinder.getPort);
 
@@ -42,8 +40,8 @@ describe('serve command', function() {
     ]).then(function() {
       let captor = td.matchers.captor();
       td.verify(tasks.Serve.prototype.run(captor.capture()), { times: 1 });
-      expect(captor.value.port).to.be.gte(4000, 'has correct port');
-      expect(captor.value.liveReloadPort).to.be.within(32768, 65535, 'has correct liveReload port');
+      expect(captor.value.port).to.be.gte(4200, 'has correct port');
+      expect(captor.value.liveReloadPort).to.be.within(7020, 65535, 'has correct liveReload port');
     });
   });
 
@@ -55,7 +53,7 @@ describe('serve command', function() {
         let captor = td.matchers.captor();
         td.verify(tasks.Serve.prototype.run(captor.capture()), { times: 1 });
         expect(captor.value.port).to.equal(port, 'has correct port');
-        expect(captor.value.liveReloadPort).to.be.within(32768, 65535, 'has correct liveReload port');
+        expect(captor.value.liveReloadPort).to.be.within(7020, 65535, 'has correct liveReload port');
       });
     });
   });
@@ -110,7 +108,7 @@ describe('serve command', function() {
     ]).then(function() {
       let captor = td.matchers.captor();
       td.verify(tasks.Serve.prototype.run(captor.capture()), { times: 1 });
-      expect(captor.value.port).to.be.within(32768, 65535, 'has correct liveReloadPort');
+      expect(captor.value.port).to.be.within(7020, 65535, 'has correct port');
       expect(captor.value.liveReloadPort).to.be.gt(captor.value.port, 'has a liveReload port greater than port');
     });
   });


### PR DESCRIPTION
I have observed that touchbar starts in the range 40,000-60,000. 5020 is
far outside that range, and in the range of open ports in general.

change to basePort to 7020 to fix this