### PR TITLE
Drop bower usage in module-unification-app blueprint.

### DIFF
--- a/blueprints/module-unification-app/files/.travis.yml
+++ b/blueprints/module-unification-app/files/.travis.yml
@@ -29,10 +29,6 @@ before_install:<% if (!yarn) { %>
 install:
   - yarn install --non-interactive<% } %>
 
-before_script:
-  - <% if (yarn) { %>yarn global add bower<% } else { %>npm install -g bower<% } %>
-  - bower install
-
 script:
   - <% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>
   - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test

--- a/blueprints/module-unification-app/files/bower.json
+++ b/blueprints/module-unification-app/files/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "<%= name %>",
-  "dependencies": {
-    "ember": "components/ember#canary"
-  }
-}

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -34,7 +34,8 @@
     "ember-data": "~2.18.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
-    "ember-resolver": "^4.0.0<% if (welcome) { %>",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "http://builds.emberjs.com/canary.tgz<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"

--- a/tests/fixtures/module-unification-app/npm/.travis.yml
+++ b/tests/fixtures/module-unification-app/npm/.travis.yml
@@ -21,10 +21,6 @@ env:
 before_install:
   - npm config set spin false
 
-before_script:
-  - npm install -g bower
-  - bower install
-
 script:
   - npm run lint:js
   - npm test

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -35,6 +35,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
+    "ember-source": "http://builds.emberjs.com/canary.tgz",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },

--- a/tests/fixtures/module-unification-app/yarn/.travis.yml
+++ b/tests/fixtures/module-unification-app/yarn/.travis.yml
@@ -24,10 +24,6 @@ before_install:
 install:
   - yarn install --non-interactive
 
-before_script:
-  - yarn global add bower
-  - bower install
-
 script:
   - yarn lint:js
   - yarn test

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -35,6 +35,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
+    "ember-source": "http://builds.emberjs.com/canary.tgz",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"


### PR DESCRIPTION
Leverage the newly setup tarball publishing of ember-source (emberjs/ember.js#16039)...

Related to #7530