### PR TITLE
use npm@4 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ branches:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - appveyor-retry npm i -g npm@^3
+  - appveyor-retry npm i -g npm@^4
   - appveyor-retry choco install phantomjs
   - appveyor-retry yarn
   - appveyor-retry yarn add mocha-appveyor-reporter # must be installed locally.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
 cache:
   - '%LOCALAPPDATA%\Yarn'
   - '%APPDATA%\Roaming\bower'
+  - '%APPDATA%\Roaming\npm-cache'
 
 # Post-install test scripts.
 test_script:


### PR DESCRIPTION
I've noticed regular [npm errors](https://ci.appveyor.com/project/embercli/ember-cli/build/13347/job/js8qgobkplwo0qki#L534) on appveyor.

From my experience npm@4 is much more stable. Can we use it on CI?