### PR TITLE
Avoid directly requiring `blueprints/app/files/package.json`.

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -17,6 +17,7 @@ let expect = chai.expect;
 let file = chai.file;
 let dir = chai.dir;
 const forEach = require('ember-cli-lodash-subset').forEach;
+const assertVersionLock = require('../helpers/assert-version-lock');
 
 let tmpDir = './tmp/new-test';
 
@@ -445,6 +446,25 @@ describe('Acceptance: ember new', function() {
         expect(file(filePath))
           .to.equal(file(path.join(__dirname, '../fixtures/addon/yarn', filePath)));
       });
+    }));
+  });
+
+  describe('verify dependencies', function() {
+    it('are locked down for pre-1.0 versions', co.wrap(function *() {
+      yield ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git',
+        '--yarn',
+        '--welcome',
+      ]);
+
+      let pkg = fs.readJsonSync('package.json');
+
+      assertVersionLock(pkg.dependencies);
+      assertVersionLock(pkg.devDependencies);
     }));
   });
 });

--- a/tests/helpers/assert-version-lock.js
+++ b/tests/helpers/assert-version-lock.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const expect = require('chai').expect;
+const semver = require('semver');
+
+module.exports = function assertVersionLock(_deps) {
+  let deps = _deps || {};
+
+  Object.keys(deps).forEach(function(name) {
+    if (name !== 'ember-cli' &&
+        semver.valid(deps[name]) &&
+        semver.gtr('1.0.0', deps[name])) {
+      // only valid if the version is fixed
+      expect(semver.valid(deps[name]), `"${name}" has a valid version`).to.be.ok;
+    }
+  });
+};

--- a/tests/unit/package/dependency-version-test.js
+++ b/tests/unit/package/dependency-version-test.js
@@ -1,20 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
-const semver = require('semver');
-
-function assertVersionLock(_deps) {
-  let deps = _deps || {};
-
-  Object.keys(deps).forEach(function(name) {
-    if (name !== 'ember-cli' &&
-        semver.valid(deps[name]) &&
-        semver.gtr('1.0.0', deps[name])) {
-      // only valid if the version is fixed
-      expect(semver.valid(deps[name]), `"${name}" has a valid version`).to.be.ok;
-    }
-  });
-}
+const assertVersionLock = require('../../helpers/assert-version-lock');
 
 describe('dependencies', function() {
   let pkg;
@@ -22,17 +8,6 @@ describe('dependencies', function() {
   describe('in package.json', function() {
     before(function() {
       pkg = require('../../../package.json');
-    });
-
-    it('are locked down for pre-1.0 versions', function() {
-      assertVersionLock(pkg.dependencies);
-      assertVersionLock(pkg.devDependencies);
-    });
-  });
-
-  describe('in blueprints/app/files/package.json', function() {
-    before(function() {
-      pkg = require('../../../blueprints/app/files/package.json');
     });
 
     it('are locked down for pre-1.0 versions', function() {


### PR DESCRIPTION
This file now contains templating (e.g. `<% %>`) that is only processed during `ember g` / `ember init` / `ember new`.  This refactors the test to assert against the final output (*not* the internal representation in the repo itself).