### PR TITLE
Give plugins and extends their own lines

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -4,8 +4,13 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  plugins: ['ember'],
-  extends: ['eslint:recommended', 'plugin:ember/recommended'],
+  plugins: [
+    'ember'
+  ],
+  extends: [
+    'eslint:recommended', 
+    'plugin:ember/recommended'
+  ],
   env: {
     browser: true
   },


### PR DESCRIPTION
I had several extra `plugins` and `extends` entries defined in some of my `.eslintrc.js` files. The idea here is, if we put each one on a separate line, and you use the default suggestions, plus add your own, you won't get a diff where the whole plugins and extends sections are completely rewritten, but the diff will just show the extra ones you added. Please let me know if you guys think this is a good idea or not!