### PR TITLE
Limit allowed concurrency in CI environments.

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -19,6 +19,9 @@ cache:
     - $HOME/.npm
 <% } %>
 env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -16,6 +16,11 @@ cache:
   directories:
     - $HOME/.npm
 <% } %>
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+
 before_install:<% if (yarn) { %>
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/docs/build-concurrency.md
+++ b/docs/build-concurrency.md
@@ -1,0 +1,15 @@
+# Build Concurrency
+
+In order to speed up your project's build time, Ember CLI has added a bit of
+concurrency throughout the build system. The exact number of parallel
+transpilation jobs that will be used can be customized via the `JOBS` process
+environment variable.
+
+The default value for `process.env.JOBS` is (max concurrency) - 1 (via
+`require('os').cpus().length - 1`), however there may be times when you need to
+customize this value to avoid issues.
+
+The most common case for this is in CI systems like TravisCI and CircleCI where
+the total number of CPU's available on the system is very large (> 32) but the
+individual CI jobs are limited to only 1.5 or 2 concurrent processes.
+

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -16,6 +16,9 @@ cache:
     - $HOME/.npm
 
 env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -15,6 +15,9 @@ cache:
   yarn: true
 
 env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8

--- a/tests/fixtures/app/npm/.travis.yml
+++ b/tests/fixtures/app/npm/.travis.yml
@@ -13,5 +13,10 @@ cache:
   directories:
     - $HOME/.npm
 
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+
 before_install:
   - npm config set spin false

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -12,6 +12,11 @@ addons:
 cache:
   yarn: true
 
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH


### PR DESCRIPTION
Ideally we could determine the actually allowed concurrency count, but I am not aware of a mechanism that works consistently here. If we could detect this, we should update [this line](https://github.com/stefanpenner/broccoli-persistent-filter/blob/57d8f901e955b5d08de72417263fd14fb1d53803/index.js#L92) to use the "right" value by default.

Happy to revert this if docker/kubernetes/xen/kvm experts can point us to a better solution than `require('os').cpus().length - 1` for default concurrency...

Fixes https://github.com/emberjs/ember.js/issues/15641