### PR TITLE
Passing defaultOptions to testem to prevent the cwd and config_dir set in testem.js from being overridden by ember-cli

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const p = require('ember-cli-preprocess-registry/preprocessors');
+const path = require('path');
 const Funnel = require('broccoli-funnel');
 const mergeTrees = require('./merge-trees');
+const ConfigLoader = require('broccoli-config-loader');
 const addonProcessTree = require('../utilities/addon-process-tree');
 
 const preprocessJs = p.preprocessJs;
@@ -22,9 +24,11 @@ module.exports = class DefaultPackager {
     this._cachedBower = null;
     this._cachedVendor = null;
     this._cachedPublic = null;
+    this._cachedConfig = null;
 
     this.options = options || {};
 
+    this.env = this.options.env;
     this.name = this.options.name;
     this.project = this.options.project;
     this.registry = this.options.registry;
@@ -205,5 +209,53 @@ module.exports = class DefaultPackager {
     }
 
     return this._cachedPublic;
+  }
+
+  /*
+   * Given an input tree, returns a properly assembled Broccoli tree with
+   * configuration files.
+   *
+   * Given a tree:
+   *
+   * ```
+   * environments/
+   * ├── development.json
+   * └── test.json
+   * ```
+   *
+   * Returns:
+   *
+   * ```
+   * └── [name]
+   *     └── config
+   *         └── environments
+   *             ├── development.json
+   *             └── test.json
+   * ```
+   * @private
+   * @method packageConfig
+   * @param {Boolean} testsEnabled Boolean flag to control the inclusion of
+   *                  `test.json` file in the resulting tree.
+  */
+  packageConfig(testsEnabled) {
+    let env = this.env;
+    let name = this.name;
+    let project = this.project;
+    let configPath = this.project.configPath();
+
+    if (this._cachedConfig === null) {
+      let configTree = new ConfigLoader(path.dirname(configPath), {
+        env,
+        tests: testsEnabled || false,
+        project,
+      });
+
+      this._cachedConfig = new Funnel(configTree, {
+        destDir: `${name}/config`,
+        annotation: 'Packaged Config',
+      });
+    }
+
+    return this._cachedConfig;
   }
 };

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -26,7 +26,6 @@ const BroccoliDebug = require('broccoli-debug');
 const ModuleNormalizer = require('broccoli-module-normalizer');
 const AmdFunnel = require('broccoli-amd-funnel');
 const ConfigReplace = require('broccoli-config-replace');
-const ConfigLoader = require('broccoli-config-loader');
 const mergeTrees = require('./merge-trees');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
