### PR TITLE
improve removal of interruption handler

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -146,24 +146,26 @@ class CLI {
       }
 
       let instrumentation = this.instrumentation;
+      let removeShutdownHandler;
       let onCommandInterrupt;
 
       let runPromise = Promise.resolve().then(() => {
+        removeShutdownHandler = onProcessInterrupt.addHandler(onCommandInterrupt);
+
         instrumentation.stopAndReport('init');
         instrumentation.start('command');
 
         loggerTesting.info('cli: command.beforeRun');
-        onProcessInterrupt.addHandler(onCommandInterrupt);
 
         return command.beforeRun(commandArgs);
       }).then(() => {
         loggerTesting.info('cli: command.validateAndRun');
 
         return command.validateAndRun(commandArgs);
+      }).finally(() => {
+        removeShutdownHandler();
       }).then(result => {
         instrumentation.stopAndReport('command', commandName, commandArgs);
-
-        onProcessInterrupt.removeHandler(onCommandInterrupt);
 
         return result;
       }).finally(() => {

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -29,12 +29,11 @@ class Builder extends CoreObject {
 
     this.setupBroccoliBuilder();
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
-    this._cleanup = this.cleanup.bind(this);
 
     this._cleanupPromise = null;
-    this._onProcessInterrupt = options.onProcessInterrupt || onProcessInterrupt;
 
-    this._onProcessInterrupt.addHandler(this._cleanup);
+    const _onShudown = options.onProcessInterrupt || onProcessInterrupt;
+    this._offShutdown = _onShudown.addHandler(this.cleanup.bind(this));
   }
 
   /**
@@ -190,7 +189,7 @@ class Builder extends CoreObject {
       // ensure any addon treeFor caches are reset
       _resetTreeCache();
 
-      this._onProcessInterrupt.removeHandler(this._cleanup);
+      this._offShutdown();
 
       let node = heimdall.start({ name: 'Builder Cleanup' });
 

--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -1,11 +1,13 @@
 'use strict';
 
-// Allows to setup process interruption handlers.
-// The process can be interrupted when ges SIGINT, SIGTERM signal,
-// something called process.exit(exitCode) or CTRL+C was pressed.
+// It allows to setup the process interruption handlers.
+// Process interrupts in the following cases:
+//   - `SIGINT` or `SIGTERM` signal caught
+//   - `process.exit(exitCode)`
+//   - CTRL+C was pressed
 //
-// Node.js doesn't allow to perform async tasks when the process is exiting.
-// Also there are some work arounds for exit in the node.js ecosystem.
+// node.js doesn't allow to perform async tasks when the process is exiting.
+// Also there are some work-arounds for exit in the node.js ecosystem.
 //
 // In order to supply reliable process exit phase, `will-interrupt-process`
 // is tightly integrated with `capture-exit` which allows us to perform async cleanup
@@ -20,8 +22,9 @@ let _process,
     windowsCtrlCTrap,
     originalIsRaw;
 
+let _exit;
 module.exports = {
-  capture(outerProcess) {
+  capture(outerProcess, _captureExit) {
     if (_process) {
       throw new Error('process already captured');
     }
@@ -31,6 +34,7 @@ module.exports = {
     }
 
     _process = outerProcess;
+    _exit = _captureExit || captureExit;
 
     // ember-cli and user apps have many dependencies, many of which require
     // process.addListener('exit', ....) for cleanup, by default this limit for
@@ -42,7 +46,7 @@ module.exports = {
     _process.setMaxListeners(1000);
 
     // work around misbehaving libraries, so we can correctly cleanup before actually exiting.
-    captureExit.captureExit();
+    _exit.captureExit(_process);
   },
 
   /**
@@ -60,7 +64,7 @@ module.exports = {
    */
   release() {
     while (handlers.length > 0) {
-      this.removeHandler(handlers[0]);
+      this._removeHandler(handlers[0]);
     }
 
     _process = null;
@@ -89,7 +93,8 @@ module.exports = {
     }
 
     handlers.push(cb);
-    captureExit.onExit(cb);
+    _exit.onExit(cb);
+    return this._removeHandler.bind(this, cb);
   },
 
   /**
@@ -99,15 +104,15 @@ module.exports = {
    * then clean up all the process interruption signal listeners
    *
    * @private
-   * @method removeHandler
+   * @method _removeHandler
    * @param {function} cb   Callback to be removed
    */
-  removeHandler(cb) {
+  _removeHandler(cb) {
     let index = handlers.indexOf(cb);
     if (index < 0) { return; }
 
     handlers.splice(index, 1);
-    captureExit.offExit(cb);
+    _exit.offExit(cb);
 
     if (handlers.length === 0) {
       teardownSignalsTrap();
@@ -158,7 +163,7 @@ function trapWindowsSignals(_process) {
 
   originalIsRaw = stdin.isRaw;
 
-  // This is required to capture Ctrl + C on Windows
+  // This is required to capture Ctrl+C in Windows
   stdin.setRawMode(true);
 
   windowsCtrlCTrap = function(data) {

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const captureExit = require('capture-exit');
-captureExit.captureExit();
-
 const glob = require('glob');
 const Mocha = require('mocha');
 const RSVP = require('rsvp');

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -6,13 +6,16 @@ const MockAnalytics = require('../../helpers/mock-analytics');
 const td = require('testdouble');
 const Command = require('../../../lib/models/command');
 const Promise = require('rsvp').Promise;
+const willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
+const MockProcess = require('../../helpers/mock-process');
+const SilentError = require('silent-error');
 
 let ui;
 let analytics;
 let commands = {};
 let isWithinProject;
 let project;
-let willInterruptProcess;
+let _process;
 
 let CLI;
 
@@ -28,11 +31,11 @@ function ember(args) {
   let stopInstr = td.replace(cli.instrumentation, 'stopAndReport');
 
   return cli.run({
+    project,
     tasks: {},
     commands,
     cliArgs: args || [],
     settings: {},
-    project,
   }).then(function(value) {
     td.verify(stopInstr('init'), { times: 1 });
     td.verify(startInstr('command'), { times: 1 });
@@ -41,6 +44,36 @@ function ember(args) {
 
     return value;
   });
+}
+
+function registerCommand(Command) {
+  project.eachAddonCommand = function(callback) {
+    callback(Command.name, {
+      Command,
+    });
+  };
+}
+
+class MockCaptureExit {
+  captureExit(process) {
+    this._process = process;
+    this._exit = process.exit;
+    this._handlers = [];
+
+    process.exit = () => this._handlers[0]()
+      .finally(() => {
+        process.exit = this._exit;
+      });
+  }
+
+  offExit() {
+    this._process = null;
+    this._handlers = [];
+  }
+
+  onExit(cb) {
+    this._handlers.push(cb);
+  }
 }
 
 function stubCallHelp() {
@@ -66,10 +99,8 @@ function stubRun(name) {
 
 describe('Unit: CLI', function() {
   beforeEach(function() {
-    willInterruptProcess = td.replace('../../../lib/utilities/will-interrupt-process', {
-      addHandler: td.function(),
-      removeHandler: td.function(),
-    });
+    _process = new MockProcess();
+    willInterruptProcess.capture(_process, new MockCaptureExit());
 
     CLI = require('../../../lib/cli/cli');
     ui = new MockUI();
@@ -92,6 +123,7 @@ describe('Unit: CLI', function() {
   afterEach(function() {
     td.reset();
 
+    willInterruptProcess.release();
     delete process.env.EMBER_ENV;
     commands = ui = undefined;
   });
@@ -228,42 +260,66 @@ describe('Unit: CLI', function() {
     });
   });
 
-  describe('command interruption handler', function() {
-    let onCommandInterrupt;
+  describe('command interruption', function() {
+    let interruptionHandeled;
+
     beforeEach(function() {
-      onCommandInterrupt = td.matchers.isA(Function);
+      interruptionHandeled = false;
+    });
+
+    const FakeCommand = Command.extend({
+      name: 'fake',
+
+      beforeRun() {
+        return Promise.resolve();
+      },
+
+      run() {
+        return new Promise(resolve => {
+          setTimeout(() => resolve(), 50);
+        });
+      },
+
+      onInterrupt() {
+        interruptionHandeled = true;
+      },
     });
 
     it('sets up handler before command run', function() {
-      const CustomCommand = Command.extend({
-        name: 'custom',
-
+      registerCommand(FakeCommand.extend({
         beforeRun() {
-          td.verify(willInterruptProcess.addHandler(onCommandInterrupt));
-
-          return Promise.resolve();
+          _process.emit('SIGINT');
         },
+      }));
 
-        run() {
-          return Promise.resolve();
-        },
+      return ember(['fake']).then(() => {
+        expect(interruptionHandeled).to.equal(true);
       });
+    });
 
     it(`tears down interruption handler after command is executed`, function() {
       registerCommand(FakeCommand.extend({
         run() {
-          setTimeout(() => _process.emit('SIGINT'), 10);
+          setTimeout(() => _process.emit('SIGINT'), 0);
         },
       }));
 
-      return ember(['custom']);
+      return ember(['fake']).then(() => {
+        expect(interruptionHandeled).to.equal(false);
+      });
     });
 
-    it('cleans up handler after command finished', function() {
-      stubValidateAndRun('serve');
+    it(`rejected with a proper error on crash`, function() {
+      const error = new SilentError('OMG');
 
-      return ember(['serve']).finally(function() {
-        td.verify(willInterruptProcess.removeHandler(onCommandInterrupt));
+      registerCommand(FakeCommand.extend({
+        run() {
+          throw error;
+        },
+      }));
+
+      return expect(ember(['fake'])).to.be.rejectedWith(error).then(() => {
+        expect(interruptionHandeled).to.equal(false);
       });
     });
   });

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -249,11 +249,12 @@ describe('Unit: CLI', function() {
         },
       });
 
-      project.eachAddonCommand = function(callback) {
-        callback('custom-addon', {
-          CustomCommand,
-        });
-      };
+    it(`tears down interruption handler after command is executed`, function() {
+      registerCommand(FakeCommand.extend({
+        run() {
+          setTimeout(() => _process.emit('SIGINT'), 10);
+        },
+      }));
 
       return ember(['custom']);
     });

--- a/tests/unit/tasks/build-watch-test.js
+++ b/tests/unit/tasks/build-watch-test.js
@@ -3,13 +3,23 @@
 const RSVP = require('rsvp');
 const BuildWatchTask = require('../../../lib/tasks/build-watch');
 const Builder = require('../../../lib/models/builder');
+const willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
 const MockProject = require('../../helpers/mock-project');
+const MockProcess = require('../../helpers/mock-process');
 const expect = require('chai').expect;
 
 const Promise = RSVP.Promise;
 
 describe('build-watch task', function() {
   let task, ui;
+
+  beforeEach(function() {
+    willInterruptProcess.capture(new MockProcess());
+  });
+
+  afterEach(function() {
+    willInterruptProcess.release();
+  });
 
   function setupBroccoliBuilder() {
     this.builder = {
@@ -35,10 +45,7 @@ describe('build-watch task', function() {
       ui,
       project,
       setupBroccoliBuilder,
-      onProcessInterrupt: {
-        addHandler() {},
-        removeHandler() {},
-      },
+      onProcessInterrupt: willInterruptProcess,
     });
 
     let _watcher = {

--- a/tests/unit/tasks/serve-test.js
+++ b/tests/unit/tasks/serve-test.js
@@ -3,6 +3,8 @@
 const RSVP = require('rsvp');
 const ServeTask = require('../../../lib/tasks/serve');
 const Builder = require('../../../lib/models/builder');
+const willInterruptProcess = require('../../../lib/utilities/will-interrupt-process');
+const MockProcess = require('../../helpers/mock-process');
 const MockProject = require('../../helpers/mock-project');
 const expect = require('chai').expect;
 
@@ -10,6 +12,14 @@ const Promise = RSVP.Promise;
 
 describe('serve task', function() {
   let task, ui;
+
+  beforeEach(function() {
+    willInterruptProcess.capture(new MockProcess());
+  });
+
+  afterEach(function() {
+    willInterruptProcess.release();
+  });
 
   function setupBroccoliBuilder() {
     this.builder = {
@@ -35,10 +45,7 @@ describe('serve task', function() {
       ui,
       project,
       setupBroccoliBuilder,
-      onProcessInterrupt: {
-        addHandler() {},
-        removeHandler() {},
-      },
+      onProcessInterrupt: willInterruptProcess,
     });
 
     let _watcher = {};

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -92,10 +92,11 @@ describe('will interrupt process', function() {
 
     it('removes exit handler', function() {
       willInterruptProcess.capture(new MockProcess());
-      willInterruptProcess.addHandler(cb);
+
+      let teardown = willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(function() {});
 
-      willInterruptProcess.removeHandler(cb);
+      teardown();
 
       expect(captureExit.listenerCount()).to.equal(1);
     });
@@ -144,9 +145,9 @@ describe('will interrupt process', function() {
     it('cleans up interruption signal listener', function() {
       // will-interrupt-process doesn't have any public API to get actual handlers count
       // so here we make a side test to ensure that we don't add the same callback twice
-      willInterruptProcess.addHandler(cb);
+      let teardown = willInterruptProcess.addHandler(cb);
 
-      willInterruptProcess.removeHandler(cb);
+      teardown(cb);
 
       expect(process.getSignalListenerCounts()).to.eql({
         SIGINT: 0,
@@ -156,10 +157,10 @@ describe('will interrupt process', function() {
     });
 
     it(`doesn't clean up interruption signal listeners if there are remaining handlers`, function() {
-      willInterruptProcess.addHandler(cb);
+      let teardown = willInterruptProcess.addHandler(cb);
       willInterruptProcess.addHandler(() => cb());
 
-      willInterruptProcess.removeHandler(cb);
+      teardown(cb);
 
       expect(process.getSignalListenerCounts()).to.eql({
         SIGINT: 1,
@@ -211,10 +212,10 @@ describe('will interrupt process', function() {
 
       willInterruptProcess.capture(process);
 
-      willInterruptProcess.addHandler(cb);
+      const removeHandler = willInterruptProcess.addHandler(cb);
       expect(process.stdin.isRaw).to.equal(true);
 
-      willInterruptProcess.removeHandler(cb);
+      removeHandler();
       expect(process.stdin.isRaw).to.equal(false);
     });
 


### PR DESCRIPTION
This pr attempts to push forward refactoring from #7019 

### Notable Changes:
 - `will-interrupt-process.addHandler(cb)` now returns a function which is resposible for handler cleanup. It simplifies `will-interrupt-process` api.
- Previously we removed interruption handler only if the command finished successfully. Now [we cleanup](https://github.com/ember-cli/ember-cli/pull/7285/files#diff-16a41bfbe414387d773df099f941217eR165) even on a [command crash](https://github.com/ember-cli/ember-cli/pull/7285/files#diff-aa94f362c4d6ae97d4d491b3a8cc4887R312). 

### Testing
The main issue is that `MockProcess.exit()` isn't able to simulate a real `process.exit()` behavior.:
```js
.then(() => mockProcess.exit())
.then(() => {
  // this will be executed
})
```
At the same time we can't unit test `cli/cli` with a real `process.exit`. If we allow `process.exit()` to be executed in the test environment then test run will be immediately stopped.

In order to avoid dealing with a real `process.exit` and work-around[ inability to pass process to the `capture-exit`](https://github.com/ember-cli/capture-exit/pull/23), [MockCapureExit](https://github.com/ember-cli/ember-cli/pull/7285/files#diff-aa94f362c4d6ae97d4d491b3a8cc4887R57) has been introduced. It doesn't 100% replicate all of the `capture-exit` functionality. Anyway I believe it should be enough to unit test what we can.

Unfortunately it's still not enough to properly unit test process interruption in the cli. We still rely on "test, SIGINT exits with error and clears tmp/" acceptance test.