### PR TITLE
Remove reference to "lib/ext/promise" from docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,7 +181,6 @@ module.exports = Task.extend({
 ```
 
 ## Style guide
-- Everything Promise based ( use: lib/ext/promise)
 - Everything async (except require)
 - Short files
 - Tests, tests, tests


### PR DESCRIPTION
it's deprecated now.

Should we promote `rsvp` instead?  