### PR TITLE
Add reasonable uglify-js options.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -233,6 +233,18 @@ class EmberApp {
       },
       minifyJS: {
         enabled: this.isProduction,
+        options: {
+          compress: {
+            // this is adversely affects heuristics for IIFE eval
+            'negate_iife': false,
+            // limit sequences because of memory issues during parsing
+            sequences: 30,
+          },
+          output: {
+            // no difference in size and much easier to debug
+            semicolons: false,
+          },
+        },
       },
       outputPaths: {
         app: {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -108,6 +108,13 @@ describe('EmberApp', function() {
         enabled: true,
         options: {
           exclusions: ['hey', 'you'],
+          compress: {
+            'negate_iife': false,
+            sequences: 30,
+          },
+          output: {
+            semicolons: false,
+          },
         },
       });
     });


### PR DESCRIPTION
These options should always have been specified, and are good defaults.

I could have sworn that these defaults were already present, but I could not find them in this repo, in ember-cli-uglify repo, or the broccoli-uglify-sourcemap repo...