### PR TITLE
Fix "travis_retry: command not found" error

### DIFF
--- a/.travis/codecoverage.sh
+++ b/.travis/codecoverage.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-# For now we will use `npm` for globals.
-# Can switch to `yarn` once we no longer support Node.js 0.12:
-# - travis_retry yarn global add coveralls codeclimate-test-reporter
-travis_retry npm install -g coveralls codeclimate-test-reporter
-cat coverage/lcov.info | codeclimate-test-reporter
-cat coverage/lcov.info | coveralls
+# fail script immediately on any errors in external commands
+set -e
+
+# Use `yarn` to install globals
+yarn global add coveralls codeclimate-test-reporter
+
+cat ./coverage/lcov.info | coveralls
+codeclimate-test-reporter < ./coverage/lcov.info

--- a/docs/CODE_COVERAGE.md
+++ b/docs/CODE_COVERAGE.md
@@ -1,0 +1,13 @@
+# Ember CLI Code Coverage & Analysis
+
+We are using [Coveralls](https://coveralls.io/) to track our code coverage
+and [Code Climate](https://codeclimate.com/) to analyze the complexity our code base.
+
+Code coverage information is generated using [istanbul](https://github.com/gotwarlost/istanbul)
+and then later uploaded to both
+[Coveralls](coveralls.io/github/ember-cli/ember-cli) and
+[Code Climate](https://codeclimate.com/github/ember-cli/ember-cli) via
+[`.travis/codecoverage.sh`](../.travis/codecoverage.sh) after each Pull Request.
+
+`CODECLIMATE_REPO_TOKEN`, `COVERALLS_REPO_TOKEN` and `COVERALLS_SERVICE_NAME` are set via Travis CI
+Settings and not exposed to the public as they are private tokens.


### PR DESCRIPTION
This issue prevents code coverage tools from working properly.

It turns out that `travis_retry` function is actually [not available on build machines](https://twitter.com/travisci/status/499196774712901632).

To work around that, we can copy `travis_retry` function from [travis-ci/travis-build repository](https://github.com/travis-ci/travis-build/blob/73f74a94957f73eb54dc821f80c0c85ad8f8aab7/lib/travis/build/script/templates/header.sh#L168-L187).

For reference, a [tweet by Travis CI](https://twitter.com/plexus/status/499194992632811520) saying that you should copy the `travis_retry` code from
[travis-ci/travis-build repository](https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/templates/header.sh).