### PR TITLE
Introduces Bundler

### DIFF
--- a/lib/broccoli/bundler.js
+++ b/lib/broccoli/bundler.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const concat = require('broccoli-concat');
+const processModulesOnly = require('./babel-process-modules-only');
+
+module.exports = class Bundler {
+  /*
+    Responsibility of this class is to intelligently produce
+    the final output given a list of trees that were passed in.
+
+    @class Bundler
+    @constructor
+    @param {Object} Configuration options
+   */
+  constructor(options) {
+    this.name = options.name;
+    this.sourcemaps = options.sourcemaps;
+    this.appOutputPath = options.appOutputPath;
+    this.isBabelAvailable = options.isBabelAvailable;
+  }
+
+  /*
+    Concatenates all javascript Broccoli trees into one, as follows:
+
+    Given an input tree that looks like:
+
+    ```
+    addon-tree-output/
+      ember-ajax/
+      ember-data/
+      ember-engines/
+      ember-resolver/
+      ...
+    bower_components/
+      usertiming/
+      sinonjs/
+      ...
+    the-best-app-ever/
+      components/
+      config/
+      helpers/
+      routes/
+      ...
+    vendor/
+      ...
+      babel-core/
+      ...
+      broccoli-concat/
+      ...
+      ember-cli-template-lint/
+      ...
+    ```
+
+    Produces a tree that looks like:
+
+    ```
+    assets/
+      the-best-app-ever.js
+      the-best-app-ever.map (if sourcemaps are enabled)
+    ```
+
+    @method bundleAppJs
+    @return {Tree} Concatenated tree (application and dependencies).
+   */
+  bundleJs(applicationAndDepsTree, options) {
+    options = options || {};
+
+    let appJs = concat(applicationAndDepsTree, {
+      inputFiles: [`${this.name}/**/*.js`],
+      headerFiles: [
+        'vendor/ember-cli/app-prefix.js',
+      ],
+      footerFiles: [
+        'vendor/ember-cli/app-suffix.js',
+        'vendor/ember-cli/app-config.js',
+        'vendor/ember-cli/app-boot.js',
+      ],
+      outputFile: this.appOutputPath,
+      annotation: options.appTreeAnnotation,
+      sourceMapConfig: this.sourcemaps,
+    });
+
+    if (!this.isBabelAvailable) {
+      appJs = processModulesOnly(appJs, 'Babel: Modules for app/');
+    }
+
+    return appJs;
+  }
+};

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -44,6 +44,7 @@ const lintAddonsByType = require('../utilities/lint-addons-by-type');
 const experiments = require('../experiments');
 const processModulesOnly = require('./babel-process-modules-only');
 const semver = require('semver');
