### PR TITLE
Update `add-to-output-repos.sh`

### DIFF
--- a/dev/add-to-output-repos.sh
+++ b/dev/add-to-output-repos.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # so you can run this script from any folder and it will find the tmp dir
 cd "`git rev-parse --show-toplevel`"
 


### PR DESCRIPTION
Specify the type of script in the file.

Before the change, if you run the script, you would get the error:

```sh
➜  ember-cli git:(release) ✗ ./dev/add-to-output-repos.sh
Failed to execute process './dev/add-to-output-repos.sh'. Reason:
exec: Exec format error
The file './dev/add-to-output-repos.sh' is marked as an executable but could not be run by the operating system.
```