### PR TITLE
EmberApp: Remove deprecated `contentFor()` hooks

### DIFF
--- a/lib/broccoli/app-prefix.js
+++ b/lib/broccoli/app-prefix.js
@@ -1,3 +1,1 @@
 "use strict";
-
-{{content-for 'app-prefix'}}

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,1 +1,0 @@
-{{content-for 'app-suffix'}}

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1827,8 +1827,6 @@ class EmberApp {
    */
   contentFor(config, match, type) {
     let content = [];
-    let deprecatedHooks = ['app-prefix', 'app-suffix', 'vendor-prefix', 'vendor-suffix'];
-    let deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
 
     // This normalizes `rootURL` to the value which we use everywhere inside of Ember CLI.
     // This makes sure that the user doesn't have to account for it in application code.
@@ -1846,7 +1844,6 @@ class EmberApp {
     content = this.project.addons.reduce((content, addon) => {
       let addonContent = addon.contentFor ? addon.contentFor(type, config, content) : null;
       if (addonContent) {
-        deprecate(`The \`${type}\` hook used in ${addon.name} is deprecated. The addon should generate a module and have consumers \`require\` it.`, deprecatedHooks.indexOf(type) === -1);
         return content.concat(addonContent);
       }
 

--- a/lib/broccoli/vendor-prefix.js
+++ b/lib/broccoli/vendor-prefix.js
@@ -1,4 +1,2 @@
 window.EmberENV = {{EMBER_ENV}};
 var runningTests = false;
-
-{{content-for 'vendor-prefix'}}

--- a/lib/broccoli/vendor-suffix.js
+++ b/lib/broccoli/vendor-suffix.js
@@ -1,1 +1,0 @@
-{{content-for 'vendor-suffix'}}


### PR DESCRIPTION
The way I understand the deprecation warning is that the `app-prefix`, `app-suffix`, `vendor-prefix` and `vendor-suffix` hooks are deprecated and can be removed completely for v3.0. Is that understanding correct?