### PR TITLE
WIP: add delayed transpilation

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -625,13 +625,53 @@ class EmberApp {
     @return {Array}       List of trees
    */
   addonTreesFor(type) {
+    return this._addonTreesFor(type).map(val => val.tree);
+  }
+
+  _addonTreesFor(type) {
     return this.project.addons.reduce((sum, addon) => {
       if (addon.treeFor) {
         let val = addon.treeFor(type);
-        if (val) { sum.push(val); }
+        if (val) {
+          sum.push({
+            addon,
+            tree: val,
+          });
+        }
       }
       return sum;
     }, []);
+  }
+
+  compileAddons(type) {
+    let collections = this._addonTreesFor(type);
+
+    let addonTrees = collections.map(collection => {
+      let addon = collection.addon;
+      let tree = collection.tree;
+
+      // ember-data hacks it's own transpilation
+      if (addon.name !== 'ember-data') {
+        tree = preprocessJs(tree, '/', '/', {
+          registry: this.registry,
+        });
+      }
+
+      // template compile can't be done during first-pass transpilation
+      // otherwise it would get double module compiled above
+      // so we do it after app transpilation here
+      if (type === 'addon') {
+        let templatesTree = addon.compileTemplates(tree);
+        tree = mergeTrees([tree, templatesTree], {
+          overwrite: true,
+          annotation: `Addon#compileAddon(${addon.name})`,
+        });
+      }
+
+      return tree;
+    });
+
+    return addonTrees;
   }
 
   /**
@@ -1089,7 +1129,7 @@ class EmberApp {
 
   _addonTree() {
     if (!this._cachedAddonTree) {
-      let addonTrees = this.addonTreesFor('addon');
+      let addonTrees = this.compileAddons('addon');
 
       let combinedAddonTree = mergeTrees(addonTrees, {
         overwrite: true,
@@ -1531,7 +1571,7 @@ class EmberApp {
     let external = this._processedExternalTree();
     let emberCLITree = this._processedEmberCLITree();
 
-    let addonTestSupportTree = mergeTrees(this.addonTreesFor('addon-test-support'), {
+    let addonTestSupportTree = mergeTrees(this.compileAddons('addon-test-support'), {
       overwrite: true,
       annotation: 'TreeMerger (addon-test-support)',
     });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -233,8 +233,20 @@ let addonProto = {
     });
 
     let emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
+
+    // the app will handle transpilation after it tree-shakes
+    let compileModules = false;
+    let disablePresetEnv = true;
+
+    // work around ember-data wonkiness
+    if (this.name === 'ember-data' || this.name === 'ember-inflector') {
+      compileModules = true;
+      disablePresetEnv = false;
+    }
+
     this.__originalOptions[emberCLIBabelConfigKey] = this.options[emberCLIBabelConfigKey] = defaultsDeep(this.options[emberCLIBabelConfigKey], {
-      compileModules: true,
+      compileModules,
+      disablePresetEnv,
     });
   },
 
@@ -1068,20 +1080,8 @@ let addonProto = {
       this.options.babel = this.__originalOptions.babel;
     }
 
-    let emberCLIBabelConfigKey = this._emberCLIBabelConfigKey();
-    if (!this.options[emberCLIBabelConfigKey] || !this.options[emberCLIBabelConfigKey].compileModules) {
-      this._warn(
-        `Ember CLI addons manage their own module transpilation during the \`treeForAddon\` processing. ` +
-        `\`${this.name}\` (found at \`${this.root}\`) has overridden the \`this.options.${emberCLIBabelConfigKey}.compileModules\` ` +
-        `value which conflicts with the addons ability to transpile its \`addon/\` files properly.`
-      );
-
-      this.options[emberCLIBabelConfigKey] = this.options[emberCLIBabelConfigKey] || {};
-      this.options[emberCLIBabelConfigKey].compileModules = true;
-    }
-
     let addonJs = this.processedAddonJsFiles(tree);
-    let templatesTree = this.compileTemplates(tree);
+    let templatesTree = this._addonTemplateFiles(tree);
 
     let trees = [addonJs, templatesTree].filter(Boolean);
 


### PR DESCRIPTION
I would like some feedback. Things to note:

* template transpilation has to happen after the app has transpiled all javascript. Otherwise, the modules would get double transpiled, once in addon and once again during app, resulting in corrupted files.
* there is a hack to work around ember-data's custom transpilation it does in `treeForAddon`.
  * any addon that also does this is gonna have a bad time (double transpilation). We might have to introduce a flag that opt's them out of the app transpilation.
* removed `treeForAddon`/`compileModules` warning, because it is now the desired behavior.
* need better names for things.
* need to delay the css transpilation as well
* addon still need to compile down to es latest, right now they just skip everything