### PR TITLE
tests/acceptance: Update test number expectation

### DIFF
--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -152,7 +152,7 @@ describe('Acceptance: smoke-test', function() {
     output = output.join(EOL);
 
     expect(output).to.match(/fail\s+0/, 'no failures');
-    expect(output).to.match(/pass\s+8/, '8 passing');
+    expect(output).to.match(/pass\s+9/, '9 passing');
   }));
 
   it('ember new foo, build development, and verify generated files', co.wrap(function *() {


### PR DESCRIPTION
`ember-qunit` is now generating a test of its own which we did not expect before. Updating the expected number of tests fixes our CI runs.