### PR TITLE
blueprints/app: Add `qunit-dom` dependency by default

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -39,7 +39,8 @@
     "ember-source": "~3.1.0-beta.1<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
     "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "qunit-dom": "^0.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -45,7 +45,8 @@
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "qunit-dom": "^0.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -46,7 +46,8 @@
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "qunit-dom": "^0.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -38,7 +38,8 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.1.0-beta.1",
     "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "qunit-dom": "^0.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -39,7 +39,8 @@
     "ember-source": "~3.1.0-beta.1",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "qunit-dom": "^0.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"


### PR DESCRIPTION
Resolves https://github.com/emberjs/ember-qunit/issues/301

**Reasons:**

- because it makes DOM assertions so much more readable

/cc @ember-cli/core @trentmwillis @cibernox 