### PR TITLE
add osx testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+
 sudo: false
 dist: trusty
 
@@ -38,12 +41,17 @@ matrix:
   - node_js: "6"
     env: TEST_COMMAND=test-all
 
-  # This is the reworking of the tests we run against the most-recent LTS.
   include:
+  # This is the reworking of the tests we run against the most-recent LTS.
   - node_js: "6"
     env: TEST_COMMAND=test-all:cover
   - node_js: "6"
     env: DISABLE_EMBER_CLI_FEATURES=true; TEST_COMMAND=test-all
+
+  - os: osx
+
+  allow_failures:
+  - os: osx
 
 before_install:
   # Once we no longer support Node.js 0.12 we can drop this entire section.


### PR DESCRIPTION
This is mainly for discussion. It is possible to test in OSX. The jobs tend to take a while to be allocated, so it would slow down our CI (as well as adding the additional job(s)).

Is this worth it? Do we ever regress in mac while Windows and Linux are fine?

cc @ember-cli/core 