### PR TITLE
remove JOBS=1 test workaround

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -35,8 +35,6 @@ describe('Acceptance: addon-smoke-test', function () {
 
   beforeEach(function () {
     addonRoot = linkDependencies(addonName);
-
-    process.env.JOBS = '1';
   });
 
   afterEach(function () {
@@ -46,8 +44,6 @@ describe('Acceptance: addon-smoke-test', function () {
 
     cleanupRun(addonName);
     expect(dir(addonRoot)).to.not.exist;
-
-    delete process.env.JOBS;
   });
 
   it('generates package.json with proper metadata', function () {


### PR DESCRIPTION
My guess is there was a regression in the recent work in broccoli-babel-transpiler. This workaround wasn't necessary as of a few days ago (maybe week or more). I debugged this locally on Windows, and I saw that three instances of "broccoli-babel-transpiler/lib/worker.js" had locks on the dir the test cleanup was trying to remove.