### PR TITLE
blueprints/addon: Replace `test` with `test:all`

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -35,7 +35,7 @@ Contributing
 
 * `ember test` – Runs the test suite on the current Ember version
 * `ember test --server` – Runs the test suite in "watch mode"
-* `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test` – Runs `ember try:each` to test your addon against multiple Ember versions
+* `ember try:each` – Runs the test suite against multiple Ember versions
 
 ### Running the dummy application
 

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -71,8 +71,8 @@ module.exports = {
     // add ember-source-channel-url
     contents.devDependencies['ember-source-channel-url'] = '^1.0.1';
 
-    // use `ember-try` as test script in addons by default
-    contents.scripts.test = 'ember try:each';
+    // add `ember-try` as `test:all` script in addons
+    contents.scripts['test:all'] = 'ember try:each';
 
     // add addon specific directories to lint:js script
     contents.scripts['lint:js'] = 'eslint ./*.js addon addon-test-support app config lib server test-support tests';

--- a/tests/fixtures/addon/npm/README.md
+++ b/tests/fixtures/addon/npm/README.md
@@ -35,7 +35,7 @@ Contributing
 
 * `ember test` – Runs the test suite on the current Ember version
 * `ember test --server` – Runs the test suite in "watch mode"
-* `npm test` – Runs `ember try:each` to test your addon against multiple Ember versions
+* `ember try:each` – Runs the test suite against multiple Ember versions
 
 ### Running the dummy application
 

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -16,7 +16,8 @@
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember try:each"
+    "test": "ember test",
+    "test:all": "ember try:each"
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0"

--- a/tests/fixtures/addon/yarn/README.md
+++ b/tests/fixtures/addon/yarn/README.md
@@ -35,7 +35,7 @@ Contributing
 
 * `ember test` – Runs the test suite on the current Ember version
 * `ember test --server` – Runs the test suite in "watch mode"
-* `yarn test` – Runs `ember try:each` to test your addon against multiple Ember versions
+* `ember try:each` – Runs the test suite against multiple Ember versions
 
 ### Running the dummy application
 

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -16,7 +16,8 @@
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember try:each"
+    "test": "ember test",
+    "test:all": "ember try:each"
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0"

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -71,7 +71,7 @@ describe('blueprint - addon', function() {
   ],\n\
   "scripts": {\n\
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",\n\
-    "test": "ember try:each"\n\
+    "test:all": "ember try:each"\n\
   },\n\
   "dependencies": {},\n\
   "devDependencies": {\n\
@@ -137,15 +137,13 @@ describe('blueprint - addon', function() {
         expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.2');
       });
 
-      it('overwrites `scripts.test`', function() {
+      it('adds `scripts.test:all`', function() {
         let output = blueprint.updatePackageJson(JSON.stringify({
-          scripts: {
-            test: 'test-string',
-          },
+          scripts: {},
         }));
 
         let json = JSON.parse(output);
-        expect(json.scripts.test).to.equal('ember try:each');
+        expect(json.scripts['test:all']).to.equal('ember try:each');
       });
 
       it('overwrites `ember-addon.configPath`', function() {


### PR DESCRIPTION
This PR adds a `test:all` script to the `package.json` file of addons, and switches the existing `test` script to `ember test`.

Reasons:

- Having `npm test` do something different from `ember test` is confusing
- Having `npm test` do something different depending on if I'm in an app or addon is confusing
- Having `npm test` start a process which takes minutes and is hard to cancel without leaving the project in an unclean state is ... not great

Open Questions:

- Should we include `test:all` at all or just refer to `ember try:each`?
- Should it be called `test:each` instead? I personally favor `test:all`, but it's unfortunately inconsistent with the ember-try command.