### PR TITLE
EmberApp: Overwrite `app/config/environment` in `tests.js`

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1222,6 +1222,33 @@ class EmberApp {
   }
 
   /**
+    @private
+    @method _testAppConfigTree
+    @return
+  */
+  _testAppConfigTree() {
+    if (!this._cachedTestAppConfigTree) {
+      let files = ['app-config.js'];
+
+      let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._configTree(), {
+        configPath: path.join(this.name, 'config', 'environments', `test.json`),
+        files,
+
+        patterns: this._configReplacePatterns(),
+      });
+
+      this._cachedTestAppConfigTree = new Funnel(emberCLITree, {
+        files,
+        srcDir: '/',
+        destDir: '/vendor/ember-cli/',
+        annotation: 'Funnel (test-app-config-tree)',
+      });
+    }
+
+    return this._cachedTestAppConfigTree;
+  }
+
+  /**
     Returns the tree for the app and its dependencies
 
     @private
@@ -1287,6 +1314,7 @@ class EmberApp {
     let appTestTrees = [].concat(
       this.hinting && this.lintTestTrees(),
       this._processedEmberCLITree(),
+      this._testAppConfigTree(),
       coreTestTree
     ).filter(Boolean);
 
@@ -1298,7 +1326,7 @@ class EmberApp {
     return this._concatFiles(appTestTrees, {
       inputFiles: [`${this.name}/tests/**/*.js`],
       headerFiles: ['vendor/ember-cli/tests-prefix.js'],
-      footerFiles: ['vendor/ember-cli/tests-suffix.js'],
+      footerFiles: ['vendor/ember-cli/app-config.js', 'vendor/ember-cli/tests-suffix.js'],
       outputFile: this.options.outputPaths.tests.js,
       annotation: 'Concat: App Tests',
     });


### PR DESCRIPTION
This PR fixes the content of the `my-app/config/environment` module when `storeConfigInMeta: false` is used and http://localhost:4200/tests/ is visited. A similarly named module will be generated in the `tests.js` file which overwrites the one contained in `my-app.js`.

Overwriting in `test-support.js` unfortunately does not work because `test-support.js` is imported before `my-app.js` which would overwrite the config in the wrong way.

This is needed to make `setApplication()` and http://localhost:4200/tests/ work well together when `storeConfigInMeta: false` is used.

Resolves #4535

/cc @stefanpenner @kellyselden 