### PR TITLE
More comprehensive detect if ember-cli is being run within CI or not.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,6 +3,7 @@
 const willInterruptProcess = require('../utilities/will-interrupt-process');
 const instrumentation = require('../utilities/instrumentation');
 const getConfig = require('../utilities/get-config');
+const ciInfo = require('ci-info');
 
 let initInstrumentation;
 if (instrumentation.instrumentationEnabled()) {
@@ -84,7 +85,7 @@ module.exports = function(options) {
     outputStream: options.outputStream,
     errorStream: options.errorStream || process.stderr,
     errorLog: options.errorLog || [],
-    ci: process.env.CI || (/^(dumb|emacs)$/).test(process.env.TERM),
+    ci: ciInfo.isCI || (/^(dumb|emacs)$/).test(process.env.TERM),
     writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
   });
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "calculate-cache-key-for-tree": "^1.0.0",
     "capture-exit": "^1.1.0",
     "chalk": "^2.0.1",
+    "ci-info": "^1.1.2",
     "clean-base-url": "^1.0.0",
     "compression": "^1.4.4",
     "configstore": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,6 +1036,10 @@ check-error@^1.0.1, check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
+ci-info@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"


### PR DESCRIPTION
For this, we are using: https://github.com/watson/ci-info/

Which has a pretty comprehensive support list: https://github.com/watson/ci-info/#supported-ci-tools

This aims to ensure that console-ui’s new “write errors to disk” doesn’t occur in CI: https://github.com/ember-cli/console-ui/pull/19