### PR TITLE
Install optional dependencies when creating a new project

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -81,7 +81,6 @@ module.exports = Command.extend({
           return this.runTask('NpmInstall', {
             verbose: commandOptions.verbose,
             useYarn: commandOptions.yarn,
-            optional: false,
           });
         }
       })


### PR DESCRIPTION
Apparently the optional dependencies were originally skipped to cut down the installation time on testruns (see https://github.com/ember-cli/ember-cli/pull/4526). Sadly this created a couple of issues lately in Glimmer.js apps (see https://github.com/glimmerjs/glimmer.js/issues/12, https://github.com/glimmerjs/glimmer-blueprint/issues/63 or https://github.com/glimmerjs/glimmer-blueprint/issues/34#issuecomment-306381243).  
From what I can tell the tests skip the dependency installation step anyway so I think it is save to install the optional dependencies when creating a project.