### PR TITLE
Pull script tags to head, add defer

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -12,14 +12,13 @@
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
 
+    <script defer src="{{rootURL}}assets/vendor.js"></script>
+    <script defer src="{{rootURL}}assets/<%= name %>.js"></script>
+
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
-
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/<%= name %>.js"></script>
-
     {{content-for "body-footer"}}
   </body>
 </html>

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -14,6 +14,12 @@
     <link rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
+    <script defer src="/testem.js" integrity="" data-embroider-ignore></script>
+    <script defer src="{{rootURL}}assets/vendor.js"></script>
+    <script defer src="{{rootURL}}assets/test-support.js"></script>
+    <script defer src="{{rootURL}}assets/<%= name %>.js"></script>
+    <script defer src="{{rootURL}}assets/tests.js"></script>
+
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
@@ -27,12 +33,6 @@
         <div id="ember-testing"></div>
       </div>
     </div>
-
-    <script src="/testem.js" integrity="" data-embroider-ignore></script>
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
-    <script src="{{rootURL}}assets/<%= name %>.js"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
This has some neat pictures explaining the timeline of the different non-blocking loading options.
https://bitsofco.de/async-vs-defer/

With the script tags in the body, I wasn't able to get a steady app-loading animation going, while my scripts downloaded and got parsed. (this was in local dev, and my css loader (which was defined inline in index.html) was stuttering / "dropping frames")