### PR TITLE
compile all addons at once optimization

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1145,8 +1145,6 @@ class EmberApp {
       let root = addonBundle.root;
 
       if (experiments.DELAYED_TRANSPILATION) {
-        tree = this._debugTree(tree, `precompiledAddonTree:${type}:${name}`);
-
         if (!options.moduleNormalizerDisabled) {
           // move legacy /modules/addon to /addon
           let hasAlreadyPrintedModuleDeprecation;
@@ -1160,9 +1158,11 @@ class EmberApp {
             annotation: `ModuleNormalizer (${type} ${name})`,
           });
         }
+      }
 
-        let precompiledSource = tree;
+      let precompiledSource = tree;
 
+      if (experiments.DELAYED_TRANSPILATION) {
         if (!options.amdFunnelDisabled) {
           // don't want to double compile the AMD modules
           let hasAlreadyPrintedAmdDeprecation;
@@ -1176,28 +1176,43 @@ class EmberApp {
             annotation: `AmdFunnel (${type} ${name})`,
           });
         }
-
-        let compiledSource = this._compileAddonTree(precompiledSource, options.skipTemplates);
-
-        if (options.amdFunnelDisabled) {
-          tree = compiledSource;
-        } else {
-          tree = mergeTrees([tree, compiledSource], {
-            overwrite: true,
-            annotation: `AmdFunnel TreeMerger (${type} ${name})`,
-          });
-        }
-
-        tree = this._debugTree(tree, `postcompiledAddonTree:${type}:${name}`);
       }
 
-      return tree;
+      return [tree, precompiledSource];
     });
 
-    let combinedAddonTree = mergeTrees(addonTrees, {
+    let precompiledSource = addonTrees.map(pair => pair[1]);
+    addonTrees = addonTrees.map(pair => pair[0]);
+
+    if (!experiments.DELAYED_TRANSPILATION) {
+      precompiledSource = addonTrees;
+    }
+
+    precompiledSource = mergeTrees(precompiledSource, {
       overwrite: true,
       annotation: `TreeMerger (${type})`,
     });
+
+    let combinedAddonTree;
+
+    if (experiments.DELAYED_TRANSPILATION) {
+      precompiledSource = this._debugTree(precompiledSource, `precompiledAddonTree:${type}`);
+
+      let compiledSource = this._compileAddonTree(precompiledSource, options.skipTemplates);
+
+      compiledSource = this._debugTree(compiledSource, `postcompiledAddonTree:${type}`);
+
+      if (options.amdFunnelDisabled) {
+        combinedAddonTree = compiledSource;
+      } else {
+        combinedAddonTree = mergeTrees(addonTrees.concat(compiledSource), {
+          overwrite: true,
+          annotation: `AmdFunnel TreeMerger (${type})`,
+        });
+      }
+    } else {
+      combinedAddonTree = precompiledSource;
+    }
 
     return new Funnel(combinedAddonTree, {
       destDir: outputDir,


### PR DESCRIPTION
This optimization post #7501 runs __compileAddonTree post mergeTrees instead of before.