### PR TITLE
Ensure test-support and addon-test-support are linted.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1109,23 +1109,43 @@ let addonProto = {
 
     let addonPath = this._treePathFor('addon');
     if (existsSync(addonPath)) {
-      let addonJs = this.addonJsFiles(addonPath);
+      let addonJs = new Funnel(this.addonJsFiles(addonPath), {
+        srcDir: this.moduleName(),
+        destDir: 'addon',
+        allowEmpty: true,
+      });
       let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
 
-      let addonTemplates = this._addonTemplateFiles(addonPath);
+      let addonTemplates = new Funnel(this._addonTemplateFiles(addonPath), {
+        srcDir: `${this.moduleName()}/templates`,
+        destDir: 'addon/templates',
+        allowEmpty: true,
+      });
       let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
 
       trees = trees.concat(lintAddonJsTrees, lintTemplateTrees);
     }
 
+    let addonTestSupportPath = this._treePathFor('addon-test-support');
+    if (existsSync(addonTestSupportPath)) {
+      let addonTestSupportTree = new Funnel(addonTestSupportPath, { destDir: 'addon-test-support' });
+      let lintAddonTestSupportJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon-test-support', addonTestSupportTree]);
+      trees = trees.concat(lintAddonTestSupportJsTrees);
+    }
 
-    let addonAppPath = this._treePathFor('app');
-    if (existsSync(addonAppPath)) {
-      let appJs = this.addonJsFiles(addonAppPath);
-      let lintAppJsTrees = this._eachProjectAddonInvoke('lintTree', ['app', appJs]);
+    let appPath = this._treePathFor('app');
+    if (existsSync(appPath)) {
+      let appTree = new Funnel(appPath, { destDir: 'app' });
+      let lintAppJsTrees = this._eachProjectAddonInvoke('lintTree', ['app', appTree]);
       trees = trees.concat(lintAppJsTrees);
     }
 
+    let testSupportPath = this._treePathFor('test-support');
+    if (existsSync(testSupportPath)) {
+      let testSupportTree = new Funnel(testSupportPath, { destDir: 'test-support' });
+      let lintTestSupportJsTrees = this._eachProjectAddonInvoke('lintTree', ['test-support', testSupportTree]);
+      trees = trees.concat(lintTestSupportJsTrees);
+    }
 
     let lintTrees = trees.filter(Boolean);
     let lintedAddon = mergeTrees(lintTrees, {

--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const co = require('co');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+
+const MockCLI = require('../../../helpers/mock-cli');
+const Project = require('../../../../lib/models/project');
+const Addon = require('../../../../lib/models/addon');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('Addon', function() {
+  let input, output, addon, lintTrees;
+
+  beforeEach(co.wrap(function *() {
+    input = yield createTempDir();
+    let MockAddon = Addon.extend({
+      name: 'first',
+      root: input.path(),
+    });
+    lintTrees = [];
+    let cli = new MockCLI();
+    let pkg = { name: 'ember-app-test' };
+
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+    project.addons = [
+      {
+        name: 'fake-linter-addon',
+        lintTree(type, tree) {
+          lintTrees.push(tree);
+        },
+      },
+    ];
+
+    addon = new MockAddon(project, project);
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield input.dispose();
+    yield output.dispose();
+  }));
+
+  it('calls lintTree on project addons for app directory', co.wrap(function *() {
+    input.write({
+      'app': {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      app: {
+        'derp.js': '// slerpy',
+      },
+    });
+  }));
+
+  it('calls lintTree on project addons for addon directory', co.wrap(function *() {
+    input.write({
+      'addon': {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    yield output.dispose();
+
+    output = yield buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {},
+      },
+    });
+  }));
+
+  it('calls lintTree on project addons for addon directory with only templates', co.wrap(function *() {
+    input.write({
+      'addon': {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
+        },
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {},
+    });
+
+    yield output.dispose();
+
+    output = yield buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
+        },
+      },
+    });
+  }));
+
+  it('calls lintTree on project addons for addon directory with templates', co.wrap(function *() {
+    input.write({
+      'addon': {
+        'derp.js': '// slerpy',
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
+        },
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    yield output.dispose();
+
+    output = yield buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
+        },
+      },
+    });
+  }));
+
+  it('calls lintTree on project addons for addon-test-support directory', co.wrap(function *() {
+    input.write({
+      'addon-test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      'addon-test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+  }));
+
+  it('calls lintTree on project addons for test-support directory', co.wrap(function *() {
+    input.write({
+      'test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
+
+    output = yield buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      'test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+  }));
+
+  it('calls lintTree for trees in an addon', co.wrap(function *() {
+    addon.project.addons[0].lintTree = function(type, tree) {
+      return tree;
+    };
+    let addonRootContents = {
+      app: {
+        'app-foo.js': '// hoo-foo',
+      },
+      addon: {
+        'addon-bar.js': '// bar-dar',
+        templates: {
+          'addon-templates-quux.hbs': '{{! quux-books }}',
+        },
+      },
+      'addon-test-support': {
+        'addon-test-support-baz.js': '// baz-jazz',
+      },
+      'test-support': {
+        'test-support-qux.js': '// qux-bucks',
+      },
+    };
+    input.write(addonRootContents);
+
+    output = yield buildOutput(addon.jshintAddonTree());
+    expect(output.read()).to.deep.equal({
+      first: {
+        tests: addonRootContents,
+      },
+    });
+  }));
+});
+


### PR DESCRIPTION
* Rebase + cleanup of #7037 (add linting for test-support and addon-test-support)
* Add basic harness for unit testing broccoli build "things" for an addon
* Add tests for regression reported in #7368
* Ensure that the module paths when linting match actual paths on disk (instead of being in "fake" paths)

Fixes #7035
Closes #7037

/cc @trentmwillis