### PR TITLE
Add custom transform when using `app.import`

### DIFF
--- a/lib/broccoli/amd-shim.js
+++ b/lib/broccoli/amd-shim.js
@@ -1,9 +1,8 @@
 'use strict';
 const stew = require('broccoli-stew');
 
-module.exports = function shimAmd(tree, nameMapping) {
-  return stew.map(tree, (content, relativePath) => {
-    let name = nameMapping[relativePath];
+module.exports = function shimAmd(tree, name) {
+  return stew.map(tree, content => {
     if (name) {
       return [
         '(function(define){\n',

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -128,7 +128,7 @@ class EmberApp {
 
 
     this._scriptOutputFiles = {};
-    this.amdModuleNames = null;
+    this.entries = null;
 
     this.legacyFilesToAppend = [];
     this.vendorStaticStyles = [];
@@ -1024,13 +1024,26 @@ class EmberApp {
         overwrite: true,
       });
 
-      if (this.amdModuleNames) {
-        let anonymousAmd = new Funnel(externalTree, {
-          files: Object.keys(this.amdModuleNames),
-          annotation: 'Funnel (named AMD)',
-        });
-        externalTree = this._mergeTrees([externalTree, shimAmd(anonymousAmd, this.amdModuleNames)], {
-          annotation: 'TreeMerger (named AMD)',
+      if (this.entries) {
+        let transformedTrees = [];
+        for (let filePath in this.entries) {
+          let entry = this.entries[filePath];
+          let treeToBeTransformed = new Funnel(externalTree, {
+            files: [filePath],
+            annotation: 'Funnel (transformation)',
+          });
+
+          if (entry.transformation === 'amd') {
+            // run the amd shim to transform to named/anonymous amd
+            transformedTrees.push(shimAmd(treeToBeTransformed, entry.as));
+          } else {
+            // run the custom transform provided by the app/addon
+            let transformation = entry.transformation;
+            transformedTrees.push(transformation.call(undefined, treeToBeTransformed));
+          }
+        }
+        externalTree = this._mergeTrees([externalTree].concat(transformedTrees), {
+          annotation: 'TreeMerger (transformation)',
           overwrite: true,
         });
       }
@@ -1525,6 +1538,7 @@ class EmberApp {
     @param {Boolean} [options.prepend=false] Whether or not this asset should be prepended
     @param {String} [options.destDir] Destination directory, defaults to the name of the directory the asset is in
     @param {String} [options.outputFile] Specifies the output file for given import. Defaults to assets/vendor.{js,css}
+    @param {Array} [options.using] Specifies the array of transformations to be done on the asset. Can do an amd shim and/or custom transformation
    */
   import(asset, options) {
     let assetPath = this._getAssetPath(asset);
@@ -1583,20 +1597,19 @@ class EmberApp {
           if (!entry.transformation) {
             throw new Error(`while importing ${assetPath}: each entry in the \`using\` list must have a \`transformation\` name`);
           }
-          if (entry.transformation !== 'amd') {
-            throw new Error(`while importing ${assetPath}: unknown transformation \`${entry.transformation}\``);
+          if (!self.entries) {
+            self.entries = {};
           }
-          if (!entry.as) {
-            throw new Error(`while importing ${assetPath}: amd transformation requires an \`as\` argument that specifies the desired module name`);
+          if (entry.transformation === 'amd') {
+            if (!entry.as) {
+              throw new Error(`while importing ${assetPath}: amd transformation requires an \`as\` argument that specifies the desired module name`);
+            }
+            // If the import is specified to be a different name we must break because of the broccoli rewrite behavior.
+            if (self.entries[assetPath] && self.entries[assetPath].as !== entry.as) {
+              throw new Error(`Highlander error while importing ${assetPath}. You may not import an AMD transformed asset at different module names.`);
+            }
           }
-          if (!self.amdModuleNames) {
-            self.amdModuleNames = {};
-          }
-          // If the import is specified to be a different name we must break because of the broccoli rewrite behavior.
-          if (self.amdModuleNames[assetPath] && self.amdModuleNames[assetPath] !== entry.as) {
-            throw new Error(`Highlander error while importing ${assetPath}. You may not import an AMD transformed asset at different module names.`);
-          }
-          self.amdModuleNames[assetPath] = entry.as;
+          self.entries[assetPath] = entry;
         });
       }
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -297,6 +297,17 @@ describe('Acceptance: brocfile-smoke-test', function() {
     })();
   }));
 
+  it('can use transformation to turn library into custom transformation', co.wrap(function *() {
+    yield copyFixtureFiles('brocfile-tests/app-import-custom-transform');
+    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+    let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
+      encoding: 'utf8',
+    });
+
+    expect(outputJS).to.be.equal('if (typeof FastBoot === \'undefined\') { window.hello = "hello world";\n }//# sourceMappingURL=output.map\n');
+  }));
+
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', co.wrap(function *() {
     yield copyFixtureFiles('brocfile-tests/custom-output-paths');

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/ember-cli-build.js
@@ -1,0 +1,22 @@
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const map = require('broccoli-stew').map;
+
+module.exports = function (defaults) {
+  var app = new EmberApp(defaults, {
+  });
+
+  app.import('vendor/custom-transform-example.js', {
+    using: [
+      {
+        transformation: function(tree) {
+          return map(tree, function(content) {
+            return `if (typeof FastBoot === 'undefined') { ${content} }`;
+          });
+        }
+      }
+    ],
+    outputFile: '/assets/output.js'
+  });
+
+  return app.toTree();
+};

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/custom-transform-example.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/custom-transform-example.js
@@ -1,0 +1,1 @@
+window.hello = "hello world";


### PR DESCRIPTION
# Motivation

Often we require addons to transform the contents of the library being imported using `app.import`. Addon authors need to have broccoli knowledge and end up writing boiler plate code. If the transformation needs to be done in multiple addons, it often causes grievances for addon authors that don't have broccoli knowledge. A classic example is the fastboot migration where addon authors need to wrap the content of their browser libraries with a fastboot check since the `process.env.EMBER_CLI_FASTBOOT` isn't available. 

`ember-cli` already provides to run AMD shim transform. This PR extends it for addon authors to provide their own transform.

# How it works:

A vendor library can be amd shim'd using the below API:

```js
app.import(<path>, { using: [{transformation: 'amd', as: 'hello-world'}]});
```

We extend the above without any API change to be:

```js
app.import(<path> {
   using: [
      {
         transformation: function(tree) {
              // do your transform
              return tree;
        }
     }, ...]
});
```

This PR extends the `transformation` to take in a custom function or `amd` and invoked the function if it is not `amd`. It also makes sure to run the transformation in the order they are provided in `using` array.

# TODO

- [ ]  Update guides [here](https://ember-cli.com/user-guide/#standard-anonymous-amd-asset) to talk about the extension.

cc: @stefanpenner @rwjblue 