### PR TITLE
Exclude addon-test-support from eslint node files

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
       excludedFiles: [
         'app/**',
         'addon/**',
-        'tests/dummy/app/**'
+        'tests/dummy/app/**',
+        'addon-test-support/**'
       ],<% } %>
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
       excludedFiles: [
         'app/**',
         'addon/**',
-        'tests/dummy/app/**'
+        'tests/dummy/app/**',
+        'addon-test-support/**'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
       excludedFiles: [
         'app/**',
         'addon/**',
-        'tests/dummy/app/**'
+        'tests/dummy/app/**',
+        'addon-test-support/**'
       ],
       parserOptions: {
         sourceType: 'script',


### PR DESCRIPTION
This PR adds `addon-test-support` folder to excluded files from eslint override for node files.

Fix #7652