### PR TITLE
Mock process

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../utilities/will-interrupt-process').capture(process);
+
 const instrumentation = require('../utilities/instrumentation');
 
 let initInstrumentation;
@@ -12,10 +14,6 @@ if (instrumentation.instrumentationEnabled()) {
   };
 }
 
-// work around misbehaving libraries, so we can correctly cleanup before
-// actually exiting.
-require('capture-exit').captureExit();
-
 // Main entry point
 const requireAsHash = require('../utilities/require-as-hash');
 const packageConfig = require('../../package.json');
@@ -23,15 +21,6 @@ const logger = require('heimdalljs-logger')('ember-cli:cli/index');
 const merge = require('ember-cli-lodash-subset').merge;
 const path = require('path');
 const heimdall = require('heimdalljs');
-
-// ember-cli and user apps have many dependencies, many of which require
-// process.addListener('exit', ....) for cleanup, by default this limit for
-// such listeners is 10, recently users have been increasing this and not to
-// their fault, rather they are including large and more diverse sets of
-// node_modules.
-//
-// https://github.com/babel/ember-cli-babel/issues/76
-process.setMaxListeners(1000);
 
 let version = packageConfig.version;
 let name = packageConfig.name;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -63,10 +63,10 @@ function configureLogger(env) {
   }
 }
 
-// Options: Array cliArgs, Stream inputStream, Stream outputStream
+// Options: Array cliArgs, Stream inputStream, Stream outputStream, EventEmitter process
 module.exports = function(options) {
-  // work around misbehaving libraries,
-  // so we can correctly cleanup before actually exiting.
+  // `process` should be captured before we require any libraries which
+  // may use `process.exit` work arounds for async cleanup.
   willInterruptProcess.capture(options.process || process);
 
   let UI = options.UI || require('console-ui');
@@ -142,5 +142,5 @@ module.exports = function(options) {
     settings: merge(defaultUpdateCheckerOptions, config.getAll()),
   };
 
-  return cli.run(environment).finally(() => willInterruptProcess.free());
+  return cli.run(environment).finally(() => willInterruptProcess.release());
 };

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-require('../utilities/will-interrupt-process').capture(process);
-
+const willInterruptProcess = require('../utilities/will-interrupt-process');
 const instrumentation = require('../utilities/instrumentation');
 
 let initInstrumentation;
