### PR TITLE
model/project: Freeze app config before caching it

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -209,6 +209,10 @@ class Project {
       let c = this.configCache.get(env);
       if (c === undefined) {
         c = this.configWithoutCache(env);
+
+        const deepFreeze = require('deep-freeze');
+        deepFreeze(c);
+
         this.configCache.set(env, c);
       }
       return c;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "console-ui": "^1.0.2",
     "core-object": "^3.1.3",
     "dag-map": "^2.0.2",
+    "deep-freeze": "^0.0.1",
     "diff": "^3.2.0",
     "ember-cli-broccoli-sane-watcher": "^2.0.4",
     "ember-cli-is-package-missing": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,10 @@ deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+deep-freeze@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
This should give at least slightly more meaningful errors and stacktraces when addons are trying to mutate the app config.