### PR TITLE
Use "ci" mode for testem.js

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,9 +9,9 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    'Chrome': {
-      "mode": "ci",
-      "args": [
+    Chrome: {
+      mode: 'ci',
+      args: [
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',

--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,11 +9,14 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+    'Chrome': {
+      "mode": "ci",
+      "args": [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
   }
 };


### PR DESCRIPTION
backport of https://github.com/ember-cli/ember-cli/pull/7342 to `beta`

/cc @scalvert 