### PR TITLE
BREAKING: remove EOL assumptions from insertIntoFile

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs-extra');
 const existsSync = require('exists-sync');
-const EOL = require('os').EOL;
 const RSVP = require('rsvp');
 
 const Promise = RSVP.Promise;
@@ -80,7 +79,7 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
         if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
 
         contentsToWrite = contentsToWrite.slice(0, insertIndex) +
-          contentsToInsert + EOL +
+          contentsToInsert +
           contentsToWrite.slice(insertIndex);
       }
     }

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -87,7 +87,7 @@ describe('insertIntoFile()', function() {
 
     fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
 
-    return insertIntoFile(filePath, toInsert, { after: line2 + EOL })
+    return insertIntoFile(filePath, toInsert + EOL, { after: line2 + EOL })
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
@@ -107,7 +107,7 @@ describe('insertIntoFile()', function() {
 
     fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
 
-    return insertIntoFile(filePath, toInsert, { after: line2 + EOL })
+    return insertIntoFile(filePath, toInsert + EOL, { after: line2 + EOL })
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
@@ -127,7 +127,7 @@ describe('insertIntoFile()', function() {
 
     fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
 
-    return insertIntoFile(filePath, toInsert, { before: line2 + EOL })
+    return insertIntoFile(filePath, toInsert + EOL, { before: line2 + EOL })
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
@@ -147,7 +147,7 @@ describe('insertIntoFile()', function() {
 
     fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
 
-    return insertIntoFile(filePath, toInsert, { before: line2 + EOL })
+    return insertIntoFile(filePath, toInsert + EOL, { before: line2 + EOL })
       .then(function(result) {
         let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 


### PR DESCRIPTION
Closes #7380.

This is probably the better fix. It's too confusing guessing whether you get a free EOL or not when you are using `before`, `after`, or neither.

Not sure what we do about the breaking nature of this though.