### PR TITLE
Fixes Project#hasDependencies to only check for dependencies instead …

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -134,7 +134,7 @@ class Project {
     }
     for (let depName in this.dependencies()) {
       try {
-        this.resolveSync(depName);
+        this.resolveSync(`${depName}/package.json`);
         return true;
       } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
…of all dependencies


cc: @rwjblue @ef4 

Not sure if this is the best solution, but I see two problems with the current implementation: 

1. If I install with `yarn --prod` I won't have the devDependencies, which may show up first when running `this.dependencies()`
2. Some dependencies can't be resolved like `@types/node`. I'm not sure how to fix this problem. All of our types are devDependencies, so this indirectly fixed it, but my guess is that there might be other packages that might be valid as a "dependency" that can't be resolved. 