### PR TITLE
Builder: Remove deprecated `Brocfile.js` support

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -1,7 +1,6 @@
 'use strict';
 const onProcessInterrupt = require('../utilities/will-interrupt-process');
 const fs = require('fs-extra');
-const existsSync = require('exists-sync');
 const path = require('path');
 const Promise = require('rsvp').Promise;
 const CoreObject = require('core-object');
@@ -46,13 +45,9 @@ class Builder extends CoreObject {
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
     const broccoli = require('broccoli-builder');
-    let hasBrocfile = existsSync(path.join('.', 'Brocfile.js'));
-    let buildFile = findBuildFile('ember-cli-build.js');
 
-    if (hasBrocfile) {
-      this.ui.writeDeprecateLine('Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.');
-      this.tree = require('broccoli-brocfile-loader')();
-    } else if (buildFile) {
+    let buildFile = findBuildFile('ember-cli-build.js');
+    if (buildFile) {
       this.tree = buildFile({ project: this.project });
     } else {
       throw new SilentError('No ember-cli-build.js found.');

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
     "broccoli-babel-transpiler": "^6.0.0",
-    "broccoli-brocfile-loader": "^0.18.0",
     "broccoli-builder": "^0.18.8",
     "broccoli-concat": "^3.2.2",
     "broccoli-config-loader": "^1.0.0",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -75,30 +75,6 @@ describe('Acceptance: brocfile-smoke-test', function() {
     expect(appFileContents).to.include('//app/styles-manager.js');
   }));
 
-  it('should fall back to the Brocfile', co.wrap(function *() {
-    yield copyFixtureFiles('brocfile-tests/no-ember-cli-build');
-
-    fs.removeSync('./ember-cli-build.js');
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('Brocfile.js')).to.exist;
-    expect(file('ember-cli-build.js')).to.not.exist;
-  }));
-
-  it('should use the Brocfile if both a Brocfile and ember-cli-build exist', co.wrap(function *() {
-    yield copyFixtureFiles('brocfile-tests/both-build-files');
-    let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
-      encoding: 'utf8',
-    });
-
-    let expected = 'var usingBrocfile = true;';
-
-    expect(vendorContents).to.contain(expected, 'includes file imported from Brocfile');
-    expect(result.output.join('\n')).to.include('Brocfile.js has been deprecated');
-  }));
-
   it('should throw if no build file is found', co.wrap(function *() {
     fs.removeSync('./ember-cli-build.js');
     try {

--- a/tests/fixtures/brocfile-tests/both-build-files/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/Brocfile.js
@@ -1,6 +1,0 @@
-const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-var app = new EmberApp();
-
-app.import('vendor/brocfile-script.js');
-
-module.exports = app.toTree();

--- a/tests/fixtures/brocfile-tests/both-build-files/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/ember-cli-build.js
@@ -1,9 +1,0 @@
-const EmberApp = require('ember-cli/lib/broccoli/ember-addon');
-
-module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
-
-  });
-
-  return app.toTree();
-};

--- a/tests/fixtures/brocfile-tests/both-build-files/vendor/brocfile-script.js
+++ b/tests/fixtures/brocfile-tests/both-build-files/vendor/brocfile-script.js
@@ -1,1 +1,0 @@
-var usingBrocfile = true;

--- a/tests/fixtures/brocfile-tests/no-ember-cli-build/Brocfile.js
+++ b/tests/fixtures/brocfile-tests/no-ember-cli-build/Brocfile.js
@@ -1,4 +1,0 @@
-const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-var app = new EmberApp();
-
-module.exports = app.toTree();

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,12 +540,6 @@ broccoli-babel-transpiler@^6.0.0:
     rsvp "^3.5.0"
     workerpool "^2.2.1"
 
-broccoli-brocfile-loader@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/broccoli-brocfile-loader/-/broccoli-brocfile-loader-0.18.0.tgz#2e86021c805c34ffc8d29a2fb721cf273e819e4b"
-  dependencies:
-    findup-sync "^0.4.2"
-
 broccoli-builder@^0.18.8:
   version "0.18.8"
   resolved "https://registry.yarnpkg.com/broccoli-builder/-/broccoli-builder-0.18.8.tgz#fe54694d544c3cdfdb01028e802eeca65749a879"
@@ -1963,15 +1957,6 @@ find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
-
-findup-sync@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
-  dependencies:
-    detect-file "^0.1.0"
-    is-glob "^2.0.1"
-    micromatch "^2.3.7"
-    resolve-dir "^0.1.0"
 
 findup-sync@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
... and the now unused `broccoli-brocfile-loader` dependency