### PR TITLE
Use bower from project root instead of relative to file path

### DIFF
--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// Runs `bower install` in cwd
 const fs = require('fs-extra');
 const path = require('path');
 const existsSync = require('exists-sync');
@@ -16,13 +15,11 @@ const Promise = RSVP.Promise;
 const resolve = RSVP.denodeify(require('resolve'));
 const writeJson = RSVP.denodeify(fs.writeJson);
 
-const cliPath = path.resolve(`${__dirname}/../..`);
-
 class BowerInstallTask extends Task {
 
   resolveBower() {
-    logger.info('Resolving "bower" from %s ...', cliPath);
-    return resolve('bower', { basedir: cliPath });
+    logger.info('Resolving "bower" from %s ...', this.project.root);
+    return resolve('bower', { basedir: this.project.root });
   }
 
   importBower(path) {
@@ -47,14 +44,14 @@ class BowerInstallTask extends Task {
   }
 
   installBower() {
-    logger.info('Installing "bower" via npm into: %s', cliPath);
+    logger.info('Installing "bower" via npm into: %s', this.project.root);
 
     let ui = this.ui;
     const chalk = require('chalk');
 
     ui.startProgress(chalk.green('npm: Installing bower ...'));
 
-    return execa('npm', ['install', 'bower@^1.3.12'], { cwd: cliPath })
+    return execa('npm', ['install', 'bower@^1.3.12'], { cwd: this.project.root })
       .finally(() => ui.stopProgress())
       .catch(error => this.handleInstallBowerError(error))
       .then(() => ui.writeLine(chalk.green('npm: Installed bower')));


### PR DESCRIPTION
During testing we change the current directory via `process.chdir(tmpdir)`. During
tests that run `ember new` this tmp directory becomes the project.root. The
bower executable should be installed into tmp/X/node_modules and not
ember-cli's node_modules. The error this was causing is that if bower
was not found (and it would not be as ember-cli does not depend on bower) bower would
install itself into ember-clis package.json and corrupt that file. This
now correctly uses the project.root as to where it should look for
bower.