### PR TITLE
Fix issue with linting within an addon without an `app/` directory.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1105,23 +1105,29 @@ let addonProto = {
   jshintAddonTree() {
     this._requireBuildPackages();
 
-    let addonPath = this._treePathFor('addon');
-    let addonAppPath = this._treePathFor('app');
+    let trees = [];
 
-    if (!existsSync(addonPath)) {
-      return;
+    let addonPath = this._treePathFor('addon');
+    if (existsSync(addonPath)) {
+      let addonJs = this.addonJsFiles(addonPath);
+      let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
+
+      let addonTemplates = this._addonTemplateFiles(addonPath);
+      let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
+
+      trees = trees.concat(lintAddonJsTrees, lintTemplateTrees);
     }
 
-    let appJs = this.addonJsFiles(addonAppPath);
-    let lintAppJsTrees = this._eachProjectAddonInvoke('lintTree', ['app', appJs]);
 
-    let addonJs = this.addonJsFiles(addonPath);
-    let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
+    let addonAppPath = this._treePathFor('app');
+    if (existsSync(addonAppPath)) {
+      let appJs = this.addonJsFiles(addonAppPath);
+      let lintAppJsTrees = this._eachProjectAddonInvoke('lintTree', ['app', appJs]);
+      trees = trees.concat(lintAppJsTrees);
+    }
 
-    let addonTemplates = this._addonTemplateFiles(addonPath);
-    let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
 
-    let lintTrees = [].concat(lintAppJsTrees, lintAddonJsTrees, lintTemplateTrees).filter(Boolean);
+    let lintTrees = trees.filter(Boolean);
     let lintedAddon = mergeTrees(lintTrees, {
       overwrite: true,
       annotation: 'TreeMerger (addon-lint)',


### PR DESCRIPTION
ember-cli 2.16 added support for linting the `app/` tree of an addon (while developing the addon itself). Unfortunately, we did not guard generation of the linting tree based on the presence of `app/` (addons are not required to have any specific directories).

This ensures that we only invoke `lintTree` on `app/` if it is present.

Tests will be in a follow up PR targeting `beta` branch.

Fixes https://github.com/ember-cli/ember-cli/issues/7368