### PR TITLE
bump lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-legacy-blueprints": "^0.1.2",
-    "ember-cli-lodash-subset": "^1.0.11",
+    "ember-cli-lodash-subset": "^2.0.1",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.1.0",
     "ember-cli-string-utils": "^1.0.0",


### PR DESCRIPTION
this version drops `assign`, `some`, `any`, `keys` in favor of natives 
