### PR TITLE
FEATURE: add the ability to pass user defined broccoli trees into the ember-app context

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -156,6 +156,8 @@ class EmberApp {
 
     this.trees = this.options.trees;
 
+    this.mergeTree = this.options.merge;
+
     this.populateLegacyFiles();
     this.initializeAddons();
     this.project.addons.forEach(addon => addon.app = this);
@@ -1807,6 +1809,7 @@ class EmberApp {
       this._srcAfterStylePreprocessing,
       this.otherAssets(),
       this.publicTree(),
+      this.mergeTree,
     ].filter(Boolean);
 
     if (this.tests && this.trees.tests) {


### PR DESCRIPTION
Howdy folks 👋

I'm opening this PR to start a conversation about my use-case and see if you would be open to the addition of this concept to the ember-cli API. I haven't added this as a RFC because it is a) a very small change and b) has no way to break existing functionality.

If the conversation goes well and we're all happy to get this merged I will add the required documentation and tests etc. For reference, this is already being used in the new Ember Deprecations-App (part of the learning team) and I have confirmed it is working as expected. All examples below will use the Deprecations-App implementation as a reference. Also, it is worth noting that this PR was required to get the Prember addon to pre-render the Deprecations-App effectively, and I will also be using that as a reference.

If anyone would like to get on a call to go into more depth on this explanation please let me know, I am @real_ate on the Community Slack.

## Main Use Case
We are statically pre-rendering the new Guides-App and Deprecations-App using Prember, and part of this whole process includes a plugin that generates a series of JSON:API `.json` files from content Markdown. It is not important to fully understand this conversion process but you can see it in action [here](https://github.com/ember-learn/deprecation-app/blob/master/ember-cli-build.js#L9). These `.json` files were originally included in the output dist folder by returning a merged tree from the Deprecation-App's `ember-cli-build.js` file, example [here](https://github.com/ember-learn/deprecation-app/blob/c084eb0c339bff1b01b2bce5a1ba0c5067777878/ember-cli-build.js#L41). This was *100%* fine for all local development and for deployment because the dist folder was exactly as it needed to be.

The issue was that we needed to pre-render all content for our deployment, and we needed to add Prember to the mix. Prember would fail when trying to hit any route that would try to access these local `.json` data files. I have recorded the details of the issue [here](https://github.com/ef4/prember/issues/12#issuecomment-361305940) but the TLDR is that Prember needed to provide an express server in much the same way as ember-cli does during development to serve local assets.

I have submitted a PR to Prember that fixes this problem, but if you look at the PR [here](https://github.com/ef4/prember/pull/15/files#diff-b9274f22838cefbb80773bfbd1453ca5R75) you will see that we have a little bit of an issue with *context* between the EmberApp and the Prember addon. 

If you combine the trees at the level of the host `ember-cli-build.js` file *the inputPath for the ember app will not include the compiled JSON files* at the point at which prember needs to build the express static file server. Instead, the EmberApp needs to have knowledge of the files so that Prember is able to pick them up in the inputPath.

This is why I wanted to add the ability to *pass a Broccoli tree directly into the Ember App*.

### Example of it running
You can clone https://github.com/ember-learn/deprecation-app and see this working in a real application. You will see that the package.json [links to this PR branch](https://github.com/ember-learn/deprecation-app/blob/master/package.json#L24) to allow for it to work out of the box. 