### PR TITLE
Make dev tests run headless

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -18,5 +18,14 @@ module.exports = {
         '--window-size=1440,900'
       ]
     },
+    Chrome: {
+      mode: 'dev',
+      args: [
+       '--disable-gpu',
+       '--headless',
+       '--remote-debugging-port=9222',
+       '--window-size=1440,900'
+      ]
+    },
   }
 };


### PR DESCRIPTION
On a prior version, the tests run headless on dev machine (as also on CI). I liked that one better, not sure if it was the intention to take this functionality out