### PR TITLE
Make blueprint.supportsAddon set this.options

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -774,9 +774,11 @@ let Blueprint = CoreObject.extend({
 
     @private
     @method supportsAddon
+    @param {Object} options
     @return {Boolean}
   */
-  supportsAddon() {
+  supportsAddon(options) {
+    this.options = this.options || options;
     return (/__root__/).test(this.files().join());
   },
 

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -23,7 +23,7 @@ class GenerateTask extends Task {
     let addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
     // otherwise, use default addon-import
 
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon(options)) && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
 

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -267,6 +267,25 @@ describe('Blueprint', function() {
       return remove(tmproot);
     });
 
+    it('returns true if supportsAddon finds the __root__ token in the files folder', function() {
+      let blueprint = new Blueprint(basicBlueprint);
+
+      expect(!!blueprint.supportsAddon(options)).to.equal(true);
+    });
+
+    it('sets the options when supportsAddon is called', function() {
+      let blueprint = new Blueprint(basicBlueprint);
+      const origFilesPath = blueprint.filesPath;
+
+      blueprint.filesPath = function(supportsAddonOptions) {
+        expect(supportsAddonOptions).to.deep.equal(options);
+
+        return origFilesPath.apply(this, arguments);
+      };
+
+      blueprint.supportsAddon(options);
+    });
+
     it('installs basic files', function() {
       expect(!!blueprint).to.equal(true);
 


### PR DESCRIPTION
This change fixes an issue where `supportsAddon` calls files
without first setting `this.options`.

If `this.options` is not set then blueprints which implement the `filesPath`
hook will not be passed an `options` object.