### PR TITLE
Add Replacer to FileInfo

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -26,6 +26,7 @@ function diffHighlight(line) {
   }
 }
 
+const NOOP = _ => _;
 class FileInfo {
   constructor(options) {
     this.action = options.action;
@@ -34,6 +35,7 @@ class FileInfo {
     this.displayPath = options.displayPath;
     this.inputPath = options.inputPath;
     this.templateVariables = options.templateVariables;
+    this.replacer = options.replacer || NOOP;
     this.ui = options.ui;
   }
 
@@ -92,25 +94,31 @@ class FileInfo {
   }
 
   render() {
-    let path = this.inputPath,
-        context = this.templateVariables;
     if (!this.rendered) {
-      this.rendered = readFile(path)
-        .then(content => lstat(path)
-          .then(fileStat => {
-            if (isBinaryFile(content, fileStat.size)) {
-              return content;
-            } else {
-              try {
-                return processTemplate(content.toString(), context);
-              } catch (err) {
-                err.message += ` (Error in blueprint template: ${path})`;
-                throw err;
-              }
-            }
-          }));
+      this.rendered = this._render().then(result => this.replacer(result, this));
     }
+
     return this.rendered;
+  }
+
+  _render() {
+    let path = this.inputPath;
+    let context = this.templateVariables;
+
+    return readFile(path)
+      .then(content => lstat(path)
+        .then(fileStat => {
+          if (isBinaryFile(content, fileStat.size)) {
+            return content;
+          } else {
+            try {
+              return processTemplate(content.toString(), context);
+            } catch (err) {
+              err.message += ` (Error in blueprint template: ${path})`;
+              throw err;
+            }
+          }
+        }));
   }
 
   checkForConflict() {

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -148,7 +148,11 @@ function npmPack() {
 function tar() {
   return new Promise((resolve, reject) => {
     let output;
-    let tar = spawn('tar', ['-tf', `${addonName}-0.0.0.tgz`]);
+    let fileName = `${addonName}-0.0.0.tgz`;
+    if (fs.existsSync(fileName) === false) {
+      throw new Error(`unknown file: '${path.resolve(fileName)}'`);
+    }
+    let tar = spawn('tar', ['-tf', fileName]);
     tar.on('error', reject);
     tar.stdout.on('data', data => (output = data.toString()));
     tar.on('close', () => resolve(output));

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -70,6 +70,25 @@ describe('Unit - FileInfo', function() {
     });
   });
 
+  it('allows mutation to the rendered file', function() {
+    validOptions.templateVariables.friend = 'Billy';
+    let fileInfo;
+
+    validOptions.replacer = function(content, theFileInfo) {
+      expect(theFileInfo).to.eql(fileInfo);
+      expect(content).to.eql('Howdy Billy\n');
+
+      return content.toUpperCase();
+    };
+
+    fileInfo = new FileInfo(validOptions);
+
+    return fileInfo.render().then(function(output) {
+      expect(output.trim()).to.equal('HOWDY BILLY',
+        'expects the template to have been run');
+    });
+  });
+
   it('rejects if templating throws', function() {
     let templateWithUndefinedVariable = path.resolve(__dirname,
       '../../fixtures/blueprints/with-templating/files/with-undefined-variable.txt');


### PR DESCRIPTION
This enables a blueprint to augment the output of a given file provided.

A concrete example would be a package.json replacer.

```js
function replacer(content) {
  let pkg = JSON.parse(content);

  delete pkg.devDependencies['ember-resolver'];
  delete pkg.devDependencies['ember-ajax'];

  pkg.devDependencies['ember-strict-resolver'] = '^0.0.3';
  pkg.devDependencies['ember-native-dom-helpers'] = '^0.4.1';
  pkg.devDependencies['ember-native-dom-event-dispatcher'] = '^0.6.1';
  pkg.devDependencies['ember-fetch'] = '^2.1.0';

  return JSON.stringify(pkg, null, 2);
}


let options = { 
  /* other valid options */,
  replacer
};

let info = new FileInfo(options);
```