### PR TITLE
mark "lib" folder as node style in eslint for apps

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -23,7 +23,8 @@ module.exports = {
         'index.js',<% } %>
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js'<% if (blueprint !== 'app') { %>,
+        'config/**/*.js'<% if (blueprint === 'app') { %>,
+        'lib/*/index.js'<% } %><% if (blueprint !== 'app') { %>,
         'tests/dummy/config/**/*.js'<% } %>
       ],<% if (blueprint !== 'app') { %>
       excludedFiles: [

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -22,7 +22,8 @@ module.exports = {
       files: [
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js'
+        'config/**/*.js',
+        'lib/*/index.js'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -22,7 +22,8 @@ module.exports = {
       files: [
         'testem.js',
         'ember-cli-build.js',
-        'config/**/*.js'
+        'config/**/*.js',
+        'lib/*/index.js'
       ],
       parserOptions: {
         sourceType: 'script',


### PR DESCRIPTION
in-repo addons will fail `npm run lint:js` without this.