### PR TITLE
{BACKPORT to release} [BUGFIX beta] ember test work with both —server and —path

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -133,18 +133,19 @@ module.exports = Command.extend({
 
       if (commandOptions.server) {
         if (hasBuild) {
-          throw new SilentError('Specifying a build is not allowed with the `--server` option.');
+          session = this.runTask('TestServer', testOptions);
+        } else {
+          let builder = new this.Builder(testOptions);
+
+          testOptions.watcher = new this.Watcher(Object.assign(this._env(), {
+            builder,
+            verbose: false,
+            options: commandOptions,
+          }));
+
+          session = this.runTask('TestServer', testOptions).finally(() => builder.cleanup());
         }
 
-        let builder = new this.Builder(testOptions);
-
-        testOptions.watcher = new this.Watcher(assign(this._env(), {
-          builder,
-          verbose: false,
-          options: commandOptions,
-        }));
-
-        session = this.runTask('TestServer', testOptions).finally(() => builder.cleanup());
       } else if (hasBuild) {
         session = this.runTask('Test', testOptions);
       } else {
@@ -152,7 +153,7 @@ module.exports = Command.extend({
           environment: commandOptions.environment,
           outputPath,
         })
-        .then(() => this.runTask('Test', testOptions));
+          .then(() => this.runTask('Test', testOptions));
       }
 
       return session.finally(this.rmTmp.bind(this));

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -30,6 +30,11 @@ class TestServerTask extends TestTask {
     // The building has actually started already, but we want some output while we wait for the server
 
     return new Promise((resolve, reject) => {
+      if (options.path) {
+        resolve(task.invokeTestem(options));
+        return;
+      }
+
       ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
       let watcher = options.watcher;

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -200,10 +200,8 @@ describe('test command', function() {
       });
     });
 
-    it('throws an error if using a build path', function() {
-      return expect(command.validateAndRun(['--server', '--path=tests'])).to.be.rejected.then(error => {
-        expect(error.message).to.equal('Specifying a build is not allowed with the `--server` option.');
-      });
+    it('DOES NOT throw an error if using a build path', function() {
+      return expect(command.validateAndRun(['--server', '--path=tests']));
     });
   });
 


### PR DESCRIPTION
This has turned out to be extremely useful/productivity boost. And poses low risk, so I would like to get another release out that includes this.