### PR TITLE
fix the shims messaging

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -543,7 +543,7 @@ class EmberApp {
       }
     }
 
-    return addons.some(addon => this._checkEmberCliBabel(addon.addons, result, roots));
+    return addons.some(addon => this._checkEmberCliBabel(addon.addons, result, roots)) || result;
   }
 
   /**

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -7,7 +7,7 @@
   "ember-addon": {
     "paths": ["./lib/ember-super-button"]
   },
-    "devDependencies": {
+  "devDependencies": {
     "ember-resolver": "^2.0.2",
     "ember-cli": "latest",
     "ember-random-addon": "latest",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1008,4 +1008,28 @@ describe('EmberApp', function() {
       });
     });
   });
+
+  it('shows ember-cli-shims deprecation', function() {
+    let root = path.resolve(__dirname, '../../fixtures/app/npm');
+    let project = setupProject(root);
+    project.require = function() {
+      return {
+        version: '5.0.0',
+      };
+    };
+    project.initializeAddons = function() {
+      this.addons = [
+        {
+          name: 'ember-cli-babel',
+          pkg: { version: '5.0.0' },
+        },
+      ];
+    };
+
+    app = new EmberApp({
+      project,
+    });
+
+    expect(project.ui.output).to.contain("You have not included `ember-cli-shims` in your project's `bower.json` or `package.json`.");
+  });
 });


### PR DESCRIPTION
It was missing the termination condition when `addons` is empty causing it to always be false.