### PR TITLE
[BUGFIX release] node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "8"
 
 branches:
   only:
@@ -46,6 +47,7 @@ before_install:
   - npm config --global set spin false
   # if npm version is less than 3.0.0, upgrade to 3
   - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
+  - if [[ $(npm -v | cut -d '.' -f 1) -gt 4 ]]; then npm i -g npm@^4; fi
 
 script:
   # For now we will use `npm` to kick off the test suite.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
+    - nodejs_version: "8"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ branches:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - appveyor-retry npm i -g npm@^3
+  - appveyor-retry npm i -g npm@^4
   - appveyor-retry choco install phantomjs
   - appveyor-retry yarn
   - appveyor-retry yarn add mocha-appveyor-reporter # must be installed locally.

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -52,7 +52,7 @@ module.exports = {
     }
 
     // add `ember-disable-prototype-extensions` to addons by default
-    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.0';
+    contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.2';
 
     // use `ember-try` as test script in addons by default
     contents.scripts.test = 'ember try:each';

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,7 +19,7 @@
     "ember-ajax": "^3.0.0",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.0.0",
+    "ember-cli-babel": "^6.3.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.1.1",
@@ -38,7 +38,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "private": true
 }

--- a/lib/utilities/platform-checker.js
+++ b/lib/utilities/platform-checker.js
@@ -18,7 +18,7 @@ if (process.platform === 'win32') {
 
 let supportedEngines = loadConfig('package.json').engines.node;
 
-class PlatformChecker {
+module.exports = class PlatformChecker {
   constructor(version) {
     this.version = version;
     this.isValid = this.checkIsValid();
@@ -35,11 +35,10 @@ class PlatformChecker {
 
   checkIsValid(range) {
     range = range || supportedEngines;
-    return semver.satisfies(this.version, range) || semver.gtr(this.version, supportedEngines);
+    return semver.satisfies(this.version, range) || semver.gtr(this.version, range);
   }
 
   checkIsDeprecated(range) {
-    range = range || supportedEngines;
     return !this.checkIsValid(range);
   }
 
@@ -47,6 +46,4 @@ class PlatformChecker {
     range = range || testedEngines;
     return semver.satisfies(this.version, range);
   }
-}
-
-module.exports = PlatformChecker;
+};

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "compression": "^1.4.4",
     "configstore": "^3.0.0",
     "console-ui": "^1.0.2",
-    "core-object": "^3.0.0",
+    "core-object": "^3.1.3",
+    "dag-map": "^2.0.2",
     "diff": "^3.2.0",
     "ember-cli-broccoli-sane-watcher": "^2.0.4",
     "ember-cli-get-component-path-option": "^1.0.0",
@@ -70,7 +71,7 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.1.0",
     "ember-cli-string-utils": "^1.0.0",
-    "ember-try": "^0.2.14",
+    "ember-try": "^0.2.15",
     "ensure-posix-path": "^1.0.2",
     "escape-string-regexp": "^1.0.3",
     "execa": "^0.6.0",
@@ -141,12 +142,12 @@
     "multiline": "^1.0.2",
     "nock": "^9.0.6",
     "supertest": "^3.0.0",
-    "testdouble": "^2.0.1",
+    "testdouble": "^2.1.2",
     "yuidoc-ember-cli-theme": "^1.0.0",
     "yuidocjs": "0.10.2"
   },
   "engines": {
-    "node": "^4.5 || 6.* || 7.*"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "trackingCode": "UA-49225444-1",
   "greenkeeper": {

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -91,7 +91,7 @@ describe('blueprint - addon', function() {
   },\n\
   "dependencies": {},\n\
   "devDependencies": {\n\
-    "ember-disable-prototype-extensions": "^1.1.0"\n\
+    "ember-disable-prototype-extensions": "^1.1.2"\n\
   },\n\
   "ember-addon": {\n\
     "configPath": "tests/dummy/config"\n\
@@ -187,7 +187,7 @@ describe('blueprint - addon', function() {
       it('overwrites any version of `ember-disable-prototype-extensions`', function() {
         td.when(readJsonSync(), { ignoreExtraArgs: true }).thenReturn({
           devDependencies: {
-            'ember-disable-prototype-extensions': '0.0.1',
+            'ember-disable-prototype-extensions': '1.1.2',
           },
         });
 
@@ -199,7 +199,7 @@ describe('blueprint - addon', function() {
         td.verify(writeFileSync(path.normalize('test-blueprint-path/files/package.json'), captor.capture()));
 
         let json = JSON.parse(captor.value);
-        expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.0');
+        expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.2');
       });
 
       it('overwrites `scripts.test`', function() {

--- a/tests/unit/lint-test.js
+++ b/tests/unit/lint-test.js
@@ -13,6 +13,6 @@ paths = paths.concat([
 ]);
 
 require('mocha-eslint')(paths, {
-  timeout: 5000,
+  timeout: 10000,
   slow: 1000,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,9 +447,9 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-broccoli-babel-transpiler@6.0.0-alpha.3:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0-alpha.3.tgz#4c46c800753242cc4109c44700db63dc3862d7d0"
+broccoli-babel-transpiler@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0.tgz#a52c5404bf36236849da503b011fd41fe64a00a2"
   dependencies:
     babel-core "^6.14.0"
     broccoli-funnel "^1.0.0"
@@ -1071,9 +1071,9 @@ core-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-1.1.0.tgz#86d63918733cf9da1a5aae729e62c0a88e66ad0a"
 
-core-object@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/core-object/-/core-object-3.1.0.tgz#f5219fec2a19c40956f1c723d121890c88c5f677"
+core-object@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/core-object/-/core-object-3.1.3.tgz#df399b3311bdb0c909e8aae8929fc3c1c4b25880"
   dependencies:
     chalk "^1.1.3"
 
@@ -1115,6 +1115,10 @@ d@^0.1.1, d@~0.1.1:
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
   dependencies:
     es5-ext "~0.10.2"
+
+dag-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
 
 debug@2, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.2"
@@ -1372,9 +1376,9 @@ ember-try-config@^2.0.1:
     rsvp "^3.2.1"
     semver "^5.1.0"
 
-ember-try@^0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.14.tgz#d47e8fa38858d5683e47856e24a260b39e9caf4a"
+ember-try@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.npmjs.org/ember-try/-/ember-try-0.2.15.tgz#559c756058717595babe70068e541625bd5e210a"
   dependencies:
     chalk "^1.0.0"
     cli-table2 "^0.2.0"
@@ -1389,7 +1393,6 @@ ember-try@^0.2.14:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
-    sync-exec "^0.6.2"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -3529,9 +3532,9 @@ qs@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-1.0.2.tgz#50a93e2b5af6691c31bcea5dae78ee6ea1903768"
 
-quibble@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/quibble/-/quibble-0.4.0.tgz#a1535c4a80b3d3617d23c5d770f1ec2c7b5523a1"
+quibble@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/quibble/-/quibble-0.5.1.tgz#b7fd1fc0a9c1eea012ac9d71bcb6da8d9a5dc9e9"
   dependencies:
     lodash "^4.17.2"
 
@@ -3689,7 +3692,7 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.0:
+resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -4088,10 +4091,6 @@ symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
 
-sync-exec@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/sync-exec/-/sync-exec-0.6.2.tgz#717d22cc53f0ce1def5594362f3a89a2ebb91105"
-
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -4119,12 +4118,13 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-testdouble@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/testdouble/-/testdouble-2.0.1.tgz#460fb3bcef0c19e58758c2ceff6911225566b9de"
+testdouble@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/testdouble/-/testdouble-2.1.2.tgz#8a376c5cb9b2c9cea90780b874168aa5b6eeb8a8"
   dependencies:
     lodash "^4.15.0"
-    quibble "^0.4.0"
+    quibble "^0.5.0"
+    resolve "^1.3.2"
     stringify-object-es5 "^2.5.0"
 
 testem@^1.15.0:


### PR DESCRIPTION
- [x] needs ember-cli-babel update (blocked on NPM not letting me release it...)
- [x] ember-try https://github.com/ember-cli/ember-try/pull/129
- [x] ember-disable-prototype-extensions (pending release -> https://github.com/ember-cli/ember-disable-prototype-extensions/issues/11)
- [x] qunitjs: https://github.com/qunitjs/qunit/pull/1184 (pending release, thanks @trentmwillis )
- [ ] not ok 1153 Acceptance: ember install installs addons via npm and runs generators
  Error: Command failed: npm install bower@^1.3.12
  npm WARN deprecated bower@1.8.0: ..psst! While Bower is maintained, we recommend Yarn and Webpack for *new* front-end projects! Yarn's advantage is security and reliability, and Webpack's is support for both CommonJS and AMD projects. Currently there's no migration path but we hope you'll help us figure out one.
  npm ERR! Maximum call stack size exceeded
  
  npm ERR! A complete log of this run can be found in:
  npm ERR!     /home/travis/.npm/_logs/2017-06-01T23_00_13_071Z-debug.log
  
      at Promise.all.then.arr (node_modules/execa/index.js:201:11)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:169:7)