### PR TITLE
Ignore all *.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
-npm-debug.log
+*.log
 /tmp
 /common-tmp
 *.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,6 @@
 /tests/!(helpers)
 /tmp
 /.*
+*.log
 !.travis.yml
 !appveyor.yml


### PR DESCRIPTION
If you run into an issue with `yarn` locally, `yarn-error.log` won't be ignored.