### PR TITLE
Allow server middleware to answer non-get (POST/PATCH...) requests

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -46,16 +46,10 @@ class HistorySupportAddon {
     let watcher = options.watcher;
 
     let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
-    let baseURLRegexp = new RegExp(`^${baseURL}`);
 
     app.use((req, res, next) => {
       watcher.then(results => {
-
-        let acceptHeaders = req.headers.accept || [];
-        let hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
-        let isForBaseURL = baseURLRegexp.test(req.path);
-
-        if (hasHTMLHeader && isForBaseURL && req.method === 'GET') {
+        if (this.shouldHandleRequest(req, options)) {
           let assetPath = req.path.slice(baseURL.length);
           let isFile = false;
           try { isFile = fs.statSync(path.join(results.directory, assetPath)).isFile(); } catch (err) { /* ignore */ }
@@ -65,6 +59,20 @@ class HistorySupportAddon {
         }
       }).finally(next);
     });
+  }
+
+  shouldHandleRequest(req, options) {
+    let acceptHeaders = req.headers.accept || [];
+    let hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
+    if (req.method !== 'GET') {
+      return false;
+    }
+    if (!hasHTMLHeader) {
+      return false;
+    }
+    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+    let baseURLRegexp = new RegExp(`^${baseURL}`);
+    return baseURLRegexp.test(req.path);
   }
 }
 


### PR DESCRIPTION
This PR goes hand by hand with [a recently merged PR in ember-cli-fastboot](https://github.com/ember-fastboot/ember-cli-fastboot/pull/457).

This PR just lifts the check that the request is a GET request so fastboot can answer other kind of requests unconditionally.

On the original thread [some concerns about security were raised](https://github.com/ember-fastboot/ember-cli-fastboot/pull/354#issuecomment-292804064). I'm unsure about what concerns are those since this is just allowing the app to access data provided by the user, and besides ember-cli is a build tool and not something to be used in production.

However, if those security concerns really seem real, which do not to me, I'd be willing to add some sort of configuration option based on which ember-cli will ignore non-GET requests like today or answer them, perhaps in `.ember-cli`

**APPROACH CHANGE**

Now this PR only contains a refactor to extract the logic of what kind of requests should the middleware answer to into a method so the users can swap that logic by something that suits them.