### PR TITLE
Add `.idea/` to gitignore by default

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -17,6 +17,9 @@ npm-debug.log*
 yarn-error.log
 testem.log
 
+# IDE
+.idea/
+
 # ember-try
 .node_modules.ember-try/
 bower.json.ember-try


### PR DESCRIPTION
I'm sure I'm not the only one using JetBrains WebStorm for Ember projects. Would it be OK to include its project files in the default .gitignore list?

(Also, I'm not sure if I modified the right file for this.)