### PR TITLE
Set entity name to current project name if none is provided

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -438,7 +438,7 @@ let Blueprint = CoreObject.extend({
         ' changes will be written.'));
     }
 
-    this._normalizeEntityName(options.entity);
+    this._normalizeEntityName(options.entity || options.project.pkg.name);
     this._checkForPod(options.verbose);
     this._checkInRepoAddonExists(options.inRepoAddon);
 
@@ -470,7 +470,7 @@ let Blueprint = CoreObject.extend({
         ' files will be deleted.'));
     }
 
-    this._normalizeEntityName(options.entity);
+    this._normalizeEntityName(options.entity || options.project.pkg.name);
     this._checkForPod(options.verbose);
 
     return this._process(


### PR DESCRIPTION
Example: 
`cd my-project`
`ember g whatever-blueprint` 

Then the entity name will be `my-project`.