### PR TITLE
only use the standard compilers to compile addon code

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -667,20 +667,35 @@ class EmberApp {
     return this._addonTreesFor(type).map(addonBundle => addonBundle.tree);
   }
 
+  _getDefaultCompiler(type) {
+    // since we are now using the app's registry to compile addon code,
+    // we could get into the case where the app has multiple compilers (coffeescript, emblem, etc.)
+    // operating on addon code where there weren't previously.
+    // This prevents that by using the default app compiler only.
+    let plugins = this.registry.load(type);
+    return plugins[plugins.length - 1];
+  }
+
   _compileAddonTemplates(tree) {
-    tree = preprocessTemplates(tree, {
-      annotation: `_compileAddonTemplates`,
-      registry: this.registry,
-    });
+    let plugin = this._getDefaultCompiler('template');
+    if (plugin) {
+      tree = plugin.toTree(tree, {
+        annotation: `_compileAddonTemplates`,
+        registry: this.registry,
+      });
+    }
 
     return tree;
   }
 
   _compileAddonJs(tree) {
-    tree = preprocessJs(tree, '/', '/', {
-      annotation: `_compileAddonJs`,
-      registry: this.registry,
-    });
+    let plugin = this._getDefaultCompiler('js');
+    if (plugin) {
+      tree = plugin.toTree(tree, '/', '/', {
+        annotation: `_compileAddonJs`,
+        registry: this.registry,
+      });
+    }
 
     return tree;
   }


### PR DESCRIPTION
instead of any custom one's added by the app. This will be an optimization for apps that have transpilers like coffeescript, typescript, stylus, emblem, etc. With the merge of #7501, now all these app transpilers run on addon code, which isn't necessary.

The question is, how safe is this? Are these addons guaranteed to be there? Is the registry ordered, could I take the last off the list instead?