### PR TITLE
 BREAKING: always append EOL in insertIntoFile

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -69,6 +69,7 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
   if (options.force) { insert = true; }
 
   if (insert) {
+    contentsToInsert += EOL;
     if (insertBehavior === 'end') {
       contentsToWrite += contentsToInsert;
     } else {
@@ -80,7 +81,7 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
         if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
 
         contentsToWrite = contentsToWrite.slice(0, insertIndex) +
-          contentsToInsert + EOL +
+          contentsToInsert +
           contentsToWrite.slice(insertIndex);
       }
     }

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -27,7 +27,7 @@ describe('insertIntoFile()', function() {
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
-        expect(contents).to.contain(toInsert);
+        expect(contents).to.contain(toInsert + EOL);
         expect(result.originalContents).to.equal('', 'returned object should contain original contents');
         expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
         expect(contents).to.equal(result.contents, 'returned object should contain contents');
@@ -44,7 +44,7 @@ describe('insertIntoFile()', function() {
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
-        expect(contents).to.equal(originalContent + toInsert, 'inserted contents should be appended to original');
+        expect(contents).to.equal(originalContent + toInsert + EOL, 'inserted contents should be appended to original');
         expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
         expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
       });
@@ -73,7 +73,7 @@ describe('insertIntoFile()', function() {
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
-        expect(contents).to.equal(toInsert + toInsert, 'contents should be unchanged');
+        expect(contents).to.equal(toInsert + toInsert + EOL, 'contents should be unchanged');
         expect(result.inserted).to.equal(true, 'inserted should indicate that the file was not modified');
       });
   });


### PR DESCRIPTION
Right now you may or may not get an EOL insterted based on whether you are inserting in the middle or appending to the end. This was confusing me. This change unifies so that you always get the EOL.

This is one solution, the other is we could take EOL out completely and always leave it up to the consumer.