### PR TITLE
[BUGFIX] Invoke transform registeration before included hook is called.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -144,8 +144,8 @@ class EmberApp {
     this.initializeAddons();
     this.project.addons.forEach(addon => addon.app = this);
     p.setupRegistry(this);
-    this._notifyAddonIncluded();
     this._importAddonTransforms();
+    this._notifyAddonIncluded();
 
     if (!this._addonInstalled('loader.js') && !this.options._ignoreMissingLoader) {
       throw new SilentError('The loader.js addon is missing from your project, please add it to `package.json`.');

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/node_modules/ember-transform-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/node_modules/ember-transform-addon/index.js
@@ -13,5 +13,16 @@ module.exports = {
         });
       }
     }
+  },
+
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    app.import('vendor/addon-vendor.js', {
+      using: [
+        { transformation: 'amd', as: 'addon-vendor' }
+      ],
+      outputFile: '/assets/addon-output.js'
+    });
   }
 };

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/addon-vendor.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/vendor/addon-vendor.js
@@ -1,0 +1,10 @@
+(function() {
+  function helloWorld() {
+    return "Hello World";
+  }
+  if (typeof define === "function" && define.amd) {
+    define([], function () { return helloWorld; });
+  } else {
+    throw new Error("No amd loader found");
+  }
+})();


### PR DESCRIPTION
Fixes https://github.com/ember-cli/ember-cli/issues/7370 . Added tests too.

I think we will need to do another release of ember-cli 2.16.x. This is blocking a few folks to upgrade to ember-cli 2.16.

cc: @rwjblue 