### PR TITLE
Drop un-needed Ember import

### DIFF
--- a/lib/broccoli/app-config.js
+++ b/lib/broccoli/app-config.js
@@ -1,3 +1,3 @@
-define('{{MODULE_PREFIX}}/config/environment', ['ember'], function(Ember) {
+define('{{MODULE_PREFIX}}/config/environment', [], function() {
   {{content-for 'config-module'}}
 });


### PR DESCRIPTION
The `app-config-from-meta.js` script, which provides the code for `{{config-module}}`, does not use the Ember variable. In apps that don't have a module for `'ember'` (like those not using ember-cli-shims but using ember-cli-babel v8.6.0+) there is no module to be imported here.

In general, Ember-CLI provided code should not rely on an `'ember'` module.

* [app-config-from-meta](https://github.com/ember-cli/ember-cli/blob/ac95fb3b2b0c5d87b4ac62edb94cd6f396e51669/lib/broccoli/app-config-from-meta.js)
* Imported via https://github.com/ember-cli/ember-cli/blob/2baa533f8d149ee10f244a67847cbd82af85b276/lib/broccoli/ember-app.js#L1901

This should get into 2.16 if we want to permit apps to drop ember-cli-shims.