### PR TITLE
Remove embertest from ESLint configuration.

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -43,15 +43,6 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })<% } %>
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -34,15 +34,6 @@ module.exports = {
         browser: false,
         node: true
       }
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -43,15 +43,6 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -43,15 +43,6 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -32,15 +32,6 @@ module.exports = {
         browser: false,
         node: true
       }
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -32,15 +32,6 @@ module.exports = {
         browser: false,
         node: true
       }
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/npm/.eslintrc.js
@@ -34,15 +34,6 @@ module.exports = {
         browser: false,
         node: true
       }
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/yarn/.eslintrc.js
@@ -34,15 +34,6 @@ module.exports = {
         browser: false,
         node: true
       }
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };


### PR DESCRIPTION
As of Ember 3.0 the new testing APIs introduced in emberjs/rfcs#232 and emberjs/rfcs#268 are enabled and used by default. In these APIs no globals are used, therefore this extra `tests/` override is removed.

This specifically removes the following globals from being allowed:

* `andThen`
* `click`
* `currentPath`
* `currentRouteName`
* `currentURL`
* `fillIn`
* `find`
* `findWithAssert`
* `keyEvent`
* `pauseTest`
* `resumeTest`
* `triggerEvent`
* `visit`
* `wait`