### PR TITLE
mention chrome is required now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ We love pull requests. Here's a quick guide:
 
    * node (latest LTS recommended) -- *do not install node using sudo*
    * npm (3.x)
+   * google chrome
 
 3. Run the tests. We only take pull requests with passing tests, and it's great
    to know that you have a clean slate: `npm install && npm run test-all`.

--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -10,6 +10,7 @@ You will need the following things properly installed on your computer.
 * [Git](https://git-scm.com/)
 * [Node.js](https://nodejs.org/) (with NPM)
 * [Ember CLI](https://ember-cli.com/)
+* [Google Chrome](https://google.com/chrome/)
 
 ## Installation
 


### PR DESCRIPTION
These locations are where it used to say PhantomJS. We should probably now call out that Chrome is now required, instead of assuming they already have it. What do y'all think?