### PR TITLE
Change isMainVendorFile check in ember-app.js

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1423,7 +1423,7 @@ class EmberApp {
     importPaths.forEach(importPath => {
       strategies.push(createVendorJsStrategy({
         files: this._scriptOutputFiles[importPath],
-        isMainVendorFile: importPath === DEFAULT_CONFIG.outputPaths.vendor.js,
+        isMainVendorFile: importPath === vendorFilePath,
         outputFile: importPath,
         sourceMapConfig: this.options.sourcemaps,
         annotation: 'Vendor JS',


### PR DESCRIPTION
Fix for #7518.

Looks like the check for `isMainVendorFile` is comparing to the `DEFAULT_CONFIG`, and not the user's option.

Any direction to add a test would be helpful!