### PR TITLE
Add minimum supported version badge to default addon readme

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -1,6 +1,8 @@
 <%= addonName %>
 ==============================================================================
 
+[![Ember Version](https://img.shields.io/badge/ember-2.18%2B-brightgreen.svg)](https://www.emberjs.com/)
+
 [Short description of the addon.]
 
 

--- a/blueprints/module-unification-addon/files/README.md
+++ b/blueprints/module-unification-addon/files/README.md
@@ -1,6 +1,8 @@
 <%= addonName %>
 ==============================================================================
 
+[![Ember Version](https://img.shields.io/badge/ember-2.18%2B-brightgreen.svg)](https://www.emberjs.com/)
+
 [Short description of the addon.]
 
 

--- a/tests/fixtures/addon/npm/README.md
+++ b/tests/fixtures/addon/npm/README.md
@@ -1,6 +1,8 @@
 foo
 ==============================================================================
 
+[![Ember Version](https://img.shields.io/badge/ember-2.18%2B-brightgreen.svg)](https://www.emberjs.com/)
+
 [Short description of the addon.]
 
 

--- a/tests/fixtures/addon/yarn/README.md
+++ b/tests/fixtures/addon/yarn/README.md
@@ -1,6 +1,8 @@
 foo
 ==============================================================================
 
+[![Ember Version](https://img.shields.io/badge/ember-2.18%2B-brightgreen.svg)](https://www.emberjs.com/)
+
 [Short description of the addon.]
 
 


### PR DESCRIPTION
This is our recommended supported ember version for new addons (2 LTS's back). I use these a lot, and it seems to me, this is a good starting point for addon authors to consider their own support.

We can discuss at our meeting further.