### PR TITLE
Make "testdouble" dependency optional in MockProcess class

### DIFF
--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -186,6 +186,7 @@ describe('will interrupt process', function() {
   describe('Windows CTRL + C Capture', function() {
     it('exits on CTRL+C when TTY', function() {
       let process = new MockProcess({
+        exit: td.function(),
         platform: 'win',
         stdin: {
           isTTY: true,
@@ -220,8 +221,11 @@ describe('will interrupt process', function() {
 
     it('does not enable raw capture when not a Windows', function() {
       const process = new MockProcess({
+        exit: td.function(),
+
         stdin: {
           isTTY: true,
+          setRawMode: td.function(),
         },
       });
 
@@ -239,7 +243,11 @@ describe('will interrupt process', function() {
 
     it('does not enable raw capture when not a TTY', function() {
       const process = new MockProcess({
+        exit: td.function(),
         platform: 'win',
+        stdin: {
+          setRawMode: td.function(),
+        },
       });
 
       willInterruptProcess.capture(process);


### PR DESCRIPTION
Seems like `mock-process` caused some [inconveniences ](https://github.com/ember-cli/ember-cli/pull/7387) due to its `testdouble` dependency.

Actually we need `testdouble` only in `will-interrupt-process` unit tesst. We have nothing to do with `testdouble` in any other [scenarios](https://github.com/ember-cli/ember-cli/blob/master/tests/helpers/ember.js#L69).

Also previously I thought it was a good idea to implement `MockProcess.exit()` as a `testdouble.function()`. Unfortunately [it wasn't](https://github.com/ember-cli/ember-cli/pull/7285). This approach isn't able to replicate a real `process.exit()` behavior and leads to dishonest tests when we test cli/cli for example. 
That is the reason why I changed `MockProcess.exit()` to throw an exception.

Known packages who was forced to install `testdouble` due to ember-cli@2.16 upgrade:
 - [ember-cli-blueprint-test-helpers](https://github.com/ember-cli/ember-cli-blueprint-test-helpers)
 - [ember-cli-page-object](https://github.com/san650/ember-cli-page-object/pull/333/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R83)
 - ...