### PR TITLE
Package tests

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const p = require('ember-cli-preprocess-registry/preprocessors');
 const Funnel = require('broccoli-funnel');
+const addonProcessTree = require('../utilities/addon-process-tree');
+
+const preprocessJs = p.preprocessJs;
 
 const DEFAULT_BOWER_PATH = 'bower_components';
 const DEFAULT_VENDOR_PATH = 'vendor';
@@ -12,9 +16,16 @@ const DEFAULT_VENDOR_PATH = 'vendor';
  * @constructor
  */
 module.exports = class DefaultPackager {
-  constructor() {
+  constructor(options) {
+    this._cachedTests = null;
     this._cachedBower = null;
     this._cachedVendor = null;
+
+    this.options = options || {};
+
+    this.name = this.options.name;
+    this.project = this.options.project;
+    this.registry = this.options.registry;
   }
 
   /*
@@ -96,5 +107,57 @@ module.exports = class DefaultPackager {
     }
 
     return this._cachedVendor;
+  }
+
+  /*
+   * Given an input tree, returns a properly assembled Broccoli tree with tests
+   * files.
+   *
+   * Given a tree:
+   *
+   * ```
+   * ├── acceptance/
+   * ├── helpers/
+   * ├── index.html
+   * ├── integration/
+   * ├── test-helper.js
+   * └── unit/
+   * ```
+   *
+   * Returns:
+   *
+   * ```
+   * [name]/
+   * └── tests
+   *     ├── acceptance/
+   *     ├── helpers/
+   *     ├── index.html
+   *     ├── integration/
+   *     ├── test-helper.js
+   *     └── unit/
+   * ```
+   *
+   * @private
+   * @method packageTests
+   * @param {BroccoliTree} tree
+   * @param {String} name The name of Ember.js application
+  */
+  packageTests(tree) {
+    if (this._cachedTests === null) {
+      tree = addonProcessTree(this.project, 'preprocessTree', 'test', tree);
+
+      tree = new Funnel(tree, {
+        destDir: `${this.name}/tests`,
+        annotation: 'Packaged Tests',
+      });
+
+      let preprocessedTests = preprocessJs(tree, '/tests', this.name, {
+        registry: this.registry,
+      });
+
+      this._cachedTests = addonProcessTree(this.project, 'postprocessTree', 'test', preprocessedTests);
+    }
+
+    return this._cachedTests;
   }
 };

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -152,7 +152,6 @@ class EmberApp {
     // ensure addon.css always gets concated
     this._styleOutputFiles[this.options.outputPaths.vendor.css] = [];
 
-
     this._scriptOutputFiles = {};
     this._customTransformsMap = new Map();
 
@@ -160,7 +159,6 @@ class EmberApp {
     this.legacyTestFilesToAppend = [];
     this.vendorTestStaticStyles = [];
     this._nodeModules = new Map();
-    this._defaultPackager = new DefaultPackager();
 
     this.trees = this.options.trees;
 
@@ -176,6 +174,12 @@ class EmberApp {
     }
 
     this._debugTree = BroccoliDebug.buildDebugCallback('ember-app');
+
+    this._defaultPackager = new DefaultPackager({
+      name: this.name,
+      project: this.project,
+      registry: this.registry,
+    });
   }
 
   /**
@@ -1071,25 +1075,6 @@ class EmberApp {
       .map(extension => `**/*/template.${extension}`);
   }
 
-  /**
-    @private
-    @method _processedTestsTree
-    @return
-  */
-  _processedTestsTree() {
-    let addonTrees = this.addonTreesFor('test-support');
-    let mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
-      overwrite: true,
-      annotation: 'TreeMerger (tests)',
-    });
-
-    return new Funnel(mergedTests, {
-      srcDir: '/',
-      destDir: `${this.name}/tests`,
-      annotation: 'ProcessedTestTree',
-    });
-  }
-
   _nodeModuleTrees() {
     if (!this._cachedNodeModuleTrees) {
       this._cachedNodeModuleTrees = Array.from(this._nodeModules.values(), module => new Funnel(module.path, {
@@ -1200,10 +1185,11 @@ class EmberApp {
         vendorTrees.push(this.trees.vendor);
       }
 
-      let vendor = this._defaultPackager.packageVendor(mergeTrees(vendorTrees, {
+      let mergedVendorTrees = mergeTrees(vendorTrees, {
         overwrite: true,
         annotation: 'TreeMerger (vendor)',
-      }));
+      });
+      let vendor = this._defaultPackager.packageVendor(mergedVendorTrees);
 
       let addons = this.addonTree();
 
@@ -1374,11 +1360,13 @@ class EmberApp {
   }
 
   test() {
-    let tests = this.addonPreprocessTree('test', this._processedTestsTree());
-    let preprocessedTests = preprocessJs(tests, '/tests', this.name, {
-      registry: this.registry,
+    let addonTrees = this.addonTreesFor('test-support');
+    let mergedTests = mergeTrees(addonTrees.concat(this.trees.tests), {
+      overwrite: true,
+      annotation: 'TreeMerger (tests)',
     });
-    let coreTestTree = this.addonPostprocessTree('test', preprocessedTests);
+
+    let coreTestTree = this._defaultPackager.packageTests(mergedTests, this.name);
 
     let appTestTree = this.appTests(coreTestTree);
     let testFilesTree = this.testFiles(coreTestTree);

--- a/tests/unit/broccoli/default-packager/tests-test.js
+++ b/tests/unit/broccoli/default-packager/tests-test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const p = require('ember-cli-preprocess-registry/preprocessors');
+const co = require('co');
+const expect = require('chai').expect;
+const DefaultPackager = require('../../../../lib/broccoli/default-packager');
+const broccoliTestHelper = require('broccoli-test-helper');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('Default Packager: Tests', function() {
+  let input, output;
+  let name = 'the-best-app-ever';
+
+  let project = {
+    dependencies() {
+      return {
+        'ember-cli-htmlbars': '^2.0.1',
+      };
+    },
+    addons: [],
+  };
+
+  let TESTS = {
+    acceptance: {},
+    helpers: {},
+    'index.html': 'index',
+    integration: {},
+    'test-helper.js': 'test-helper',
+    unit: {},
+  };
+
+  before(co.wrap(function *() {
+    input = yield createTempDir();
+
+    input.write(TESTS);
+  }));
+
+  after(co.wrap(function *() {
+    yield input.dispose();
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield output.dispose();
+  }));
+
+  it('caches packaged tests tree', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      registry: p.defaultRegistry(project),
+    });
+
+    expect(defaultPackager._cachedTests).to.equal(null);
+
+    output = yield buildOutput(defaultPackager.packageTests(input.path()));
+
+    expect(defaultPackager._cachedTests).to.not.equal(null);
+    expect(defaultPackager._cachedTests._annotation).to.equal('Packaged Tests');
+  }));
+
+  it('packages tests files', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      registry: p.defaultRegistry(project),
+    });
+
+    output = yield buildOutput(defaultPackager.packageTests(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles).to.deep.equal({
+      [name]: {
+        tests: TESTS,
+      },
+    });
+  }));
+});


### PR DESCRIPTION
This change is related to the [spike](https://github.com/ember-cli/ember-cli/pull/7562) and is backwards compatible. To avoid making changes to `ember-app` in one go, we can move processing/packaging logic (one tree at a time) to `DefaultPackager` while adding tests/documentation and deprecating private undocumented methods.

Should be merged after https://github.com/ember-cli/ember-cli/pull/7654