### PR TITLE
add option to not create file

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -22,6 +22,9 @@ const writeFile = RSVP.denodeify(fs.outputFile);
   If neither `options.before` nor `options.after` are present, `contentsToInsert`
   will be inserted at the end of the file.
 
+  It will create a new file if one doesn't exist, unless you set the `options.create`
+  option to `false`.
+
   Example:
 
   ```
@@ -50,58 +53,65 @@ const writeFile = RSVP.denodeify(fs.outputFile);
   @return {Promise}
 */
 function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
-  let originalContents = '';
-
-  if (existsSync(fullPath)) {
-    originalContents = fs.readFileSync(fullPath, { encoding: 'utf8' });
-  }
-
-  let contentsToWrite = originalContents;
-
   let options = providedOptions || {};
-  let alreadyPresent = originalContents.indexOf(contentsToInsert) > -1;
-  let insert = !alreadyPresent;
-  let insertBehavior = 'end';
-
-  if (options.before) { insertBehavior = 'before'; }
-  if (options.after) { insertBehavior = 'after'; }
-
-  if (options.force) { insert = true; }
-
-  if (insert) {
-    if (insertBehavior === 'end') {
-      contentsToWrite += contentsToInsert;
-    } else {
-      let contentMarker = options[insertBehavior];
-      let contentMarkerIndex = contentsToWrite.indexOf(contentMarker);
-
-      if (contentMarkerIndex !== -1) {
-        let insertIndex = contentMarkerIndex;
-        if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
-
-        contentsToWrite = contentsToWrite.slice(0, insertIndex) +
-          contentsToInsert + EOL +
-          contentsToWrite.slice(insertIndex);
-      }
-    }
-  }
 
   let returnValue = {
     path: fullPath,
-    originalContents,
-    contents: contentsToWrite,
+    originalContents: '',
+    contents: '',
     inserted: false,
   };
 
-  if (contentsToWrite !== originalContents) {
-    returnValue.inserted = true;
+  let exists = existsSync(fullPath);
 
-    return writeFile(fullPath, contentsToWrite)
-      .then(() => returnValue);
+  if (exists || (!exists && options.create !== false)) {
+    let originalContents = '';
 
-  } else {
-    return Promise.resolve(returnValue);
+    if (exists) {
+      originalContents = fs.readFileSync(fullPath, { encoding: 'utf8' });
+    }
+
+    let contentsToWrite = originalContents;
+
+    let alreadyPresent = originalContents.indexOf(contentsToInsert) > -1;
+    let insert = !alreadyPresent;
+    let insertBehavior = 'end';
+
+    if (options.before) { insertBehavior = 'before'; }
+    if (options.after) { insertBehavior = 'after'; }
+
+    if (options.force) { insert = true; }
+
+    if (insert) {
+      if (insertBehavior === 'end') {
+        contentsToWrite += contentsToInsert;
+      } else {
+        let contentMarker = options[insertBehavior];
+        let contentMarkerIndex = contentsToWrite.indexOf(contentMarker);
+
+        if (contentMarkerIndex !== -1) {
+          let insertIndex = contentMarkerIndex;
+          if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
+
+          contentsToWrite = contentsToWrite.slice(0, insertIndex) +
+            contentsToInsert + EOL +
+            contentsToWrite.slice(insertIndex);
+        }
+      }
+    }
+
+    returnValue.originalContents = originalContents;
+    returnValue.contents = contentsToWrite;
+
+    if (contentsToWrite !== originalContents) {
+      returnValue.inserted = true;
+
+      return writeFile(fullPath, contentsToWrite)
+        .then(() => returnValue);
+    }
   }
+
+  return Promise.resolve(returnValue);
 }
 
 module.exports = insertIntoFile;

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -34,6 +34,18 @@ describe('insertIntoFile()', function() {
       });
   });
 
+  it('will not create the file if not already existing and creation disabled', function() {
+    let toInsert = 'blahzorz blammo';
+
+    return insertIntoFile(filePath, toInsert, { create: false })
+      .then(function(result) {
+        expect(fs.existsSync(filePath)).to.equal(false, 'file should not exist');
+        expect(result.originalContents).to.equal('', 'returned object should contain original contents');
+        expect(result.inserted).to.equal(false, 'inserted should indicate that the file was not modified');
+        expect(result.contents).to.equal('', 'returned object should contain original contents');
+      });
+  });
+
   it('will insert into the file if it already exists', function() {
     let toInsert = 'blahzorz blammo';
     let originalContent = 'some original content\n';


### PR DESCRIPTION
Useful when you are dealing with app vs addon inconsistencies, for example the .npmignore file. You want to append if exists, otherwise ignore and don't create.