### PR TITLE
[BUGFIX] pass --yarn through AddonInstall task to NpmInstall task

### DIFF
--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -42,6 +42,7 @@ class AddonInstallTask extends Task {
       'save': commandOptions.save,
       'save-dev': !commandOptions.save,
       'save-exact': commandOptions.saveExact,
+      useYarn: Boolean(commandOptions.yarn),
     }).then(() => this.project.reloadAddons())
       .then(() => this.installBlueprint(blueprintInstall, packageNames, blueprintOptions))
       .finally(() => ui.stopProgress())

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -106,6 +106,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
       });
     });
@@ -125,6 +126,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
       });
     });
@@ -138,6 +140,7 @@ describe('install command', function() {
           'save': true,
           'save-dev': false,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
       });
     });
@@ -157,6 +160,21 @@ describe('install command', function() {
           'save': true,
           'save-dev': false,
           'save-exact': false,
+          useYarn: false,
+        }), { times: 1 });
+      });
+    });
+
+    it('runs the npm install task with yarn when given the --yarn option', function() {
+      return command.validateAndRun(['ember-data', '--yarn']).then(function() {
+        let npmRun = tasks.NpmInstall.prototype.run;
+
+        td.verify(npmRun({
+          packages: ['ember-data'],
+          'save': false,
+          'save-dev': true,
+          'save-exact': false,
+          useYarn: true,
         }), { times: 1 });
       });
     });
@@ -200,6 +218,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -217,6 +236,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -233,6 +253,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;
@@ -250,6 +271,7 @@ describe('install command', function() {
           'save': false,
           'save-dev': true,
           'save-exact': false,
+          useYarn: false,
         }), { times: 1 });
 
         let generateRun = tasks.GenerateFromBlueprint.prototype.run;


### PR DESCRIPTION
The `install` task documents a --yarn option which should change the behavior of the NpmInstall task. However, the AddonInstall task did not pass the option all the way through.