### PR TITLE
trivial error-message fix for bad watcher type

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -84,7 +84,7 @@ class Watcher extends CoreObject {
     let watcher = this.options && this.options.watcher;
 
     if (watcher && ['polling', 'watchman', 'node', 'events'].indexOf(watcher) === -1) {
-      throw new Error(`Unknown watcher type --watcher=[polling|watchman|node] but was: ${watcher}`);
+      throw new Error(`Unknown watcher type --watcher=[polling|watchman|node|events] but was: ${watcher}`);
     }
 
     return {


### PR DESCRIPTION
I just wanted the error message to reflect the values being checked against.