### PR TITLE
Adds the ability to specify `.ember-cli` options at the root of the r…

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -63,6 +63,24 @@ function configureLogger(env) {
   }
 }
 
+function getConfig (options, Project) {
+  const Yam = options.Yam || require('yam');
+  const projectRoot = Project.getProjectRoot();
+  const repositoryRoot = Project.getRepositoryRoot();
+  const useRepositoryRootAsSecondary = projectRoot !== repositoryRoot;
+  const projectConfig = new Yam('ember-cli', {
+    primary: projectRoot,
+    secondary: useRepositoryRootAsSecondary ? repositoryRoot : undefined
+  });
+  if (useRepositoryRootAsSecondary) {
+    // In this case we just want the home options, which are overriden by the options above
+    const homeConfig = new Yam('ember-cli', {primary: undefined});
+    Object.assign(homeConfig.options, projectConfig.options)
+    return homeConfig;
+  }
+  return projectConfig;
+}
+
 // Options: Array cliArgs, Stream inputStream, Stream outputStream, EventEmitter process
 module.exports = function(options) {
   // `process` should be captured before we require any libraries which
@@ -70,7 +88,6 @@ module.exports = function(options) {
   willInterruptProcess.capture(options.process || process);
 
   let UI = options.UI || require('console-ui');
-  let Yam = options.Yam || require('yam');
   const CLI = require('./cli');
   let Leek = options.Leek || require('leek');
   const Project = require('../models/project');
@@ -87,9 +104,7 @@ module.exports = function(options) {
     writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
   });
 
-  let config = new Yam('ember-cli', {
-    primary: Project.getProjectRoot(),
-  });
+  let config = getConfig(options, Project);
 
   let leekOptions;
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -739,6 +739,23 @@ class Project {
     logger.info('getProjectRoot %s -> %s', process.cwd(), directory);
     return directory;
   }
+
+  /**
+    Returns the repository root based on the first .git that is found
+
+    @static
+    @method getRepositoryRoot
+    @return {String} The project's repository root
+   */
+
+  static getRepositoryRoot() {
+    let gitsPath = findup.sync('.git');
+    if (!gitsPath) {
+      logger.info('getRepositoryRoot: not found. Will use getProjectRoot: %s', Project.getProjectRoot());
+      return process.cwd();
+    }
+    return path.dirname(gitsPath);
+  }
 }
 
 class NotFoundError extends Error {


### PR DESCRIPTION
…epository.

Today we only check at the projectRoot and home (~/). 
With this change, the precedence is projectRoot, repositoryRoot and home. 
This is mostly important when we want to maintain consistent options in a monorepo.

cc: @rwjblue @ef4 this is what I mentioned on #ember-cli earlier today. 