### PR TITLE
link + integrity is currently causing double loads

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -9,8 +9,8 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
 
     {{content-for "head-footer"}}
   </head>


### PR DESCRIPTION
> The `integrity` attribute for link elements has not yet been implemented and there’s an open spec issue about it
> In the wild, it can also result in duplicate requests where you have to make a trade-off between security and performance.

* https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf
* https://bugs.chromium.org/p/chromium/issues/detail?id=677022