### PR TITLE
Remove redundant checks

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -947,13 +947,11 @@ class EmberApp {
     @return {Tree} Tree for /public
    */
   publicTree() {
-    let trees = this.addonTreesFor('public');
+    let addonPublicTrees = this.addonTreesFor('public');
 
-    if (this.trees.public) {
-      trees.push(this.trees.public);
-    }
+    addonPublicTrees = addonPublicTrees.concat(this.trees.public);
 
-    return mergeTrees(trees, {
+    return mergeTrees(addonPublicTrees, {
       overwrite: true,
       annotation: 'TreeMerge (public)',
     });
@@ -1196,9 +1194,7 @@ class EmberApp {
     if (!this._cachedExternalTree) {
       let vendorTrees = this.addonTreesFor('vendor');
 
-      if (this.trees.vendor) {
-        vendorTrees.push(this.trees.vendor);
-      }
+      vendorTrees.push(this.trees.vendor);
 
       let vendor = this._defaultPackager.packageVendor(mergeTrees(vendorTrees, {
         overwrite: true,


### PR DESCRIPTION
It turns out that our `mergeTrees` utilities only merges "truthy" and
non-empty trees so it's safe to remove these checks.