### PR TITLE
Updating testem.js for the app blueprint

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,9 +9,9 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    'Chrome': {
-      "mode": "ci",
-      "args": [
+    Chrome: {
+      mode: 'ci',
+      args: [
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',

--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,11 +9,14 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+    'Chrome': {
+      "mode": "ci",
+      "args": [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
   }
 };


### PR DESCRIPTION
Updates `app` blueprint's `testem.js` file to enable Chrome to run headless in CI, but non-headless otherwise.