### PR TITLE
Remove "style file" silent error

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1448,10 +1448,6 @@ class EmberApp {
   */
   styles() {
     if (!this._cachedStylesTree) {
-      if (existsSync(`${this._stylesPath}/${this.name}.css`)) {
-        throw new SilentError(`Style file cannot have the name of the application - ${this.name}`);
-      }
-
       let addonTrees = this.addonTreesFor('styles');
       let external = this._processedExternalTree();
       let styles = new Funnel(this.trees.styles, {


### PR DESCRIPTION
This check was originally added as a part of [this PR](https://github.com/ember-cli/ember-cli/pull/3642). Motivation behind the change was that build crashed w/ not-so-obvious error if stylesheet file had the same name as the project. I have doubts this check needs to exist anymore.