### PR TITLE
Guide new addons away from jQuery dependency

### DIFF
--- a/blueprints/addon/files/ember-cli-build.js
+++ b/blueprints/addon/files/ember-cli-build.js
@@ -4,6 +4,13 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    /* 
+      Leave jQuery out of this addon's own test suite & dummy app by default, 
+      so that the addon can be used in apps without jQuery. If you really need 
+      jQuery, it's safe to remove this line.
+    */
+    vendorFiles: { 'jquery.js': null, 'app-shims.js': null }
+    
     // Add options here
   });
 


### PR DESCRIPTION
We already have consensus in a [merged RFC](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md) that we want addons to not depend on jQuery whenever possible.

This is a change to the default addon blueprint that will make jQuery opt-in, rather than opt-out.

I realize there is a longer-term plan that would clean this up even further by creating an API clearer than `vendorFiles` for controlling jQuery dependency, but this seems like a stepwise improvement.