### PR TITLE
remove "Aligned require statements" style guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -209,11 +209,6 @@ This list only contains style decisions not already covered by ESLint (e.g.
 mandatory semicolons and other rules are omitted).
 
 ### Indentation
-#### Aligned require statements
-``` JavaScript
-let RSVP    = require('rsvp');
-let Promise = RSVP.Promise;
-```
 
 #### Multi-line return statement
 ``` JavaScript


### PR DESCRIPTION
it's not used in a code base anymore