### PR TITLE
Use `overrides` for a single `.eslintrc.js`.

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   <% if (yarn) { %>useYarn: true,
   <% } %>scenarios: [

--- a/blueprints/addon/files/addon-config/environment.js
+++ b/blueprints/addon/files/addon-config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/blueprints/addon/files/ember-cli-build.js
+++ b/blueprints/addon/files/ember-cli-build.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

--- a/blueprints/addon/files/index.js
+++ b/blueprints/addon/files/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -9,5 +9,34 @@ module.exports = {
     browser: true
   },
   rules: {
-  }
+  },
+  overrides: [
+    // node files
+    {
+      files: [
+        'index.js',
+        'testem.js',
+        'ember-cli-build.js',
+        'config/**/*.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      parserOptions: {
+        sourceType: 'script',
+        ecmaVersion: 2015
+      },
+      env: {
+        browser: false,
+        node: true
+      }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**/*.js'],
+      env: {
+        embertest: true
+      }
+    }
+  ]
 };

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(environment) {

--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   browsers: [
     'ie 9',

--- a/blueprints/app/files/ember-cli-build.js
+++ b/blueprints/app/files/ember-cli-build.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,

--- a/blueprints/app/files/tests/.eslintrc.js
+++ b/blueprints/app/files/tests/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    embertest: true
-  }
-};

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   scenarios: [
     {

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   useYarn: true,
   scenarios: [


### PR DESCRIPTION
Update the `.eslintrc.js` used by apps and addons, to avoid needing separate "sprinkles" of eslint configuration throughout the projects codebase.

Compatible with `eslint@4.1.0`.

Additional reading:

* https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns
* https://github.com/eslint/eslint/pull/8081