### PR TITLE
Allows users to `disableDependencyChecker` from `.ember-cli` options.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -126,7 +126,7 @@ module.exports = function(options) {
     analytics: leek,
     testing: options.testing,
     name: options.cli ? options.cli.name : 'ember',
-    disableDependencyChecker: options.disableDependencyChecker,
+    disableDependencyChecker: config.options.disableDependencyChecker || options.disableDependencyChecker,
     root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
     npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli',
     initInstrumentation,


### PR DESCRIPTION
Right now we need to pass this option via the constructor, 
which is used for tests, but as a user I don't have a way to disable this. 
There are reasons to disable this outside of tests: 
* The DependencyChecker doesn't work today with yarn workspaces
* We may be using a different way to check dependencies like yarn --check-integrity