### PR TITLE
[WIP] Addons using module unification

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -4,7 +4,13 @@
 @module ember-cli
 */
 const defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
+const WatchedDir = require('broccoli-source').WatchedDir;
+const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 const Funnel = require('broccoli-funnel');
+const existsSync = require('exists-sync');
+const path = require('path');
+
+const experiments = require('../experiments');
 const EmberApp = require('./ember-app');
 
 class EmberAddon extends EmberApp {
@@ -26,17 +32,56 @@ class EmberAddon extends EmberApp {
       defaultsDeep(options, defaults);
     }
 
+    let project = defaults.project;
+
+    function _resolveLocal(to) {
+      return path.join(project.root, to);
+    }
+
     process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';
+
+    let srcPath = _resolveLocal('tests/dummy/src');
+    let srcTree = existsSync(srcPath) ? new WatchedDir(srcPath) : null;
+
+    let appPath = _resolveLocal('tests/dummy/app');
+    let appTree;
+    if (experiments.MODULE_UNIFICATION) {
+      appTree = existsSync(appPath) ? new WatchedDir(appPath) : null;
+    } else {
+      appTree = new WatchedDir(appPath);
+    }
+
+    let testsPath = _resolveLocal('tests');
+    let testsTree = existsSync(testsPath) ? new WatchedDir(testsPath) : null;
+
+    // these are contained within app/ no need to watch again
+    // (we should probably have the builder or the watcher dedup though)
+    let stylesPath;
+
+    if (experiments.MODULE_UNIFICATION) {
+      let srcStylesPath = _resolveLocal('tests/dummy/src/ui/styles');
+      stylesPath = existsSync(srcStylesPath) ? srcStylesPath : _resolveLocal('tests/dummy/app/styles');
+    } else {
+      stylesPath = _resolveLocal('tests/dummy/app/styles');
+    }
+    let stylesTree = new UnwatchedDir(stylesPath);
+
+    let templatesPath = _resolveLocal('tests/dummy/app/templates');
+    let templatesTree = existsSync(templatesPath) ? new UnwatchedDir(templatesPath) : null;
+
+    let publicPath = _resolveLocal('tests/dummy/public');
+    let publicTree = existsSync(publicPath) ? new WatchedDir(publicPath) : null;
 
     super(defaultsDeep(options, {
       name: 'dummy',
       configPath: './tests/dummy/config/environment',
       trees: {
-        app: 'tests/dummy/app',
-        styles: 'tests/dummy/app/styles',
-        templates: 'tests/dummy/app/templates',
-        public: 'tests/dummy/public',
-        tests: new Funnel('tests', {
+        app: appTree,
+        src: srcTree,
+        styles: stylesTree,
+        templates: templatesTree,
+        public: publicTree,
+        tests: new Funnel(testsTree, {
           exclude: [/^dummy/],
         }),
       },

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1105,6 +1105,24 @@ class EmberApp {
     return this._cachedAddonTree;
   }
 
+  _addonSrcTree() {
+    if (!this._cachedAddonSrcTree) {
+      let addonTrees = this.addonTreesFor('src');
+
+      let combinedAddonTree = mergeTrees(addonTrees, {
+        overwrite: true,
+        annotation: 'TreeMerger: `src/` trees',
+      });
+
+      this._cachedAddonSrcTree = new Funnel(combinedAddonTree, {
+        destDir: 'addon-tree-output',
+        annotation: 'Funnel: addon-tree-output',
+      });
+    }
+
+    return this._cachedAddonSrcTree;
+  }
+
   /**
     @private
     @method _processedVendorTree
@@ -1143,8 +1161,9 @@ class EmberApp {
       let vendor = this._processedVendorTree();
       let bower = this._processedBowerTree();
       let addons = this._addonTree();
+      let addonsSrc = this._addonSrcTree();
 
-      let trees = [vendor].concat(addons);
+      let trees = [vendor].concat(addons, addonsSrc);
       if (bower) {
         trees.unshift(bower);
       }

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -689,6 +689,20 @@ let addonProto = {
     @return {Tree} App file tree
   */
   treeForApp(tree) {
+    let srcTreePath = path.resolve(this.root, this.treePaths.src);
+
+    if (existsSync(srcTreePath)) {
+      const MUReexporter = require('broccoli-module-unification-reexporter');
+
+      let srcTree = this.treeGenerator(srcTreePath);
+
+      let reexportedOutput = new MUReexporter(srcTree, {
+        namespace: this.name,
+      });
+
+      return reexportedOutput;
+    }
+
     return tree;
   },
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -34,6 +34,8 @@ const addonProcessTree = require('../utilities/addon-process-tree');
 const semver = require('semver');
 const processModulesOnly = require('../broccoli/babel-process-modules-only');
 
+const experiments = require('../experiments');
+
 const BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS = Symbol('BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS');
 
 if (!heimdall.hasMonitor('addon-tree-cache')) {
@@ -53,6 +55,7 @@ if (!heimdall.hasMonitor('cache-key-for-tree')) {
 
 let DEFAULT_TREE_FOR_METHODS = {
   app: 'treeForApp',
+  src: 'treeForSrc',
   addon: 'treeForAddon',
   'addon-styles': 'treeForAddonStyles',
   'addon-templates': 'treeForAddonTemplates',
@@ -67,6 +70,7 @@ let DEFAULT_TREE_FOR_METHODS = {
 let GLOBAL_TREE_FOR_METHOD_METHODS = ['treeFor', '_treeFor', 'treeGenerator'];
 let DEFAULT_TREE_FOR_METHOD_METHODS = {
   app: ['treeForApp'],
+  src: ['treeForSrc'],
   addon: [
     'treeForAddon', 'treeForAddonStyles', 'treeForAddonTemplates',
     'compileAddon', 'processedAddonJsFiles', 'compileTemplates',
@@ -209,6 +213,7 @@ let addonProto = {
 
     this.treePaths = {
       app: 'app',
+      src: 'src',
       styles: 'app/styles',
       templates: 'app/templates',
       addon: 'addon',
@@ -697,6 +702,52 @@ let addonProto = {
   */
   treeForTemplates(tree) {
     return tree;
+  },
+
+  /**
+    @private
+    @method treeForSrc
+    @return
+  */
+  treeForSrc(rawSrcTree) {
+    if (!experiments.MODULE_UNIFICATION) {
+      return null;
+    }
+    // styles
+    // templates
+    if (!rawSrcTree) { return null; }
+
+    let srcNamespacedTree = new Funnel(rawSrcTree, {
+      destDir: 'src',
+    });
+
+    let srcAfterPreprocessTreeHook = this._addonPreprocessTree('src', srcNamespacedTree);
+
+    // let options = {
+    //   outputPaths: this.options.outputPaths.app.css,
+    //   registry: this.registry,
+    // };
+    //
+    // // TODO: This isn't quite correct (but it does function properly in most cases),
+    // // and should be re-evaluated before enabling the `MODULE_UNIFICATION` feature
+    // this._srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
+
+    let srcAfterTemplatePreprocessing = preprocessTemplates(srcAfterPreprocessTreeHook, {
+      registry: this.registry,
+      annotation: `Addon#treeForSrc(${this.name})`,
+    });
+
+    let namespacedSrc = new Funnel(srcAfterTemplatePreprocessing, {
+      srcDir: '/',
+      destDir: `${this.name}`,
+      annotation: `Addon#treeForSrc(${this.name}) namespace`,
+    });
+
+    let srcAfterJsPreprocessing = preprocessJs(namespacedSrc, '/', this.name, {
+      registry: this.registry,
+    });
+
+    return this._addonPostprocessTree('src', srcAfterJsPreprocessing);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "broccoli-funnel-reducer": "^1.0.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-middleware": "^1.0.0",
+    "broccoli-module-unification-reexporter": "^1.0.0",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.2.0",
     "calculate-cache-key-for-tree": "^1.0.0",


### PR DESCRIPTION
## Todo: 
- [ ] Dry up lib/broccoli/ember-addon.js (copied from lib/broccoli/ember-app.js)
- [ ] Process styles (in some way) from src/ in addon (models/addon.js)
- [ ] fix bad error message for `Missing template processor` when missing ember-cli-htmlbars in dependecies i.e. it exists in dev-dependencies
- [ ] broccoli-module-unification-reexporter [edge cases?](https://github.com/stonecircle/broccoli-module-unification-reexporter/blob/538d923e7e8a8f134369d8b0b8b9bf1473e99e49/test/index.js#L83)
- [ ] throw an error (or do something) when an addon can't decide if it's mu or classic (i.e. has src/ **and** addon/ or app/ folders)

## Tests:
- [ ]  _addonSrcTree - ember-app.js
- [ ] _processedVendorTree - test that it includes stuff from the addon src/ folder
- [ ] treeForSrc - models/addon.js
- [ ] addons with src/ folder in classic apps