### PR TITLE
Update init to be src/ friendly

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -32,8 +32,14 @@ module.exports = Command.extend({
 
   _defaultBlueprint() {
     if (this.project.isEmberCLIAddon()) {
+      if (this.project.isModuleUnification()) {
+        return 'module-unification-addon';
+      }
       return 'addon';
     } else {
+      if (this.project.isModuleUnification()) {
+        return 'module-unification-app';
+      }
       return 'app';
     }
   },


### PR DESCRIPTION
I need some testing solution for this, but I'd like to try and get `init` working with module unification today.

Without `init` working, there isn't a good canonical way for someone who uses the ember-module-migrator to get the remaining setup files in place.