### PR TITLE
cherry pick "install npm 4 in addon travis using npm"

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -37,6 +37,8 @@ install:
 <% } else { %>
 before_install:
   - npm config set spin false
+  - npm install -g npm@4
+  - npm --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
 


### PR DESCRIPTION
Addons are installing with npm 2 and having a bad (slow) time. We should probably port this to release.

Backport of https://github.com/ember-cli/ember-cli/pull/7180