### PR TITLE
NpmInstallTask: `useYarn` from constructor args

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -136,8 +136,6 @@ class NpmTask extends Task {
   }
 
   run(options) {
-    this.useYarn = options.useYarn;
-
     return this.findPackageManager().then(() => {
       let ui = this.ui;
       let startMessage = this.formatStartMessage(options.packages);


### PR DESCRIPTION
Instead of from the args passed to `#run`.

This replaces https://github.com/ember-cli/ember-cli/pull/7354