### PR TITLE
Don't run `addon-import` blueprint if `project.isModuleUnification()`

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -21,9 +21,10 @@ class GenerateTask extends Task {
     let testBlueprint = this.lookupBlueprint(`${name}-test`, true);
     // lookup custom addon blueprint
     let addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
-    // otherwise, use default addon-import
 
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
+    // otherwise, use default addon-import
+    let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && !this.project.isModuleUnification();
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprintSupportsAddon && options.args[1]) {
       addonBlueprint = this.lookupBlueprint('addon-import', true);
     }
 


### PR DESCRIPTION
Required for https://github.com/emberjs/ember.js/pull/16397#discussion_r177098663. Module unification addons don't have an `/app` path. This PR prevents the default `addon-import` blueprint from running when `project.isModuleUnification() === true`.

TODO:

 * [x] tests (hopefully there are existing tests somewhere)
 * [x] refactor (as the line we're modifying is already too complex)

CI failures look unrelated: https://github.com/ember-cli/ember-cli/issues/7716