### PR TITLE
Revert "EmberApp: Remove deprecated `contentFor()` hooks"

### DIFF
--- a/lib/broccoli/app-prefix.js
+++ b/lib/broccoli/app-prefix.js
@@ -1,1 +1,3 @@
 "use strict";
+
+{{content-for 'app-prefix'}}

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,0 +1,1 @@
+{{content-for 'app-suffix'}}

--- a/lib/broccoli/vendor-prefix.js
+++ b/lib/broccoli/vendor-prefix.js
@@ -1,2 +1,4 @@
 window.EmberENV = {{EMBER_ENV}};
 var runningTests = false;
+
+{{content-for 'vendor-prefix'}}

--- a/lib/broccoli/vendor-suffix.js
+++ b/lib/broccoli/vendor-suffix.js
@@ -1,0 +1,1 @@
+{{content-for 'vendor-suffix'}}


### PR DESCRIPTION
This reverts commit 8bd6fa6cb4abac46f8ba157601852ae3a638237f and if accepted will need to be back-ported to 3.0.x

----

I believe this may need to be brought back. Specifically, there may not be a reasonable way to wrap `app.js` and `vendor.js` in timing metrics.

A concrete example would be to wrap `app.js` and `vendor.js` in `performance.mark` via the following content-for hooks:

* `vendor-prefix`
* `vendor-suffix`
* `app-prefix`
* `app-suffix`

```js
(typeof window !== 'undefined' && window && window.performance && window.performance.mark) {
  window.performance.mark('mark_app_start');
}

// ... <app.js or vendor.js> content...

if (typeof window !== 'undefined' && window && window.performance && window.performance.mark) {
  window.performance.mark('mark_app_end');
  if (window.performance.getEntriesByName('mark_app_start').length > 0) {
    window.performance.measure('mark_app_eval', 'mark_app_start', 'mark_app_end');
  }
}
```

---

I've tried a-few alternatives, the only one I can come up with would either break or risk breaking sourcemaps further, or require a second (both costly/error prone) sourcemap concat.

---

I also tend to agree the existing interface/api isn't really ideal, and I welcome alternative solutions.