### PR TITLE
Removes babel module transform

### DIFF
--- a/lib/broccoli/bundler.js
+++ b/lib/broccoli/bundler.js
@@ -3,7 +3,6 @@
 const concat = require('broccoli-concat');
 const mergeTrees = require('./merge-trees');
 const BroccoliDebug = require('broccoli-debug');
-const processModulesOnly = require('./babel-process-modules-only');
 
 module.exports = class Bundler {
   /*
@@ -166,10 +165,6 @@ module.exports = class Bundler {
       annotation: 'Concat: App',
       sourceMapConfig: this.sourcemaps,
     });
-
-    if (!this.isBabelAvailable) {
-      appJs = processModulesOnly(appJs, 'Babel: Modules for app/');
-    }
 
     let vendorFiles = this.getVendorFiles(applicationAndDepsDebugTree, scriptOutputFiles);
 


### PR DESCRIPTION
This transform was introduced in https://github.com/ember-cli/ember-cli/pull/6828 to make sure files are transpiled properly. It doesn't seem like we need to do it anymore.

I was hesitant to remove it across `lib/broccoli/ember-app.js` but it seems to make sense.

@rwjblue thoughts?