### PR TITLE
Only warn when unknown transform name is used and skip transformation.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1686,16 +1686,18 @@ class EmberApp {
 
           let transformName = entry.transformation;
 
-          if (this._customTransformOrder.indexOf(transformName) === -1) {
-            let availableTransformNames = this._customTransformOrder.join(',');
-            throw new Error(`while import ${assetPath}: found an unknown transformation name ${transformName}. Available transformNames are: ${availableTransformNames}`);
-          }
-
           // process options for the transform and update the options
           this._customTransforms[transformName].options = this._customTransforms[transformName].processOptions(assetPath,
             entry, this._customTransforms[transformName].options);
-
-          this._customTransforms[transformName].files.push(assetPath);
+          
+          if (this._customTransformOrder.indexOf(transformName) === -1) {
+            // if transformation not found we ignore doing the transformation with warning
+            let availableTransformNames = this._customTransformOrder.join(',');
+            this.project.ui.writeWarnLine(`while import ${assetPath}: found an unknown transformation name ${transformName}. Available transformNames are: ${availableTransformNames}`);
+          } else {
+            // transformation is valid, so add it to the list
+            this._customTransforms[transformName].files.push(assetPath);
+          }
         });
       }
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -314,6 +314,23 @@ describe('Acceptance: brocfile-smoke-test', function() {
     expect(outputJS).to.be.equal('if (typeof FastBoot === \'undefined\') { window.hello = "hello world"; }//# sourceMappingURL=output.map\n');
   }));
 
+  it('ignores transformation if transformation is not found', co.wrap(function *() {
+    yield copyFixtureFiles('brocfile-tests/app-import-custom-transform');
+
+    let packageJsonPath = path.join(appRoot, 'package.json');
+    let packageJson = fs.readJsonSync(packageJsonPath);
+    packageJson.devDependencies['ember-transform-addon'] = 'latest';
+    fs.writeJsonSync(packageJsonPath, packageJson);
+
+    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+    let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output-no-transform.js'), {
+      encoding: 'utf8',
+    });
+
+    expect(outputJS).to.be.equal('window.noTransform = true;//# sourceMappingURL=output-no-transform.map\n');
+  }));
+
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', co.wrap(function *() {
     yield copyFixtureFiles('brocfile-tests/custom-output-paths');

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/ember-cli-build.js
@@ -14,5 +14,14 @@ module.exports = function (defaults) {
     outputFile: '/assets/output.js'
   });
 
+  app.import('vendor/custom-transform-example.js', {
+    using: [
+      {
+        transformation: 'dubiousShim'
+      }
+    ],
+    outputFile: '/assets/output-no-transform.js'
+  });
+
   return app.toTree();
 };

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/no-transform-example.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/no-transform-example.js
@@ -1,0 +1,1 @@
+window.noTransform = true;


### PR DESCRIPTION
# Motivation
Currently in Ember CLI if a transformation name with `app.import` isn't found, we throw an error. Ember Addons that are fastboot compatible would also want to use `app.import` with the extended transformation API. These addons don't have control if the host app is fastboot compatible or not. Hence every addon would need to check if host app has fastboot addon installed and only then use the transformation. 

In order to avoid these `if else` blocks across addons, if the transform name isn't found we will warn the user and not add the file to the list of transforms. This addons can be used in apps that don't have fastboot enabled.

# Tests

Added relevant tests