### PR TITLE
Pass given yarn cli option to NpmInstall.run

### DIFF
--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -42,6 +42,7 @@ class AddonInstallTask extends Task {
       'save': commandOptions.save,
       'save-dev': !commandOptions.save,
       'save-exact': commandOptions.saveExact,
+      'useYarn': commandOptions.yarn,
     }).then(() => this.project.reloadAddons())
       .then(() => this.installBlueprint(blueprintInstall, packageNames, blueprintOptions))
       .finally(() => ui.stopProgress())

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -106,6 +106,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
       });
     });
@@ -125,6 +126,35 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
+        }), { times: 1 });
+      });
+    });
+
+    it('runs the npm install task with given name useYarn true with the --yarn option', function() {
+      return command.validateAndRun(['ember-data', '--yarn']).then(function() {
+        let npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save': false,
+          'save-dev': true,
+          'save-exact': false,
+          useYarn: true,
+        }), { times: 1 });
+      });
+    });
+
+    it('runs the npm install task with given name useYarn false with the --no-yarn option', function() {
+      return command.validateAndRun(['ember-data', '--no-yarn']).then(function() {
+        let npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save': false,
+          'save-dev': true,
+          'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
       });
     });
@@ -138,6 +168,7 @@ describe('install command', function() {
           'save': true,
           'save-dev': false,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
       });
     });
@@ -157,6 +188,7 @@ describe('install command', function() {
           'save': true,
           'save-dev': false,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
       });
     });
@@ -200,6 +232,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -217,6 +250,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -233,6 +267,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -250,6 +285,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: undefined,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;


### PR DESCRIPTION
Fixes: #7355 

In `NpmTask.run` `this.useYarn` is overwritten by `options.useYarn` passed to the method when it's being called from `NpmInstallTask.run`.

However, when `NpmInstallTask.run` is being called from `AddonInstallTask.run`, `useYarn` is not passed as one of the options, meaning that in `NpmTask.findPackageManager`, `useYarn` will always be undefined and will always use Yarn if a lockfile is present.

This PR makes it so the option `useYarn` is passed to `NpmInstallTask.run`, with the value of either true (--yarn), false (--no-yarn) or undefined (not specified after which it will check for a yarn.lock file).