### PR TITLE
Addon._treeFor optimization

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -611,7 +611,7 @@ class EmberApp {
     return this.project.addons.reduce((sum, addon) => {
       if (addon.treeFor) {
         let tree = addon.treeFor(type);
-        if (tree) {
+        if (tree && !mergeTrees.isEmptyTree(tree)) {
           sum.push({
             name: addon.name,
             tree,

--- a/lib/broccoli/merge-trees.js
+++ b/lib/broccoli/merge-trees.js
@@ -94,5 +94,9 @@ module.exports = function mergeTrees(_inputTrees, options) {
   }
 };
 
+module.exports.isEmptyTree = function isEmptyTree(tree) {
+  return tree === EMPTY_MERGE_TREE;
+};
+
 module.exports._overrideEmptyTree = overrideEmptyTree;
 module.exports._upstreamMergeTrees = upstreamMergeTrees;


### PR DESCRIPTION
Without this, an empty array goes through mergeTrees and becomes a valid tree. With this change, it remains a falsy value and fails this check https://github.com/ember-cli/ember-cli/blob/203164d6cc5be60918b39ce7e25530bdd22b739f/lib/broccoli/ember-app.js#L618 meaning less trees to deal with.

This change is only a minor optimization now, but is more noticeable when paired with #7501.