### PR TITLE
Add eslint-plugin-ember to default linting config.

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  extends: 'eslint:recommended',
+  plugins: ['ember'],
+  extends: ['eslint:recommended', 'plugin:ember/recommended'],
   env: {
     browser: true
   },

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -36,6 +36,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0-beta.2<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
+    "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },
   "engines": {


### PR DESCRIPTION
Brings back part of #7450 which was reverted in #7453.

From the original description of #7450:

> eslint-plugin-ember@5 will be released soon, and includes a number of changes to the default recommended config. Specifically, the recommended set follows with eslint's own strategy of only including "saftey related" rules in the recommended rule set. As such, all "style related" rules are no longer "on by default". This definitely does not infer there is anything wrong with those rules (and we may even add some of them into the default app config in the future), but we would like to bring eslint-plugin-ember into ember-cli gradually.