### PR TITLE
Add `project.isModuleUnification()`

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -141,6 +141,10 @@ class Project {
       return false;
     };
 
+    NULL_PROJECT.isModuleUnification = function() {
+      return false;
+    };
+
     NULL_PROJECT.name = function() {
       return path.basename(process.cwd());
     };
@@ -183,6 +187,16 @@ class Project {
    */
   isEmberCLIAddon() {
     return !!this.pkg.keywords && this.pkg.keywords.indexOf('ember-addon') > -1;
+  }
+
+  /**
+     Returns whether this is using a module unification format.
+     @private
+     @method isModuleUnification
+     @return {Boolean} Whether this is using a module unification format.
+    */
+  isModuleUnification() {
+    return this.has('src');
   }
 
   /**

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -63,6 +63,10 @@ class MockProject extends Project {
   isEmberCLIAddon() {
     return false;
   }
+
+  isModuleUnification() {
+    return false;
+  }
 }
 
 module.exports = MockProject;

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -526,6 +526,25 @@ describe('models/project.js', function() {
     });
   });
 
+  describe('isModuleUnification', function() {
+    beforeEach(function() {
+      projectPath = `${process.cwd()}/tmp/test-app`;
+
+      makeProject();
+    });
+
+    it('returns false when `./src` does not exist', function() {
+      expect(project.isModuleUnification()).to.equal(false);
+    });
+
+    it('returns true when `./src` exists', function() {
+      let srcPath = path.join(projectPath, 'src');
+      fs.ensureDirSync(srcPath);
+
+      expect(project.isModuleUnification()).to.equal(true);
+    });
+  });
+
   describe('findAddonByName', function() {
     beforeEach(function() {
       projectPath = `${process.cwd()}/tmp/test-app`;


### PR DESCRIPTION
part of https://github.com/emberjs/ember.js/pull/16043
(which is part of https://github.com/ember-cli/ember-cli/issues/7530)

This PR adds initial support for `ember g *` commands within a module unification project. The existence of a `src` directory in the ember project determines if that project is a module unification project. After this is merged, the next step will be to update the [Ember blueprints](https://github.com/emberjs/ember.js/tree/master/blueprints) to support MU output by checking `project.isModuleUnification()`

/cc @rwjblue 
  
  