### PR TITLE
[WIP] Add fastboot-disable import transformation

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -29,6 +29,7 @@ const ConfigReplace = require('broccoli-config-replace');
 const ConfigLoader = require('broccoli-config-loader');
 const mergeTrees = require('./merge-trees');
 const shimAmd = require('./amd-shim');
+const fastbootDisable = require('./fastboot-disable');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
@@ -129,6 +130,7 @@ class EmberApp {
 
     this._scriptOutputFiles = {};
     this.amdModuleNames = null;
+    this.fastbootDisabledModuleNames = null;
 
     this.legacyFilesToAppend = [];
     this.vendorStaticStyles = [];
@@ -1039,6 +1041,17 @@ class EmberApp {
         });
       }
 
+      if (this.fastbootDisabledModuleNames) {
+        let fastbootDisabledModules = new Funnel(externalTree, {
+          files: Object.keys(this.fastbootDisabledModuleNames),
+          annotation: 'Funnel (Fastboot disabled)',
+        });
+        externalTree = this._mergeTrees([externalTree, fastbootDisable(fastbootDisabledModules)], {
+          annotation: 'TreeMerger (Fastboot disabled)',
+          overwrite: true,
+        });
+      }
+
       this._cachedExternalTree = externalTree;
     }
 
@@ -1586,20 +1599,27 @@ class EmberApp {
           if (!entry.transformation) {
             throw new Error(`while importing ${assetPath}: each entry in the \`using\` list must have a \`transformation\` name`);
           }
-          if (entry.transformation !== 'amd') {
+          if (entry.transformation !== 'amd' && entry.transformation !== 'fastboot-disable') {
             throw new Error(`while importing ${assetPath}: unknown transformation \`${entry.transformation}\``);
           }
-          if (!entry.as) {
-            throw new Error(`while importing ${assetPath}: amd transformation requires an \`as\` argument that specifies the desired module name`);
+          if (entry.transformation === 'amd') {
+            if (!entry.as) {
+              throw new Error(`while importing ${assetPath}: amd transformation requires an \`as\` argument that specifies the desired module name`);
+            }
+            if (!self.amdModuleNames) {
+              self.amdModuleNames = {};
+            }
+            // If the import is specified to be a different name we must break because of the broccoli rewrite behavior.
+            if (self.amdModuleNames[assetPath] && self.amdModuleNames[assetPath] !== entry.as) {
+              throw new Error(`Highlander error while importing ${assetPath}. You may not import an AMD transformed asset at different module names.`);
+            }
+            self.amdModuleNames[assetPath] = entry.as;
+          } else if (entry.transformation === 'fastboot-disable') {
+            if (!self.fastbootDisabledModuleNames) {
+              self.fastbootDisabledModuleNames = {};
+            }
+            self.fastbootDisabledModuleNames[assetPath] = assetPath;
           }
-          if (!this.amdModuleNames) {
-            this.amdModuleNames = {};
-          }
-          // If the import is specified to be a different name we must break because of the broccoli rewrite behavior.
-          if (this.amdModuleNames[assetPath] && this.amdModuleNames[assetPath] !== entry.as) {
-            throw new Error(`Highlander error while importing ${assetPath}. You may not import an AMD transformed asset at different module names.`);
-          }
-          this.amdModuleNames[assetPath] = entry.as;
         });
       }
 

--- a/lib/broccoli/fastboot-disable.js
+++ b/lib/broccoli/fastboot-disable.js
@@ -1,0 +1,6 @@
+'use strict';
+const stew = require('broccoli-stew');
+
+module.exports = function fastbootDisable(tree) {
+  return stew.map(tree, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+};


### PR DESCRIPTION
This adds a new transformation to `app.import` statement, similar to `transformation: 'amd'`, enabling you to avoid the boilerplate associated with wrapping libraries that break fastboot in `if (typeof FastBoot === 'undefined')`
Usage: 
```js
app.import('bower_components/datatables/media/js/jquery.dataTables.js', { using: [{ transformation: 'fastboot-disable' }] });
```
Just an initial riff to open a discussion.