### PR TITLE
Add Documentation Link and Supported Versions

### DIFF
--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -12,6 +12,7 @@
 | 5.x              | 1.13.9 - 2.6.3               |
 | 6.x              | 2.9.0 - Current              |
 | 7.x              | 2.10.0 - Current             |
+| 8.x              | 2.13.3 - Current             |
 
 # Design
 

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -2,6 +2,17 @@
 
 * original proposal/discussion: https://github.com/ember-cli/rfcs/pull/47
 
+## Supported Versions
+
+| Node LTS Version | Supported Ember CLI Versions |
+|------------------|------------------------------|
+| 0.10.x           | 0.0.0 - 2.8.x                |
+| 0.12.x           | 0.0.0 - 2.11.x               |
+| 4.x              | 1.13.9 - Current             |
+| 5.x              | 1.13.9 - 2.6.3               |
+| 6.x              | 2.9.0 - Current              |
+| 7.x              | 2.10.0 - Current             |
+
 # Design
 
 Commits to the `HEAD` of the master branch will provide support for any Active

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -120,7 +120,8 @@ class CLI {
 
       const PlatformChecker = require('../utilities/platform-checker');
       let platform = new PlatformChecker(process.version);
-      let recommendation = ' We recommend that you use the most-recent "Active LTS" version of Node.js.';
+      let recommendation = ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
+                           ' See https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md for details.';
 
       if (!this.testing) {
         if (platform.isDeprecated) {

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -121,7 +121,7 @@ class CLI {
       const PlatformChecker = require('../utilities/platform-checker');
       let platform = new PlatformChecker(process.version);
       let recommendation = ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
-                           ' See https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md for details.';
+                           ' See https://git.io/v7S5n for details.';
 
       if (!this.testing) {
         if (platform.isDeprecated) {


### PR DESCRIPTION
Addresses #7168.

- Adds a link to the `node-support.md` document in the console messages if there's a Node version issue.
- Updates `node-support.md` with version ranges for past and current Node JS releases.