### PR TITLE
Add '--no-sandbox' flag to Chrome in CI mode

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -14,6 +14,7 @@ module.exports = {
       args: [
         '--disable-gpu',
         '--headless',
+        '--no-sandbox',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ]


### PR DESCRIPTION
Hey there,

I did run into issues while using Ember in a Docker container (during the `test` phase).

```
Built project successfully. Stored in "/builds/data-lab/module-experts/tmp/class-tests_dist-lkKOjWEl.tmp".
not ok 1 Chrome - error
    ---
        message: >
            Error: Browser exited unexpectedly
            Non-zero exit code: 1
            Stderr: 
             [1019/133040.691989:ERROR:zygote_host_impl_linux.cc(88)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
            
            
        Log: |
            { type: 'error', text: 'Error: Browser exited unexpectedly' }
            { type: 'error', text: 'Non-zero exit code: 1' }
            { type: 'error',
              text: '[1019/133040.691989:ERROR:zygote_host_impl_linux.cc(88)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.\n' }
```

This fixes the problem, does it make sense to add it to the global Ember-CLI blueprint ? I'm not sure about the performance issues that this flag may have.