### PR TITLE
install npm 4 in addon travis using npm

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -41,6 +41,7 @@ install:
   - yarn install --no-lockfile
 <% } else { %>
   - npm config set spin false
+  - npm install -g npm@4
   - npm --version
 <% } %>
 script:

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -32,6 +32,7 @@ matrix:
 
 before_install:
   - npm config set spin false
+  - npm install -g npm@4
   - npm --version
 
 script:


### PR DESCRIPTION
I was using node 4 in some addons, and bundled npm 2 makes it unbearably slow. npm 4 makes it a lot better. npm 5 was not stable enough in my testing.