### PR TITLE
Restore `separator: '\n;'` to vendor JS concat

### DIFF
--- a/lib/broccoli/strategies.js
+++ b/lib/broccoli/strategies.js
@@ -119,6 +119,7 @@ module.exports = {
       footerFiles: vendorObject.footerFiles,
       outputFile: options.outputFile,
       annotation: options.annotation,
+      separator: '\n;',
       sourceMapConfig: options.sourceMapConfig,
     });
   },

--- a/tests/unit/broccoli/strategies-test.js
+++ b/tests/unit/broccoli/strategies-test.js
@@ -69,6 +69,7 @@ describe('assembler strategies', function() {
         ],
         inputFiles: [],
         outputFile: '/assets/vendor.js',
+        separator: '\n;',
         sourceMapConfig: {
           'enabled': true,
         },


### PR DESCRIPTION
Closes #7470

Retargeted the commit:

Prior to 2.17, Ember CLI used a semicolon to separate files concatenated into vendor.js: https://github.com/ember-cli/ember-cli/blob/v2.16.2/lib/broccoli/bundler.js#L92

Vendor shims are still generated with a leading paren:
```
(function() {
  function vendorModule() {
    'use strict';

    return {
      'default': self['test'],
      __esModule: true,
    };
  }

  define('test', [], vendorModule);
})();
```

This can cause `TypeError: (intermediate value)(...) is not a function` if the code immediately prior does not end in a semicolon.
.