### PR TITLE
update ember-data version in beta

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -29,7 +29,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "~2.15.0-beta.2",
+    "ember-data": "~2.15.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",


### PR DESCRIPTION
since ember-data doesn't have a 2.16 beta yet, should we at least update to the latest version of the addon?