### PR TITLE
Double linting test timeout

### DIFF
--- a/tests/unit/lint-test.js
+++ b/tests/unit/lint-test.js
@@ -10,6 +10,6 @@ paths = paths.concat([
 ]);
 
 require('mocha-eslint')(paths, {
-  timeout: 10000,
+  timeout: 20000,
   slow: 1000,
 });


### PR DESCRIPTION
With `eslint-plugin-node`(https://github.com/ember-cli/ember-cli/pull/7585) linting test needs more time to process: https://travis-ci.org/ember-cli/ember-cli/jobs/348450302#L563