### PR TITLE
Fix JSON format of asset sizes report

### DIFF
--- a/lib/commands/asset-sizes.js
+++ b/lib/commands/asset-sizes.js
@@ -7,7 +7,8 @@ module.exports = Command.extend({
   description: 'Shows the sizes of your asset files.',
 
   availableOptions: [
-    { name: 'output-path', type: 'Path', default: 'dist/', aliases: ['o'] },
+    { name: 'output-path', type: 'Path',  default: 'dist/', aliases: ['o'] },
+    { name: 'json',        type: Boolean, default: false },
   ],
 
   run(commandOptions) {

--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -35,7 +35,12 @@ class AssetPrinterSize {
     let ui = this.ui;
     return this.makeAssetSizesObject().then(files => {
       if (files.length !== 0) {
-        ui.writeLine(JSON.stringify({ files }));
+        let entries = files.map(file => ({
+          name: file.name,
+          size: file.size,
+          gzipSize: file.gzipSize,
+        }));
+        ui.writeLine(JSON.stringify({ files: entries }));
       } else {
         ui.writeLine(chalk.red(`No asset files found in the path provided: ${this.outputPath}`));
       }

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -24,6 +24,7 @@ ember asset-sizes \u001b[36m<options...>\u001b[39m
   Shows the sizes of your asset files.
   \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m \u001b[36m(Default: dist/)\u001b[39m
     \u001b[90maliases: -o <value>\u001b[39m
+  \u001b[36m--json\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
 
 ember build \u001b[36m<options...>\u001b[39m
   Builds your app and places it into the output path (dist/ by default).

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -88,6 +88,12 @@ module.exports = {
           required: false,
           aliases: ['o'],
           type: 'Path'
+        },
+        {
+          default: false,
+          key: 'json',
+          name: 'json',
+          required: false
         }
       ]
     },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -24,6 +24,7 @@ ember asset-sizes \u001b[36m<options...>\u001b[39m
   Shows the sizes of your asset files.
   \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m \u001b[36m(Default: dist/)\u001b[39m
     \u001b[90maliases: -o <value>\u001b[39m
+  \u001b[36m--json\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
 
 ember build \u001b[36m<options...>\u001b[39m
   Builds your app and places it into the output path (dist/ by default).

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -88,6 +88,12 @@ module.exports = {
           required: false,
           aliases: ['o'],
           type: 'Path'
+        },
+        {
+          default: false,
+          key: 'json',
+          name: 'json',
+          required: false
         }
       ]
     },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -88,6 +88,12 @@ module.exports = {
           required: false,
           aliases: ['o'],
           type: 'Path'
+        },
+        {
+          default: false,
+          key: 'json',
+          name: 'json',
+          required: false
         }
       ]
     },

--- a/tests/unit/models/asset-size-printer-test.js
+++ b/tests/unit/models/asset-size-printer-test.js
@@ -123,6 +123,7 @@ describe('models/asset-size-printer', function() {
         expect(output.files[1].name).to.include('nested-asset.js');
         expect(output.files[1].size).to.equal(32);
         expect(output.files[1].gzipSize).to.equal(52);
+        expect(output.files[0]).to.not.have.property('showGzipped');
       });
   });
 


### PR DESCRIPTION
This fixes the JSON variant of the asset sizes report by

* allowing the `--json` option (which actually was supported already: https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/show-asset-sizes.js#L13)
* preventing the `showGzipped` flag from being printed to the JSON report