### PR TITLE
Reject on interruption

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -17,6 +17,7 @@ const SilentError = require('silent-error');
 const execSync = require('child_process').execSync;
 const fs = require('fs');
 const existsSync = require('exists-sync');
+const RSVP = require('rsvp');
 
 let cache = {};
 
@@ -197,7 +198,7 @@ let Command = CoreObject.extend({
       return this._currentTask.onInterrupt();
     } else {
       // interrupt all external commands which don't use `runTask()` with an error
-      process.exit(1);
+      return RSVP.reject();
     }
   },
 
@@ -212,15 +213,15 @@ let Command = CoreObject.extend({
   },
 
   /**
-   * Looks up for the task and runs
-   * It also keeps the reference for the current active task
-   * Keeping reference for the current task allows to cleanup task on interruption
+   * Lookup and run the task
+   * Stores the reference to the current task
+   * It allows us to handle task interruption
    *
    * @private
    * @method runTask
    * @throws {Error} when no task found
    * @throws {Error} on attempt to run concurrent task
-   * @param {string} name Task name from the tasks registry. Should be capitalized
+   * @param {string} name `PascalCase` task names
    * @param {object} options
    * @return {Promise} Task run
    */

--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const CoreObject = require('core-object');
+const RSVP = require('rsvp');
 
 class Task extends CoreObject {
   run(/*options*/) {
@@ -8,14 +9,15 @@ class Task extends CoreObject {
   }
 
   /**
-   * Interrupt comamd with an exit code
-   * Called when the process is interrupted from outside, e.g. CTRL+C or `process.kill()`
+   * Reject all the interrupted tasks by default
+   * Called when the process is interrupted from outside(CTRL+C)
    *
    * @private
    * @method onInterrupt
+   * @returns RSVP.Promise
    */
   onInterrupt() {
-    process.exit(1);
+    return RSVP.reject();
   }
 }
 


### PR DESCRIPTION
Signal interruption history is very interesting but complex part of cli.
In short the less `process.exit` we call the better.

In this pr I've replaced `process.exit(1)` invocations in the `Command` and `Task` models with the `Promise.reject()`s. All the interruption promises are handled with `capture-exit`. 