@@ -66,6 +65,10 @@ function configureLogger(env) {
 
 // Options: Array cliArgs, Stream inputStream, Stream outputStream
 module.exports = function(options) {
+  // work around misbehaving libraries,
+  // so we can correctly cleanup before actually exiting.
+  willInterruptProcess.capture(options.process || process);
+
   let UI = options.UI || require('console-ui');
   let Yam = options.Yam || require('yam');
   const CLI = require('./cli');
@@ -139,5 +142,5 @@ module.exports = function(options) {
     settings: merge(defaultUpdateCheckerOptions, config.getAll()),
   };
 
-  return cli.run(environment);
+  return cli.run(environment).finally(() => willInterruptProcess.free());
 };

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -5,11 +5,12 @@
 // When the process interrupted("CTR+C") all the registered handlers are being invoked via `capture-exit`.
 // The process finishes after the last interruption handler is settled.
 
-let captureExit = require('capture-exit');
+const captureExit = require('capture-exit');
+const handlers = [];
+const EventEmitter = require('events');
 
 let _process,
     windowsCtrlCTrap,
-    handlers = [],
     originalIsRaw;
 
 module.exports = {
@@ -18,7 +19,11 @@ module.exports = {
       throw new Error('process already captured');
     }
 
-    _process = outerProcess || process;
+    if (outerProcess instanceof EventEmitter === false) {
+      throw new Error('attempt to capture bad process instance');
+    }
+
+    _process = outerProcess;
 
     // ember-cli and user apps have many dependencies, many of which require
     // process.addListener('exit', ....) for cleanup, by default this limit for

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -50,6 +50,8 @@ module.exports = {
    *
    * Note: We don't call `captureExit.releaseExit() here.
    * In some rare scenarios it can lead to the hard to debug issues.
+   * see: https://github.com/ember-cli/ember-cli/issues/6779#issuecomment-280940358
+   *
    * We can more or less feel comfortable with a captured exit because it behaves very
    * similar to the original `exit` except of cases when we need to do cleanup before exit.
    *

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -1,13 +1,20 @@
 'use strict';
 
-// (un)Register process interruption signals(SIGINT, SIGTERM, process.kill()) handlers.
+// Allows to setup process interruption handlers.
+// The process can be interrupted when ges SIGINT, SIGTERM signal,
+// something called process.exit(exitCode) or CTRL+C was pressed.
 //
-// When the process interrupted("CTR+C") all the registered handlers are being invoked via `capture-exit`.
-// The process finishes after the last interruption handler is settled.
+// Node.js doesn't allow to perform async tasks when the process is exiting.
+// Also there are some work arounds for exit in the node.js ecosystem.
+//
+// In order to supply reliable process exit phase, `will-interrupt-process`
+// is tightly integrated with `capture-exit` which allows us to perform async cleanup
+// on `process.exit()` and control the final exit code.
 
 const captureExit = require('capture-exit');
-const handlers = [];
 const EventEmitter = require('events');
+
+const handlers = [];
 
 let _process,
     windowsCtrlCTrap,
@@ -34,12 +41,26 @@ module.exports = {
     // https://github.com/babel/ember-cli-babel/issues/76
     _process.setMaxListeners(1000);
 
-    // work around misbehaving libraries, so we can correctly cleanup before
-    // actually exiting.
+    // work around misbehaving libraries, so we can correctly cleanup before actually exiting.
     captureExit.captureExit();
   },
 
-  free() {
+  /**
+   * Drops all the interruption handlers and disables an ability to add new one
+   *
+   * Note: We don't call `captureExit.releaseExit() here.
+   * In some rare scenarios it can lead to the hard to debug issues.
+   * We can more or less feel comfortable with a captured exit because it behaves very
+   * similar to the original `exit` except of cases when we need to do cleanup before exit.
+   *
+   * @private
+   * @method release
+   */
+  release() {
+    while (handlers.length > 0) {
+      this.removeHandler(handlers[0]);
+    }
+
     _process = null;
   },
 
@@ -88,18 +109,6 @@ module.exports = {
 
     if (handlers.length === 0) {
       teardownSignalsTrap();
-    }
-  },
-
-  /**
-   * Tears down all the handlers and cleans up all signal listeners
-   *
-   * @private
-   * @method teardown
-   */
-  teardown() {
-    while (handlers.length > 0) {
-      this.removeHandler(handlers[0]);
     }
   },
 };

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -8,10 +8,13 @@
 let exit = require('capture-exit');
 exit.captureExit();
 
-let windowsCtrlCTrap, originalIsRaw;
+let windowsCtrlCTrap, _exit, _onMessage, originalIsRaw;
+
 let handlers = [];
 
 module.exports = {
+  _process: process,
+
   /**
    * Add process interruption handler
    *
@@ -27,7 +30,7 @@ module.exports = {
     if (index > -1) { return; }
 
     if (handlers.length === 0) {
-      setupSignalsTrap();
+      setupSignalsTrap(this._process);
     }
 
     handlers.push(cb);
@@ -52,7 +55,7 @@ module.exports = {
     exit.offExit(cb);
 
     if (handlers.length === 0) {
-      teardownSignalsTrap();
+      teardownSignalsTrap(this._process);
     }
   },
 
@@ -77,13 +80,21 @@ module.exports = {
  *
  * @method setupSignalsTrap
  */
-function setupSignalsTrap() {
-  process.on('SIGINT', _exit);
-  process.on('SIGTERM', _exit);
-  process.on('message', onMessage);
+function setupSignalsTrap(_process) {
+  _exit = function() { _process.exit(); };
+  _onMessage = function(message) {
+    if (message.kill) {
+      _exit();
+    }
+  };
 
-  if (isWindowsTTY()) {
-    trapWindowsSignals();
+  _process.on('SIGINT', _exit);
+  _process.on('SIGTERM', _exit);
+  _process.on('message', _onMessage);
+
+
+  if (isWindowsTTY(_process)) {
+    trapWindowsSignals(_process);
   }
 }
 
@@ -92,13 +103,13 @@ function setupSignalsTrap() {
  *
  * @method teardownSignalsTrap
  */
-function teardownSignalsTrap() {
-  process.removeListener('SIGINT', _exit);
-  process.removeListener('SIGTERM', _exit);
-  process.removeListener('message', onMessage);
+function teardownSignalsTrap(_process) {
+  _process.removeListener('SIGINT', _exit);
+  _process.removeListener('SIGTERM', _exit);
+  _process.removeListener('message', _onMessage);
 
-  if (isWindowsTTY()) {
-    cleanupWindowsSignals();
+  if (isWindowsTTY(_process)) {
+    cleanupWindowsSignals(_process);
   }
 }
 
@@ -107,8 +118,8 @@ function teardownSignalsTrap() {
  *
  * @method trapWindowsSignals
  */
-function trapWindowsSignals() {
-  const stdin = process.stdin;
+function trapWindowsSignals(_process) {
+  const stdin = _process.stdin;
 
   originalIsRaw = stdin.isRaw;
 
@@ -117,37 +128,20 @@ function trapWindowsSignals() {
 
   windowsCtrlCTrap = function(data) {
     if (data.length === 1 && data[0] === 0x03) {
-      process.emit('SIGINT');
+      _process.emit('SIGINT');
     }
   };
   stdin.on('data', windowsCtrlCTrap);
 }
 
-function cleanupWindowsSignals() {
-  const stdin = process.stdin;
+function cleanupWindowsSignals(_process) {
+  const stdin = _process.stdin;
 
   stdin.setRawMode(originalIsRaw);
 
   stdin.removeListener('data', windowsCtrlCTrap);
 }
 
-function isWindowsTTY() {
-  return (/^win/).test(process.platform) && process.stdin && process.stdin.isTTY;
-}
-
-/**
- * Handles the `message` event on the `process`.
- *
- * Calls `process.exit` if the `kill` property on the `message` is set.
- *
- * @method onMessage
- */
-function onMessage(message) {
-  if (message.kill) {
-    _exit();
-  }
-}
-
-function _exit() {
-  process.exit();
+function isWindowsTTY(_process) {
+  return (/^win/).test(_process.platform) && _process.stdin && _process.stdin.isTTY;
 }

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -5,15 +5,38 @@
 // When the process interrupted("CTR+C") all the registered handlers are being invoked via `capture-exit`.
 // The process finishes after the last interruption handler is settled.
 
-let exit = require('capture-exit');
-exit.captureExit();
+let captureExit = require('capture-exit');
 
-let windowsCtrlCTrap, _exit, _onMessage, originalIsRaw;
-
-let handlers = [];
+let _process,
+    windowsCtrlCTrap,
+    handlers = [],
+    originalIsRaw;
 
 module.exports = {
-  _process: process,
+  capture(outerProcess) {
+    if (_process) {
+      throw new Error('process already captured');
+    }
+
+    _process = outerProcess || process;
+
+    // ember-cli and user apps have many dependencies, many of which require
+    // process.addListener('exit', ....) for cleanup, by default this limit for
+    // such listeners is 10, recently users have been increasing this and not to
+    // their fault, rather they are including large and more diverse sets of
+    // node_modules.
+    //
+    // https://github.com/babel/ember-cli-babel/issues/76
+    _process.setMaxListeners(1000);
+
+    // work around misbehaving libraries, so we can correctly cleanup before
+    // actually exiting.
+    captureExit.captureExit();
+  },
+
+  free() {
+    _process = null;
+  },
 
   /**
    * Add process interruption handler
@@ -26,15 +49,19 @@ module.exports = {
    * @param {function} cb   Callback to be called when process interruption fired
    */
   addHandler(cb) {
+    if (!_process) {
+      throw new Error('process is not captured');
+    }
+
     let index = handlers.indexOf(cb);
     if (index > -1) { return; }
 
     if (handlers.length === 0) {
-      setupSignalsTrap(this._process);
+      setupSignalsTrap();
     }
 
     handlers.push(cb);
-    exit.onExit(cb);
+    captureExit.onExit(cb);
   },
 
   /**
@@ -52,10 +79,10 @@ module.exports = {
     if (index < 0) { return; }
 
     handlers.splice(index, 1);
-    exit.offExit(cb);
+    captureExit.offExit(cb);
 
     if (handlers.length === 0) {
-      teardownSignalsTrap(this._process);
+      teardownSignalsTrap();
     }
   },
 
@@ -80,18 +107,10 @@ module.exports = {
  *
  * @method setupSignalsTrap
  */
-function setupSignalsTrap(_process) {
-  _exit = function() { _process.exit(); };
-  _onMessage = function(message) {
-    if (message.kill) {
-      _exit();
-    }
-  };
-
-  _process.on('SIGINT', _exit);
-  _process.on('SIGTERM', _exit);
-  _process.on('message', _onMessage);
-
+function setupSignalsTrap() {
+  _process.on('SIGINT', exit);
+  _process.on('SIGTERM', exit);
+  _process.on('message', onMessage);
 
   if (isWindowsTTY(_process)) {
     trapWindowsSignals(_process);
@@ -103,10 +122,10 @@ function setupSignalsTrap(_process) {
  *
  * @method teardownSignalsTrap
  */
-function teardownSignalsTrap(_process) {
-  _process.removeListener('SIGINT', _exit);
-  _process.removeListener('SIGTERM', _exit);
-  _process.removeListener('message', _onMessage);
+function teardownSignalsTrap() {
+  _process.removeListener('SIGINT', exit);
+  _process.removeListener('SIGTERM', exit);
+  _process.removeListener('message', onMessage);
 
   if (isWindowsTTY(_process)) {
     cleanupWindowsSignals(_process);
@@ -144,4 +163,14 @@ function cleanupWindowsSignals(_process) {
 
 function isWindowsTTY(_process) {
   return (/^win/).test(_process.platform) && _process.stdin && _process.stdin.isTTY;
+}
+
+function exit() {
+  _process.exit();
+}
+
+function onMessage(message) {
+  if (message.kill) {
+    exit();
+  }
 }

--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -3,6 +3,7 @@
 const MockUI = require('console-ui/mock');
 const MockAnalytics = require('./mock-analytics');
 const cli = require('../../lib/cli');
+const MockProcess = require('./mock-process');
 const path = require('path');
 
 /*
@@ -65,6 +66,7 @@ module.exports = function ember(args, options) {
   }
 
   cliInstance = cli({
+    process: new MockProcess(),
     inputStream,
     outputStream,
     errorLog,

--- a/tests/helpers/mock-process.js
+++ b/tests/helpers/mock-process.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let td = require('testdouble');
+let EventEmitter = require('events');
+
+module.exports = class FakeProcess extends EventEmitter {
+  constructor(options) {
+    super();
+
+    options = options || {};
+
+    const stdin = Object.assign(new EventEmitter(), {
+      isRaw: false,
+      setRawMode: td.function(),
+    }, options.stdin || {});
+
+    const topLevelProps = Object.assign({
+      platform: 'MockOS',
+      exit: td.function(),
+    }, options);
+
+    Object.assign(this, topLevelProps, { stdin });
+  }
+
+  getSignalListenerCounts() {
+    return {
+      SIGINT: this.listenerCount('SIGINT'),
+      SIGTERM: this.listenerCount('SIGTERM'),
+      message: this.listenerCount('message'),
+    };
+  }
+};

--- a/tests/helpers/mock-process.js
+++ b/tests/helpers/mock-process.js
@@ -10,9 +10,13 @@ module.exports = class FakeProcess extends EventEmitter {
     options = options || {};
 
     const stdin = Object.assign(new EventEmitter(), {
-      isRaw: false,
+      isRaw: process.stdin.isRaw,
       setRawMode: td.function(),
     }, options.stdin || {});
+
+    td.when(stdin.setRawMode(td.matchers.anything())).thenDo(function(flag) {
+      this.isRaw = flag;
+    });
 
     const topLevelProps = Object.assign({
       platform: 'MockOS',

--- a/tests/integration/tasks/build-test.js
+++ b/tests/integration/tasks/build-test.js
@@ -38,7 +38,7 @@ describe('build task test', function() {
   });
 
   afterEach(function() {
-    willInterruptProcess.free();
+    willInterruptProcess.release();
     process.chdir(root);
     delete process.env.BROCCOLI_VIZ;
 

--- a/tests/integration/tasks/build-test.js
+++ b/tests/integration/tasks/build-test.js
@@ -10,16 +10,20 @@ const BuildTask = require('../../../lib/tasks/build');
 const RSVP = require('rsvp');
 const MockProject = require('../../helpers/mock-project');
 const MockAnalytics = require('../../helpers/mock-analytics');
+const MockProcess = require('../../helpers/mock-process');
 const copyFixtureFiles = require('../../helpers/copy-fixture-files');
 const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
+const willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
 let remove = RSVP.denodeify(fs.remove);
 let root = process.cwd();
 let tmproot = path.join(root, 'tmp');
 
 describe('build task test', function() {
-  let project, ui;
+  let project, ui, _process;
 
   beforeEach(function() {
+    _process = new MockProcess();
+    willInterruptProcess.capture(_process);
     return mkTmpDirIn(tmproot)
       .then(function(tmpdir) {
         process.chdir(tmpdir);
@@ -34,6 +38,7 @@ describe('build task test', function() {
   });
 
   afterEach(function() {
+    willInterruptProcess.free();
     process.chdir(root);
     delete process.env.BROCCOLI_VIZ;
 

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -19,6 +19,69 @@ describe('will interrupt process', function() {
     willInterruptProcess.release();
   });
 
+  describe('capture', function() {
+    it('throws if already captured', function() {
+      const mockProcess = new MockProcess();
+
+      willInterruptProcess.capture(mockProcess);
+      try {
+        willInterruptProcess.capture(mockProcess);
+        expect(true).to.equal(false);
+      } catch (e) {
+        expect(e.message).to.equal('process already captured');
+      }
+    });
+
+    it('throws if the process is not an EventEmitter instance', function() {
+      const dissallowedArgs = [null, true, '', [], {}];
+
+      dissallowedArgs.forEach(arg => {
+        try {
+          willInterruptProcess.capture(arg);
+          expect(true).to.equal(false);
+        } catch (e) {
+          expect(e.message).to.equal('attempt to capture bad process instance');
+        }
+      });
+    });
+
+    it('sets process maxListeners count', function() {
+      const mockProcess = new MockProcess();
+
+      willInterruptProcess.capture(mockProcess);
+
+      expect(mockProcess.getMaxListeners()).to.equal(1000);
+    });
+  });
+
+  describe('addHandler', function() {
+    it('throws if process is not captured', function() {
+      try {
+        willInterruptProcess.addHandler(() => {});
+        expect(true).to.equal(false);
+      } catch (e) {
+        expect(e.message).to.equal('process is not captured');
+      }
+
+      const mockProcess = new MockProcess();
+
+      willInterruptProcess.capture(mockProcess);
+      willInterruptProcess.release();
+    });
+
+    it('throws if process is released', function() {
+      willInterruptProcess.capture(new MockProcess());
+      willInterruptProcess.release();
+
+      try {
+        willInterruptProcess.addHandler(() => {});
+        expect(true).to.equal(false);
+      } catch (e) {
+        expect(e.message).to.equal('process is not captured');
+      }
+    });
+  });
+
   describe('capture-exit', function() {
     it('adds exit handler', function() {
       willInterruptProcess.capture(new MockProcess());

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -1,40 +1,12 @@
 'use strict';
 
 let willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
+let MockProcess = require('../../helpers/mock-process');
 let captureExit;
 
 let td = require('testdouble');
 let chai = require('../../chai');
 let expect = chai.expect;
-let EventEmitter = require('events');
-
-class MockProcess extends EventEmitter {
-  constructor(options) {
-    super();
-
-    options = options || {};
-
-    const stdin = Object.assign(new EventEmitter(), {
-      isRaw: false,
-      setRawMode: td.function(),
-    }, options.stdin || {});
-
-    const topLevelProps = Object.assign({
-      platform: 'MockOS',
-      exit: td.function(),
-    }, options);
-
-    Object.assign(this, topLevelProps, { stdin });
-  }
-
-  getSignalListenerCounts() {
-    return {
-      SIGINT: this.listenerCount('SIGINT'),
-      SIGTERM: this.listenerCount('SIGTERM'),
-      message: this.listenerCount('message'),
-    };
-  }
-}
 
 describe('will interrupt process', function() {
   let cb;
@@ -50,14 +22,14 @@ describe('will interrupt process', function() {
 
   describe('capture-exit', function() {
     it('adds exit handler', function() {
-      willInterruptProcess.capture();
+      willInterruptProcess.capture(new MockProcess());
       willInterruptProcess.addHandler(cb);
 
       expect(captureExit.listenerCount()).to.equal(1);
     });
 
     it('removes exit handler', function() {
-      willInterruptProcess.capture();
+      willInterruptProcess.capture(new MockProcess());
       willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
@@ -67,7 +39,7 @@ describe('will interrupt process', function() {
     });
 
     it('removes all exit handlers', function() {
-      willInterruptProcess.capture();
+      willInterruptProcess.capture(new MockProcess());
 
       willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -16,8 +16,7 @@ describe('will interrupt process', function() {
   });
 
   afterEach(function() {
-    willInterruptProcess.teardown();
-    willInterruptProcess.free();
+    willInterruptProcess.release();
   });
 
   describe('capture-exit', function() {
@@ -44,7 +43,7 @@ describe('will interrupt process', function() {
       willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
-      willInterruptProcess.teardown();
+      willInterruptProcess.release();
 
       expect(captureExit.listenerCount()).to.equal(0);
     });
@@ -111,7 +110,7 @@ describe('will interrupt process', function() {
       willInterruptProcess.addHandler(function() {});
       willInterruptProcess.addHandler(() => cb);
 
-      willInterruptProcess.teardown();
+      willInterruptProcess.release();
 
       expect(process.getSignalListenerCounts()).to.eql({
         SIGINT: 0,

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -204,21 +204,18 @@ describe('will interrupt process', function() {
       const process = new MockProcess({
         platform: 'win',
         stdin: {
+          isRaw: false,
           isTTY: true,
         },
       });
 
       willInterruptProcess.capture(process);
+
       willInterruptProcess.addHandler(cb);
-      td.verify(process.stdin.setRawMode(true));
+      expect(process.stdin.isRaw).to.equal(true);
 
       willInterruptProcess.removeHandler(cb);
-      td.verify(process.stdin.setRawMode(false));
-
-      td.verify(process.stdin.setRawMode(), {
-        ignoreExtraArgs: true,
-        times: 2,
-      });
+      expect(process.stdin.isRaw).to.equal(false);
     });
 
     it('does not enable raw capture when not a Windows', function() {

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let willInterruptProcess;
+let willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
 let captureExit;
 
 let td = require('testdouble');
@@ -37,27 +37,27 @@ class MockProcess extends EventEmitter {
 }
 
 describe('will interrupt process', function() {
-  let cb, originalProcess;
+  let cb;
   beforeEach(function() {
-    willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
-    originalProcess = willInterruptProcess._process;
     captureExit = require('capture-exit');
     cb = td.function();
   });
 
   afterEach(function() {
     willInterruptProcess.teardown();
-    willInterruptProcess._process = originalProcess;
+    willInterruptProcess.free();
   });
 
   describe('capture-exit', function() {
     it('adds exit handler', function() {
+      willInterruptProcess.capture();
       willInterruptProcess.addHandler(cb);
 
       expect(captureExit.listenerCount()).to.equal(1);
     });
 
     it('removes exit handler', function() {
+      willInterruptProcess.capture();
       willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
@@ -67,6 +67,8 @@ describe('will interrupt process', function() {
     });
 
     it('removes all exit handlers', function() {
+      willInterruptProcess.capture();
+
       willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
@@ -81,7 +83,7 @@ describe('will interrupt process', function() {
 
     beforeEach(function() {
       process = new MockProcess();
-      willInterruptProcess._process = process;
+      willInterruptProcess.capture(process);
     });
 
     it('sets up interruption signal listeners when the first handler added', function() {
@@ -156,7 +158,7 @@ describe('will interrupt process', function() {
         },
       });
 
-      willInterruptProcess._process = process;
+      willInterruptProcess.capture(process);
       willInterruptProcess.addHandler(cb);
 
       process.stdin.emit('data', [0x03]);
@@ -172,7 +174,7 @@ describe('will interrupt process', function() {
         },
       });
 
-      willInterruptProcess._process = process;
+      willInterruptProcess.capture(process);
       willInterruptProcess.addHandler(cb);
       td.verify(process.stdin.setRawMode(true));
 
@@ -192,6 +194,7 @@ describe('will interrupt process', function() {
         },
       });
 
+      willInterruptProcess.capture(process);
       willInterruptProcess.addHandler(cb);
 
       td.verify(process.stdin.setRawMode(true), {
@@ -208,6 +211,7 @@ describe('will interrupt process', function() {
         platform: 'win',
       });
 
+      willInterruptProcess.capture(process);
       willInterruptProcess.addHandler(cb);
 
       td.verify(process.stdin.setRawMode(true), {


### PR DESCRIPTION
Solves #7073 

This pr introduces `MockProcess` test helper. `MockProcess` and `MockProcess.stdin` both inherit `EventEmitter`. Non-`EventEmitter` methods are implemented as `testdouble.function()`s.

It allows to test `process.exit`, `SIGINT`, `CTRL+C` behaviors in a more safe and flexible way.
```js
let process = new MockProcess({
  platform: 'win',
  stdin: {
    isTTY: true,
  },
});

willInterruptProcess.capture(process);

process.stdin.emit('data', [0x03]); // CTRL+C

td.verify(process.exit());
```

**General Changes:**

- `will-interrupt-process` now gets new ~~public~~ method `.capture(EventEmitter process)`
- `cli/index` captures the process once it is invoked
- `tests/helpers/ember` now passes `MockProcess` instance to the `cli/index`


**Todo:**

 - [x] unit tests for new ~~public~~ api in `will-interrupt-process`
 - [x] collapse/rework `.free()` and `.teardown()`
 - [x] is it acceptable to [move `process` capture from the top of the `cli/index` to the invocation](https://github.com/ember-cli/ember-cli/pull/7086/files#diff-3386b9e4d97ad97b803f4678beb66c5aR70)? and why not. explanation - https://github.com/ember-cli/ember-cli/pull/7086#discussion_r121495275
 - [ ] ~~merge #7019~~ now i think if this pr lands first it can improve test setup in #7019.
 - [ ] ~~merge #7041~~ now i think if this pr lands first it can improve test setup in #7041.
 - [x] rebase
 - [ ] optional. expand build task integration test to cover builder interruption/cleanup