### PR TITLE
ENHANCEMENT - don't compress responses with the x-no-compression response header

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -192,7 +192,17 @@ class ExpressServerTask extends Task {
 
   startHttpServer() {
     this.app = this.express();
-    this.app.use(require('compression')());
+    const compression = require('compression');
+    this.app.use(compression({
+      filter(req, res) {
+        if (res.getHeader('x-no-compression')) {
+          // don't compress responses with this response header
+          return false;
+        } else {
+          return compression.filter(req, res);
+        }
+      },
+    }));
 
     this.setupHttpServer();
 


### PR DESCRIPTION
I'm using an http-proxy to proxy to an endpoint intended for long polling. Now this endpoint writes a newline to the HTTP connection in regular intervals to make sure the connection stays alive.

The compression middleware however buffers the output produced by the endpoint (and the http-proxy) waiting for it to complete so it can compress it. This leads to the initiator closing the connection after not receiving back any data.

Having the proposed change in place lets me circumvent this problem by setting a header on the response object like this:
```js
// server/proxies/long-poll.js
module.exports = function(app) {
  app.use('/long-poll', function(req, res) {
    res.setHeader('x-no-compression', 'true');
    require('http-proxy').createProxyServer().web(req, res, {
      target: 'http://long-polling.service.lvh.me:1234'
    });
  });
};
```