### PR TITLE
Use fs-extra's `ensureDir` to avoid race condition in `mk-tmp-dir-in`.

### DIFF
--- a/lib/utilities/mk-tmp-dir-in.js
+++ b/lib/utilities/mk-tmp-dir-in.js
@@ -4,22 +4,10 @@ const fs = require('fs-extra');
 const temp = require('temp');
 const RSVP = require('rsvp');
 
-const Promise = RSVP.Promise;
-const mkdir = RSVP.denodeify(fs.mkdir);
 const mkdirTemp = RSVP.denodeify(temp.mkdir);
 
-function exists(dir) {
-  return new Promise(resolve => {
-    fs.exists(dir, resolve);
-  });
-}
-
 function mkTmpDirIn(dir) {
-  return exists(dir).then(doesExist => {
-    if (!doesExist) {
-      return mkdir(dir);
-    }
-  }).then(() => mkdirTemp({ dir }));
+  return fs.ensureDir(dir).then(() => mkdirTemp({ dir }));
 }
 
 module.exports = mkTmpDirIn;


### PR DESCRIPTION
CI is somewhat plagued by random race conditiony failure for the following test:

```
not ok 153 Blueprint basic blueprint installation "before each" hook for "calls appropriate hooks with correct arguments"
  Error: EEXIST: file already exists, mkdir '/home/travis/build/ember-cli/ember-cli/tmp'
```

This removes some crufty code (`fs.exists` has been deprecated for a while) in favor of using a nice convenience method from `fs-extra`.

I am not 100% certain this "solves the race condition" (since I can't reproduce locally), but it seems like a nice bit of cleanup/refactoring regardless...