### PR TITLE
Fix `ember install` for scoped packages

### DIFF
--- a/lib/utilities/get-package-base-name.js
+++ b/lib/utilities/get-package-base-name.js
@@ -4,18 +4,9 @@ const npa = require('npm-package-arg');
 
 
 module.exports = function(name) {
-  let parsed, parsedName;
-
   if (!name) {
     return null;
   }
 
-  parsed = npa(name);
-  parsedName = parsed.name;
-
-  if (parsed.scope) {
-    parsedName = parsedName.replace(parsed.scope, '').slice(1);
-  }
-
-  return parsedName;
+  return npa(name).name;
 };

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -41,6 +41,11 @@ describe('install command', function() {
             name: 'ember-cli-qunit',
           },
         },
+        {
+          pkg: {
+            name: '@ember-cli/ember-cli-qunit',
+          },
+        },
       ];
     };
 
@@ -249,7 +254,7 @@ describe('install command', function() {
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
         let generateRunArgs = td.explain(generateRun).calls.map(function(call) { return call.args[0].args[0]; });
-        expect(generateRunArgs).to.deep.equal(['ember-cli-qunit']);
+        expect(generateRunArgs).to.deep.equal(['@ember-cli/ember-cli-qunit']);
       });
     });
 

--- a/tests/unit/utilities/get-package-base-name-test.js
+++ b/tests/unit/utilities/get-package-base-name-test.js
@@ -8,8 +8,8 @@ describe('getPackageBaseName', function() {
     expect(getPackageBaseName('my-addon')).to.equal('my-addon');
   });
 
-  it('should return the package name without its scope', function() {
-    expect(getPackageBaseName('@scope/my-addon')).to.equal('my-addon');
+  it('should return the full name when scoped', function() {
+    expect(getPackageBaseName('@scope/my-addon')).to.equal('@scope/my-addon');
   });
 
   it('should strip away version numbers', function() {


### PR DESCRIPTION
It's not correct to try to strip the scope out of package names. I don't know why the test mock was set up this way, but you can verify this change against a real scoped package by doing:

 * `ember new my-app`
 * `cd my-app`
 * `ember install @cardstack/git`

Without this change it fails, after this change it succeeds.

Stripping off scopes fundamentally can't be correct because it's legal for `@foo/x` and `@bar/x` to want to coexist in a single app. NPM consistently treats the scope as part of the name.