### PR TITLE
correct `rsvp` version in yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.8",
     "resolve": "^1.3.0",
-    "rsvp": "^4.0.2",
+    "rsvp": "^4.7.0",
     "sane": "^1.6.0",
     "semver": "^5.1.1",
     "silent-error": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,9 +3715,9 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.2.
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
-rsvp@^4.0.2:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.6.1.tgz#fcc3bda359da00fd06fb1f2c517f2051541b05b5"
+rsvp@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.7.0.tgz#dc1b0b1a536f7dec9d2be45e0a12ad4197c9fd96"
 
 rsvp@~3.2.1:
   version "3.2.1"


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/pull/7340 in yarn.lock rsvp locked to fetch `4.6.1` when `4.0.2` needs to be fetched