### PR TITLE
Headless chrome only in CI

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,11 +9,14 @@ module.exports = {
     'Chrome'
   ],
   'browser_args': {
-      'Chrome': [
+    'Chrome': {
+      'mode': 'ci',
+      'args': [
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',
         '--window-size=1440,900'
-      ],
+      ]
+    }
   }
 };

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -11,11 +11,14 @@ module.exports = {
     "Chrome"
   ],
   "browser_args": {
-    "Chrome": [
-      "--disable-gpu",
-      "--headless",
-      "--remote-debugging-port=9222",
-      "--window-size=1440,900"
-    ],
+    "Chrome": {
+      "mode": "ci",
+      "args": [
+        "--disable-gpu",
+        "--headless",
+        "--remote-debugging-port=9222",
+        "--window-size=1440,900"
+      ]
+    }
   }
 };

--- a/tests/fixtures/tasks/testem-config/testem-with-query-string.json
+++ b/tests/fixtures/tasks/testem-config/testem-with-query-string.json
@@ -9,11 +9,14 @@
     "Chrome"
   ],
   "browser_args": {
-    "Chrome": [
-      "--disable-gpu",
-      "--headless",
-      "--remote-debugging-port=9222",
-      "--window-size=1440,900"
-    ]
+    "Chrome": {
+      "mode": "ci",
+      "args": [
+        "--disable-gpu",
+        "--headless",
+        "--remote-debugging-port=9222",
+        "--window-size=1440,900"
+      ]
+    }
   }
 }

--- a/tests/fixtures/tasks/testem-config/testem.json
+++ b/tests/fixtures/tasks/testem-config/testem.json
@@ -8,11 +8,14 @@
     "Chrome"
   ],
   "browser_args": {
-    "Chrome": [
-      "--disable-gpu",
-      "--headless",
-      "--remote-debugging-port=9222",
-      "--window-size=1440,900"
-    ]
+    "Chrome": {
+      "mode": "ci",
+      "args": [
+        "--disable-gpu",
+        "--headless",
+        "--remote-debugging-port=9222",
+        "--window-size=1440,900"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Testem recently added the ability to support browser args specific to a testem mode. So we should've probably limited headless chrome only to CI mode. This PR addresses that.
//cc @Turbo87 & @rwjblue 