### PR TITLE
Make async/await work nicely by default.

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,8 +1,16 @@
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
-  browsers: [
-    'ie 9',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
-  ]
+  browsers
 };

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~3.0.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~2.18.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -37,6 +37,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -37,6 +37,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1",
     "ember-welcome-page": "^3.0.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~3.0.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~3.0.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1",
     "ember-welcome-page": "^3.0.0",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~2.18.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -34,6 +34,7 @@
     "ember-data": "~2.18.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",


### PR DESCRIPTION
This change does a few things:

* Add `ember-maybe-import-regenerator` to the default blueprint.
* Drop IE9 from `config/targets.js`, and replace with IE11 (to match
  Ember 3.0.0's minimum browser requirements).
* Modify `config/targets.js` to make development builds target modern
  browsers.

This essentially brings over the configuration discussed in [this blog post](http://rwjblue.com/2017/10/30/async-await-configuration-adventure/):

* [Section 30](http://rwjblue.com/2017/10/30/async-await-configuration-adventure/#install-maybe-install-regenerator)
* [Section 10](http://rwjblue.com/2017/10/30/async-await-configuration-adventure/#limit-targets-locally)