### PR TITLE
[BUGFIX release] Dummy app files follow Ember rules

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -28,7 +28,8 @@ module.exports = {
       ],<% if (blueprint !== 'app') { %>
       excludedFiles: [
         'app/**',
-        'addon/**'
+        'addon/**',
+        'tests/dummy/app/**'
       ],<% } %>
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -28,7 +28,8 @@ module.exports = {
       ],
       excludedFiles: [
         'app/**',
-        'addon/**'
+        'addon/**',
+        'tests/dummy/app/**'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -28,7 +28,8 @@ module.exports = {
       ],
       excludedFiles: [
         'app/**',
-        'addon/**'
+        'addon/**',
+        'tests/dummy/app/**'
       ],
       parserOptions: {
         sourceType: 'script',


### PR DESCRIPTION
Addons should use Ember linting rules for their `tests/dummy/app/` directories. In 2.18.0 the default configuration has `index.js` files in the `tests/dummy/app/` directory using CJS rules instead.

For example:

```
> ember --version
ember-cli: 2.18.0
node: 9.3.0
os: darwin x64
> ember g addon demo-eslint-index
> cd demo-eslint-index
> echo "import Controller from '@ember/controller'; export default Controller.extend();" > tests/dunny/app/controllers/index.js
> yarn lint:js
yarn run v1.3.2
$ eslint ./*.js addon addon-test-support app config lib server test-support tests

/Users/mixonic/Projects/demo-eslint-index/tests/dummy/app/controllers/index.js
  1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This patch fixes the default configuration to exclude `tests/dummy/app/` from node rules entirely. The ember rules are then permitted to apply on the `index.js` files. It is basically a workaround for https://github.com/eslint/eslint/issues/9740 which would permit the `index.js` rule to be absolute.