### PR TITLE
Ensure testing honors config/environment settings.

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   if (environment === 'production') {

--- a/blueprints/app/files/tests/helpers/start-app.js
+++ b/blueprints/app/files/tests/helpers/start-app.js
@@ -5,6 +5,7 @@ import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);
+  attributes.autoboot = true;
   attributes = merge(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {

--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -1,7 +1,8 @@
 import Application from '../app';
+import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
-setApplication(Application.create({ autoboot: false }));
+setApplication(Application.create(config.APP));
 
 start();

--- a/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-ember-env/config/environment.js
@@ -3,6 +3,9 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     EmberENV: {
       asdflkmawejf: ';jlnu3yr23'
+    },
+    APP: {
+      autoboot: false
     }
   };
 };

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
@@ -3,6 +3,6 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/environment.js',
     baseURL: '/',
-    locationType: 'auto'
+    locationType: 'auto',
   };
 };

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
@@ -4,6 +4,8 @@ module.exports = function() {
     fileUsed: 'config/something-else.js',
     baseURL: '/',
     locationType: 'auto',
-    APP: { }
+    APP: {
+      autoboot: false
+    }
   };
 };


### PR DESCRIPTION
The update to `setApplication` in `tests/test-helper.js` originally used `ImportedApplication.create({ autoboot: false })`, but unfortunately that means that the application under test does not have any of the other properties that are set in `config/environment.js` (e.g. `rootElement`).

This updates `tests/test-helper.js` to create the application in the same way as the actual production app is booted (`App.create(config.APP)`), and adds `ENV.APP.autoboot = false;` to the `test` environment section of `config/environment.js`.

The `tests/helpers/start-app.js` is also updated to ensure the prior behavior is preserved ("legacy" acceptance tests require the `autoboot` functionality so all current usages of `startApp()` need `autoboot: true`).

For the curious, the reason we do not use `startApp()` directly from `tests/test-helper.js` is that future blueprint iterations will remove `tests/helpers/start-app.js` for new applications, and existing applications will remove it after they have migrated to the new testing system. The changes in this commit ensure that `startApp()` always has the same semantics (e.g. doesn't need to switch between autoboot and non-autoboot scenarios) and that global test setup is still extremely
simple and easy to follow...

Fixes https://github.com/ember-cli/ember-cli/issues/7497