### PR TITLE
Fix 'const' declarations in non-strict mode are not supported

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',


### PR DESCRIPTION
Backport of https://github.com/ember-cli/ember-cli/pull/7563 to the `release` branch.

Resolves https://github.com/ember-cli/ember-cli/issues/7624

/cc @elwayman02 @rwwagner90 