### PR TITLE
improve logic for if addon is module-unification

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -252,6 +252,16 @@ let addonProto = {
       defaultsDeep(this.options[emberCLIBabelConfigKey], defaultEmberCLIBabelOptions);
   },
 
+  /**
+     Returns whether this is using a module unification format.
+     @private
+     @method isModuleUnification
+     @return {Boolean} Whether this is using a module unification format.
+  */
+  isModuleUnification() {
+    return existsSync(path.join(this.root, this.treePaths.src));
+  },
+
   /*
    * Find an addon of the current addon.
    *
@@ -702,7 +712,9 @@ let addonProto = {
     @return {Tree} App file tree
   */
   treeForApp(tree) {
-    if (!experiments.MODULE_UNIFICATION || this.project.isModuleUnification()) {
+    if (!experiments.MODULE_UNIFICATION) {
+      return tree;
+    } else if (this.project.isModuleUnification() && this.isModuleUnification()) {
       return null;
     }
 


### PR DESCRIPTION
 - required so that a module-unification app can handle a mix of addons
   which are module-unification (in which case they have a src folder
   but no app folder), or classic (in which case they have an app folder).