### PR TITLE
[BUGFIX] give `ember new` error messages consistent color

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -43,7 +43,7 @@ module.exports = Command.extend({
     commandOptions.name = rawArgs.shift();
 
     if (!packageName) {
-      message = chalk.yellow(`The \`ember ${this.name}\` command requires a name to be specified. For more details, use \`ember help\`.`);
+      message = `The \`ember ${this.name}\` command requires a name to be specified. For more details, use \`ember help\`.`;
 
       return Promise.reject(new SilentError(message));
     }


### PR DESCRIPTION
Running `ember new` currently results in a yellow message which is different from the other types of errors that `ember new *` can produce:

<img width="1201" alt="screen shot 2017-12-06 at 12 26 00" src="https://user-images.githubusercontent.com/2526/33661736-27b18228-da81-11e7-893f-a0b7f313f330.png">

This PR makes all error messages red text
