### PR TITLE
Use a recent release of Ember canary for MU

### DIFF
--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -36,7 +36,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "http://builds.emberjs.com/canary.tgz<% if (welcome) { %>",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz<% if (welcome) { %>",
     "ember-welcome-page": "^3.0.0<% } %>",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"

--- a/tests/fixtures/module-unification-addon/package.json
+++ b/tests/fixtures/module-unification-addon/package.json
@@ -40,7 +40,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "http://builds.emberjs.com/canary.tgz",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -36,7 +36,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "http://builds.emberjs.com/canary.tgz",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -36,7 +36,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "http://builds.emberjs.com/canary.tgz",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"


### PR DESCRIPTION
The `canary.tgz` file is not a very up to date version of Ember.js master. This PR forces us to use a more recent SHA.

We would like to use https://github.com/ember-cli/ember-source-channel-url to fetch the latest canary URL for module unification generators, however I would like these blueprints to work properly in the interim.

/cc @rwjblue 