### PR TITLE
Cache Project model config.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -171,7 +171,8 @@ class Builder extends CoreObject {
       .catch(error => {
         this.processAddonBuildSteps('buildError', error);
         throw error;
-      });
+      })
+      .finally(this.finalizeBuild.bind(this));
   }
 
   /**
@@ -221,6 +222,14 @@ class Builder extends CoreObject {
     this.project.ui.writeDeprecateLine('Heimdalljs < 0.1.4 found.  Please remove old versions of heimdalljs and reinstall (you can find them with `npm ls heimdalljs` as long as you have nothing `npm link`d).  Performance instrumentation data will be incomplete until then.', !process._heimdall);
 
     return value;
+  }
+
+  /**
+   * @private
+   * @method finalizeBuild
+   */
+  finalizeBuild() {
+    this.project.configCache.clear();
   }
 }
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -52,6 +52,7 @@ class Project {
     this.setupNodeModulesPath();
     this.addonDiscovery = new AddonDiscovery(this.ui);
     this.addonsFactory = new AddonsFactory(this, this);
+    this.configCache = new Map();
 
     /**
       Set when the `Watcher.detectWatchman` helper method finishes running,
@@ -203,6 +204,21 @@ class Project {
     @return {Object}     Merged confiration object
    */
   config(env) {
+    let c = this.configCache.get(env);
+    if (c === undefined) {
+      c = this.configWithoutCache(env);
+      this.configCache.set(env, c);
+    }
+    return c;
+  }
+
+  /**
+   * @private
+   * @method configWithoutCache
+   * @param  {String} env Environment name
+   * @return {Object}     Merged confiration object
+   */
+  configWithoutCache(env) {
     let configPath = this.configPath();
 
     if (existsSync(`${configPath}.js`)) {


### PR DESCRIPTION
Add-ons have the expectation that project.config is "cheap" to call and this is not true.  The config for a build should be stable.