### PR TITLE
bugfix(legacy-addons): Fixes typo in babel transpilation options

### DIFF
--- a/lib/broccoli/babel-process-modules-only.js
+++ b/lib/broccoli/babel-process-modules-only.js
@@ -17,7 +17,7 @@ const ModulesTransform = (function() {
 module.exports = function processModulesOnly(tree, annotation) {
   let options = {
     plugins: [
-      [ModulesTransform, { loose: true, noIterop: true }],
+      [ModulesTransform, { loose: true, noInterop: true }],
     ],
     moduleIds: true,
     resolveModuleSource: require('amd-name-resolver').moduleResolve,


### PR DESCRIPTION
Fixes a small typo that causes the AMD interop to be added to legacy addons which don't specify their own transpiler. This probably only affects a very small set of users, we ran into it because we have a couple really old addons still and we're using the pre-npm ember-cli-shims which don't specify `__esModule`.

Unsure if this needs tests/how to test it, if it does I'm happy to add them with some guidance.