### PR TITLE
Remove redundant chrome installation since appveyor has latest chrome

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ branches:
 install:
   - ps: Install-Product node $env:nodejs_version
   - appveyor-retry npm i -g npm@^3
-  - appveyor-retry choco install googlechrome
   - appveyor-retry yarn
   - appveyor-retry yarn add mocha-appveyor-reporter # must be installed locally.
 


### PR DESCRIPTION
AppVeyor seems to be flaky at installing chrome via choco.  But [appveyor does bundle the latest chrome ](https://www.appveyor.com/docs/build-environment/#web-browsers) in the default image, so removing the redundant install step.

//cc @twokul 