### PR TITLE
Revert "Revert "Remove arbitrary *.js filtering for addon tree.""

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1137,11 +1137,7 @@ let addonProto = {
   addonJsFiles(tree) {
     this._requireBuildPackages();
 
-    let includePatterns = this.registry.extensionsForType('js')
-      .map(extension => new RegExp(`${extension}$`));
-
     return new Funnel(tree, {
-      include: includePatterns,
       destDir: this.moduleName(),
       annotation: 'Funnel: Addon JS',
     });


### PR DESCRIPTION
This reverts commit dee542cdf9aad28df93b093ccdea21b0d9e103ab.

We should get this back in

- [ ] reproduction of the original issue
- [ ] ensure it is already addressed, or address the issue.