### PR TITLE
Migrate to new format for mode specific arguments in testem config.

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -9,8 +9,7 @@ module.exports = {
   ],
   browser_args: {
     Chrome: {
-      mode: 'ci',
-      args: [
+      ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
 


### PR DESCRIPTION
Testem is deprecated the format currently in use for `browser_args` in https://github.com/testem/testem/pull/1182.

Specifically, this format is deprecated:

```js
browser_args: {
  Chrome: {
    mode: 'ci',
    args: [
      // args go here....
    ]
  }
}
```

In favor of this format:

```js
browser_args: {
  Chrome: {
    ci: [
      // args go here....
    ]
  }
}
```

This change is being made so that Testem can support using different sets of arguments for different modes. The change also adds an `all` key that can be used for shared arguments between modes (they are merged with the mode specific args).

---

The change in Testem is merged but not yet released, we will need to land this PR when the Testem release is done (likely into the release branch at that time to silence the deprecations as quickly as possible).