### PR TITLE
Replace file fixtures with `broccoli-helpers`

### DIFF
--- a/tests/fixtures/load-config/.something
+++ b/tests/fixtures/load-config/.something
@@ -1,1 +1,0 @@
-hello: world

--- a/tests/fixtures/load-config/.travis.yaml
+++ b/tests/fixtures/load-config/.travis.yaml
@@ -1,1 +1,0 @@
-hello: world

--- a/tests/fixtures/load-config/.travis.yml
+++ b/tests/fixtures/load-config/.travis.yml
@@ -1,1 +1,0 @@
-hello: world

--- a/tests/fixtures/load-config/child/test.json
+++ b/tests/fixtures/load-config/child/test.json
@@ -1,3 +1,0 @@
-{
-  "hello": "world"
-}

--- a/tests/fixtures/load-config/package.json
+++ b/tests/fixtures/load-config/package.json
@@ -1,3 +1,0 @@
-{
-  "hello": "world"
-}

--- a/tests/unit/utilities/load-config-test.js
+++ b/tests/unit/utilities/load-config-test.js
@@ -1,27 +1,53 @@
 'use strict';
 
+const co = require('co');
 const expect = require('chai').expect;
 const path = require('path');
 const loadConfig = require('../../../lib/utilities/load-config');
+const broccoliTestHelper = require('broccoli-test-helper');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('load-config', function() {
-  let fixtureDirectory = path.resolve(__dirname, '../../fixtures/load-config');
+  let fixtureDirectoryPath, fixtureDirectory;
+
+  before(co.wrap(function *() {
+    fixtureDirectory = yield createTempDir();
+    fixtureDirectoryPath = fixtureDirectory.path();
+
+    fixtureDirectory.write({
+      '.something': 'hello: world\n',
+      '.travis.yaml': 'hello: world',
+      '.travis.yml': 'hello: world',
+      'package.json': '{ "hello": "world" }',
+      child: {
+        'test.json': '{ "hello": "world" }',
+      },
+    });
+
+    yield buildOutput(fixtureDirectoryPath);
+  }));
+
+  after(co.wrap(function *() {
+    yield fixtureDirectory.dispose();
+  }));
 
   it('loads and parses a yml file', function() {
-    expect(loadConfig('.travis.yml', fixtureDirectory).hello).to.equal('world');
+    expect(loadConfig('.travis.yml', fixtureDirectoryPath).hello).to.equal('world');
   });
   it('loads and parses a yaml file', function() {
-    expect(loadConfig('.travis.yml', fixtureDirectory).hello).to.equal('world');
+    expect(loadConfig('.travis.yml', fixtureDirectoryPath).hello).to.equal('world');
   });
   it('loads and parses a json file', function() {
-    expect(loadConfig('package.json', fixtureDirectory).hello).to.equal('world');
+    expect(loadConfig('package.json', fixtureDirectoryPath).hello).to.equal('world');
   });
   it('loads a vanilla file', function() {
-    expect(loadConfig('.something', fixtureDirectory)).to.equal('hello: world\n');
+    expect(loadConfig('.something', fixtureDirectoryPath)).to.equal('hello: world\n');
   });
   it('works across directories', function() {
-    expect(loadConfig('.something', path.join(fixtureDirectory, 'child'))).to.equal('hello: world\n');
-    expect(loadConfig('test.json', path.join(fixtureDirectory, 'child')).hello).to.equal('world');
+    expect(loadConfig('.something', path.join(fixtureDirectoryPath, 'child'))).to.equal('hello: world\n');
+    expect(loadConfig('test.json', path.join(fixtureDirectoryPath, 'child')).hello).to.equal('world');
   });
 });
 


### PR DESCRIPTION
Removes file fixtures and replaces them with broccoli-helpers
in-memory ones. This approach is more flexible since all configuration
is done through code and remains the part of the test code.