### PR TITLE
Fix 'const' declarations in non-strict mode are not supported

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',


### PR DESCRIPTION
Without `'use strict';` I get lint errors of `'const' declarations in non-strict mode are not supported yet on Node 4.5.0` due to the new node linting rules. Adding this fixes the issue. Alternatively, we could disable that rule for this file or altogether.