### PR TITLE
add in-app testing page reference

### DIFF
--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -23,6 +23,7 @@ You will need the following things properly installed on your computer.
 
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 
 ### Code Generators
 

--- a/tests/fixtures/app/npm/README.md
+++ b/tests/fixtures/app/npm/README.md
@@ -22,6 +22,7 @@ You will need the following things properly installed on your computer.
 
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 
 ### Code Generators
 

--- a/tests/fixtures/app/yarn/README.md
+++ b/tests/fixtures/app/yarn/README.md
@@ -23,6 +23,7 @@ You will need the following things properly installed on your computer.
 
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 
 ### Code Generators
 


### PR DESCRIPTION
Feel free to veto, but it seemed to me that a reference to this section should be called out in the readme.