@@ -163,6 +162,7 @@ class EmberApp {
     this._debugTree = BroccoliDebug.buildDebugCallback('ember-app');
 
     this._defaultPackager = new DefaultPackager({
+      env: this.env,
       name: this.name,
       project: this.project,
       registry: this.registry,
@@ -853,7 +853,7 @@ class EmberApp {
       index = mergeTrees([appIndex, srcIndex], { overwrite: true });
     }
 
-    return new ConfigReplace(index, this._configTree(), {
+    return new ConfigReplace(index, this._defaultPackager.packageConfig(this.tests), {
       configPath: path.join(this.name, 'config', 'environments', `${this.env}.json`),
       files: [htmlName],
       patterns: this._configReplacePatterns(),
@@ -993,7 +993,7 @@ class EmberApp {
       annotation: 'Funnel (test index)',
     });
 
-    return new ConfigReplace(index, this._configTree(), {
+    return new ConfigReplace(index, this._defaultPackager.packageConfig(this.tests), {
       configPath: path.join(this.name, 'config', 'environments', 'test.json'),
       files: ['tests/index.html'],
       env: 'test',
@@ -1302,30 +1302,6 @@ class EmberApp {
 
   /**
     @private
-    @method _configTree
-    @return
-  */
-  _configTree() {
-    if (!this._cachedConfigTree) {
-      let configPath = this.project.configPath();
-      let configTree = new ConfigLoader(path.dirname(configPath), {
-        env: this.env,
-        tests: this.tests,
-        project: this.project,
-      });
-
-      this._cachedConfigTree = new Funnel(configTree, {
-        srcDir: '/',
-        destDir: `${this.name}/config`,
-        annotation: 'Funnel (config)',
-      });
-    }
-
-    return this._cachedConfigTree;
-  }
-
-  /**
-    @private
     @method _processedEmberCLITree
     @return
   */
@@ -1343,7 +1319,7 @@ class EmberApp {
         'tests-prefix.js',
         'tests-suffix.js',
       ];
-      let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._configTree(), {
+      let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._defaultPackager.packageConfig(this.tests), {
         configPath: path.join(this.name, 'config', 'environments', `${this.env}.json`),
         files,
 
@@ -1370,7 +1346,7 @@ class EmberApp {
     if (!this._cachedTestAppConfigTree) {
       let files = ['app-config.js'];
 
-      let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._configTree(), {
+      let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), this._defaultPackager.packageConfig(this.tests), {
         configPath: path.join(this.name, 'config', 'environments', `test.json`),
         files,
 
@@ -1396,7 +1372,7 @@ class EmberApp {
     @return {Tree} Merged tree
   */
   appAndDependencies() {
-    let config = this._configTree();
+    let config = this._defaultPackager.packageConfig(this.tests);
     let templates = this._processedTemplatesTree();
 
     let srcTree = this._processedSrcTree();

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -539,7 +539,7 @@ class EmberApp {
       }
       if (semver.lt(version, '6.0.0') && !roots[babelInstance.root]) {
         roots[babelInstance.root] = true;
-        this.project.ui.writeWarnLine(`DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version ${version} located: ${babelInstance.root}`);
+        this.project.ui.writeDeprecateLine(`ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version ${version} located: ${babelInstance.root}`);
       }
     }
 

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -21,9 +21,10 @@ class GenerateTask extends Task {
     let testBlueprint = this.lookupBlueprint(`${name}-test`, true);
     // lookup custom addon blueprint
     let addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
-    // otherwise, use default addon-import
 
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
+    // otherwise, use default addon-import
+    let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && !this.project.isModuleUnification();
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprintSupportsAddon && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
 

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -9,13 +9,7 @@ class TestServerTask extends TestTask {
   invokeTestem(options) {
     let task = this;
     return new Promise((resolve, reject) => {
-      if (task.testem.setDefaultOptions) {
-        task.testem.setDefaultOptions(task.testemOptions(options));
-      } else {
-        // To make it backward compatibile with older versions of testem (2.0.0 and lower)
-        options = task.testemOptions(options);
-      }
-
+      task.testem.setDefaultOptions(task.testemOptions(options));
       task.testem.startDev(options, (exitCode, error) => {
         if (error) {
           reject(error);

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -8,9 +8,15 @@ const SilentError = require('silent-error');
 class TestServerTask extends TestTask {
   invokeTestem(options) {
     let task = this;
-
     return new Promise((resolve, reject) => {
-      task.testem.startDev(task.testemOptions(options), (exitCode, error) => {
+      if (task.testem.setDefaultOptions) {
+        task.testem.setDefaultOptions(task.testemOptions(options));
+      } else {
+        // To make it backward compatibile with older versions of testem (2.0.0 and lower)
+        options = task.testemOptions(options);
+      }
+
+      task.testem.startDev(options, (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {
@@ -39,7 +45,6 @@ class TestServerTask extends TestTask {
 
       let watcher = options.watcher;
       let started = false;
-
       // Wait for a build and then either start or restart testem
       watcher.on('change', () => {
         try {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -15,7 +15,13 @@ class TestTask extends Task {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      testem.startCI(task.testemOptions(options), (exitCode, error) => {
+      if (testem.setDefaultOptions) {
+        testem.setDefaultOptions(task.testemOptions(options));
+      } else {
+        // To make it backward compatibile with older versions of testem (2.0.0 and lower)
+        options = task.testemOptions(options);
+      }
+      testem.startCI(options, (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -15,12 +15,7 @@ class TestTask extends Task {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      if (testem.setDefaultOptions) {
-        testem.setDefaultOptions(task.testemOptions(options));
-      } else {
-        // To make it backward compatibile with older versions of testem (2.0.0 and lower)
-        options = task.testemOptions(options);
-      }
+      testem.setDefaultOptions(task.testemOptions(options));
       testem.startCI(options, (exitCode, error) => {
         if (error) {
           reject(error);

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "sort-package-json": "^1.4.0",
     "symlink-or-copy": "^1.1.8",
     "temp": "0.8.3",
-    "testem": "^2.0.0",
+    "testem": "^2.2.0",
     "tiny-lr": "^1.0.3",
     "tree-sync": "^1.2.1",
     "uuid": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "fs-extra": "^5.0.0",
     "fs-tree-diff": "^0.5.2",
     "get-caller-file": "^1.0.0",
-    "git-repo-info": "^1.4.1",
+    "git-repo-info": "^2.0.0",
     "glob": "^7.1.2",
     "heimdalljs": "^0.2.3",
     "heimdalljs-fs-monitor": "^0.2.0",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -168,6 +168,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   }));
 
   it('addon trees are not jshinted', co.wrap(function *() {
+    let assertions = 0;
     yield copyFixtureFiles('brocfile-tests/jshint-addon');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -176,8 +177,14 @@ describe('Acceptance: brocfile-smoke-test', function() {
       paths: ['./lib/ember-random-thing'],
     };
     fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--filter=jshint');
+    try {
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--filter=jshint');
+    } catch (e) {
+      let outputMatch = e.output.join(' ').match(/(No tests matched the filter "jshint")/g).length;
+      chai.expect(outputMatch).to.equal(3);
+      assertions++;
+    }
+    chai.expect(assertions).to.equal(1);
   }));
 
   it('specifying custom output paths works properly', co.wrap(function *() {

--- a/tests/unit/broccoli/default-packager/config-test.js
+++ b/tests/unit/broccoli/default-packager/config-test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const co = require('co');
+const expect = require('chai').expect;
+const DefaultPackager = require('../../../../lib/broccoli/default-packager');
+const broccoliTestHelper = require('broccoli-test-helper');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('Default Packager: Config', function() {
+  let input, output;
+  let name = 'the-best-app-ever';
+  let env = 'development';
+
+  let CONFIG = {
+    config: {
+      'environment.js': '',
+    },
+  };
+  let project = {
+    configPath() {
+      return `${input.path()}/config/environment`;
+    },
+
+    config() {
+      return { a: 1 };
+    },
+  };
+
+  before(co.wrap(function *() {
+    input = yield createTempDir();
+
+    input.write(CONFIG);
+  }));
+
+  after(co.wrap(function *() {
+    yield input.dispose();
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield output.dispose();
+  }));
+
+  it('caches packaged config tree', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+    });
+
+    expect(defaultPackager._cachedConfig).to.equal(null);
+
+    output = yield buildOutput(defaultPackager.packageConfig());
+
+    expect(defaultPackager._cachedConfig).to.not.equal(null);
+    expect(defaultPackager._cachedConfig._annotation).to.equal('Packaged Config');
+  }));
+
+  it('packages config files w/ tests disabled', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+    });
+
+    output = yield buildOutput(defaultPackager.packageConfig(false));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles).to.deep.equal({
+      [name]: {
+        config: {
+          environments: {
+            'development.json': '{"a":1}',
+          },
+        },
+      },
+    });
+  }));
+
+  it('packages config files w/ tests enabled', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+    });
+
+    output = yield buildOutput(defaultPackager.packageConfig(true));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles).to.deep.equal({
+      [name]: {
+        config: {
+          environments: {
+            'development.json': '{"a":1}',
+            'test.json': '{"a":1}',
+          },
+        },
+      },
+    });
+  }));
+});

--- a/tests/unit/broccoli/ember-app/import-test.js
+++ b/tests/unit/broccoli/ember-app/import-test.js
@@ -112,6 +112,10 @@ describe('EmberApp.import()', function() {
     let cli = new MockCLI();
     let project = new Project(path, pkg, cli.ui, cli);
 
+    EmberApp.env = function() {
+      return options.env || 'development';
+    };
+
     let app = new EmberApp({
       project,
       _ignoreMissingLoader: true,
@@ -166,9 +170,10 @@ describe('EmberApp.import()', function() {
   }));
 
   it('handles imports with different environments (production)', co.wrap(function *() {
-    let app = createApp();
+    let app = createApp({
+      env: 'production',
+    });
 
-    app.env = 'production';
     app.import({
       development: 'bower_components/moment/moment.js',
       production: 'bower_components/moment/moment.min.js',
@@ -213,9 +218,10 @@ describe('EmberApp.import()', function() {
   }));
 
   it('handles imports from node with different environments (production)', co.wrap(function *() {
-    let app = createApp();
+    let app = createApp({
+      env: 'production',
+    });
 
-    app.env = 'production';
     app.import({
       development: 'node_modules/moment/moment.js',
       production: 'node_modules/moment/moment.min.js',

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -10,42 +10,7 @@ const MockWatcher = require('../../helpers/mock-watcher');
 describe('test server', function() {
   let subject;
 
-  it('transforms the options and invokes testem properly', function(done) {
-    let ui = new MockUI();
-    let watcher = new MockWatcher();
-
-    subject = new TestServerTask({
-      project: new MockProject(),
-      ui,
-      addonMiddlewares() {
-        return ['middleware1', 'middleware2'];
-      },
-      testem: {
-        startDev(options) {
-          expect(options.host).to.equal('greatwebsite.com');
-          expect(options.port).to.equal(123324);
-          expect(options.cwd).to.equal('blerpy-derpy');
-          expect(options.reporter).to.equal('xunit');
-          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
-          expect(options.test_page).to.equal('http://my/test/page');
-          expect(options.config_dir).to.be.an('string');
-          done();
-        },
-      },
-    });
-
-    subject.run({
-      host: 'greatwebsite.com',
-      port: 123324,
-      reporter: 'xunit',
-      outputPath: 'blerpy-derpy',
-      watcher,
-      testPage: 'http://my/test/page',
-    });
-    watcher.emit('change');
-  });
-
-  it('transforms and sets defaultOptions in testem and invokes testem properly', function(done) {
+  it('transforms and sets defaultOptions in testem and invokes testem properly', function() {
     let ui = new MockUI();
     let watcher = new MockWatcher();
 
@@ -71,7 +36,7 @@ describe('test server', function() {
       },
     });
 
-    subject.run({
+    let runResult = subject.run({
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',
@@ -82,7 +47,7 @@ describe('test server', function() {
       expect(value, 'expected exist status of 0').to.eql(0);
     });
     watcher.emit('change');
-    done();
+    return runResult;
   });
 
   describe('completion', function() {
@@ -116,6 +81,9 @@ describe('test server', function() {
     describe('firstRun', function() {
       it('rejects with testem exceptions', function() {
         let error = new Error('OMG');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(1, error);
@@ -132,6 +100,9 @@ describe('test server', function() {
 
       it('rejects with exit status (1)', function() {
         let error = new SilentError('Testem finished with non-zero exit code. Tests failed.');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(1);
@@ -142,11 +113,14 @@ describe('test server', function() {
         });
 
         watcher.emit('change');
-
         return runResult;
       });
 
       it('resolves with exit status (0)', function() {
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
+
         subject.testem.startDev = function(options, finalizer) {
           finalizer(0);
         };
@@ -164,6 +138,9 @@ describe('test server', function() {
     describe('restart', function() {
       it('rejects with testem exceptions', function() {
         let error = new Error('OMG');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(0);

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -45,6 +45,46 @@ describe('test server', function() {
     watcher.emit('change');
   });
 
+  it('transforms and sets defaultOptions in testem and invokes testem properly', function(done) {
+    let ui = new MockUI();
+    let watcher = new MockWatcher();
+
+    subject = new TestServerTask({
+      project: new MockProject(),
+      ui,
+      addonMiddlewares() {
+        return ['middleware1', 'middleware2'];
+      },
+      testem: {
+        setDefaultOptions(options) {
+          this.defaultOptions = options;
+        },
+        startDev(options, finalizer) {
+          this.config.setDefaultOptions(options);
+          finalizer(0);
+        },
+        config: {
+          setDefaultOptions(options) {
+            this.defaultOptions = options;
+          },
+        },
+      },
+    });
+
+    subject.run({
+      host: 'greatwebsite.com',
+      port: 123324,
+      reporter: 'xunit',
+      outputPath: 'blerpy-derpy',
+      watcher,
+      testPage: 'http://my/test/page',
+    }).then(function(value) {
+      expect(value, 'expected exist status of 0').to.eql(0);
+    });
+    watcher.emit('change');
+    done();
+  });
+
   describe('completion', function() {
     let ui, watcher, subject, runOptions;
 

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -50,6 +50,46 @@ describe('test server', function() {
     return runResult;
   });
 
+  it('transforms and sets defaultOptions in testem and invokes testem properly', function(done) {
+    let ui = new MockUI();
+    let watcher = new MockWatcher();
+
+    subject = new TestServerTask({
+      project: new MockProject(),
+      ui,
+      addonMiddlewares() {
+        return ['middleware1', 'middleware2'];
+      },
+      testem: {
+        setDefaultOptions(options) {
+          this.defaultOptions = options;
+        },
+        startDev(options, finalizer) {
+          this.config.setDefaultOptions(options);
+          finalizer(0);
+        },
+        config: {
+          setDefaultOptions(options) {
+            this.defaultOptions = options;
+          },
+        },
+      },
+    });
+
+    subject.run({
+      host: 'greatwebsite.com',
+      port: 123324,
+      reporter: 'xunit',
+      outputPath: 'blerpy-derpy',
+      watcher,
+      testPage: 'http://my/test/page',
+    }).then(function(value) {
+      expect(value, 'expected exist status of 0').to.eql(0);
+    });
+    watcher.emit('change');
+    done();
+  });
+
   describe('completion', function() {
     let ui, watcher, subject, runOptions;
 

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -50,46 +50,6 @@ describe('test server', function() {
     return runResult;
   });
 
-  it('transforms and sets defaultOptions in testem and invokes testem properly', function(done) {
-    let ui = new MockUI();
-    let watcher = new MockWatcher();
-
-    subject = new TestServerTask({
-      project: new MockProject(),
-      ui,
-      addonMiddlewares() {
-        return ['middleware1', 'middleware2'];
-      },
-      testem: {
-        setDefaultOptions(options) {
-          this.defaultOptions = options;
-        },
-        startDev(options, finalizer) {
-          this.config.setDefaultOptions(options);
-          finalizer(0);
-        },
-        config: {
-          setDefaultOptions(options) {
-            this.defaultOptions = options;
-          },
-        },
-      },
-    });
-
-    subject.run({
-      host: 'greatwebsite.com',
-      port: 123324,
-      reporter: 'xunit',
-      outputPath: 'blerpy-derpy',
-      watcher,
-      testPage: 'http://my/test/page',
-    }).then(function(value) {
-      expect(value, 'expected exist status of 0').to.eql(0);
-    });
-    watcher.emit('change');
-    done();
-  });
-
   describe('completion', function() {
     let ui, watcher, subject, runOptions;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,9 +2467,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-repo-info@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-1.4.1.tgz#2a072823254aaf62fcf0766007d7b6651bd41943"
+git-repo-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-2.0.0.tgz#2e7a68ba3d0253e8e885c4138f922e6561de59bb"
 
 github@^9.0.0:
   version "9.3.1"


### PR DESCRIPTION
When ember-cli invokes testem it provides defaultOptions for testem to use as a fallback option. But currently, the fallback option from ember-cli is used as progOptions in testem. And since progOptions has higher priority than fileOptions, the cwd being set in the testem.js file of an ember app is being overridden by ember-cli's fallbackOption.

Solution is to add defaultOptions as a sibling to progOptions and fileOptions in testem. And ember-cli can set defaultOptions invoke testem.

Related work in testem is in the below PR.
https://github.com/testem/testem/pull/1219