### PR TITLE
[FIX] Allow preprocessors to use module unification dir structure

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -904,7 +904,11 @@ class EmberApp {
 
     // TODO: This isn't quite correct (but it does function properly in most cases),
     // and should be re-evaluated before enabling the `MODULE_UNIFICATION` feature
-    this._srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
+    let srcStylesPath = this._resolveLocal('src/ui/styles');
+
+    if (existsSync(srcStylesPath)) {
+      this._srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
+    }
 
     let srcAfterTemplatePreprocessing = preprocessTemplates(srcAfterPreprocessTreeHook, {
       registry: this.registry,

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1397,11 +1397,21 @@ class EmberApp {
         throw new SilentError(`Style file cannot have the name of the application - ${this.name}`);
       }
 
+      let directory = '/app/styles';
+
+      if (experiments.MODULE_UNIFICATION) {
+        let srcStylesPath = this._resolveLocal('src/ui/styles');
+
+        if (existsSync(srcStylesPath)) {
+          directory = '/src/ui/styles';
+        }
+      }
+
       let addonTrees = this.addonTreesFor('styles');
       let external = this._processedExternalTree();
       let styles = new Funnel(this.trees.styles, {
         srcDir: '/',
-        destDir: '/app/styles',
+        destDir: directory,
         annotation: 'Funnel (styles)',
       });
 
@@ -1415,7 +1425,7 @@ class EmberApp {
         overwrite: true,
       }));
 
-      let preprocessedStyles = preprocessCss(stylesAndVendor, '/app/styles', '/assets', options);
+      let preprocessedStyles = preprocessCss(stylesAndVendor, directory, '/assets', options);
 
       if (this.vendorStaticStyles.length > 0) {
         this.project.ui.writeDeprecateLine(`Usage of EmberApp.vendorStaticStyles is deprecated. Please use EmberApp.import instead for the following files: '${this.vendorStaticStyles.join('\', \'')}'`);


### PR DESCRIPTION
Currently using the MODULE_UNIFICATION flag works for traditional CSS files, but there was a hardcoded reference to `/app/styles` when instantiating preprocessors.

I have tested this with a new module unification app with sass stylesheets in:

* app/styles/app.scss
* src/ui/styles/app.scss

This may not solve all issues as there was an existing TODO in the file noting a needed fix for CSS preprocessing with module unification, but this is a first stab and gets `ember-cli-sass` to compile correctly.