### PR TITLE
Backport & fixup linting changes.

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -49,6 +49,7 @@ install:
   - npm --version
 <% } %>
 script:
+  - <% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -65,6 +65,9 @@ module.exports = {
     // use `ember-try` as test script in addons by default
     contents.scripts.test = 'ember try:each';
 
+    // add addon specific directories to lint:js script
+    contents.scripts['lint:js'] = 'eslint ./*.js addon addon-test-support app config lib server test-support tests';
+
     contents['ember-addon'] = contents['ember-addon'] || {};
     contents['ember-addon'].configPath = 'tests/dummy/config';
 

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -62,6 +62,9 @@ module.exports = {
     // add `ember-disable-prototype-extensions` to addons by default
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.2';
 
+    // add `eslint-plugin-node` to addons by default
+    contents.devDependencies['eslint-plugin-node'] = '^5.2.1';
+
     // use `ember-try` as test script in addons by default
     contents.scripts.test = 'ember try:each';
 
@@ -124,6 +127,7 @@ module.exports = {
       year: date.getFullYear(),
       yarn: options.yarn,
       welcome: options.welcome,
+      blueprint: 'addon',
     };
   },
 

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -19,13 +19,17 @@ module.exports = {
   overrides: [
     // node files
     {
-      files: [
-        'index.js',
+      files: [<% if (blueprint !== 'app') { %>
+        'index.js',<% } %>
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js',
-        'tests/dummy/config/**/*.js'
-      ],
+        'config/**/*.js'<% if (blueprint !== 'app') { %>,
+        'tests/dummy/config/**/*.js'<% } %>
+      ],<% if (blueprint !== 'app') { %>
+      excludedFiles: [
+        'app/**',
+        'addon/**'
+      ],<% } %>
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2015

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -21,13 +21,14 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
-before_install:<% if (yarn) { %>
+before_install:<% if (!yarn) { %>
+  - npm config set spin false<% } else { %>
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --non-interactive
+  - yarn install --non-interactive<% } %>
 
 script:
-  - yarn test<% } else { %>
-  - npm config set spin false<% } %>
+  - <% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>
+  - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -27,6 +27,7 @@ module.exports = {
       emberCLIVersion: require('../../package').version,
       yarn: options.yarn,
       welcome: options.welcome,
+      blueprint: 'app',
     };
   },
 };

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -366,6 +366,16 @@ describe('Acceptance: ember new', function() {
   }));
 
   describe('verify fixtures', function() {
+    function checkPackageJson(fixtureName) {
+      let currentVersion = require('../../package').version;
+      let fixturePath = path.join(__dirname, '../fixtures', fixtureName, 'package.json');
+      let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' })
+        .replace("<%= emberCLIVersion %>", currentVersion);
+
+      expect(file('package.json'))
+        .to.equal(fixtureContents);
+    }
+
     it('app + npm + !welcome', co.wrap(function *() {
       yield ember([
         'new',
@@ -376,14 +386,17 @@ describe('Acceptance: ember new', function() {
         '--no-welcome',
       ]);
 
+      let fixturePath = 'app/npm';
       [
         'app/templates/application.hbs',
         '.travis.yml',
         'README.md',
       ].forEach(filePath => {
         expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures/app/npm', filePath)));
+          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
+
+      checkPackageJson(fixturePath);
     }));
 
     it('app + yarn + welcome', co.wrap(function *() {
@@ -396,14 +409,17 @@ describe('Acceptance: ember new', function() {
         '--yarn',
       ]);
 
+      let fixturePath = 'app/yarn';
       [
         'app/templates/application.hbs',
         '.travis.yml',
         'README.md',
       ].forEach(filePath => {
         expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures/app/yarn', filePath)));
+          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
+
+      checkPackageJson(fixturePath);
     }));
 
     it('addon + npm + !welcome', co.wrap(function *() {
@@ -415,6 +431,7 @@ describe('Acceptance: ember new', function() {
         '--skip-git',
       ]);
 
+      let fixturePath = 'addon/npm';
       [
         'config/ember-try.js',
         'tests/dummy/app/templates/application.hbs',
@@ -422,8 +439,10 @@ describe('Acceptance: ember new', function() {
         'README.md',
       ].forEach(filePath => {
         expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures/addon/npm', filePath)));
+          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
+
+      checkPackageJson(fixturePath);
     }));
 
     it('addon + yarn + welcome', co.wrap(function *() {
@@ -437,6 +456,7 @@ describe('Acceptance: ember new', function() {
         '--welcome',
       ]);
 
+      let fixturePath = 'addon/yarn';
       [
         'config/ember-try.js',
         'tests/dummy/app/templates/application.hbs',
@@ -444,8 +464,10 @@ describe('Acceptance: ember new', function() {
         'README.md',
       ].forEach(filePath => {
         expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures/addon/yarn', filePath)));
+          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
+
+      checkPackageJson(fixturePath);
     }));
   });
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -391,6 +391,7 @@ describe('Acceptance: ember new', function() {
         'app/templates/application.hbs',
         '.travis.yml',
         'README.md',
+        '.eslintrc.js',
       ].forEach(filePath => {
         expect(file(filePath))
           .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
@@ -414,6 +415,7 @@ describe('Acceptance: ember new', function() {
         'app/templates/application.hbs',
         '.travis.yml',
         'README.md',
+        '.eslintrc.js',
       ].forEach(filePath => {
         expect(file(filePath))
           .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
@@ -437,6 +439,7 @@ describe('Acceptance: ember new', function() {
         'tests/dummy/app/templates/application.hbs',
         '.travis.yml',
         'README.md',
+        '.eslintrc.js',
       ].forEach(filePath => {
         expect(file(filePath))
           .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
@@ -462,6 +465,7 @@ describe('Acceptance: ember new', function() {
         'tests/dummy/app/templates/application.hbs',
         '.travis.yml',
         'README.md',
+        '.eslintrc.js',
       ].forEach(filePath => {
         expect(file(filePath))
           .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -26,6 +26,10 @@ module.exports = {
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],
+      excludedFiles: [
+        'app/**',
+        'addon/**'
+      ],
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2015

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -33,11 +33,11 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }<% if (blueprint !== 'app') { %>,
+      },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
-      })<% } %>
+      })
     },
 
     // test files

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -40,6 +40,7 @@ before_install:
   - npm --version
 
 script:
+  - npm run lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "<%= name %>",
+  "name": "foo",
   "version": "0.0.0",
-  "private": true,
-  "description": "Small description for <%= name %> goes here",
+  "description": "The default blueprint for ember-cli addons.",
+  "keywords": [
+    "ember-addon"
+  ],
   "license": "MIT",
   "author": "",
   "directories": {
@@ -12,16 +14,17 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "ember try:each"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
-    "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
@@ -31,16 +34,18 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-data": "~2.18.0-beta.1",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0-beta.3<% if (welcome) { %>",
-    "ember-welcome-page": "^3.0.0<% } %>",
+    "ember-source": "~2.18.0-beta.3",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
+  },
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
   }
 }

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -40,6 +40,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.18.0-beta.3",
     "eslint-plugin-ember": "^5.0.0",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -26,6 +26,10 @@ module.exports = {
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],
+      excludedFiles: [
+        'app/**',
+        'addon/**'
+      ],
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2015

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -33,11 +33,11 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }<% if (blueprint !== 'app') { %>,
+      },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
-      })<% } %>
+      })
     },
 
     // test files

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -41,6 +41,7 @@ install:
   - yarn install --no-lockfile --non-interactive
 
 script:
+  - yarn lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "<%= name %>",
+  "name": "foo",
   "version": "0.0.0",
-  "private": true,
-  "description": "Small description for <%= name %> goes here",
+  "description": "The default blueprint for ember-cli addons.",
+  "keywords": [
+    "ember-addon"
+  ],
   "license": "MIT",
   "author": "",
   "directories": {
@@ -12,16 +14,17 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "ember try:each"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
-    "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
@@ -31,16 +34,19 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-data": "~2.18.0-beta.1",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0-beta.3<% if (welcome) { %>",
-    "ember-welcome-page": "^3.0.0<% } %>",
+    "ember-source": "~2.18.0-beta.3",
+    "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
+  },
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
   }
 }

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -41,6 +41,7 @@
     "ember-source": "~2.18.0-beta.3",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -20,11 +20,9 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'config/**/*.js'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -33,11 +33,7 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }<% if (blueprint !== 'app') { %>,
-      plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      })<% } %>
+      }
     },
 
     // test files

--- a/tests/fixtures/app/npm/.travis.yml
+++ b/tests/fixtures/app/npm/.travis.yml
@@ -20,3 +20,7 @@ env:
 
 before_install:
   - npm config set spin false
+
+script:
+  - npm run lint:js
+  - npm test

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "<%= name %>",
+  "name": "foo",
   "version": "0.0.0",
   "private": true,
-  "description": "Small description for <%= name %> goes here",
+  "description": "Small description for foo goes here",
   "license": "MIT",
   "author": "",
   "directories": {
@@ -35,8 +35,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0-beta.3<% if (welcome) { %>",
-    "ember-welcome-page": "^3.0.0<% } %>",
+    "ember-source": "~2.18.0-beta.3",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -20,11 +20,9 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'config/**/*.js'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -33,11 +33,7 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }<% if (blueprint !== 'app') { %>,
-      plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      })<% } %>
+      }
     },
 
     // test files

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -25,4 +25,5 @@ install:
   - yarn install --non-interactive
 
 script:
+  - yarn lint:js
   - yarn test

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "<%= name %>",
+  "name": "foo",
   "version": "0.0.0",
   "private": true,
-  "description": "Small description for <%= name %> goes here",
+  "description": "Small description for foo goes here",
   "license": "MIT",
   "author": "",
   "directories": {
@@ -35,8 +35,8 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0-beta.3<% if (welcome) { %>",
-    "ember-welcome-page": "^3.0.0<% } %>",
+    "ember-source": "~2.18.0-beta.3",
+    "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -70,6 +70,7 @@ describe('blueprint - addon', function() {
     "ember-addon"\n\
   ],\n\
   "scripts": {\n\
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",\n\
     "test": "ember try:each"\n\
   },\n\
   "dependencies": {},\n\

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -75,7 +75,8 @@ describe('blueprint - addon', function() {
   },\n\
   "dependencies": {},\n\
   "devDependencies": {\n\
-    "ember-disable-prototype-extensions": "^1.1.2"\n\
+    "ember-disable-prototype-extensions": "^1.1.2",\n\
+    "eslint-plugin-node": "^5.2.1"\n\
   },\n\
   "ember-addon": {\n\
     "configPath": "tests/dummy/config"\n\
@@ -170,6 +171,7 @@ describe('blueprint - addon', function() {
 
         let json = JSON.parse(output);
         delete json.devDependencies['ember-disable-prototype-extensions'];
+        delete json.devDependencies['eslint-plugin-node'];
         expect(json.dependencies).to.deep.equal({ a: "1", b: "1" });
         expect(json.devDependencies).to.deep.equal({ a: "1", b: "1" });
       });


### PR DESCRIPTION
As discussed in a recent ember-cli team meeting, this backports the linting changes added in https://github.com/ember-cli/ember-cli/pull/7452 and https://github.com/ember-cli/ember-cli/pull/7451 to beta branch.

It also fixes an issue where `index.js` in subdirectories is incorrectly marked as a "node file" (due to eslint/eslint#9740).  For apps, we avoid adding `index.js` (or `tests/dummy/config/**/*.js`) to the list of overrides which side-steps the entire issue. For addons, we add `excludedFiles` to ensure that `app/` and `addon/` are _never_ matched by the node file overrides.