### PR TITLE
Issue warning for Node 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
   - "8"
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"
-    - nodejs_version: "7"
     - nodejs_version: "8"
 
 branches:


### PR DESCRIPTION
Removing `7` from `.travis.yml` and `appveyor.yml` will trigger a warning for users still using Node 7.

We can drop support in `engines` once this deprecation has been absorbed throughout the community.