### PR TITLE
double test timeout for install-test-slow

### DIFF
--- a/tests/acceptance/install-test-slow.js
+++ b/tests/acceptance/install-test-slow.js
@@ -14,7 +14,7 @@ let expect = chai.expect;
 let file = chai.file;
 
 describe('Acceptance: ember install', function() {
-  this.timeout(60000);
+  this.timeout(120000);
 
   beforeEach(co.wrap(function *() {
     let tmpdir = yield mkTmpDirIn(tmproot);


### PR DESCRIPTION
this installs 2 npm packages:
 - ember-cli-fastclick
 - ember-cli-photoswipe

Then it installs `bower` in order to install bower deps.

In some environments(#7253) 60 sec is not enough.