### PR TITLE
[BUGFIX release] fix shutdown/interrupt code (rebased)

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -84,8 +84,6 @@ class CLI {
    * @return {Promise}
    */
   run(environment) {
-    let shutdownOnExit = null;
-
     return RSVP.hash(environment).then(environment => {
       let args = environment.cliArgs.slice();
       let commandName = args.shift();
@@ -146,31 +144,27 @@ class CLI {
       }
 
       let instrumentation = this.instrumentation;
-      let onCommandInterrupt;
+      let removeInterruptionHandler;
 
-      let runPromise = Promise.resolve().then(() => {
+      return Promise.resolve().then(() => {
+        removeInterruptionHandler = onProcessInterrupt.addHandler(() => command.onInterrupt());
         instrumentation.stopAndReport('init');
         instrumentation.start('command');
 
         loggerTesting.info('cli: command.beforeRun');
-        onProcessInterrupt.addHandler(onCommandInterrupt);
 
         return command.beforeRun(commandArgs);
       }).then(() => {
         loggerTesting.info('cli: command.validateAndRun');
 
         return command.validateAndRun(commandArgs);
+      }).finally(() => {
+        removeInterruptionHandler();
       }).then(result => {
         instrumentation.stopAndReport('command', commandName, commandArgs);
-
-        onProcessInterrupt.removeHandler(onCommandInterrupt);
-
         return result;
       }).finally(() => {
         instrumentation.start('shutdown');
-        shutdownOnExit = function() {
-          instrumentation.stopAndReport('shutdown');
-        };
       }).then(result => {
         // if the help option was passed, call the help command
         if (result === 'callHelp') {
@@ -199,16 +193,8 @@ class CLI {
           }
         });
       });
-
-      onCommandInterrupt = () =>
-        Promise.resolve(command.onInterrupt())
-          .then(() => runPromise);
-
-      return runPromise;
     }).finally(() => {
-      if (shutdownOnExit) {
-        shutdownOnExit();
-      }
+      this.instrumentation.stopAndReport('shutdown');
     }).catch(this.logError.bind(this));
   }
 

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -29,12 +29,11 @@ class Builder extends CoreObject {
 
     this.setupBroccoliBuilder();
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
-    this._cleanup = this.cleanup.bind(this);
 
     this._cleanupPromise = null;
-    this._onProcessInterrupt = options.onProcessInterrupt || onProcessInterrupt;
+    let _onProcessInterrupt = options.onProcessInterrupt || onProcessInterrupt;
 
-    this._onProcessInterrupt.addHandler(this._cleanup);
+    this._teardownCleanup = _onProcessInterrupt.addHandler(this.cleanup.bind(this));
   }
 
   /**
@@ -190,7 +189,7 @@ class Builder extends CoreObject {
       // ensure any addon treeFor caches are reset
       _resetTreeCache();
 
-      this._onProcessInterrupt.removeHandler(this._cleanup);
+      this._teardownCleanup();
 
       let node = heimdall.start({ name: 'Builder Cleanup' });
 

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -60,7 +60,7 @@ module.exports = {
    */
   release() {
     while (handlers.length > 0) {
-      this.removeHandler(handlers[0]);
+      this._removeHandler(handlers[0]);
     }
 
     _process = null;
@@ -90,6 +90,7 @@ module.exports = {
 
     handlers.push(cb);
     captureExit.onExit(cb);
+    return this._removeHandler.bind(this, cb);
   },
 
   /**
@@ -102,7 +103,7 @@ module.exports = {
    * @method removeHandler
    * @param {function} cb   Callback to be removed
    */
-  removeHandler(cb) {
+  _removeHandler(cb) {
     let index = handlers.indexOf(cb);
     if (index < 0) { return; }
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const captureExit = require('capture-exit');
-captureExit.captureExit();
-
 const glob = require('glob');
 const Mocha = require('mocha');
 const RSVP = require('rsvp');

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const captureExit = require('capture-exit');
+captureExit.captureExit();
+
 const glob = require('glob');
 const Mocha = require('mocha');
 const RSVP = require('rsvp');

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -6,6 +6,7 @@ const MockAnalytics = require('../../helpers/mock-analytics');
 const td = require('testdouble');
 const Command = require('../../../lib/models/command');
 const Promise = require('rsvp').Promise;
+const SilentError = require('silent-error');
 
 let ui;
 let analytics;
@@ -65,10 +66,16 @@ function stubRun(name) {
 }
 
 describe('Unit: CLI', function() {
+  let teardownHandler;
   beforeEach(function() {
+    teardownHandler = td.function();
+    let teardown = td.function();
+    let addHandler = td.function();
+    td.when(addHandler(td.matchers.isA(Function))).thenReturn(teardownHandler);
+
     willInterruptProcess = td.replace('../../../lib/utilities/will-interrupt-process', {
-      addHandler: td.function(),
-      removeHandler: td.function(),
+      addHandler,
+      teardown,
     });
 
     CLI = require('../../../lib/cli/cli');
@@ -228,6 +235,29 @@ describe('Unit: CLI', function() {
     });
   });
 
+  describe('command crash', function() {
+    const error = new SilentError('OMG');
+    it('correctly cleansup', function() {
+      let CustomCommand = Command.extend({
+        name: 'custom',
+
+        run() {
+          throw error;
+        },
+      });
+
+      project.eachAddonCommand = function(callback) {
+        callback('custom-addon', {
+          custom: CustomCommand,
+        });
+      };
+
+      return expect(ember(['custom'])).to.be.rejectedWith(error).then(() => {
+        td.verify(teardownHandler());
+      });
+    });
+  });
+
   describe('command interruption handler', function() {
     let onCommandInterrupt;
     beforeEach(function() {
@@ -255,14 +285,16 @@ describe('Unit: CLI', function() {
         });
       };
 
-      return ember(['custom']);
+      return ember(['custom']).finally(function() {
+        td.verify(teardownHandler());
+      });
     });
 
     it('cleans up handler after command finished', function() {
       stubValidateAndRun('serve');
 
       return ember(['serve']).finally(function() {
-        td.verify(willInterruptProcess.removeHandler(onCommandInterrupt));
+        td.verify(teardownHandler());
       });
     });
   });
@@ -711,8 +743,8 @@ describe('Unit: CLI', function() {
           return expect(verboseCommand(['fake_option_1', '--fake-option', 'fake_option_2'])).to.be.rejected.then(error => {
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_1).to.be.ok;
             expect(process.env.EMBER_VERBOSE_FAKE_OPTION_2).to.not.be.ok;
-            expect(error.name).to.equal('SilentError');
             expect(error.message).to.equal('The specified command fake-command is invalid. For available options, see `ember help`.');
+            expect(error.name).to.equal('SilentError');
           });
         });
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -7,13 +7,17 @@ const td = require('testdouble');
 const Command = require('../../../lib/models/command');
 const Promise = require('rsvp').Promise;
 const SilentError = require('silent-error');
+const willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
+const captureExit = require('capture-exit');
+const MockProcess = require('../../helpers/mock-process');
 
 let ui;
 let analytics;
 let commands = {};
 let isWithinProject;
 let project;
-let willInterruptProcess;
+let _process;
+let origExit;
 
 let CLI;
 
@@ -44,6 +48,14 @@ function ember(args) {
   });
 }
 
+function registerCommand(Command) {
+  project.eachAddonCommand = function(callback) {
+    callback(Command.name, {
+      Command,
+    });
+  };
+}
+
 function stubCallHelp() {
   return td.replace(CLI.prototype, 'callHelp', td.function());
 }
@@ -66,18 +78,22 @@ function stubRun(name) {
 }
 
 describe('Unit: CLI', function() {
-  let teardownHandler;
   beforeEach(function() {
-    teardownHandler = td.function();
-    let teardown = td.function();
-    let addHandler = td.function();
-    td.when(addHandler(td.matchers.isA(Function))).thenReturn(teardownHandler);
 
-    willInterruptProcess = td.replace('../../../lib/utilities/will-interrupt-process', {
-      addHandler,
-      teardown,
+    _process = new MockProcess({
+      exit() {
+        // force `process-exit` to handle exit
+        process.exit();
+      },
     });
 
+    // capture-exit doesn't support `process` injection
+    // instead it always uses global `process`
+    origExit = process.exit;
+    // if we leave original exit then test run will be stopped once we send SIGINT
+    process.exit = function() {};
+
+    willInterruptProcess.capture(_process);
     CLI = require('../../../lib/cli/cli');
     ui = new MockUI();
     analytics = new MockAnalytics();
@@ -101,6 +117,9 @@ describe('Unit: CLI', function() {
 
     delete process.env.EMBER_ENV;
     commands = ui = undefined;
+    willInterruptProcess.release();
+    captureExit._reset();
+    process.exit = origExit;
   });
 
   this.timeout(10000);
@@ -235,68 +254,78 @@ describe('Unit: CLI', function() {
     });
   });
 
-  describe('command crash', function() {
-    const error = new SilentError('OMG');
-    it('correctly cleansup', function() {
-      let CustomCommand = Command.extend({
-        name: 'custom',
-
-        run() {
-          throw error;
-        },
-      });
-
-      project.eachAddonCommand = function(callback) {
-        callback('custom-addon', {
-          custom: CustomCommand,
-        });
-      };
-
-      return expect(ember(['custom'])).to.be.rejectedWith(error).then(() => {
-        td.verify(teardownHandler());
-      });
-    });
-  });
-
-  describe('command interruption handler', function() {
-    let onCommandInterrupt;
+  describe('command interruption', function() {
+    let interruptionHandeled;
     beforeEach(function() {
-      onCommandInterrupt = td.matchers.isA(Function);
+      interruptionHandeled = false;
+    });
+
+    const FakeCommand = Command.extend({
+      name: 'fake',
+
+      beforeRun() {
+        return Promise.resolve();
+      },
+
+      run() {
+        return new Promise(resolve => {
+          setTimeout(() => resolve(), 50);
+        });
+      },
+
+      onInterrupt() {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            interruptionHandeled = true;
+            resolve();
+          }, 100); // ensure we cleanup longer than command run executed
+        });
+      },
     });
 
     it('sets up handler before command run', function() {
-      const CustomCommand = Command.extend({
-        name: 'custom',
-
+      registerCommand(FakeCommand.extend({
         beforeRun() {
-          td.verify(willInterruptProcess.addHandler(onCommandInterrupt));
-
-          return Promise.resolve();
+          _process.emit('SIGINT');
         },
+      }));
 
+      return ember(['fake']).finally(function() {
+        expect(interruptionHandeled).to.equal(true);
+      });
+    });
+
+    it('cleans up handler right after command is finished', function() {
+      registerCommand(FakeCommand.extend({
+        onInterrupt() {
+          interruptionHandeled = true;
+        },
+      }));
+
+      return ember(['fake']).finally(function() {
+        _process.emit('SIGINT');
+
+        // ensure interruption handler has enough time to be triggered
+        return new Promise(resolve => setTimeout(resolve, 50));
+      }).then(() => {
+        expect(interruptionHandeled).to.equal(false);
+      });
+    });
+
+    it(`rejected with a proper error on crash`, function() {
+      const error = new SilentError('OMG');
+
+      registerCommand(FakeCommand.extend({
         run() {
-          return Promise.resolve();
+          throw error;
         },
-      });
+      }));
 
-      project.eachAddonCommand = function(callback) {
-        callback('custom-addon', {
-          CustomCommand,
-        });
-      };
-
-      return ember(['custom']).finally(function() {
-        td.verify(teardownHandler());
+      return expect(ember(['fake'])).to.be.rejectedWith(error).then(() => {
+        expect(interruptionHandeled).to.equal(false);
       });
     });
 
-    it('cleans up handler after command finished', function() {
-      stubValidateAndRun('serve');
-
-      return ember(['serve']).finally(function() {
-        td.verify(teardownHandler());
-      });
-    });
   });
 
   describe('help', function() {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -36,9 +36,11 @@ describe('models/builder.js', function() {
   }
 
   before(function() {
+    let addHandler = td.function();
+    let teardownHandler = td.function();
+    td.when(addHandler(td.matchers.isA(Function))).thenReturn(teardownHandler);
     td.replace('../../../lib/utilities/will-interrupt-process', {
-      addHandler: td.function(),
-      removeHandler: td.function(),
+      addHandler,
     });
 
     Builder = require('../../../lib/models/builder');

--- a/tests/unit/tasks/build-watch-test.js
+++ b/tests/unit/tasks/build-watch-test.js
@@ -36,8 +36,7 @@ describe('build-watch task', function() {
       project,
       setupBroccoliBuilder,
       onProcessInterrupt: {
-        addHandler() {},
-        removeHandler() {},
+        addHandler() { return function() { }; },
       },
     });
 

--- a/tests/unit/tasks/serve-test.js
+++ b/tests/unit/tasks/serve-test.js
@@ -36,8 +36,7 @@ describe('serve task', function() {
       project,
       setupBroccoliBuilder,
       onProcessInterrupt: {
-        addHandler() {},
-        removeHandler() {},
+        addHandler() { return function() { }; },
       },
     });
 

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -92,10 +92,10 @@ describe('will interrupt process', function() {
 
     it('removes exit handler', function() {
       willInterruptProcess.capture(new MockProcess());
-      willInterruptProcess.addHandler(cb);
+      let teardown = willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
-      willInterruptProcess.removeHandler(cb);
+      teardown();
 
       expect(captureExit.listenerCount()).to.equal(1);
     });
@@ -142,11 +142,12 @@ describe('will interrupt process', function() {
     });
 
     it('cleans up interruption signal listener', function() {
+      let teardown = willInterruptProcess.addHandler(cb);
       // will-interrupt-process doesn't have any public API to get actual handlers count
       // so here we make a side test to ensure that we don't add the same callback twice
       willInterruptProcess.addHandler(cb);
 
-      willInterruptProcess.removeHandler(cb);
+      teardown();
 
       expect(process.getSignalListenerCounts()).to.eql({
         SIGINT: 0,
@@ -156,10 +157,10 @@ describe('will interrupt process', function() {
     });
 
     it(`doesn't clean up interruption signal listeners if there are remaining handlers`, function() {
-      willInterruptProcess.addHandler(cb);
+      let teardown = willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(() => cb());
 
-      willInterruptProcess.removeHandler(cb);
+      teardown();
 
       expect(process.getSignalListenerCounts()).to.eql({
         SIGINT: 1,
@@ -211,10 +212,10 @@ describe('will interrupt process', function() {
 
       willInterruptProcess.capture(process);
 
-      willInterruptProcess.addHandler(cb);
+      const removeHandler = willInterruptProcess.addHandler(cb);
       expect(process.stdin.isRaw).to.equal(true);
 
-      willInterruptProcess.removeHandler(cb);
+      removeHandler();
       expect(process.stdin.isRaw).to.equal(false);
     });
 


### PR DESCRIPTION
rebased #7019 on top of master with #7086 included. 

There is one notable change in this PR: I've removed [`teardown()` from `cli/cli`](https://github.com/ember-cli/ember-cli/pull/7019/files#diff-16a41bfbe414387d773df099f941217eR197).
`teardown()` have changed the name to `release()` in master and it's now called from the [`cli/index`](https://github.com/ember-cli/ember-cli/blob/7f6246d63ef820a3eb07fbbb021969dbdcb9a262/lib/cli/index.js#L145)

Feel free to close it. Just wanted to push this fix/refactoring somehow in order to unlock #7069 

todo:
 - [ ] Simplify dealing with `capture-exit` vs `process.exit()` in the `cli/cli-test`. Possible solution: https://github.com/ember-cli/capture-exit/pull/23 
 - [ ] catch "ember new foo, test, SIGINT exits with error and clears tmp/" with unit tests and fix