### PR TITLE
Convert blueprints to use modules and bump ember-cli-babel

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -1,7 +1,7 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -19,7 +19,7 @@
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.3.0",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.1",

--- a/blueprints/app/files/tests/helpers/destroy-app.js
+++ b/blueprints/app/files/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
 import { module } from 'qunit';
-import Ember from 'ember';
+import { resolve } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();


### PR DESCRIPTION
I converted the blueprints used in `ember init` over to use the new modules syntax, and bumped the `ember-cli-babel` version to ensure backwards compatibility with the polyfill.

We will also need to convert all the blueprints people run for the generators themselves, which I can do in a followup PR.