### PR TITLE
testem: Use `--no-sandbox` on TravisCI

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -11,11 +11,14 @@ module.exports = {
     Chrome: {
       mode: 'ci',
       args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
-      ]
+      ].filter(Boolean)
     }
   }
 };

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -152,7 +152,7 @@ describe('Acceptance: smoke-test', function() {
     output = output.join(EOL);
 
     expect(output).to.match(/fail\s+0/, 'no failures');
-    expect(output).to.match(/pass\s+11/, '11 passing');
+    expect(output).to.match(/pass\s+12/, '12 passing');
   }));
 
   it('ember new foo, build development, and verify generated files', co.wrap(function *() {

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -12,10 +12,13 @@ module.exports = {
   ],
   "browser_args": {
     "Chrome": [
+      // --no-sandbox is needed when running Chrome inside a container
+      process.env.TRAVIS ? '--no-sandbox' : null,
+
       "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"
-    ],
+    ].filter(Boolean),
   }
 };

--- a/tests/fixtures/tasks/testem-config/testem-with-query-string.json
+++ b/tests/fixtures/tasks/testem-config/testem-with-query-string.json
@@ -10,6 +10,7 @@
   ],
   "browser_args": {
     "Chrome": [
+      "--no-sandbox",
       "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",

--- a/tests/fixtures/tasks/testem-config/testem.json
+++ b/tests/fixtures/tasks/testem-config/testem.json
@@ -9,6 +9,7 @@
   ],
   "browser_args": {
     "Chrome": [
+      "--no-sandbox",
       "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",


### PR DESCRIPTION
Similar to https://github.com/ember-cli/ember-cli-chai/pull/45 this updates the `testem.js` file of the `app` blueprint to run Chrome with `--no-sandbox` when used on TravisCI to avoid https://github.com/travis-ci/travis-ci/issues/8836

/cc @backspace 