### PR TITLE
Deprecate ember-cli-babel 5.x

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -86,19 +86,7 @@ let DEFAULT_CONFIG = {
   addons: {},
 };
 
-function needsEmberCLIShims(addons) {
-  let babelInstance = addons.find(addon => addon.name === 'ember-cli-babel');
-  if (!babelInstance) {
-    return false;
-  }
 
-  let version = babelInstance.pkg.version;
-  if (semver.lt(version, '6.6.0')) {
-    return true;
-  }
-
-  return addons.some(addon => needsEmberCLIShims(addon.addons));
-}
 
 class EmberApp {
   /**
@@ -458,7 +446,8 @@ class EmberApp {
     // certain versions of `ember-source` bundle them by default,
     // so we must check if that is the load mechanism of ember
     // before checking `bower`.
-    if (!emberShims && !addonEmberCliShims && !bowerEmberCliShims && needsEmberCLIShims(this.project.addons)) {
+    let emberCliShimsRequired = this._checkEmberCliBabel(this.project.addons);
+    if (!emberShims && !addonEmberCliShims && !bowerEmberCliShims && emberCliShimsRequired) {
       this.project.ui.writeWarnLine('You have not included `ember-cli-shims` in your project\'s `bower.json` or `package.json`. This only works if you provide an alternative yourself and unset `app.vendorFiles[\'app-shims.js\']`.');
     }
 
@@ -529,6 +518,32 @@ class EmberApp {
   _addonDisabledByWhitelist(addon) {
     let whitelist = this.options.addons.whitelist;
     return !!whitelist && whitelist.indexOf(addon.name) === -1;
+  }
+
+  /**
+    @private
+    @method _checkEmberCliBabel
+    @param {Addons} addons
+    @return {Boolean}
+  */
+  _checkEmberCliBabel(addons, result, roots) {
+    addons = addons || [];
+    result = result || false;
+    roots = roots || {};
+
+    let babelInstance = addons.find(addon => addon.name === 'ember-cli-babel');
+    if (babelInstance) {
+      let version = babelInstance.pkg.version;
+      if (semver.lt(version, '6.6.0')) {
+        result = true;
+      }
+      if (semver.lt(version, '6.0.0') && !roots[babelInstance.root]) {
+        roots[babelInstance.root] = true;
+        this.project.ui.writeWarnLine(`DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version ${version} located: ${babelInstance.root}`);
+      }
+    }
+
+    return addons.some(addon => this._checkEmberCliBabel(addon.addons, result, roots));
   }
 
   /**


### PR DESCRIPTION
This renames the `checkEmberCliShims` to `_checkEmberCliBabel`. The return value still represents if shims are required, but while recursing the addons a warning is logged for any `ember-cli-babel` versions less then `6.x`.

Implements #7642 