### PR TITLE
Only watch test/dummy/app on addons if it exist

### DIFF
--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -49,8 +49,14 @@ class EmberAddon extends EmberApp {
       },
     };
 
+    if (!fs.existsSync('tests/dummy/app')) {
+      overrides.trees.app = null;
+      overrides.trees.styles = null;
+      overrides.trees.templates = null;
+    }
     if (fs.existsSync('tests/dummy/src')) {
       overrides.trees.src = 'tests/dummy/src';
+      overrides.trees.styles = 'tests/dummy/src/ui/styles';
     }
 
     if (fs.existsSync('tests/dummy/vendor')) {


### PR DESCRIPTION
Related with #7667 

Without this change, the default generated addon fails on `ember serve`