### PR TITLE
Include _super call in example of Addon.included

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -669,6 +669,7 @@ let addonProto = {
     @example
     ```js
     included(parent) {
+      this._super.included.apply(this, arguments);
       this.import(somePath);
     }
     ```


### PR DESCRIPTION
Since [failing to call this._super.included can cause problems](https://github.com/brianhjelle/ember-plotly-shim/issues/1#issuecomment-371619744) I think it would be nice if the example showed this.
(Moved from [docs site PR](https://github.com/ember-cli/api/pull/1#event-1512176392))