### PR TITLE
move from implicit towards explicit testdouble dependency

### DIFF
--- a/tests/helpers/mock-process.js
+++ b/tests/helpers/mock-process.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let td = require('testdouble');
 let EventEmitter = require('events');
 
 module.exports = class FakeProcess extends EventEmitter {
@@ -8,6 +7,8 @@ module.exports = class FakeProcess extends EventEmitter {
     super();
 
     options = options || {};
+
+    let td = options.testdouble || require('testdouble');
 
     const stdin = Object.assign(new EventEmitter(), {
       isRaw: process.stdin.isRaw,


### PR DESCRIPTION
This came up in https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/138#issuecomment-336514382.

This hidden dependency is fishy. I think we should move towards the consumer passing it in, so the dependency is more clear.