### PR TITLE
Avoid publishing massive temp folder leaked by ember-try

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -14,3 +14,4 @@
 bower.json
 ember-cli-build.js
 testem.js
+.node_modules.ember-try


### PR DESCRIPTION
If anything interrupts an ember-try run this folder will be left behind, and it contains all your node_modules. It's easy to accidentally publish to npm. This happened to liquid-fire 0.29.0, which contains 153MB of uselessness.

I think this is appropriate in the base addon blueprint because ember-try is also in the blueprint. The alternative is to add a blueprint to ember-try that would insert this line, but that is more error prone and easier to drop during an ember-cli upgrade.