### PR TITLE
fix: Add some defaults for index.html

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -15,10 +15,6 @@
     {{content-for "head-footer"}}
   </head>
   <body>
-    <noscript>
-      JavaScript must be enabled to run this application.
-    </noscript>
-    
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -15,6 +15,10 @@
     {{content-for "head-footer"}}
   </head>
   <body>
+    <noscript>
+      JavaScript must be enabled to run this application.
+    </noscript>
+    
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>


### PR DESCRIPTION
Basically, these are defaults that can be updated or left as is.
The use case for these is to improve accessibility. These metrics were brought up by the Lighthouse test.

Feel free to close, if these don't make sense. I know that `noscript` doesn't make sense if using fastboot, but I think most people aren't using it.