### PR TITLE
Add prettier to default linting configuration.

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -5,71 +5,71 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
+          'ember-source': '~2.12.0',
+        },
+      },
     },
     {
       name: 'ember-lts-2.16',
       npm: {
         devDependencies: {
-          'ember-source': '~2.16.0'
-        }
-      }
+          'ember-source': '~2.16.0',
+        },
+      },
     },
     {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          ember: 'components/ember#release',
         },
         resolutions: {
-          'ember': 'release'
-        }
+          ember: 'release',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          ember: 'components/ember#beta',
         },
         resolutions: {
-          'ember': 'beta'
-        }
+          ember: 'beta',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          ember: 'components/ember#canary',
         },
         resolutions: {
-          'ember': 'canary'
-        }
+          ember: 'canary',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-default',
       npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+        devDependencies: {},
+      },
+    },
+  ],
 };

--- a/blueprints/addon/files/addon-config/environment.js
+++ b/blueprints/addon/files/addon-config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {};
 };

--- a/blueprints/addon/files/index.js
+++ b/blueprints/addon/files/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: '<%= addonModulePrefix %>'
+  name: '<%= addonModulePrefix %>',
 };

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -2,13 +2,19 @@ module.exports = {
   root: true,
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'module'
+    sourceType: 'module',
   },
-  extends: 'eslint:recommended',
+  plugins: ['prettier'],
+  extends: ['eslint:recommended', 'prettier'],
   env: {
-    browser: true
+    browser: true,
   },
   rules: {
+    'prettier/prettier': ['error', {
+      singleQuote: true,
+      trailingComma: 'es5',
+      printWidth: 120,
+    }],
   },
   overrides: [
     // node files
@@ -18,15 +24,15 @@ module.exports = {
         'testem.js',
         'ember-cli-build.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'tests/dummy/config/**/*.js',
       ],
       parserOptions: {
         sourceType: 'script',
-        ecmaVersion: 2015
+        ecmaVersion: 2015,
       },
       env: {
         browser: false,
-        node: true
+        node: true,
       }
     },
 
@@ -35,8 +41,8 @@ module.exports = {
       files: ['tests/**/*.js'],
       excludedFiles: ['tests/dummy/**/*.js'],
       env: {
-        embertest: true
-      }
-    }
-  ]
+        embertest: true,
+      },
+    },
+  ],
 };

--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -6,7 +6,7 @@ import config from './config/environment';
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -3,10 +3,9 @@ import config from './config/environment';
 
 const Router = EmberRouter.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
 });
 
-Router.map(function() {
-});
+Router.map(function() {});
 
 export default Router;

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -13,14 +13,14 @@ module.exports = function(environment) {
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
-        Date: false
-      }
+        Date: false,
+      },
     },
 
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
   };
 
   if (environment === 'development') {

--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,8 +1,3 @@
 module.exports = {
-  browsers: [
-    'ie 9',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
-  ]
+  browsers: ['ie 9', 'last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'],
 };

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -36,7 +36,10 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0-beta.2<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
-    "loader.js": "^4.2.3"
+    "eslint-config-prettier": "^2.7.0",
+    "eslint-plugin-prettier": "^2.3.1",
+    "loader.js": "^4.2.3",
+    "prettier": "^1.8.2"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -1,21 +1,12 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: [
-    'Chrome'
-  ],
-  launch_in_dev: [
-    'Chrome'
-  ],
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
   browser_args: {
     Chrome: {
       mode: 'ci',
-      args: [
-        '--disable-gpu',
-        '--headless',
-        '--remote-debugging-port=0',
-        '--window-size=1440,900'
-      ]
+      args: ['--disable-gpu', '--headless', '--remote-debugging-port=0', '--window-size=1440,900'],
     },
-  }
+  },
 };

--- a/blueprints/app/files/tests/helpers/module-for-acceptance.js
+++ b/blueprints/app/files/tests/helpers/module-for-acceptance.js
@@ -16,6 +16,6 @@ export default function(name, options = {}) {
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
       return resolve(afterEach).then(() => destroyApp(this.application));
-    }
+    },
   });
 }

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -4,71 +4,71 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
+          'ember-source': '~2.12.0',
+        },
+      },
     },
     {
       name: 'ember-lts-2.16',
       npm: {
         devDependencies: {
-          'ember-source': '~2.16.0'
-        }
-      }
+          'ember-source': '~2.16.0',
+        },
+      },
     },
     {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          ember: 'components/ember#release',
         },
         resolutions: {
-          'ember': 'release'
-        }
+          ember: 'release',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          ember: 'components/ember#beta',
         },
         resolutions: {
-          'ember': 'beta'
-        }
+          ember: 'beta',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          ember: 'components/ember#canary',
         },
         resolutions: {
-          'ember': 'canary'
-        }
+          ember: 'canary',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-default',
       npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+        devDependencies: {},
+      },
+    },
+  ],
 };

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -5,71 +5,71 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
+          'ember-source': '~2.12.0',
+        },
+      },
     },
     {
       name: 'ember-lts-2.16',
       npm: {
         devDependencies: {
-          'ember-source': '~2.16.0'
-        }
-      }
+          'ember-source': '~2.16.0',
+        },
+      },
     },
     {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          ember: 'components/ember#release',
         },
         resolutions: {
-          'ember': 'release'
-        }
+          ember: 'release',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          ember: 'components/ember#beta',
         },
         resolutions: {
-          'ember': 'beta'
-        }
+          ember: 'beta',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          ember: 'components/ember#canary',
         },
         resolutions: {
-          'ember': 'canary'
-        }
+          ember: 'canary',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-default',
       npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+        devDependencies: {},
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Brings back part of #7450 which was reverted in #7453.

From the original description of #7450:

> `prettier` has taken the JavaScript ecosystem by storm! It has quickly become the most common way to acheive "standard code style" without being nit-picky with linting rules. The configuration that is landed here integrates `prettier` into `eslint` so that `eslint` properly identifies things that are not "pretty" and a quick `eslint --fix` will auto-correct them. This also means that any editors with built-in `eslint --fix` support already support `prettier`.