### PR TITLE
use newer yarn on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,11 @@ before_install:
   - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
   - if [[ $(npm -v | cut -d '.' -f 1) -gt 4 ]]; then npm i -g npm@^4; fi
 
+  # travis currently includes yarn v0.17.8 (20170705)
+  # this isn't new enough for our use of --non-interactive
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 script:
   # For now we will use `npm` to kick off the test suite.
   # Can switch to `yarn` once we no longer support Node.js 0.12:


### PR DESCRIPTION
https://travis-ci.org/ember-cli/ember-cli/jobs/250484161#L1848-L1851

```
not ok 91 Acceptance: ember new ember new uses yarn when blueprint has yarn.lock
  Error: Command failed: yarn install --ignore-optional --non-interactive
  
    error: unknown option `--non-interactive'
```