### PR TITLE
[ENHANCEMENT] Fix eslint warning on generated config/environment.js

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -44,7 +44,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // here you can enable a production-specific feature
   }
 
   return ENV;


### PR DESCRIPTION
When opening the generated file config/environment.js with my IDE (with eslint integrated), an empty if is showing an error (the production one)

side note: on the build in ember-cli an empty if is not an error