+const Bundler = require('./bundler');
 
 let DEFAULT_CONFIG = {
   storeConfigInMeta: true,
@@ -149,6 +150,13 @@ class EmberApp {
     if (!this._addonInstalled('loader.js') && !this.options._ignoreMissingLoader) {
       throw new SilentError('The loader.js addon is missing from your project, please add it to `package.json`.');
     }
+
+    this.bundler = new Bundler({
+      name: this.name,
+      sourcemaps: this.options.sourcemaps,
+      appOutputPath: this.options.outputPaths.app.js,
+      isBabelAvailable: this._addonInstalled('ember-cli-babel'),
+    });
   }
 
   /**
@@ -1326,25 +1334,7 @@ class EmberApp {
   javascript() {
     let deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
     let applicationJs = this.appAndDependencies();
-    let appOutputPath = this.options.outputPaths.app.js;
-    let appJs = applicationJs;
-
-    // Note: If ember-cli-babel is installed we have already performed the transpilation at this point
-    if (!this._addonInstalled('ember-cli-babel')) {
-      appJs = processModulesOnly(appJs, 'Babel: Modules for app/');
-    }
-
-    appJs = this._concatFiles(appJs, {
-      inputFiles: [`${this.name}/**/*.js`],
-      headerFiles: [
-        'vendor/ember-cli/app-prefix.js',
-      ],
-      footerFiles: [
-        'vendor/ember-cli/app-suffix.js',
-        'vendor/ember-cli/app-config.js',
-        'vendor/ember-cli/app-boot.js',
-      ],
-      outputFile: appOutputPath,
+    let appJs = this.bundler.bundleJs(applicationJs, {
       annotation: 'Concat: App',
     });
 

--- a/tests/unit/broccoli/bundler-test.js
+++ b/tests/unit/broccoli/bundler-test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const co = require('co');
+const chai = require('chai');
+const Bundler = require('../../../lib/broccoli/bundler');
+const walkSync = require('walk-sync');
+const broccoliTestHelper = require('broccoli-test-helper');
+
+const expect = chai.expect;
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('Bundler', function() {
+  describe('constructor', function() {
+    it('should set properties', function() {
+      let bundler = new Bundler({
+        name: 'the-best-app-ever',
+        sourcemaps: { enabled: true },
+        appOutputPath: 'the-best-app-ever.js',
+      });
+
+      expect(bundler.name).to.equal('the-best-app-ever');
+      expect(bundler.sourcemaps).to.deep.equal({ enabled: true });
+      expect(bundler.appOutputPath).to.equal('the-best-app-ever.js');
+    });
+  });
+
+  describe('bundleAppJs', function() {
+    let input;
+
+    beforeEach(co.wrap(function *() {
+      input = yield createTempDir();
+
+      input.write({
+        'addon-tree-output': {
+          'ember-ajax': {
+            'request.js': '',
+          },
+          'ember-cli-app-version': {
+            'initializer-factory.js': '',
+          },
+          'modules': {
+            'ember-data': {
+              'transform.js': '',
+              'store.js': '',
+            },
+          },
+        },
+        'the-best-app-ever': {
+          'router.js': 'router.js',
+          'app.js': 'app.js',
+          'components': {
+            'x-foo.js': 'x-foo.js',
+          },
+          'config': {
+            'environment.js': 'environment.js',
+          },
+        },
+        'vendor': {
+          'ember-cli': {
+            'app-boot.js': 'app-boot.js',
+            'app-config.js': 'app-config.js',
+            'app-prefix.js': 'app-prefix.js',
+            'app-suffix.js': 'app-suffix.js',
+            'test-support-prefix.js': 'test-support-prefix.js',
+            'test-support-suffix.js': 'test-support-suffix.js',
+            'tests-prefix.js': 'tests-prefix.js',
+            'tests-suffix.js': 'tests-suffix.js',
+            'vendor-prefix.js': 'vendor-prefix.js',
+            'vendor-suffix.js': 'vendor-suffix.js',
+          },
+        },
+      });
+    }));
+
+    afterEach(function() {
+      input.dispose();
+    });
+
+    it('given a tree with `addon` and `vendor` produces a final tree with one javascript file and sourcemap associated with it', co.wrap(function *() {
+      let bundler = new Bundler({
+        name: 'the-best-app-ever',
+        sourcemaps: { enabled: true },
+        appOutputPath: 'the-best-app-ever.js',
+        appTreeAnnotation: 'concat yo',
+      });
+
+      let output = yield buildOutput(bundler.bundleJs(input.path(), {
+        annotation: 'concatinatin\' silly trees',
+      }));
+
+      let files = walkSync(output.path(), { directories: false });
+      expect(files).to.deep.equal([
+        'the-best-app-ever.js',
+        'the-best-app-ever.map',
+      ]);
+    }));
+  });
+});

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1050,6 +1050,21 @@ describe('EmberApp', function() {
     describe('concat order', function() {
       let count = 0;
       let args = [];
+      let concatAppJsTree = {
+        annotation: "Concat: App",
+        footerFiles: [
+          "vendor/ember-cli/app-suffix.js",
+          "vendor/ember-cli/app-config.js",
+          "vendor/ember-cli/app-boot.js",
+        ],
+        headerFiles: [
+          "vendor/ember-cli/app-prefix.js",
+        ],
+        inputFiles: [
+          "test-project/**/*.js",
+        ],
+        outputFile: "/assets/test-project.js",
+      };
 
       beforeEach(function() {
         count = 0;
@@ -1060,6 +1075,12 @@ describe('EmberApp', function() {
         app._concatFiles = function(tree, options) {
           count++;
           args.push(options);
+          return tree;
+        };
+
+        app.bundler.bundleJs = function(tree) {
+          count++;
+          args.push(concatAppJsTree);
           return tree;
         };
 
@@ -1133,21 +1154,7 @@ describe('EmberApp', function() {
 
         expect(count).to.eql(2);
         // should be unrelated files
-        expect(args[0]).to.deep.eql({
-          annotation: "Concat: App",
-          footerFiles: [
-            "vendor/ember-cli/app-suffix.js",
-            "vendor/ember-cli/app-config.js",
-            "vendor/ember-cli/app-boot.js",
-          ],
-          headerFiles: [
-            "vendor/ember-cli/app-prefix.js",
-          ],
-          inputFiles: [
-            "test-project/**/*.js",
-          ],
-          outputFile: "/assets/test-project.js",
-        });
+        expect(args[0]).to.deep.eql(concatAppJsTree);
 
         // should be: a,b,c,d in output
         expect(args[1]).to.deep.eql({

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,11 +110,11 @@ ansicolors@~0.2.1:
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
 
 anymatch@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
   dependencies:
-    arrify "^1.0.0"
     micromatch "^2.1.5"
+    normalize-path "^2.0.0"
 
 aproba@^1.0.3:
   version "1.1.2"
@@ -212,10 +212,11 @@ async-disk-cache@^1.2.1:
     username-sync "1.0.1"
 
 async-promise-queue@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/async-promise-queue/-/async-promise-queue-1.0.3.tgz#70c9c37635620f894978814b6c65e6e14e2573ee"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/async-promise-queue/-/async-promise-queue-1.0.4.tgz#308baafbc74aff66a0bb6e7f4a18d4fe8434440c"
   dependencies:
     async "^2.4.1"
+    debug "^2.6.8"
 
 async@1.x, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
@@ -338,8 +339,8 @@ babel-register@^6.24.1:
     source-map-support "^0.4.2"
 
 babel-runtime@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -1153,7 +1154,7 @@ dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
 
-debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@~2.6.7:
+debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -3205,7 +3206,7 @@ nopt@3.x, nopt@^3.0.6:
   dependencies:
     abbrev "1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -3488,9 +3489,13 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@6.4.0, qs@^6.0.2, qs@^6.1.0, qs@^6.4.0:
+qs@6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+qs@^6.0.2, qs@^6.1.0, qs@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
 qs@~1.0.0:
   version "1.0.2"
@@ -3661,8 +3666,8 @@ resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
 
@@ -4041,7 +4046,7 @@ supertest@^3.0.0:
     methods "~1.1.2"
     superagent "^3.0.0"
 
-supports-color@3.1.2, supports-color@^3.1.0:
+supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -4054,6 +4059,12 @@ supports-color@^0.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.1.0:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^4.0.0:
   version "4.2.1"


### PR DESCRIPTION
After talking to @stefanpenner and @rwjblue about how we should approach tree shaking, I believe this is the minimal change we should make to proceed forward and start experimenting.

`Bundler` does not introduce any new functionality (it's basically an extraction of our `concat` step from `ember-app`) but it make it one place where we can access a single tree with application code, addons and vendor files (`bower` and `node_modules`). It makes it a perfect place to start experimenting with tree shaking (say, introduce a new Broccoli Plugin that would do the heavy lifting).

There are couple of other PRs that I opened that helped me to understand the problem space better and ultimately could be closed (for now):

+ https://github.com/ember-cli/ember-cli/pull/7251/ is a good summary of the changes we need to do to land functionality described in https://github.com/ember-cli/ember-cli/issues/7228 and help us track down problems described in https://github.com/ember-cli/ember-cli/issues/7243
+ https://github.com/ember-cli/ember-cli/pull/7240/ is a good summary of the changes we need to make to split out "tree generation" and "config" (general thinking there is that we should be able to specify how to build trees in `ember-app` and let something else build it for us; this will make it way easier to write unit tests and we can finally trim down slow acceptance tests).