### PR TITLE
Allow --yarn to be respected when installing a blueprint module

### DIFF
--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -25,11 +25,12 @@ class InstallBlueprintTask extends Task {
   run(options) {
     let cwd = process.cwd();
     let name = options.rawName;
-    let blueprintOption = options.blueprint;
     // If we're in a dry run, pretend we changed directories.
     // Pretending we cd'd avoids prompts in the actual current directory.
     let fakeCwd = path.join(cwd, name);
     let target = options.dryRun ? fakeCwd : cwd;
+
+    this.execa = execa;
 
     let installOptions = {
       target,
@@ -44,24 +45,24 @@ class InstallBlueprintTask extends Task {
 
     installOptions = merge(installOptions, options || {});
 
-    return this._resolveBlueprint(blueprintOption).then(blueprint => {
+    return this._resolveBlueprint(installOptions).then(blueprint => {
       logger.info(`Installing blueprint into "${target}" ...`);
       return blueprint.install(installOptions);
     });
   }
 
-  _resolveBlueprint(name) {
-    name = name || 'app';
+  _resolveBlueprint(options) {
+    let name = options.blueprint || 'app';
     logger.info(`Resolving blueprint "${name}" ...`);
 
     if (!isGitRepo(name)) {
       return this._lookupBlueprint(name)
-        .catch(error => this._handleLookupFailure(name, error));
+        .catch(error => this._handleLookupFailure(name, error, options));
     }
 
     return this._createTempFolder()
       .then(pathName => this._gitClone(name, pathName)
-        .then(() => this._npmInstall(pathName))
+        .then(() => this._npmInstall(pathName, options))
         .then(() => this._loadBlueprintFromPath(pathName)));
   }
 
@@ -72,7 +73,7 @@ class InstallBlueprintTask extends Task {
     }));
   }
 
-  _handleLookupFailure(name, error) {
+  _handleLookupFailure(name, error, options) {
     logger.info(`Blueprint lookup for "${name}" failed`);
 
     if (!validateNpmPackageName(name).validForNewPackages) {
@@ -81,12 +82,12 @@ class InstallBlueprintTask extends Task {
     }
 
     logger.info(`"${name} is a valid npm package name -> trying npm`);
-    return this._tryNpmBlueprint(name);
+    return this._tryNpmBlueprint(name, options);
   }
 
-  _tryNpmBlueprint(name) {
+  _tryNpmBlueprint(name, options) {
     return this._createTempFolder()
-      .then(pathName => this._npmInstallModule(name, pathName)
+      .then(pathName => this._npmInstallModule(name, pathName, options)
         .catch(error => this._handleNpmInstallModuleError(error)))
       .then(modulePath => {
         this._validateNpmModule(modulePath, name);
@@ -100,21 +101,37 @@ class InstallBlueprintTask extends Task {
 
   _gitClone(source, destination) {
     logger.info(`Cloning from git (${source}) into "${destination}" ...`);
-    return execa('git', ['clone', source, destination]);
+    return this.execa('git', ['clone', source, destination]);
   }
 
-  _npmInstall(cwd) {
-    logger.info(`Running "npm install" in "${cwd}" ...`);
+  _npmInstall(cwd, options) {
+    let command = 'npm';
+    let args = ['install'];
+
+    if (options && options.yarn === true) {
+      command = 'yarn';
+      args = ['install'];
+    }
+
+    logger.info(`Running "${command} ${args.join(' ')}" in "${cwd}" ...`);
 
     this._copyNpmrc(cwd);
-    return execa('npm', ['install'], { cwd });
+    return this.execa(command, args, { cwd });
   }
 
-  _npmInstallModule(module, cwd) {
-    logger.info(`Running "npm install ${module}" in "${cwd}" ...`);
+  _npmInstallModule(module, cwd, options) {
+    let command = 'npm';
+    let args = ['install', module];
+
+    if (options && options.yarn === true) {
+      command = 'yarn';
+      args = ['add', module];
+    }
+
+    logger.info(`Running "${command} ${args.join(' ')}" in "${cwd}" ...`);
 
     this._copyNpmrc(cwd);
-    return execa('npm', ['install', module], { cwd })
+    return this.execa(command, args, { cwd })
       .then(() => path.join(cwd, 'node_modules', module));
   }
 

--- a/tests/unit/tasks/install-blueprint-test.js
+++ b/tests/unit/tasks/install-blueprint-test.js
@@ -234,8 +234,8 @@ describe('InstallBlueprintTask', function() {
       let execaArgs = [];
       task._copyNpmrc = td.function();
 
-      task.execa = (...args) => {
-        execaArgs.push(args);
+      task.execa = (command, args, path) => {
+        execaArgs.push([command, args, path]);
         return RSVP.Promise.resolve();
       };
 


### PR DESCRIPTION
Currently if `--yarn` is present and you include a module name as a blueprint (ie: `ember init -b foobar --yarn`) ember-cli will install the module via npm and not yarn. This PR conditionally allows it to be installed via yarn or npm depending on the flags passed.