### PR TITLE
[tests] fix brocfile-tests fixtures that override config/environment

### DIFF
--- a/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
@@ -1,6 +1,7 @@
 module.exports = function() {
   return  {
     modulePrefix: 'some-cool-app',
+    APP: {},
     EmberENV: {
       asdflkmawejf: ';jlnu3yr23'
     }

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
@@ -3,6 +3,7 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/environment.js',
     baseURL: '/',
-    locationType: 'auto'
+    locationType: 'auto',
+    APP: {}
   };
 };


### PR DESCRIPTION
ember-cli-app-version assumes that config/environment includes an `APP` property. The brocfile-tests acceptance tests were failing with an exception if it didn't.

The issue in ember-cli-app-version is being addressed in EmberSherpa/ember-cli-app-version#53.