### PR TITLE
Use `sudo: required` to work around issue in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 dist: trusty
 
 addons:


### PR DESCRIPTION
Without this change all tests that run `ember test` (which leverages headless chrome) will end up failing:

```
not ok 1 Chrome - error
    ---
        message: >
            Error: Browser exited unexpectedly
            Non-zero exit code: null
            Stderr: 
             [0111/201538.220867:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.
            Failed to generate minidump.
            
        Log: |
            { type: 'error', text: 'Error: Browser exited unexpectedly' }
            { type: 'error', text: 'Non-zero exit code: null' }
            { type: 'error',
              text: '[0111/201538.220867:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I\'m aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.\nFailed to generate minidump.' }
    ...
```