### PR TITLE
Fix regression with scoped package name mismatches

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -35,6 +35,7 @@ const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const addonProcessTree = require('../utilities/addon-process-tree');
 const semver = require('semver');
 const processModulesOnly = require('../broccoli/babel-process-modules-only');
+const npa = require('npm-package-arg');
 
 const BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS = Symbol('BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS');
 
@@ -333,7 +334,29 @@ let addonProto = {
   */
   isDevelopingAddon() {
     if (process.env.EMBER_ADDON_ENV === 'development' && (this.parent instanceof Project)) {
-      return this.parent.name() === this.name;
+      const parentName = this.parent.name();
+      // If the name in package.json and index.js match, we're definitely developing
+      if (parentName === this.name) {
+        return true;
+      }
+
+      // If package.json and index.js names do not match, we should check for scoped vs non-scoped
+      const parsed = npa(parentName);
+      let parsedName = parsed.name;
+      if (parsed.scope) {
+        parsedName = parsedName.replace(parsed.scope, '').slice(1);
+      }
+      if (parsedName === this.name) {
+        if (!this._hasWarnedForMismatchedNames) {
+          this.ui.writeWarnLine(
+            'Your names in package.json and index.js should match. ' +
+            `You currently have ${parsed.name} in package.json and ${this.name} in index.js.`);
+
+          this._hasWarnedForMismatchedNames = true;
+        }
+
+        return true;
+      }
     }
     return false;
   },

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -364,7 +364,7 @@ describe('models/addon.js', function() {
 
         project = new Project(projectPath, packageContents, cli.ui, cli);
 
-        addon = new MyAddon(project);
+        addon = new MyAddon(project, project);
 
         originalEnvValue = process.env.EMBER_ADDON_ENV;
       });
@@ -380,6 +380,14 @@ describe('models/addon.js', function() {
       it('returns true when `EMBER_ADDON_ENV` is set to development', function() {
         process.env.EMBER_ADDON_ENV = 'development';
 
+        expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
+      });
+
+      it('returns true when the addon name is prefixed in package.json and not in index.js', function() {
+        process.env.EMBER_ADDON_ENV = 'development';
+
+        project.name = () => ('@foo/my-addon');
+        addon.name = 'my-addon';
         expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
       });
 


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/commit/69750c9b8a078900e163598542c295a518d1b49f introduced a regression where, if your package name is scoped in package.json and not scoped in index.js, `isDevelopingAddon` would now evaluate to `false`, when it used to evaluate to `true`. This caused the `addon` folder to not be linted anymore.

This fixes the regression and allows the old behavior to work again, but also issues a warning, saying you should sync the names up, per the suggestion of @rwjblue 