### PR TITLE
Allow instrumentation to be turned on using .ember-cli

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2,6 +2,7 @@
 
 const willInterruptProcess = require('../utilities/will-interrupt-process');
 const instrumentation = require('../utilities/instrumentation');
+const getConfig = require('../utilities/get-config');
 
 let initInstrumentation;
 if (instrumentation.instrumentationEnabled()) {
@@ -70,10 +71,10 @@ module.exports = function(options) {
   willInterruptProcess.capture(options.process || process);
 
   let UI = options.UI || require('console-ui');
-  let Yam = options.Yam || require('yam');
   const CLI = require('./cli');
   let Leek = options.Leek || require('leek');
   const Project = require('../models/project');
+  let config = getConfig(options.Yam);
 
   configureLogger(process.env);
 
@@ -85,10 +86,6 @@ module.exports = function(options) {
     errorLog: options.errorLog || [],
     ci: process.env.CI || (/^(dumb|emacs)$/).test(process.env.TERM),
     writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
-  });
-
-  let config = new Yam('ember-cli', {
-    primary: Project.getProjectRoot(),
   });
 
   let leekOptions;

--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -9,9 +9,9 @@ const logger = require('heimdalljs-logger')('ember-cli:instrumentation');
 let vizEnabled = utilsInstrumentation.vizEnabled;
 let instrumentationEnabled = utilsInstrumentation.instrumentationEnabled;
 
-function _enableFSMonitorIfInstrumentationEnabled() {
+function _enableFSMonitorIfInstrumentationEnabled(config) {
   let monitor;
-  if (instrumentationEnabled()) {
+  if (instrumentationEnabled(config)) {
     const FSMonitor = require('heimdalljs-fs-monitor');
     monitor = new FSMonitor();
     monitor.start();

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -14,7 +14,6 @@ const logger = require('heimdalljs-logger')('ember-cli:project');
 const versionUtils = require('../utilities/version-utils');
 const emberCLIVersion = versionUtils.emberCLIVersion;
 const findAddonByName = require('../utilities/find-addon-by-name');
-const Instrumentation = require('./instrumentation');
 const heimdall = require('heimdalljs');
 
 let processCwd = process.cwd();
@@ -717,6 +716,10 @@ function ensureInstrumentation(cli, ui) {
     return cli.instrumentation;
   }
 
+  // Instrumentation `require` needs to occur inline due to circular dependencies between
+  // Instrumentation => getConfig => Project => Instrumentation. getConfig is used in Project to
+  // get the project root.
+  let Instrumentation = require('./instrumentation');
   // created without a `cli` object (possibly from deprecated `Brocfile.js`)
   return new Instrumentation({ ui, initInstrumentation: null });
 }

--- a/lib/utilities/get-config.js
+++ b/lib/utilities/get-config.js
@@ -1,0 +1,23 @@
+'use strict';
+
+let config;
+let Yam = require('yam');
+let Project = require('../models/project');
+
+function generateConfig() {
+  return new Yam('ember-cli', {
+    primary: Project.getProjectRoot(),
+  });
+}
+
+module.exports = function getConfig(configOverride) {
+  if (configOverride) {
+    return configOverride;
+  }
+
+  if (config === undefined) {
+    config = generateConfig();
+  }
+
+  return config;
+};

--- a/lib/utilities/instrumentation.js
+++ b/lib/utilities/instrumentation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const getConfig = require('./get-config');
+
 let _hasWarnedLegacyViz = false;
 
 function vizEnabled() {
@@ -15,8 +17,13 @@ function vizEnabled() {
   return isEnabled || isLegacyEnabled;
 }
 
-function instrumentationEnabled() {
-  return vizEnabled() || process.env.EMBER_CLI_INSTRUMENTATION === '1';
+function isInstrumentationConfigEnabled(configOverride) {
+  let config = getConfig(configOverride);
+  return !!config.get('enableInstrumentation');
+}
+
+function instrumentationEnabled(config) {
+  return vizEnabled() || process.env.EMBER_CLI_INSTRUMENTATION === '1' || isInstrumentationConfigEnabled(config);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "git-repo-info": "^1.4.1",
     "glob": "^7.1.2",
     "heimdalljs": "^0.2.3",
-    "heimdalljs-fs-monitor": "^0.1.0",
+    "heimdalljs-fs-monitor": "^0.2.0",
     "heimdalljs-graph": "^0.3.1",
     "heimdalljs-logger": "^0.1.7",
     "http-proxy": "^1.9.0",

--- a/tests/fixtures/instrumentation-disabled-config/.ember-cli
+++ b/tests/fixtures/instrumentation-disabled-config/.ember-cli
@@ -1,0 +1,3 @@
+{
+  "enableInstrumentation": false
+}

--- a/tests/fixtures/instrumentation-enabled-config/.ember-cli
+++ b/tests/fixtures/instrumentation-enabled-config/.ember-cli
@@ -1,0 +1,3 @@
+{
+  "enableInstrumentation": true
+}

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const MockUI = require('console-ui/mock');
 const RSVP = require('rsvp');
+const Yam = require('yam');
 
 const MockProject = require('../../helpers/mock-project');
 const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
@@ -39,9 +40,11 @@ describe('models/instrumentation.js', function() {
     beforeEach(function() {
       expect(!!process.env.BROCCOLI_VIZ).to.eql(false);
       expect(!!process.env.EMBER_CLI_INSTRUMENTATION).to.eql(false);
+      expect(fs.statSync).to.equal(originalStatSync);
     });
 
     afterEach(function() {
+      fs.statSync = originalStatSync;
       td.reset();
     });
 
@@ -72,6 +75,35 @@ describe('models/instrumentation.js', function() {
     it('if instrumentation is enabled, monitor', function() {
       process.env.EMBER_CLI_INSTRUMENTATION = '1';
       let monitor = Instrumentation._enableFSMonitorIfInstrumentationEnabled();
+      try {
+        expect(fs.statSync).to.not.equal(originalStatSync);
+      } finally {
+        if (monitor) {
+          monitor.stop();
+        }
+      }
+    });
+
+    it('if enableInstrumentation is NOT enabled in .ember-cli, do not monitor', function() {
+      let mockedYam = new Yam('ember-cli', {
+        primary: `${process.cwd()}/tests/fixtures/instrumentation-disabled-config`,
+      });
+      let monitor = Instrumentation._enableFSMonitorIfInstrumentationEnabled(mockedYam);
+      try {
+        expect(fs.statSync).to.equal(originalStatSync);
+        expect(monitor).to.eql(undefined);
+      } finally {
+        if (monitor) {
+          monitor.stop();
+        }
+      }
+    });
+
+    it('if enableInstrumentation is enabled in .ember-cli, monitor', function() {
+      let mockedYam = new Yam('ember-cli', {
+        primary: `${process.cwd()}/tests/fixtures/instrumentation-enabled-config`,
+      });
+      let monitor = Instrumentation._enableFSMonitorIfInstrumentationEnabled(mockedYam);
       try {
         expect(fs.statSync, 'fs.statSync').to.not.equal(originalStatSync, '[original] fs.statSync');
       } finally {

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -44,7 +44,6 @@ describe('models/instrumentation.js', function() {
     });
 
     afterEach(function() {
-      fs.statSync = originalStatSync;
       td.reset();
     });
 

--- a/tests/unit/settings-file/leek-options-test.js
+++ b/tests/unit/settings-file/leek-options-test.js
@@ -11,7 +11,7 @@ const buildOutput = broccoliTestHelper.buildOutput;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('.ember-cli leek options', function() {
-  let settings, passedOptions, leekConfigFolder;
+  let passedOptions, leekConfigFolder;
 
   before(co.wrap(function *() {
     leekConfigFolder = yield createTempDir();
@@ -33,16 +33,12 @@ describe('.ember-cli leek options', function() {
 
     yield buildOutput(primaryPath);
 
-    settings = new Yam('ember-cli', {
+    let mockedYam = new Yam('ember-cli', {
       primary: primaryPath,
     });
 
     let mockedLeek = function(options) {
       passedOptions = options;
-    };
-
-    let mockedYam = function() {
-      return settings;
     };
 
     cliEntry({

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ chai-files@^1.0.0, chai-files@^1.1.0, chai-files@^1.2.0:
   dependencies:
     assertion-error "^1.0.1"
 
-"chai@>=1.9.2 <4.0.0", chai@^3.3.0:
+"chai@>=1.9.2 <4.0.0", chai@^3.3.0, chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
   dependencies:
@@ -1160,6 +1160,12 @@ commander@2.11.0:
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
@@ -1372,6 +1378,12 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
 debug@3.1.0, debug@^3.0.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1473,6 +1485,10 @@ detect-indent@^4.0.0:
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@3.3.1:
   version "3.3.1"
@@ -2422,6 +2438,17 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.1.2, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.0, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -2489,6 +2516,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2613,12 +2644,14 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-heimdalljs-fs-monitor@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/heimdalljs-fs-monitor/-/heimdalljs-fs-monitor-0.1.0.tgz#d404a65688c6714c485469ed3495da4853440272"
+heimdalljs-fs-monitor@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/heimdalljs-fs-monitor/-/heimdalljs-fs-monitor-0.2.0.tgz#42504bc6da0e0016d0b7c8172fc71bb63185a518"
   dependencies:
+    chai "^3.5.0"
     heimdalljs "^0.2.0"
     heimdalljs-logger "^0.1.7"
+    mocha "^3.2.0"
 
 heimdalljs-graph@^0.3.1:
   version "0.3.4"
@@ -3237,6 +3270,10 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
 lodash._basecreate@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz#9b88a86a4dcff7b7f3c61d83a2fcfc0671ec9de0"
@@ -3379,6 +3416,14 @@ lodash.castarray@^4.4.0:
 lodash.clonedeep@^4.4.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^3.1.1:
   version "3.1.1"
@@ -3802,6 +3847,23 @@ mocha-eslint@^4.1.0:
     eslint "^4.2.0"
     glob-all "^3.0.1"
     replaceall "^0.1.6"
+
+mocha@^3.2.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 mocha@^5.0.0:
   version "5.0.0"
@@ -5100,6 +5162,12 @@ supertest@^3.0.0:
   dependencies:
     methods "~1.1.2"
     superagent "^3.0.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
Addresses https://github.com/ember-cli/ember-cli/issues/7429

This is a WIP so hoping to get some feedback. I'm open to changing the namings + approach if required. What I initially thought to be straightforward has turned into somewhat of a rabbit-hole 😄 

* abstracted retrieving the `Yam` config for the project out to `utilities/get-config`.
* Introducing the config into `utiltities/instrumentation` meant needing to move some things around as there are circular dependencies between Instrumentation => Project => Instrumentation. Otherwise it would blow up on init.
* Testing is pretty tricky and not fully 🍏 yet. Due to:
  1. Finding an issue with `yam` whereby a falsey value returns `undefined`. I have a fix here https://github.com/twokul/yam/pull/16
  2. The `_enableFSMonitorIfInstrumentationEnabled ` tests in `models/instrumentation-test.js` are not atomic. Using `heimdall-fs-monitor` to wrap around `fs.statSync` doesn't clean up after itself so affects later tests. https://github.com/ember-cli/ember-cli/blob/d9c015974436ab0b80f552ed7689e968e3d50f91/tests/unit/models/instrumentation-test.js#L36-L83. In particular it's because 1) we don't reassign `fs.statSync` back to it's initial state after each test and 2) calling `FSMonitor()` sets some module-level vars in `heimdall-fs-monitor` (`isFirstInstance`, `isMonitorRegistrant`)  which means trying to set up `FSMonitor()` in a following test doesn't fully work. It doesn't re-"attach" the monitor functions.

Any feedback on the approach in general is appreciated. Also any ideas how to workaround around the `heimdall-fs-monitor` testing issue. I could submit a PR to fix that repo too if useful?