### PR TITLE
Install optional dependencies when creating a new project

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -81,7 +81,6 @@ module.exports = Command.extend({
           return this.runTask('NpmInstall', {
             verbose: commandOptions.verbose,
             useYarn: commandOptions.yarn,
-            optional: false,
           });
         }
       })


### PR DESCRIPTION
Due to a bad bug with Yarn and the `--ignore-optional` flag, generating new Ember apps with `--yarn` (or new Glimmer.js apps, which use Yarn by default) is broken.

This PR cherry-picks the fix from #7573 into the release branch, which disables skipping optional dependencies.

I think this can be safely reverted once Yarn is patched, but the fix (I believe https://github.com/yarnpkg/yarn/pull/5059) has not been merged yet.