### PR TITLE
Revert "EmberApp: Remove deprecated `contentFor()` hooks"

### DIFF
--- a/lib/broccoli/app-prefix.js
+++ b/lib/broccoli/app-prefix.js
@@ -1,1 +1,3 @@
 "use strict";
+
+{{content-for 'app-prefix'}}

--- a/lib/broccoli/app-suffix.js
+++ b/lib/broccoli/app-suffix.js
@@ -1,0 +1,1 @@
+{{content-for 'app-suffix'}}

--- a/lib/broccoli/vendor-prefix.js
+++ b/lib/broccoli/vendor-prefix.js
@@ -1,2 +1,4 @@
 window.EmberENV = {{EMBER_ENV}};
 var runningTests = false;
+
+{{content-for 'vendor-prefix'}}

--- a/lib/broccoli/vendor-suffix.js
+++ b/lib/broccoli/vendor-suffix.js
@@ -1,0 +1,1 @@
+{{content-for 'vendor-suffix'}}


### PR DESCRIPTION
This reverts commit 8bd6fa6cb4abac46f8ba157601852ae3a638237f, more context -> https://github.com/ember-cli/ember-cli/pull/7673