### PR TITLE
move "private" key in package.json

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -1,6 +1,7 @@
 {
   "name": "<%= name %>",
   "version": "0.0.0",
+  "private": true,
   "description": "Small description for <%= name %> goes here",
   "license": "MIT",
   "author": "",
@@ -39,6 +40,5 @@
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
This is where [sort-package-json](https://github.com/keithamus/sort-package-json/blob/0a89107a30a4a1982ca8c1a1d720d33c624775a4/index.js#L72) says "private" should be, and since various ember-cli updater projects are using `sort-package-json` when changing "package.json", moving "private" would make for some nicer git diffs.

cc @rwjblue and @Turbo87 since you made `package.json` ordering changes.