### PR TITLE
[bugfix release] Ember try remove node modules

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -50,5 +50,5 @@ install:
 <% } %>
 script:
   # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  # to the addon's original dependency state, skipping "cleanup".
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup


### PR DESCRIPTION
Travis is able to resolve the `ember` bin in node_modules no problem. Is this a legacy thing that I'm not aware of, or can it be safely removed?

cc @kategengler 