### PR TITLE
WIP: Use `glimmer-wrapper` resolver by default for module unification apps

### DIFF
--- a/blueprints/module-unification-app/files/src/resolver.js
+++ b/blueprints/module-unification-app/files/src/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember-resolver/resolvers/fallback';
+import Resolver from 'ember-resolver/resolvers/glimmer-wrapper';
 import buildResolverConfig from 'ember-resolver/ember-config';
 import config from '../config/environment';
 


### PR DESCRIPTION
Part of https://github.com/ember-cli/ember-cli/issues/7530

TODO:

 * [ ] either update [ember-welcome-page](https://github.com/ember-cli/ember-welcome-page) to support MU or inline the welcome component

--

I mistook [@rwjblue's suggestion](https://github.com/ember-cli/ember-cli/pull/7488#discussion_r155540131) to test the `ember-resolver/resolvers/fallback` resolver as a suggestion to change the default.

<img width="810" alt="screen shot 2018-01-02 at 12 20 47" src="https://user-images.githubusercontent.com/2526/34483584-62b9aa12-efb7-11e7-9ac2-6f34ad7fac92.png">

[@mixonic noticed this](https://github.com/ember-cli/ember-cli/pull/7488#discussion_r157553773) and indicated that the default resolver should be `ember-resolver/resolvers/glimmer-wrapper`.

<img width="787" alt="screen shot 2018-01-02 at 12 21 07" src="https://user-images.githubusercontent.com/2526/34483620-9f4f50ee-efb7-11e7-821b-6ca014d4f77b.png">


