### PR TITLE
support regex in insertIntoFile

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -17,7 +17,7 @@ const writeFile = RSVP.denodeify(fs.outputFile);
   the first instance of that string.  If `options.after` is specified, the
   contents will be inserted after the first instance of that string.
   If the string specified by options.before or options.after is not in the file,
-  no change will be made.
+  no change will be made. Both of these options support regular expressions.
 
   If neither `options.before` nor `options.after` are present, `contentsToInsert`
   will be inserted at the end of the file.
@@ -87,6 +87,10 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
         contentsToWrite += contentsToInsert;
       } else {
         let contentMarker = options[insertBehavior];
+        let matches = contentsToWrite.match(contentMarker);
+        if (matches) {
+          contentMarker = matches[0];
+        }
         let contentMarkerIndex = contentsToWrite.indexOf(contentMarker);
 
         if (contentMarkerIndex !== -1) {

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -170,7 +170,6 @@ describe('insertIntoFile()', function() {
       });
   });
 
-
   it('it will make no change if options.after is not found in the original', function() {
     let toInsert = 'blahzorz blammo';
     let originalContent = 'the original content';
@@ -200,6 +199,42 @@ describe('insertIntoFile()', function() {
         expect(contents).to.equal(originalContent, 'original content is unchanged');
         expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
         expect(result.inserted).to.equal(false, 'inserted should indicate that the file was not modified');
+      });
+  });
+
+  it('options.after supports regex', function() {
+    let toInsert = 'blahzorz blammo';
+    let line1 = 'line1 is here';
+    let line2 = 'line2 here';
+    let line3 = 'line3';
+    let originalContent = [line1, line2, line3].join(EOL);
+
+    fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+    return insertIntoFile(filePath, toInsert, { after: /line2 here(\r?\n)/ })
+      .then(function() {
+        let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+        expect(contents).to.equal([line1, line2, toInsert, line3].join(EOL),
+          'inserted contents should be inserted after the `after` value');
+      });
+  });
+
+  it('options.before supports regex', function() {
+    let toInsert = 'blahzorz blammo';
+    let line1 = 'line1 is here';
+    let line2 = 'line2 here';
+    let line3 = 'line3';
+    let originalContent = [line1, line2, line3].join(EOL);
+
+    fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+    return insertIntoFile(filePath, toInsert, { before: /line2 here(\r?\n)/ })
+      .then(function() {
+        let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+        expect(contents).to.equal([line1, toInsert, line2, line3].join(EOL),
+          'inserted contents should be inserted before the `before` value');
       });
   });
 });


### PR DESCRIPTION
Right now if you use `{ before: '/tests' + EOL }`, you are missing those Windows users that choose to check in Unix line endings. Now you can use regex to catch both line endings.