### PR TITLE
[BACKPORT release] Ensure config() memoizing is considers if the

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -211,12 +211,13 @@ class Project {
     @return {Object}     Merged confiration object
    */
   config(env) {
-    let c = this.configCache.get(env);
-    if (c === undefined) {
-      c = this.configWithoutCache(env);
-      this.configCache.set(env, c);
+    let key = `${this.configPath()}|${env}`;
+    let config = this.configCache.get(key);
+    if (config === undefined) {
+      config = this.configWithoutCache(env);
+      this.configCache.set(key, config);
     }
-    return _.cloneDeep(c);
+    return _.cloneDeep(config);
   }
 
   /**


### PR DESCRIPTION
configPath has changed as part of its cache key.

For addons, we end up hot-swapping configPath. Although this isn't a
great idea, it turns out we relied on it working.

Offending code:
https://github.com/ember-cli/ember-cli/blob/6a1f80efe39f3e87533cfd0ef062ef42cd5899a5/lib/broccoli/ember-app.js#L201-L203

Future config related work should likely tidy this up...