### PR TITLE
Change when availableOptions are normalized

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -155,8 +155,6 @@ let Command = CoreObject.extend({
      * ```
      */
     this.anonymousOptions = this.anonymousOptions || [];
-
-    this.registerOptions();
   },
 
   /**
@@ -542,6 +540,8 @@ let Command = CoreObject.extend({
     let knownOpts = {}; // Parse options
     let commandOptions = {};
     let parsedOptions;
+
+    this.registerOptions();
 
     let assembleAndValidateOption = function(option) {
       return this.assignOption(option, parsedOptions, commandOptions);

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -640,6 +640,8 @@ let Command = CoreObject.extend({
    */
   getJson(options) {
     let json = {};
+
+    this.registerOptions(options);
     this._printableProperties.forEach(key => (json[key] = this[key]));
 
     if (this.addAdditionalJsonForHelp) {

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -48,7 +48,7 @@ describe('Acceptance: ember help', function() {
   });
 
   it('works', function() {
-    command.validateAndRun([]);
+    command.run(options, []);
 
     let output = options.ui.output;
 
@@ -157,6 +157,7 @@ describe('Acceptance: ember help', function() {
 
       let json = convertToJson(options.ui.output);
       const expected = require('../fixtures/help/with-addon-commands.js');
+
       expect(json).to.deep.equal(expected);
     });
 
@@ -166,6 +167,7 @@ describe('Acceptance: ember help', function() {
       };
 
       command.run(options, []);
+
       let json = convertToJson(options.ui.output);
       const expected = require('../fixtures/help/with-addon-blueprints.js');
 

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -48,7 +48,7 @@ describe('Acceptance: ember help', function() {
   });
 
   it('works', function() {
-    command.run(options, []);
+    command.validateAndRun([]);
 
     let output = options.ui.output;
 
@@ -140,12 +140,12 @@ describe('Acceptance: ember help', function() {
     });
 
     it('works', function() {
-      command.run(options, []);
+      command.validateAndRun([]).then(() => {
+        let json = convertToJson(options.ui.output);
+        const expected = require('../fixtures/help/help.js');
 
-      let json = convertToJson(options.ui.output);
-      const expected = require('../fixtures/help/help.js');
-
-      expect(json).to.deep.equal(expected);
+        expect(json).to.deep.equal(expected);
+      });
     });
 
     it('prints commands from addons', function() {
@@ -153,12 +153,12 @@ describe('Acceptance: ember help', function() {
         cb('dummy-addon', { Foo: FooCommand });
       };
 
-      command.run(options, []);
+      command.validateAndRun([]).then(() => {
+        let json = convertToJson(options.ui.output);
+        const expected = require('../fixtures/help/with-addon-commands.js');
 
-      let json = convertToJson(options.ui.output);
-      const expected = require('../fixtures/help/with-addon-commands.js');
-
-      expect(json).to.deep.equal(expected);
+        expect(json).to.deep.equal(expected);
+      });
     });
 
     it('prints blueprints from addons', function() {
@@ -166,12 +166,12 @@ describe('Acceptance: ember help', function() {
         return [path.join(__dirname, '..', 'fixtures', 'blueprints')];
       };
 
-      command.run(options, []);
+      command.validateAndRun([]).then(() => {
+        let json = convertToJson(options.ui.output);
+        const expected = require('../fixtures/help/with-addon-blueprints.js');
 
-      let json = convertToJson(options.ui.output);
-      const expected = require('../fixtures/help/with-addon-blueprints.js');
-
-      expect(json).to.deep.equal(expected);
+        expect(json).to.deep.equal(expected);
+      });
     });
   });
 });

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -140,12 +140,12 @@ describe('Acceptance: ember help', function() {
     });
 
     it('works', function() {
-      command.validateAndRun([]).then(() => {
-        let json = convertToJson(options.ui.output);
-        const expected = require('../fixtures/help/help.js');
+      command.run(options, []);
 
-        expect(json).to.deep.equal(expected);
-      });
+      let json = convertToJson(options.ui.output);
+      const expected = require('../fixtures/help/help.js');
+
+      expect(json).to.deep.equal(expected);
     });
 
     it('prints commands from addons', function() {
@@ -153,12 +153,11 @@ describe('Acceptance: ember help', function() {
         cb('dummy-addon', { Foo: FooCommand });
       };
 
-      command.validateAndRun([]).then(() => {
-        let json = convertToJson(options.ui.output);
-        const expected = require('../fixtures/help/with-addon-commands.js');
+      command.run(options, []);
 
-        expect(json).to.deep.equal(expected);
-      });
+      let json = convertToJson(options.ui.output);
+      const expected = require('../fixtures/help/with-addon-commands.js');
+      expect(json).to.deep.equal(expected);
     });
 
     it('prints blueprints from addons', function() {
@@ -166,12 +165,11 @@ describe('Acceptance: ember help', function() {
         return [path.join(__dirname, '..', 'fixtures', 'blueprints')];
       };
 
-      command.validateAndRun([]).then(() => {
-        let json = convertToJson(options.ui.output);
-        const expected = require('../fixtures/help/with-addon-blueprints.js');
+      command.run(options, []);
+      let json = convertToJson(options.ui.output);
+      const expected = require('../fixtures/help/with-addon-blueprints.js');
 
-        expect(json).to.deep.equal(expected);
-      });
+      expect(json).to.deep.equal(expected);
     });
   });
 });

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -218,7 +218,7 @@ describe('models/command.js', function() {
     let AvailableOptionsInitCommand = Command.extend({
       name: 'available-options-init-command',
       init() {
-        this._super(...arguments);
+        this._super.apply(this, arguments);
 
         this.availableOptions = [{
           name: 'spicy',


### PR DESCRIPTION
The normalization of the availableOptions was done during the init step on the parent Command class. However, this meant that if a child class was to extend from Command they could not set availableOptions within their own init or beforeRun steps as the normalization would have already been done. This change moves the normalization to just before it is needed and after init, beforeRun, etc have happened.

Fixes: #7459 