### PR TITLE
Consider all the root js files as a node files

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -19,10 +19,8 @@ module.exports = {
   overrides: [
     // node files
     {
-      files: [<% if (blueprint !== 'app') { %>
-        'index.js',<% } %>
-        'testem.js',
-        'ember-cli-build.js',
+      files: [
+        '*.js',
         'config/**/*.js'<% if (blueprint === 'app') { %>,
         'lib/*/index.js'<% } %><% if (blueprint !== 'app') { %>,
         'tests/dummy/config/**/*.js'<% } %>

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -20,9 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -20,9 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -20,9 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -20,8 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'lib/*/index.js'
       ],

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -20,8 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'lib/*/index.js'
       ],

--- a/tests/fixtures/module-unification-app/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/npm/.eslintrc.js
@@ -20,9 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/module-unification-app/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/yarn/.eslintrc.js
@@ -20,9 +20,7 @@ module.exports = {
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
+        '*.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],


### PR DESCRIPTION
I think it's safe to say that there shouldn't be frontend files in the root of ember package. So we can probably simplify eslint rule?