### PR TITLE
Added package-info-cache (fast package caching)

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -75,7 +75,7 @@ class CLI {
       initInstrumentation: options.initInstrumentation,
     });
 
-    this._packageInfoCache = new PackageInfoCache();
+    this._packageInfoCache = new PackageInfoCache(this.ui);
 
     logger.info('testing %o', !!this.testing);
   }

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1,17 +1,17 @@
-'use strict';
+"use strict";
 
-const RSVP = require('rsvp');
+const RSVP = require("rsvp");
 
-const lookupCommand = require('./lookup-command');
-const getOptionArgs = require('../utilities/get-option-args');
-const logger = require('heimdalljs-logger')('ember-cli:cli');
-const loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
-const Instrumentation = require('../models/instrumentation');
+const lookupCommand = require("./lookup-command");
+const getOptionArgs = require("../utilities/get-option-args");
+const logger = require("heimdalljs-logger")("ember-cli:cli");
+const loggerTesting = require("heimdalljs-logger")("ember-cli:testing");
+const Instrumentation = require("../models/instrumentation");
 const PackageInfoCache = require("../models/package-info-cache");
-const heimdall = require('heimdalljs');
+const heimdall = require("heimdalljs");
 
 const Promise = RSVP.Promise;
-const onProcessInterrupt = require('../utilities/will-interrupt-process');
+const onProcessInterrupt = require("../utilities/will-interrupt-process");
 
 class CLI {
   /**
@@ -70,14 +70,16 @@ class CLI {
      * @private
      * @property instrumentation
      */
-    this.instrumentation = options.instrumentation || new Instrumentation({
-      ui: options.ui,
-      initInstrumentation: options.initInstrumentation,
-    });
+    this.instrumentation =
+      options.instrumentation ||
+      new Instrumentation({
+        ui: options.ui,
+        initInstrumentation: options.initInstrumentation
+      });
 
     this._packageInfoCache = new PackageInfoCache(this.ui);
 
-    logger.info('testing %o', !!this.testing);
+    logger.info("testing %o", !!this.testing);
   }
 
   /**
@@ -89,149 +91,179 @@ class CLI {
   run(environment) {
     let shutdownOnExit = null;
 
-    return RSVP.hash(environment).then(environment => {
-      let args = environment.cliArgs.slice();
-      let commandName = args.shift();
-      let commandArgs = args;
-      let helpOptions;
+    return RSVP.hash(environment)
+      .then(environment => {
+        let args = environment.cliArgs.slice();
+        let commandName = args.shift();
+        let commandArgs = args;
+        let helpOptions;
 
-      let commandLookupCreationToken = heimdall.start('lookup-command');
+        let commandLookupCreationToken = heimdall.start("lookup-command");
 
-      let CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
-        project: environment.project,
-        ui: this.ui,
-      });
-
-      let command = new CurrentCommand({
-        ui: this.ui,
-        analytics: this.analytics,
-        commands: environment.commands,
-        tasks: environment.tasks,
-        project: environment.project,
-        settings: environment.settings,
-        testing: this.testing,
-        cli: this,
-      });
-
-      commandLookupCreationToken.stop();
-
-      getOptionArgs('--verbose', commandArgs).forEach(arg => {
-        process.env[`EMBER_VERBOSE_${arg.toUpperCase()}`] = 'true';
-      });
-
-      let platformCheckerToken = heimdall.start('platform-checker');
-
-      const PlatformChecker = require('../utilities/platform-checker');
-      let platform = new PlatformChecker(process.version);
-      let recommendation = ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
-                           ' See https://git.io/v7S5n for details.';
-
-      if (!this.testing) {
-        if (platform.isDeprecated) {
-          this.ui.writeDeprecateLine(`Node ${process.version} is no longer supported by Ember CLI.${recommendation}`);
-        }
-
-        if (!platform.isTested) {
-          this.ui.writeWarnLine(`Node ${process.version} is not tested against Ember CLI on your platform.${recommendation}`);
-        }
-      }
-
-      platformCheckerToken.stop();
-
-      logger.info('command: %s', commandName);
-
-      if (!this.testing) {
-        process.chdir(environment.project.root);
-        let skipInstallationCheck = commandArgs.indexOf('--skip-installation-check') !== -1;
-        if (environment.project.isEmberCLIProject() && !skipInstallationCheck) {
-          const InstallationChecker = require('../models/installation-checker');
-          new InstallationChecker({ project: environment.project }).checkInstallations();
-        }
-      }
-
-      let instrumentation = this.instrumentation;
-      let onCommandInterrupt;
-
-      let runPromise = Promise.resolve().then(() => {
-        instrumentation.stopAndReport('init');
-        instrumentation.start('command');
-
-        loggerTesting.info('cli: command.beforeRun');
-        onProcessInterrupt.addHandler(onCommandInterrupt);
-
-        return command.beforeRun(commandArgs);
-      }).then(() => {
-        loggerTesting.info('cli: command.validateAndRun');
-
-        return command.validateAndRun(commandArgs);
-      }).then(result => {
-        instrumentation.stopAndReport('command', commandName, commandArgs);
-
-        onProcessInterrupt.removeHandler(onCommandInterrupt);
-
-        return result;
-      }).finally(() => {
-        instrumentation.start('shutdown');
-        shutdownOnExit = function() {
-          instrumentation.stopAndReport('shutdown');
-        };
-      }).then(result => {
-        // if the help option was passed, call the help command
-        if (result === 'callHelp') {
-          helpOptions = {
-            environment,
-            commandName,
-            commandArgs,
-          };
-
-          return this.callHelp(helpOptions);
-        }
-
-        return result;
-      }).then(exitCode => {
-        loggerTesting.info(`cli: command run complete. exitCode: ${exitCode}`);
-        // TODO: fix this
-        // Possibly this issue: https://github.com/joyent/node/issues/8329
-        // Wait to resolve promise when running on windows.
-        // This ensures that stdout is flushed so acceptance tests get full output
-
-        return new Promise(resolve => {
-          if (process.platform === 'win32') {
-            setTimeout(resolve, 250, exitCode);
-          } else {
-            resolve(exitCode);
+        let CurrentCommand = lookupCommand(
+          environment.commands,
+          commandName,
+          commandArgs,
+          {
+            project: environment.project,
+            ui: this.ui
           }
+        );
+
+        let command = new CurrentCommand({
+          ui: this.ui,
+          analytics: this.analytics,
+          commands: environment.commands,
+          tasks: environment.tasks,
+          project: environment.project,
+          settings: environment.settings,
+          testing: this.testing,
+          cli: this
         });
-      });
 
-      onCommandInterrupt = () =>
-        Promise.resolve(command.onInterrupt())
-          .then(() => runPromise);
+        commandLookupCreationToken.stop();
 
-      return runPromise;
-    }).finally(() => {
-      if (shutdownOnExit) {
-        shutdownOnExit();
-      }
-    }).catch(this.logError.bind(this));
+        getOptionArgs("--verbose", commandArgs).forEach(arg => {
+          process.env[`EMBER_VERBOSE_${arg.toUpperCase()}`] = "true";
+        });
+
+        let platformCheckerToken = heimdall.start("platform-checker");
+
+        const PlatformChecker = require("../utilities/platform-checker");
+        let platform = new PlatformChecker(process.version);
+        let recommendation =
+          ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
+          " See https://git.io/v7S5n for details.";
+
+        if (!this.testing) {
+          if (platform.isDeprecated) {
+            this.ui.writeDeprecateLine(
+              `Node ${
+                process.version
+              } is no longer supported by Ember CLI.${recommendation}`
+            );
+          }
+
+          if (!platform.isTested) {
+            this.ui.writeWarnLine(
+              `Node ${
+                process.version
+              } is not tested against Ember CLI on your platform.${recommendation}`
+            );
+          }
+        }
+
+        platformCheckerToken.stop();
+
+        logger.info("command: %s", commandName);
+
+        if (!this.testing) {
+          process.chdir(environment.project.root);
+          let skipInstallationCheck =
+            commandArgs.indexOf("--skip-installation-check") !== -1;
+          if (
+            environment.project.isEmberCLIProject() &&
+            !skipInstallationCheck
+          ) {
+            const InstallationChecker = require("../models/installation-checker");
+            new InstallationChecker({
+              project: environment.project
+            }).checkInstallations();
+          }
+        }
+
+        let instrumentation = this.instrumentation;
+        let onCommandInterrupt;
+
+        let runPromise = Promise.resolve()
+          .then(() => {
+            instrumentation.stopAndReport("init");
+            instrumentation.start("command");
+
+            loggerTesting.info("cli: command.beforeRun");
+            onProcessInterrupt.addHandler(onCommandInterrupt);
+
+            return command.beforeRun(commandArgs);
+          })
+          .then(() => {
+            loggerTesting.info("cli: command.validateAndRun");
+
+            return command.validateAndRun(commandArgs);
+          })
+          .then(result => {
+            instrumentation.stopAndReport("command", commandName, commandArgs);
+
+            onProcessInterrupt.removeHandler(onCommandInterrupt);
+
+            return result;
+          })
+          .finally(() => {
+            instrumentation.start("shutdown");
+            shutdownOnExit = function() {
+              instrumentation.stopAndReport("shutdown");
+            };
+          })
+          .then(result => {
+            // if the help option was passed, call the help command
+            if (result === "callHelp") {
+              helpOptions = {
+                environment,
+                commandName,
+                commandArgs
+              };
+
+              return this.callHelp(helpOptions);
+            }
+
+            return result;
+          })
+          .then(exitCode => {
+            loggerTesting.info(
+              `cli: command run complete. exitCode: ${exitCode}`
+            );
+            // TODO: fix this
+            // Possibly this issue: https://github.com/joyent/node/issues/8329
+            // Wait to resolve promise when running on windows.
+            // This ensures that stdout is flushed so acceptance tests get full output
+
+            return new Promise(resolve => {
+              if (process.platform === "win32") {
+                setTimeout(resolve, 250, exitCode);
+              } else {
+                resolve(exitCode);
+              }
+            });
+          });
+
+        onCommandInterrupt = () =>
+          Promise.resolve(command.onInterrupt()).then(() => runPromise);
+
+        return runPromise;
+      })
+      .finally(() => {
+        if (shutdownOnExit) {
+          shutdownOnExit();
+        }
+      })
+      .catch(this.logError.bind(this));
   }
 
   /**
-    * @private
-    * @method callHelp
-    * @param options
-    * @return {Promise}
-    */
+   * @private
+   * @method callHelp
+   * @param options
+   * @return {Promise}
+   */
   callHelp(options) {
     let environment = options.environment;
     let commandName = options.commandName;
     let commandArgs = options.commandArgs;
-    let helpIndex = commandArgs.indexOf('--help');
-    let hIndex = commandArgs.indexOf('-h');
+    let helpIndex = commandArgs.indexOf("--help");
+    let hIndex = commandArgs.indexOf("-h");
 
-    let HelpCommand = lookupCommand(environment.commands, 'help', commandArgs, {
+    let HelpCommand = lookupCommand(environment.commands, "help", commandArgs, {
       project: environment.project,
-      ui: this.ui,
+      ui: this.ui
     });
 
     let help = new HelpCommand({
@@ -241,7 +273,7 @@ class CLI {
       tasks: environment.tasks,
       project: environment.project,
       settings: environment.settings,
-      testing: this.testing,
+      testing: this.testing
     });
 
     if (helpIndex > -1) {

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -7,6 +7,7 @@ const getOptionArgs = require('../utilities/get-option-args');
 const logger = require('heimdalljs-logger')('ember-cli:cli');
 const loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
 const Instrumentation = require('../models/instrumentation');
+const PackageInfoCache = require("../models/package-info-cache");
 const heimdall = require('heimdalljs');
 
 const Promise = RSVP.Promise;
@@ -74,6 +75,8 @@ class CLI {
       initInstrumentation: options.initInstrumentation,
     });
 
+    this._packageInfoCache = new PackageInfoCache();
+
     logger.info('testing %o', !!this.testing);
   }
 
@@ -92,7 +95,7 @@ class CLI {
       let commandArgs = args;
       let helpOptions;
 
-      let commandLookupCreationtoken = heimdall.start('lookup-command');
+      let commandLookupCreationToken = heimdall.start('lookup-command');
 
       let CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
         project: environment.project,
@@ -110,7 +113,7 @@ class CLI {
         cli: this,
       });
 
-      commandLookupCreationtoken.stop();
+      commandLookupCreationToken.stop();
 
       getOptionArgs('--verbose', commandArgs).forEach(arg => {
         process.env[`EMBER_VERBOSE_${arg.toUpperCase()}`] = 'true';

--- a/lib/models/addon-info.js
+++ b/lib/models/addon-info.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * @module addon-info
+ *
+ * A simple class to store metadata info about an addon. This used to be created
+ * directly as an object in addon-discovery, but it then become confusing when
+ * 'addon' was used as the name of a parameter in functions that took this object.
+ * This is just for clarity. Later there may be more info added to it.
+ */
+
+class AddonInfo {
+  constructor(name, path, pkg) {
+    this.name = name;
+    this.path = path;
+    this.pkg = pkg;
+  }
+}
+
+module.exports = AddonInfo;

--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -35,14 +35,8 @@ class AddonsFactory {
     logger.info('     addon names are:', Object.keys(addonPackages));
 
     for (let name in addonPackages) {
-      console.log(`### factory.initAddons for '${name}'`);
       addonInfo = addonPackages[name];
       emberAddonConfig = addonInfo.pkg['ember-addon'];
-
-      if (!emberAddonConfig) {
-        //console.log(`  pkg['ember-addon'] undefined!!!`);
-        continue;  // we want to see which one
-      }
 
       graph.add(name, addonInfo, emberAddonConfig.before, emberAddonConfig.after);
     }

--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -35,8 +35,14 @@ class AddonsFactory {
     logger.info('     addon names are:', Object.keys(addonPackages));
 
     for (let name in addonPackages) {
+      console.log(`### factory.initAddons for '${name}'`);
       addonInfo = addonPackages[name];
       emberAddonConfig = addonInfo.pkg['ember-addon'];
+
+      if (!emberAddonConfig) {
+        //console.log(`  pkg['ember-addon'] undefined!!!`);
+        continue;  // we want to see which one
+      }
 
       graph.add(name, addonInfo, emberAddonConfig.before, emberAddonConfig.after);
     }

--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -1,12 +1,12 @@
-'use strict';
+"use strict";
 
 /**
 @module ember-cli
 */
 
-const DAGMap = require('dag-map').default;
-const logger = require('heimdalljs-logger')('ember-cli:addons-factory');
-const heimdall = require('heimdalljs');
+const DAGMap = require("dag-map").default;
+const logger = require("heimdalljs-logger")("ember-cli:addons-factory");
+const heimdall = require("heimdalljs");
 
 /**
   AddonsFactory is responsible for instantiating a collection of addons, in the right order.
@@ -24,21 +24,31 @@ class AddonsFactory {
   initializeAddons(addonPackages) {
     let addonParent = this.addonParent;
     let project = this.project;
-    let addonParentName = typeof addonParent.name === 'function' ? addonParent.name() : addonParent.name;
+    let addonParentName =
+      typeof addonParent.name === "function"
+        ? addonParent.name()
+        : addonParent.name;
 
-    let initializeAddonsToken = heimdall.start(`${addonParentName}: initializeAddons`);
+    let initializeAddonsToken = heimdall.start(
+      `${addonParentName}: initializeAddons`
+    );
     let graph = new DAGMap();
-    const Addon = require('../models/addon');
+    const Addon = require("../models/addon");
     let addonInfo, emberAddonConfig;
 
-    logger.info('initializeAddons for: ', addonParentName);
-    logger.info('     addon names are:', Object.keys(addonPackages));
+    logger.info("initializeAddons for: ", addonParentName);
+    logger.info("     addon names are:", Object.keys(addonPackages));
 
     for (let name in addonPackages) {
       addonInfo = addonPackages[name];
-      emberAddonConfig = addonInfo.pkg['ember-addon'];
+      emberAddonConfig = addonInfo.pkg["ember-addon"];
 
-      graph.add(name, addonInfo, emberAddonConfig.before, emberAddonConfig.after);
+      graph.add(
+        name,
+        addonInfo,
+        emberAddonConfig.before,
+        emberAddonConfig.after
+      );
     }
 
     let addons = [];
@@ -48,7 +58,7 @@ class AddonsFactory {
         let initializeAddonToken = heimdall.start({
           name: `initialize ${addonInfo.name}`,
           addonName: addonInfo.name,
-          addonInitializationNode: true,
+          addonInitializationNode: true
         });
         let start = Date.now();
         let AddonConstructor = Addon.lookup(addonInfo);
@@ -58,8 +68,12 @@ class AddonsFactory {
           addon = new AddonConstructor(addonParent, project);
         } catch (e) {
           project.ui.writeError(e);
-          const SilentError = require('silent-error');
-          throw new SilentError(`An error occurred in the constructor for ${addonInfo.name} at ${addonInfo.path}`);
+          const SilentError = require("silent-error");
+          throw new SilentError(
+            `An error occurred in the constructor for ${addonInfo.name} at ${
+              addonInfo.path
+            }`
+          );
         }
 
         if (addon.initializeAddons) {
@@ -74,13 +88,16 @@ class AddonsFactory {
       }
     });
 
-    logger.info(' addon info %o', addons.map(addon => ({
-      name: addon.name,
-      times: {
-        initialize: addon.constructor._meta_.initializeIn,
-        lookup: addon.constructor._meta_.lookupIn,
-      },
-    })));
+    logger.info(
+      " addon info %o",
+      addons.map(addon => ({
+        name: addon.name,
+        times: {
+          initialize: addon.constructor._meta_.initializeIn,
+          lookup: addon.constructor._meta_.lookupIn
+        }
+      }))
+    );
 
     initializeAddonsToken.stop();
 

--- a/lib/models/package-info-cache.js
+++ b/lib/models/package-info-cache.js
@@ -146,17 +146,18 @@ class PackageInfo {
     this.cache = cache;
     this.errors = new ErrorList();
 
-    // other fields that will be set as needed:
-    //  this.addonConstructor (ctor function or object - addons only)
-    //  this.addonMainPath (when setting up addonConstructor - addons only)
-    //  this.inRepoAddons   (list of PackageInfo - project only)
-    //  this.internalAddons (list of PackageInfo - project only)
-    //  this.cliInfo       (PackageInfo - project only)
-    //  this.dependencyPackages (obj keyed by dependency name: PackageInfo)
-    //     NOTE: these are ALL dependencies, not just addons
-    //  this.devDependencyPackages (obj keyed by devDependency name: PackageInfo)
-    //     NOTE: these are ALL dependencies, not just addons
-    //  this.nodeModules    (NodeModulesList)
+    // other fields that will be set as needed. For JIT we'll define
+    // them here.
+    this.addonConstructor = undefined;      // (ctor function or object - addons only)
+    this.addonMainPath = undefined;         // (when setting up addonConstructor - addons only)
+    this.inRepoAddons  = undefined;         // (list of PackageInfo - project only)
+    this.internalAddons = undefined;        // (list of PackageInfo - project only)
+    this.cliInfo = undefined;               // (PackageInfo - project only)
+    this.dependencyPackages = undefined;    // (obj keyed by dependency name: PackageInfo)
+                                            // NOTE: ALL dependencies, not just addons
+    this.devDependencyPackages = undefined; // (obj keyed by devDependency name: PackageInfo)
+                                            // NOTE: these are ALL dependencies, not just addons
+    this.nodeModules = undefined;           // (NodeModulesList, set only if pkg contains node_modules)
   }
 
   // Make various fields of the pkg object available.
@@ -272,6 +273,9 @@ class PackageInfo {
         return null;
       }
 
+      // Load the addon.
+      // TODO: Future work - allow a time budget for loading each addon and warn
+      // or error for those that take too long.
       let module = require(this.addonMainPath);
       let mainDir = path.dirname(this.addonMainPath);
 
@@ -794,17 +798,3 @@ class PackageInfoCache {
 }
 
 module.exports = PackageInfoCache;
-
-/*
-let t1 = process.hrtime();
-
-var cache = new PackageInfoCache();
-cache.loadProject("/Users/dcombs/dev/voyager-web_trunk");
-cache.loadProject("/Users/dcombs/dev/voyager-web_trunk/core");
-cache.loadProject("/Users/dcombs/dev/voyager-web_trunk/extended");
-
-let timeDiff = process.hrtime(t1);
-console.log(`Overall processing took ${(timeDiff[0] * 1e9 + timeDiff[1]).toLocaleString()} ns`);
-
-cache.showErrors();
-*/

--- a/lib/models/package-info-cache.js
+++ b/lib/models/package-info-cache.js
@@ -2,18 +2,19 @@
  * Performance cache for information about packages (projects/addons/"apps"/modules)
  * under an initial root directory and resolving addon/dependency links to other packages.
  */
-var fs = require("fs-extra");
-var path = require("path");
-var pathParse = path.parse || require("path-parse");
-var Addon = require("./addon.js");
-var Project = require("./project.js");
+"use strict";
+
+const fs = require("fs-extra");
+const path = require("path");
+const pathParse = path.parse || require("path-parse");
+const Addon = require("./addon.js");
 
 /**
  * Resolve the real path for a file, return null if does not
  * exist or is not a file, return the real path otherwise.
  */
-var realFilePathCache = Object.create(null);
-var realDirectoryPathCache = Object.create(null);
+let realFilePathCache = Object.create(null);
+let realDirectoryPathCache = Object.create(null);
 
 /**
  * Resolve the real path for a file, return null if does not

--- a/lib/models/package-info-cache.js
+++ b/lib/models/package-info-cache.js
@@ -1,0 +1,810 @@
+/**
+ * Performance cache for information about packages (projects/addons/"apps"/modules)
+ * under an initial root directory and resolving addon/dependency links to other packages.
+ */
+var fs = require("fs-extra");
+var path = require("path");
+var pathParse = path.parse || require("path-parse");
+var Addon = require("./addon.js");
+var Project = require("./project.js");
+
+/**
+ * Resolve the real path for a file, return null if does not
+ * exist or is not a file, return the real path otherwise.
+ */
+var realFilePathCache = Object.create(null);
+var realDirectoryPathCache = Object.create(null);
+
+/**
+ * Resolve the real path for a file, return null if does not
+ * exist or is not a file or FIFO, return the real path otherwise.
+ *
+ * @private
+ * @method getRealFilePath
+ * @param  {String} file file path
+ * @return {String} real path or null
+ */
+function getRealFilePath(file) {
+  let realPath;
+  
+  try {
+    realPath = realFilePathCache[file];
+
+    if (realPath) {
+      return realPath;
+    }
+
+    let stat = fs.statSync(file);
+    
+    if (stat.isFile() || stat.isFIFO()) {
+      realPath = fs.realpathSync(file);
+    }
+  } catch (e) {
+    if (e !== null && (typeof e === 'object') && (e.code === "ENOENT" || e.code === "ENOTDIR")) {
+      realPath = null;
+    } else {
+      throw e;
+    }
+  }
+  
+  realFilePathCache[file] = realPath;
+  return realPath;
+}
+
+/**
+ * Resolve the real path for a directory, return null if does not
+ * exist or is not a directory, return the real path otherwise.
+ *
+ * @private
+ * @method getRealDirectoryPath
+ * @param  {String} file file path
+ * @return {String} real path or null
+ */
+function getRealDirectoryPath(dir) {
+  let realPath;
+  
+  try {
+    realPath = realDirectoryPathCache[dir];
+
+    if (realPath) {
+      return realPath;
+    }
+
+    let stat = fs.statSync(dir);
+
+    if (stat.isDirectory()) {
+      realPath = fs.realpathSync(dir);
+    }
+  } catch (e) {
+    if (e !== null && (typeof e === 'object') && (e.code === "ENOENT" || e.code === "ENOTDIR")) {
+      realPath = null;
+    } else {
+      throw e;
+    }
+  }
+
+  realDirectoryPathCache[dir] = realPath;
+  return realPath;
+}
+
+/**
+ * Small utility class to store a single error during processing.
+ */
+class ErrorEntry {
+  constructor(type, data) {
+    this.type = type;
+    this.data = data;
+  }
+}
+
+/**
+ * Small utility class to store a list of errors during processing.
+ * Instances of this exist in the PackageInfo and PackageInfoCache
+ * objects.
+ */
+class ErrorList {
+  constructor() {
+    this.errors = [];
+  }
+
+  /**
+   * Add an error. The error obj is optional, and can be anything.
+   * We do this so we don't really need to create a series of error
+   * classes.
+   */
+  addError(errorType, errorData) {
+    this.errors.push(new ErrorEntry(errorType, errorData));
+  }
+
+  insertError(errorEntry) {
+    this.errors.push(errorEntry);
+  }
+
+  getErrors() {
+    return this.errors;
+  }
+
+  hasErrors() {
+    return (this.errors.length > 0);
+  }
+}
+
+const PACKAGE_JSON = "package.json";
+
+const ERROR_PACKAGE_DIR_MISSING = "packageDirectoryMissing";
+const ERROR_PACKAGE_JSON_MISSING = "packageJsonMissing";
+const ERROR_PACKAGE_JSON_PARSE = "packageJsonParse";
+const ERROR_EMBER_ADDON_MAIN_MISSING = "emberAddonMainMissing";
+const ERROR_DEPENDENCIES_MISSING = "dependenciesMissing";
+const ERROR_NODEMODULES_ENTRY_MISSING = "modulesEntryMissing";
+
+class PackageInfo {
+  constructor(pkgObj, realPath, cache) {
+    this.pkg = pkgObj;
+    this.pkg['ember-addon'] = this.pkg['ember-addon'] || {};
+    this.realPath = realPath;
+    this.cache = cache;
+    this.errors = new ErrorList();
+
+    // other fields that will be set as needed:
+    //  this.addonConstructor (ctor function or object - addons only)
+    //  this.addonMainPath (when setting up addonConstructor - addons only)
+    //  this.inRepoAddons   (list of PackageInfo - project only)
+    //  this.internalAddons (list of PackageInfo - project only)
+    //  this.cliInfo       (PackageInfo - project only)
+    //  this.dependencyPackages (obj keyed by dependency name: PackageInfo)
+    //     NOTE: these are ALL dependencies, not just addons
+    //  this.devDependencyPackages (obj keyed by devDependency name: PackageInfo)
+    //     NOTE: these are ALL dependencies, not just addons
+    //  this.nodeModules    (NodeModulesList)
+  }
+
+  // Make various fields of the pkg object available.
+  get name() {
+    return this.pkg.name;
+  }
+
+  _addError(errorType, errorData) {
+    this.errors.addError(errorType, errorData);
+  }
+
+  _insertError(errorEntry) {
+    this.errors.insertError(errorEntry);
+  }
+
+  _hasErrors() {
+    return this.errors.hasErrors();
+  }
+
+  /**
+   * Add a reference to an in-repo addon PackageInfo object.
+   */
+  _addInRepoAddon(inRepoAddonPkg) {
+    if (!this.inRepoAddons) {
+      this.inRepoAddons = [];
+    }
+    this.inRepoAddons.push(inRepoAddonPkg);
+  }
+
+  /**
+   * Add a reference to an internal addon PackageInfo object.
+   * "internal" addons (note: not in-repo addons) only exist in 
+   * Projects, not other packages. Since the cache is loaded from
+   * 'loadProject', this can be done appropriately.
+   */
+  _addInternalAddon(internalAddonPkg) {
+    if (!this.internalAddons) {
+      this.internalAddons = [];
+    }
+    this.internalAddons.push(internalAddonPkg);
+  }
+
+  /**
+   * For each dependency in the given list, find the corresponding 
+   * PackageInfo object in the cache (going up the file tree if 
+   * necessary, as in the node resolution algorithm). Return a map
+   * of the dependencyName to PackageInfo object. Caller can then
+   * store it wherever they like.
+   *
+   * Note: this is not to be  called until all packages that can be have 
+   * been added to the cache. 
+   * 
+   * Note: this is for ALL dependencies, not just addons. To get just
+   * addons, filter the result by calling pkgInfo.isAddon().
+   */
+  _addDependencies(dependencies) {
+    if (!dependencies) {
+      return null;
+    }
+
+    let dependencyNames = Object.keys(dependencies);
+
+    if (dependencyNames.length === 0) {
+      return null;
+    }
+
+    let packages = Object.create(null);
+
+    let missingDependencies = [];
+    
+    dependencyNames.forEach(dependencyName => {
+      let dependencyPackage;
+
+      // much of the time the package will have dependencies in
+      // a node_modules inside it, so check there first because it's
+      // quicker since we have the reference. Only check externally
+      // if we don't find it there.
+      if (this.nodeModules) {
+        dependencyPackage = this.nodeModules._findPackage(dependencyName);
+      }
+
+      if (!dependencyPackage) {
+        dependencyPackage = this.cache._findPackage(
+          dependencyName,
+          path.dirname(this.realPath)  
+        );
+      }
+
+      if (dependencyPackage) {
+        packages[dependencyName] = dependencyPackage;
+      } else {
+        missingDependencies.push(dependencyName);
+      }
+    });
+
+    if (missingDependencies.length > 0) {
+      this._addError(ERROR_DEPENDENCIES_MISSING, missingDependencies);
+    }
+
+    return packages;
+  }
+
+  isAddon() {
+    let val =
+        Array.isArray(this.pkg.keywords) && (this.pkg.keywords.indexOf("ember-addon") >= 0);
+    return val;
+  }
+
+  // XXX Should this move to Addon.js (and change appropriately to use the cache here?)
+  getAddonConstructor() {
+    if (this.isAddon() && !this.addonConstructor) {
+      if (!this.addonMainPath) {
+        return null;
+      }
+
+      let module = require(this.addonMainPath);
+      let mainDir = path.dirname(this.addonMainPath);
+
+      let ctor;
+
+      if (typeof module === "function") {
+        ctor = module;
+        ctor.prototype.root = ctor.prototype.root || mainDir;
+        ctor.prototype.pkg = ctor.prototype.pkg || this.pkg;
+      } else {
+        ctor = Addon.extend(
+          Object.assign({ root: mainDir, pkg: this.pkg }, module)
+        );
+      }
+
+      ctor._meta_ = {
+        modulePath: this.addonMainPath,
+        //        lookupDuration,
+        initializeIn: 0
+      };
+
+      this.addonConstructor = ctor;
+    }
+
+    return this.addonConstructor;
+  }
+}
+
+class NodeModulesList {
+  constructor(realPath, cache) {
+    this.realPath = realPath;
+    this.cache = cache;
+    this.entries = Object.create(null);
+    this.errors = new ErrorList();
+  }
+
+  _addError(errorType, errorData) {
+    this.errors.addError(errorType, errorData);
+  }
+
+  _insertError(errorEntry) {
+    this.errors.insertError(errorEntry);
+  }
+
+  _hasErrors() {
+    return this.errors.hasErrors();
+  }
+
+  _addEntry(entryName, entryVal) {
+    this.entries[entryName] = entryVal;
+  }
+
+  /**
+   * Given a package name (which may include a scope on the front),
+   * return the PackageInfo that corresponds to the name. 
+   *
+   * Returns null if the package is not found.
+   */
+  _findPackage(packageName) {
+    let val;
+
+    if (packageName.startsWith("@")) {
+      let parts = packageName.split("/");
+      let entry = this.entries[parts[0]]; // scope
+      val =
+        entry instanceof NodeModulesList
+        ? entry._findPackage(parts[1]) // the real name
+        : null;
+    } else {
+      val = this.entries[packageName];
+    }
+
+    return val;
+  }
+}
+
+/**
+ * Class that stores entries that are either PackageInfo or NodeModulesList objects.
+ * The entries are stored in a map keyed by real directory path.
+ */
+class PackageInfoCache {
+  constructor() {
+    this.entries = Object.create(null);
+    this.errors = new ErrorList();
+  }
+
+  _insertError(errorEntry) {
+    this.errors.insertError(errorEntry);
+  }
+
+  /**
+   * Private method to ask just if our PIC-level errors object has errors.
+   */
+  _hasErrors() {
+    return this.errors.hasErrors();
+  }
+
+  /**
+   * Callable externally, does the cache have any objects with errors?
+   */
+  hasErrors() {
+    if (this._hasErrors) {
+      return true;
+    }
+
+    let paths = Object.keys(this.entries);
+
+    if (paths.find(entryPath => this.getEntry(entryPath)._hasErrors())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Gather all the errors in the PIC and any cached objects, then dump them
+   * out to the console.
+   */
+  showErrors() {
+    this._showObjErrors(this);
+
+    let paths = Object.keys(this.entries).sort();
+
+    paths.forEach(entryPath => {
+      this._showObjErrors(this.getEntry(entryPath));
+    });
+  }
+
+  _showObjErrors(obj) {
+    if (!obj._hasErrors()) {
+      return;
+    }
+
+    console.log("");
+    let rootPath;
+    
+    if (obj instanceof PackageInfoCache) {
+      console.warn("Top level errors:");
+      rootPath = this.realPath;
+    } else {
+      console.warn(obj.realPath + ":");
+      rootPath = obj.realPath;
+    }
+
+    let errorList = obj.errors;
+
+    errorList.getErrors().forEach(errorEntry => {
+      switch(errorEntry.type) {
+      case ERROR_PACKAGE_DIR_MISSING:
+        console.warn(`   Missing package directory at relative path '${path.relative(rootPath, errorEntry.data)}'`);
+        break;
+      case ERROR_PACKAGE_JSON_MISSING:
+        console.warn(`   Missing package.json file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
+        break;
+      case ERROR_PACKAGE_JSON_PARSE:
+        console.warn(`   Error parsing package.json file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
+        break;
+      case ERROR_EMBER_ADDON_MAIN_MISSING:
+        console.warn(`   Missing ember-addon 'main' file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
+        break;
+      case ERROR_DEPENDENCIES_MISSING:
+        let missingDependencies = errorEntry.data;
+        if (missingDependencies.length === 1) {
+          console.warn(`   Missing dependency '${missingDependencies[0]}'`);
+        } else {
+          console.warn(`   Missing dependencies:`);
+          missingDependencies.forEach(dependencyName => {
+            console.warn(`      ${dependencyName}`);
+          });
+        }
+        break;
+      case ERROR_NODEMODULES_ENTRY_MISSING:
+        console.warn(`   Missing node_modules entry '[${errorEntry.data}'`);
+        break;
+      }
+    });
+  }
+
+  /**
+   * Do the actual processing of the root directory of a project, given a 
+   * Project object (we need the object in order to find the internal addons).
+   * Read the root package and the tree below it, then go back through the tree to
+   * construct references between the various items (e.g., locate the actual
+   * cache entries for particular addons, resolve the constructor function
+   * for each package, etc.
+   */
+  loadProject(projectObj) {
+
+    let val = this._readPackage(projectObj.root, projectObj);
+
+    if (val instanceof PackageInfo) {
+      // Resolve the node_module dependencies across all packages after they have
+      // been loaded into the cache, because we don't know when a particular package
+      // will enter the cache.
+      let packageInfos = this._getPackageInfos();
+      packageInfos.forEach(packageInfo => {
+        // Since loadProject can be called multiple times for different projects,
+        // we don't want to reprocess any packages that happen to be common
+        // between them. We'll handle this by marking any packageInfo once it
+        // has been processed here, then ignore it in any later processing.
+        if (!packageInfo.processed) {
+          let pkgs = packageInfo._addDependencies(packageInfo.pkg.dependencies);
+          if (pkgs) {
+            packageInfo.dependencyPackages = pkgs;
+          }
+
+          // for Projects only, we also add the devDependencies
+          if (packageInfo === val) {
+            pkgs = packageInfo._addDependencies(packageInfo.pkg.devDependencies);
+            if (pkgs) {
+              packageInfo.devDependencyPackages = pkgs;
+            }
+          }
+          packageInfo.processed = true;
+        }
+      });
+    } else {
+      this._insertError(val);
+    }
+
+    return val;
+  }
+
+  _addEntry(path, entry) {
+    this.entries[path] = entry;
+  }
+
+  getEntry(path) {
+    return this.entries[path];
+  }
+
+  contains(path) {
+    return this.entries[path] !== undefined;
+  }
+
+  _getPackageInfos() {
+    let result = Object.values(this.entries).filter(entry => entry instanceof PackageInfo);
+    return result;
+  }
+
+  // Find a PackageInfo cache entry with the given path. If there is
+  // no entry in the startPath, do as done in resolve.sync() - travel up
+  // the directory hierarchy, attaching 'node_modules' to each directory and
+  // seeing if the directory exists and has the relevant entry.
+  //
+  // We'll do things a little differently, though, for speed.
+  //
+  // If there is no cache entry, we'll try to use _readNodeModulesList to create
+  // a new cache entry and its contents. If the directory does not exist,
+  // We'll create a NodeModulesList cache entry anyway, just so we don't have
+  // to check with the file system more than once for that directory (we
+  // waste a bit of space, but gain speed by not hitting the file system
+  // again for that path).
+  // Once we have a NodeModulesList, check for the package name, and continue
+  // up the path until we hit the root or the PackageInfo is found.
+  _findPackage(packageName, startPath) {
+    let parsedPath = pathParse(startPath);
+    let root = parsedPath.root;
+
+    let currPath = startPath;
+
+    while (currPath !== root) {
+      let endsWithNodeModules = (path.basename(currPath) === "node_modules");
+
+      let nodeModulesPath = (endsWithNodeModules ? currPath : currPath + path.sep + "node_modules");
+
+      let nodeModulesList = this._readNodeModulesList(nodeModulesPath);
+
+      // _readNodeModulesList only returns a NodeModulesList or null
+      if (nodeModulesList) {
+        let pkg = nodeModulesList._findPackage(packageName);
+        if (pkg) {
+          return pkg;
+        }
+      }
+
+      currPath = path.dirname(currPath);
+    }
+
+    return null;
+  }
+
+
+  /**
+   * Given a directory that supposedly contains a package, if there is a
+   * readable package.json create a PackageInfo object and try to fill it out.
+   * Assuming there are no "fatal" errors (like a missing package.json), 
+   * return the PackageInfo object, after installing it as an entry in 
+   * our entries cache, keyed on real path.
+   *
+   * If there is no package.json or it's bad or the package is an addon with
+   * no main, the only thing we can do is return an ErrorEntry to the caller.
+   * Once past all those problems, if any error occurs with any of the contents
+   * of the package, they'll be cached in the PackageInfo itself.
+   *
+   * In summary, only PackageInfo or ErrorEntry will be returned.
+   *
+   * Projects are somewhat different than other package types in that they
+   * also may have 'internal' (as opposed to 'in repo') addons. Unfortunately,
+   * there is nothing in the package.json to identify a Project. To handle
+   * that, if the 'project' parameter is set, that's indicating this package 
+   * is for a project so we should process those internal addons as well.
+   */
+  _readPackage(pkgDir, project) {
+
+    let realPath = getRealDirectoryPath(pkgDir);
+    if (!realPath) {
+      return new ErrorEntry(ERROR_PACKAGE_DIR_MISSING, pkgDir);
+    }
+
+    let pkgInfo = this.getEntry(realPath);
+    if (pkgInfo) {
+      return pkgInfo;
+    }
+
+    let packageJsonPath = path.join(realPath, PACKAGE_JSON);
+    let pkgfile = getRealFilePath(packageJsonPath);
+    if (!pkgfile) {
+      return new ErrorEntry(ERROR_PACKAGE_JSON_MISSING, packageJsonPath);
+    }
+
+    let pkg;
+
+    try {
+      pkg = fs.readJsonSync(pkgfile);
+    } catch (e) {
+      return new ErrorEntry(ERROR_PACKAGE_JSON_PARSE, pkgfile);
+    }
+
+    // If we have an ember-addon, check that the main exists and points
+    // to a valid file.
+    let ctor;
+
+    if (Array.isArray(pkg.keywords) && (pkg.keywords.indexOf("ember-addon") >= 0)) {
+      let main = pkg.main;
+
+      if (!main || main === "." || main === "./") {
+        main = "index.js";
+        pkg.main = main;
+      } else if (!path.extname(main)) {
+        main = main + ".js";
+        pkg.main = main;
+      }
+
+      let mainPath = path.join(realPath, main);
+      let mainRealPath = getRealFilePath(mainPath);
+
+      if (mainRealPath) {
+        pkgInfo = new PackageInfo(pkg, realPath, this);
+        pkgInfo.addonMainPath = mainRealPath;
+      } else {
+        return new ErrorEntry(ERROR_EMBER_ADDON_MAIN_MISSING, mainPath);
+      }
+    } else {
+      pkgInfo = new PackageInfo(pkg, realPath, this);
+    }
+
+    // If we get to here without errors, we're basically 'okay' as far as
+    // adding the PackageInfo for the package to the cache. Later errors
+    // go in the PackageInfo.
+    this._addEntry(realPath, pkgInfo);
+
+    // Steps:
+
+    // Process the project here, rather than internally, so it doesn't
+    // have to know too much about how the cache works.
+    if (project) {
+      pkgInfo.project = project; 
+
+      let val;
+
+      if (project.cli) {
+        val = this._readPackage(project.cli.root);
+
+        if (val instanceof PackageInfo) {
+          pkgInfo.cliInfo = val;
+        } else {
+          // CLI package was not able to be created.
+          pkgInfo._insertError(val);
+        }
+      }
+
+      // add any internal addons in the project. Since internal addons are
+      // optional, we don't want to just call _readPackage without checking,
+      // since that would return an error if they aren't present.
+      project.supportedInternalAddonPaths().forEach(internalAddonPath => {
+        if (getRealDirectoryPath(internalAddonPath)) {
+          val = this._readPackage(internalAddonPath);
+          
+          if (val instanceof PackageInfo) {
+            pkgInfo._addInternalAddon(val);
+          } else {
+            // internal addon package was not able to be created.
+            pkgInfo._insertError(val);
+          } 
+        }
+      })
+    }
+
+    let emberAddonInfo = pkg["ember-addon"];
+
+    // Set up packageInfos for any in-repo addons
+    if (emberAddonInfo) {
+      let paths = emberAddonInfo.paths;
+
+      if (paths) {
+        paths.forEach(p => {
+          let addonPath = path.join(realPath, p); // real path, though may not exist
+          let val = this._readPackage(addonPath);  
+          if (val instanceof PackageInfo) {
+            pkgInfo._addInRepoAddon(val);
+          } else {
+            // package was not able to be created.
+            pkgInfo._insertError(val);
+          }
+        });
+      }
+    }
+
+    // read addon modules from node_modules. We read the whole directory
+    // because it's assumed that npm/yarn may have placed addons in the
+    // directory from lower down in the project tree, and we want to get
+    // the data into the cache ASAP. It may not necessarily be a 'real' error
+    // if we find an issue, if nobody below is actually invoking the addon.
+    let nodeModules = this._readNodeModulesList(
+      path.join(realPath, "node_modules")
+    );
+
+    if (nodeModules) {
+      pkgInfo.nodeModules = nodeModules;
+    }
+
+    return pkgInfo;
+  }
+
+  /**
+   * Process a directory of modules in a given package directory.
+   *
+   * We will allow cache entries for node_modules that actually
+   * have no contents, just so we don't have to hit the file system more
+   * often than necessary--it's much quicker to check an in-memory object.
+   * object.
+   *
+   * Note: only a NodeModulesList or null is returned.
+   */
+  _readNodeModulesList(nodeModulesDir) {
+    let realPath = getRealDirectoryPath(nodeModulesDir);
+
+    if (!realPath) {
+      // NOTE: because we call this when searching for objects in node_modules
+      // directories that may not exist, we'll just return null here.
+      // If it actually is an error in some case, the caller can create the
+      // error there.
+      return null;
+    }
+
+    let nodeModulesList = this.getEntry(realPath);
+    if (nodeModulesList) {
+      return nodeModulesList;
+    }
+
+    // At this point we know the directory node_modules exists and we can
+    // process it. Further errors will be recorded here, or in the objects
+    // that correspond to the node_modules entries.
+    nodeModulesList = new NodeModulesList(realPath, this);
+
+    let entries = fs.readdirSync(realPath); // should not fail because getRealDirectoryPath passed
+
+    entries.forEach(entryName => {
+      // entries should be either a package or a scoping directory. I think
+      // there can also be files, but we'll ignore those.
+
+      if (entryName.startsWith(".") || entryName.startsWith("_")) {
+        // we explicitly want to ignore these, according to the
+        // definition of a valid package name.
+        return;
+      }
+
+      let entryPath = path.join(realPath, entryName);
+
+      if (getRealFilePath(entryPath)) {
+        // we explicitly want to ignore valid regular files in node_modules.
+        // This is a bit slower than just checking for directories, but we need to be sure.
+        return;
+      }
+
+      // At this point we have an entry name that should correspond to
+      // a directory, which should turn into either a NodeModulesList or
+      // PackageInfo. If not, it's an error on this NodeModulesList.
+      let entryVal;
+
+      if (entryName.startsWith("@")) {
+        // we should have a scoping directory.
+        entryVal = this._readNodeModulesList(entryPath);
+
+        // readModulesDir only returns NodeModulesList or null
+        if (entryVal instanceof NodeModulesList) {
+          nodeModulesList._addEntry(entryName, entryVal);
+        } else {
+          // This (null return) really should not occur, unless somehow the 
+          // dir disappears between the time of fs.readdirSync and now.
+          nodeModulesList._addError(ERROR_NODEMODULES_ENTRY_MISSING, entryName);
+        }
+      } else {
+        // we should have a package.
+        entryVal = this._readPackage(entryPath);
+
+        if (entryVal instanceof PackageInfo) {
+          nodeModulesList._addEntry(entryName, entryVal);
+        } else {
+          nodeModulesList._insertError(entryVal);
+        }
+      }
+    });
+
+    this._addEntry(realPath, nodeModulesList);
+
+    return nodeModulesList;
+  }
+}
+
+module.exports = PackageInfoCache;
+
+/*
+let t1 = process.hrtime();
+
+var cache = new PackageInfoCache();
+cache.loadProject("/Users/dcombs/dev/voyager-web_trunk");
+cache.loadProject("/Users/dcombs/dev/voyager-web_trunk/core");
+cache.loadProject("/Users/dcombs/dev/voyager-web_trunk/extended");
+
+let timeDiff = process.hrtime(t1);
+console.log(`Overall processing took ${(timeDiff[0] * 1e9 + timeDiff[1]).toLocaleString()} ns`);
+
+cache.showErrors();
+*/

--- a/lib/models/package-info-cache.js
+++ b/lib/models/package-info-cache.js
@@ -26,7 +26,7 @@ var realDirectoryPathCache = Object.create(null);
  */
 function getRealFilePath(file) {
   let realPath;
-  
+
   try {
     realPath = realFilePathCache[file];
 
@@ -35,18 +35,22 @@ function getRealFilePath(file) {
     }
 
     let stat = fs.statSync(file);
-    
+
     if (stat.isFile() || stat.isFIFO()) {
       realPath = fs.realpathSync(file);
     }
   } catch (e) {
-    if (e !== null && (typeof e === 'object') && (e.code === "ENOENT" || e.code === "ENOTDIR")) {
+    if (
+      e !== null &&
+      typeof e === "object" &&
+      (e.code === "ENOENT" || e.code === "ENOTDIR")
+    ) {
       realPath = null;
     } else {
       throw e;
     }
   }
-  
+
   realFilePathCache[file] = realPath;
   return realPath;
 }
@@ -62,7 +66,7 @@ function getRealFilePath(file) {
  */
 function getRealDirectoryPath(dir) {
   let realPath;
-  
+
   try {
     realPath = realDirectoryPathCache[dir];
 
@@ -76,7 +80,11 @@ function getRealDirectoryPath(dir) {
       realPath = fs.realpathSync(dir);
     }
   } catch (e) {
-    if (e !== null && (typeof e === 'object') && (e.code === "ENOENT" || e.code === "ENOTDIR")) {
+    if (
+      e !== null &&
+      typeof e === "object" &&
+      (e.code === "ENOENT" || e.code === "ENOTDIR")
+    ) {
       realPath = null;
     } else {
       throw e;
@@ -125,7 +133,7 @@ class ErrorList {
   }
 
   hasErrors() {
-    return (this.errors.length > 0);
+    return this.errors.length > 0;
   }
 }
 
@@ -141,23 +149,23 @@ const ERROR_NODEMODULES_ENTRY_MISSING = "modulesEntryMissing";
 class PackageInfo {
   constructor(pkgObj, realPath, cache) {
     this.pkg = pkgObj;
-    this.pkg['ember-addon'] = this.pkg['ember-addon'] || {};
+    this.pkg["ember-addon"] = this.pkg["ember-addon"] || {};
     this.realPath = realPath;
     this.cache = cache;
     this.errors = new ErrorList();
 
     // other fields that will be set as needed. For JIT we'll define
     // them here.
-    this.addonConstructor = undefined;      // (ctor function or object - addons only)
-    this.addonMainPath = undefined;         // (when setting up addonConstructor - addons only)
-    this.inRepoAddons  = undefined;         // (list of PackageInfo - project only)
-    this.internalAddons = undefined;        // (list of PackageInfo - project only)
-    this.cliInfo = undefined;               // (PackageInfo - project only)
-    this.dependencyPackages = undefined;    // (obj keyed by dependency name: PackageInfo)
-                                            // NOTE: ALL dependencies, not just addons
+    this.addonConstructor = undefined; // (ctor function or object - addons only)
+    this.addonMainPath = undefined; // (when setting up addonConstructor - addons only)
+    this.inRepoAddons = undefined; // (list of PackageInfo - project only)
+    this.internalAddons = undefined; // (list of PackageInfo - project only)
+    this.cliInfo = undefined; // (PackageInfo - project only)
+    this.dependencyPackages = undefined; // (obj keyed by dependency name: PackageInfo)
+    // NOTE: ALL dependencies, not just addons
     this.devDependencyPackages = undefined; // (obj keyed by devDependency name: PackageInfo)
-                                            // NOTE: these are ALL dependencies, not just addons
-    this.nodeModules = undefined;           // (NodeModulesList, set only if pkg contains node_modules)
+    // NOTE: these are ALL dependencies, not just addons
+    this.nodeModules = undefined; // (NodeModulesList, set only if pkg contains node_modules)
   }
 
   // Make various fields of the pkg object available.
@@ -189,7 +197,7 @@ class PackageInfo {
 
   /**
    * Add a reference to an internal addon PackageInfo object.
-   * "internal" addons (note: not in-repo addons) only exist in 
+   * "internal" addons (note: not in-repo addons) only exist in
    * Projects, not other packages. Since the cache is loaded from
    * 'loadProject', this can be done appropriately.
    */
@@ -201,15 +209,15 @@ class PackageInfo {
   }
 
   /**
-   * For each dependency in the given list, find the corresponding 
-   * PackageInfo object in the cache (going up the file tree if 
+   * For each dependency in the given list, find the corresponding
+   * PackageInfo object in the cache (going up the file tree if
    * necessary, as in the node resolution algorithm). Return a map
    * of the dependencyName to PackageInfo object. Caller can then
    * store it wherever they like.
    *
-   * Note: this is not to be  called until all packages that can be have 
-   * been added to the cache. 
-   * 
+   * Note: this is not to be  called until all packages that can be have
+   * been added to the cache.
+   *
    * Note: this is for ALL dependencies, not just addons. To get just
    * addons, filter the result by calling pkgInfo.isAddon().
    */
@@ -227,7 +235,7 @@ class PackageInfo {
     let packages = Object.create(null);
 
     let missingDependencies = [];
-    
+
     dependencyNames.forEach(dependencyName => {
       let dependencyPackage;
 
@@ -242,7 +250,7 @@ class PackageInfo {
       if (!dependencyPackage) {
         dependencyPackage = this.cache._findPackage(
           dependencyName,
-          path.dirname(this.realPath)  
+          path.dirname(this.realPath)
         );
       }
 
@@ -262,7 +270,8 @@ class PackageInfo {
 
   isAddon() {
     let val =
-        Array.isArray(this.pkg.keywords) && (this.pkg.keywords.indexOf("ember-addon") >= 0);
+      Array.isArray(this.pkg.keywords) &&
+      this.pkg.keywords.indexOf("ember-addon") >= 0;
     return val;
   }
 
@@ -330,7 +339,7 @@ class NodeModulesList {
 
   /**
    * Given a package name (which may include a scope on the front),
-   * return the PackageInfo that corresponds to the name. 
+   * return the PackageInfo that corresponds to the name.
    *
    * Returns null if the package is not found.
    */
@@ -342,8 +351,8 @@ class NodeModulesList {
       let entry = this.entries[parts[0]]; // scope
       val =
         entry instanceof NodeModulesList
-        ? entry._findPackage(parts[1]) // the real name
-        : null;
+          ? entry._findPackage(parts[1]) // the real name
+          : null;
     } else {
       val = this.entries[packageName];
     }
@@ -411,7 +420,7 @@ class PackageInfoCache {
 
     console.log("");
     let rootPath;
-    
+
     if (obj instanceof PackageInfoCache) {
       console.warn("Top level errors:");
       rootPath = this.realPath;
@@ -423,39 +432,59 @@ class PackageInfoCache {
     let errorList = obj.errors;
 
     errorList.getErrors().forEach(errorEntry => {
-      switch(errorEntry.type) {
-      case ERROR_PACKAGE_DIR_MISSING:
-        console.warn(`   Missing package directory at relative path '${path.relative(rootPath, errorEntry.data)}'`);
-        break;
-      case ERROR_PACKAGE_JSON_MISSING:
-        console.warn(`   Missing package.json file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
-        break;
-      case ERROR_PACKAGE_JSON_PARSE:
-        console.warn(`   Error parsing package.json file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
-        break;
-      case ERROR_EMBER_ADDON_MAIN_MISSING:
-        console.warn(`   Missing ember-addon 'main' file at relative path '${path.relative(rootPath, errorEntry.data)}'`);
-        break;
-      case ERROR_DEPENDENCIES_MISSING:
-        let missingDependencies = errorEntry.data;
-        if (missingDependencies.length === 1) {
-          console.warn(`   Missing dependency '${missingDependencies[0]}'`);
-        } else {
-          console.warn(`   Missing dependencies:`);
-          missingDependencies.forEach(dependencyName => {
-            console.warn(`      ${dependencyName}`);
-          });
-        }
-        break;
-      case ERROR_NODEMODULES_ENTRY_MISSING:
-        console.warn(`   Missing node_modules entry '[${errorEntry.data}'`);
-        break;
+      switch (errorEntry.type) {
+        case ERROR_PACKAGE_DIR_MISSING:
+          console.warn(
+            `   Missing package directory at relative path '${path.relative(
+              rootPath,
+              errorEntry.data
+            )}'`
+          );
+          break;
+        case ERROR_PACKAGE_JSON_MISSING:
+          console.warn(
+            `   Missing package.json file at relative path '${path.relative(
+              rootPath,
+              errorEntry.data
+            )}'`
+          );
+          break;
+        case ERROR_PACKAGE_JSON_PARSE:
+          console.warn(
+            `   Error parsing package.json file at relative path '${path.relative(
+              rootPath,
+              errorEntry.data
+            )}'`
+          );
+          break;
+        case ERROR_EMBER_ADDON_MAIN_MISSING:
+          console.warn(
+            `   Missing ember-addon 'main' file at relative path '${path.relative(
+              rootPath,
+              errorEntry.data
+            )}'`
+          );
+          break;
+        case ERROR_DEPENDENCIES_MISSING:
+          let missingDependencies = errorEntry.data;
+          if (missingDependencies.length === 1) {
+            console.warn(`   Missing dependency '${missingDependencies[0]}'`);
+          } else {
+            console.warn(`   Missing dependencies:`);
+            missingDependencies.forEach(dependencyName => {
+              console.warn(`      ${dependencyName}`);
+            });
+          }
+          break;
+        case ERROR_NODEMODULES_ENTRY_MISSING:
+          console.warn(`   Missing node_modules entry '[${errorEntry.data}'`);
+          break;
       }
     });
   }
 
   /**
-   * Do the actual processing of the root directory of a project, given a 
+   * Do the actual processing of the root directory of a project, given a
    * Project object (we need the object in order to find the internal addons).
    * Read the root package and the tree below it, then go back through the tree to
    * construct references between the various items (e.g., locate the actual
@@ -463,7 +492,6 @@ class PackageInfoCache {
    * for each package, etc.
    */
   loadProject(projectObj) {
-
     let val = this._readPackage(projectObj.root, projectObj);
 
     if (val instanceof PackageInfo) {
@@ -484,7 +512,9 @@ class PackageInfoCache {
 
           // for Projects only, we also add the devDependencies
           if (packageInfo === val) {
-            pkgs = packageInfo._addDependencies(packageInfo.pkg.devDependencies);
+            pkgs = packageInfo._addDependencies(
+              packageInfo.pkg.devDependencies
+            );
             if (pkgs) {
               packageInfo.devDependencyPackages = pkgs;
             }
@@ -512,7 +542,9 @@ class PackageInfoCache {
   }
 
   _getPackageInfos() {
-    let result = Object.values(this.entries).filter(entry => entry instanceof PackageInfo);
+    let result = Object.values(this.entries).filter(
+      entry => entry instanceof PackageInfo
+    );
     return result;
   }
 
@@ -538,9 +570,11 @@ class PackageInfoCache {
     let currPath = startPath;
 
     while (currPath !== root) {
-      let endsWithNodeModules = (path.basename(currPath) === "node_modules");
+      let endsWithNodeModules = path.basename(currPath) === "node_modules";
 
-      let nodeModulesPath = (endsWithNodeModules ? currPath : currPath + path.sep + "node_modules");
+      let nodeModulesPath = endsWithNodeModules
+        ? currPath
+        : currPath + path.sep + "node_modules";
 
       let nodeModulesList = this._readNodeModulesList(nodeModulesPath);
 
@@ -558,12 +592,11 @@ class PackageInfoCache {
     return null;
   }
 
-
   /**
    * Given a directory that supposedly contains a package, if there is a
    * readable package.json create a PackageInfo object and try to fill it out.
-   * Assuming there are no "fatal" errors (like a missing package.json), 
-   * return the PackageInfo object, after installing it as an entry in 
+   * Assuming there are no "fatal" errors (like a missing package.json),
+   * return the PackageInfo object, after installing it as an entry in
    * our entries cache, keyed on real path.
    *
    * If there is no package.json or it's bad or the package is an addon with
@@ -576,11 +609,10 @@ class PackageInfoCache {
    * Projects are somewhat different than other package types in that they
    * also may have 'internal' (as opposed to 'in repo') addons. Unfortunately,
    * there is nothing in the package.json to identify a Project. To handle
-   * that, if the 'project' parameter is set, that's indicating this package 
+   * that, if the 'project' parameter is set, that's indicating this package
    * is for a project so we should process those internal addons as well.
    */
   _readPackage(pkgDir, project) {
-
     let realPath = getRealDirectoryPath(pkgDir);
     if (!realPath) {
       return new ErrorEntry(ERROR_PACKAGE_DIR_MISSING, pkgDir);
@@ -609,7 +641,10 @@ class PackageInfoCache {
     // to a valid file.
     let ctor;
 
-    if (Array.isArray(pkg.keywords) && (pkg.keywords.indexOf("ember-addon") >= 0)) {
+    if (
+      Array.isArray(pkg.keywords) &&
+      pkg.keywords.indexOf("ember-addon") >= 0
+    ) {
       let main = pkg.main;
 
       if (!main || main === "." || main === "./") {
@@ -643,7 +678,7 @@ class PackageInfoCache {
     // Process the project here, rather than internally, so it doesn't
     // have to know too much about how the cache works.
     if (project) {
-      pkgInfo.project = project; 
+      pkgInfo.project = project;
 
       let val;
 
@@ -664,15 +699,15 @@ class PackageInfoCache {
       project.supportedInternalAddonPaths().forEach(internalAddonPath => {
         if (getRealDirectoryPath(internalAddonPath)) {
           val = this._readPackage(internalAddonPath);
-          
+
           if (val instanceof PackageInfo) {
             pkgInfo._addInternalAddon(val);
           } else {
             // internal addon package was not able to be created.
             pkgInfo._insertError(val);
-          } 
+          }
         }
-      })
+      });
     }
 
     let emberAddonInfo = pkg["ember-addon"];
@@ -684,7 +719,7 @@ class PackageInfoCache {
       if (paths) {
         paths.forEach(p => {
           let addonPath = path.join(realPath, p); // real path, though may not exist
-          let val = this._readPackage(addonPath);  
+          let val = this._readPackage(addonPath);
           if (val instanceof PackageInfo) {
             pkgInfo._addInRepoAddon(val);
           } else {
@@ -775,7 +810,7 @@ class PackageInfoCache {
         if (entryVal instanceof NodeModulesList) {
           nodeModulesList._addEntry(entryName, entryVal);
         } else {
-          // This (null return) really should not occur, unless somehow the 
+          // This (null return) really should not occur, unless somehow the
           // dir disappears between the time of fs.readdirSync and now.
           nodeModulesList._addError(ERROR_NODEMODULES_ENTRY_MISSING, entryName);
         }

--- a/lib/models/package-info-cache.js
+++ b/lib/models/package-info-cache.js
@@ -366,9 +366,10 @@ class NodeModulesList {
  * The entries are stored in a map keyed by real directory path.
  */
 class PackageInfoCache {
-  constructor() {
+  constructor(ui) {
     this.entries = Object.create(null);
     this.errors = new ErrorList();
+    this.ui = ui;  // a console-ui instance
   }
 
   _insertError(errorEntry) {
@@ -418,14 +419,14 @@ class PackageInfoCache {
       return;
     }
 
-    console.log("");
+    this.ui.writeWarnLine("");
     let rootPath;
 
     if (obj instanceof PackageInfoCache) {
-      console.warn("Top level errors:");
+      this.ui.writeWarnLine("Top level errors:");
       rootPath = this.realPath;
     } else {
-      console.warn(obj.realPath + ":");
+      this.ui.writeWarnLine(obj.realPath + ":");
       rootPath = obj.realPath;
     }
 
@@ -434,7 +435,7 @@ class PackageInfoCache {
     errorList.getErrors().forEach(errorEntry => {
       switch (errorEntry.type) {
         case ERROR_PACKAGE_DIR_MISSING:
-          console.warn(
+          this.ui.writeWarnLine(
             `   Missing package directory at relative path '${path.relative(
               rootPath,
               errorEntry.data
@@ -442,7 +443,7 @@ class PackageInfoCache {
           );
           break;
         case ERROR_PACKAGE_JSON_MISSING:
-          console.warn(
+          this.ui.writeWarnLine(
             `   Missing package.json file at relative path '${path.relative(
               rootPath,
               errorEntry.data
@@ -450,7 +451,7 @@ class PackageInfoCache {
           );
           break;
         case ERROR_PACKAGE_JSON_PARSE:
-          console.warn(
+          this.ui.writeWarnLine(
             `   Error parsing package.json file at relative path '${path.relative(
               rootPath,
               errorEntry.data
@@ -458,7 +459,7 @@ class PackageInfoCache {
           );
           break;
         case ERROR_EMBER_ADDON_MAIN_MISSING:
-          console.warn(
+          this.ui.writeWarnLine(
             `   Missing ember-addon 'main' file at relative path '${path.relative(
               rootPath,
               errorEntry.data
@@ -468,16 +469,16 @@ class PackageInfoCache {
         case ERROR_DEPENDENCIES_MISSING:
           let missingDependencies = errorEntry.data;
           if (missingDependencies.length === 1) {
-            console.warn(`   Missing dependency '${missingDependencies[0]}'`);
+            this.ui.writeWarnLine(`   Missing dependency '${missingDependencies[0]}'`);
           } else {
-            console.warn(`   Missing dependencies:`);
+            this.ui.writeWarnLine(`   Missing dependencies:`);
             missingDependencies.forEach(dependencyName => {
-              console.warn(`      ${dependencyName}`);
+              this.ui.writeWarnLine(`      ${dependencyName}`);
             });
           }
           break;
         case ERROR_NODEMODULES_ENTRY_MISSING:
-          console.warn(`   Missing node_modules entry '[${errorEntry.data}'`);
+          this.ui.writeWarnLine(`   Missing node_modules entry '[${errorEntry.data}'`);
           break;
       }
     });

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -48,7 +48,7 @@ class Project {
     this.pkg = pkg;
     this.ui = ui;
     this.cli = cli;
-    this.addonPackages = {};
+    this.addonPackages = Object.create(null);
     this.addons = [];
     this.liveReloadFilterPatterns = [];
     this.setupBowerDirectory();
@@ -446,8 +446,6 @@ class Project {
     @method discoverAddons
    */
   discoverAddons() {
-    console.log(" ");
-    console.log(`discoverAddons for root ${this.root}, pkg ${this.pkg.name}.`);
     let cache = this._packageInfoCache;
 
     let projectPackageInfo = cache.getEntry(this.root);
@@ -487,11 +485,10 @@ class Project {
       addonPackageList.push(...projectPackageInfo.inRepoAddons);
     }
 
-    this.addonPackages = {};
+    this.addonPackages = Object.create(null);
 
     addonPackageList.forEach(packageInfo => {
       let relpath = path.relative(this.root, packageInfo.realPath);
-      console.log(`  ${packageInfo.name}: relpath: ${relpath}`);
       this.addonPackages[packageInfo.name] = new AddonInfo(packageInfo.name, packageInfo.realPath, packageInfo.pkg);
     }); 
   }
@@ -529,7 +526,9 @@ class Project {
    */
   addonCommands() {
     const Command = require('../models/command');
-    let commands = {};
+
+    let commands = Object.create(null);
+
     this.addons.forEach(addon => {
       if (!addon.includedCommands) { return; }
 
@@ -540,7 +539,7 @@ class Project {
       });
 
       let includedCommands = addon.includedCommands();
-      let addonCommands = {};
+      let addonCommands = Object.create(null);
 
       for (let key in includedCommands) {
         if (typeof includedCommands[key] === 'function') {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -1,24 +1,24 @@
-'use strict';
+"use strict";
 
 /**
 @module ember-cli
 */
-const RSVP = require('rsvp');
-const path = require('path');
-const findup = require('find-up');
-const resolve = RSVP.denodeify(require('resolve'));
-const fs = require('fs-extra');
-const existsSync = require('exists-sync');
-const _ = require('ember-cli-lodash-subset');
-const logger = require('heimdalljs-logger')('ember-cli:project');
-const versionUtils = require('../utilities/version-utils');
+const RSVP = require("rsvp");
+const path = require("path");
+const findup = require("find-up");
+const resolve = RSVP.denodeify(require("resolve"));
+const fs = require("fs-extra");
+const existsSync = require("exists-sync");
+const _ = require("ember-cli-lodash-subset");
+const logger = require("heimdalljs-logger")("ember-cli:project");
+const versionUtils = require("../utilities/version-utils");
 const emberCLIVersion = versionUtils.emberCLIVersion;
-const findAddonByName = require('../utilities/find-addon-by-name');
-const heimdall = require('heimdalljs');
-const experiments = require('../experiments');
-const AddonDiscovery = require('../models/addon-discovery');  // singleton, stateless
-const AddonInfo = require('../models/addon-info');
-const PackageInfoCache = require('../models/package-info-cache');
+const findAddonByName = require("../utilities/find-addon-by-name");
+const heimdall = require("heimdalljs");
+const experiments = require("../experiments");
+const AddonDiscovery = require("../models/addon-discovery"); // singleton, stateless
+const AddonInfo = require("../models/addon-info");
+const PackageInfoCache = require("../models/package-info-cache");
 
 let processCwd = process.cwd();
 
@@ -39,10 +39,10 @@ class Project {
     @param {CLI} cli
   */
   constructor(root, pkg, ui, cli) {
-    const AddonDiscovery = require('../models/addon-discovery');
-    const AddonsFactory = require('../models/addons-factory');
+    const AddonDiscovery = require("../models/addon-discovery");
+    const AddonsFactory = require("../models/addons-factory");
 
-    logger.info('init root: %s', root);
+    logger.info("init root: %s", root);
 
     this.root = root;
     this.pkg = pkg;
@@ -73,10 +73,11 @@ class Project {
     this._watchmanInfo = {
       enabled: false,
       version: null,
-      canNestRoots: false,
+      canNestRoots: false
     };
 
-    let instrumentation = this._instrumentation = ensureInstrumentation(cli, ui);
+    let instrumentation =
+        (this._instrumentation = ensureInstrumentation(cli, ui));
     instrumentation.project = this;
 
     this.emberCLIVersion = emberCLIVersion;
@@ -113,21 +114,21 @@ class Project {
     @method setupBowerDirectory
    */
   setupBowerDirectory() {
-    let bowerrcPath = path.join(this.root, '.bowerrc');
+    let bowerrcPath = path.join(this.root, ".bowerrc");
 
-    logger.info('bowerrc path: %s', bowerrcPath);
+    logger.info("bowerrc path: %s", bowerrcPath);
 
     if (existsSync(bowerrcPath)) {
       try {
         this.bowerDirectory = fs.readJsonSync(bowerrcPath).directory;
       } catch (exception) {
-        logger.info('failed to parse bowerc: %s', exception);
+        logger.info("failed to parse bowerc: %s", exception);
         this.bowerDirectory = null;
       }
     }
 
-    this.bowerDirectory = this.bowerDirectory || 'bower_components';
-    logger.info('bowerDirectory: %s', this.bowerDirectory);
+    this.bowerDirectory = this.bowerDirectory || "bower_components";
+    logger.info("bowerDirectory: %s", this.bowerDirectory);
   }
 
   // Checks whether the project's npm dependencies are
@@ -142,13 +143,13 @@ class Project {
     }
 
     // look for all the dependencies by name, returning true if
-    // found, false if not. 
+    // found, false if not.
     for (let depName in this.dependencies()) {
       try {
         this.resolveSync(`${depName}/package.json`);
         return true;
       } catch (err) {
-        if (err.code !== 'MODULE_NOT_FOUND') {
+        if (err.code !== "MODULE_NOT_FOUND") {
           throw err;
         }
         return false;
@@ -157,9 +158,10 @@ class Project {
     return false;
   }
 
-
   static nullProject(ui, cli) {
-    if (NULL_PROJECT) { return NULL_PROJECT; }
+    if (NULL_PROJECT) {
+      return NULL_PROJECT;
+    }
 
     NULL_PROJECT = new Project(processCwd, {}, ui, cli);
 
@@ -192,7 +194,7 @@ class Project {
     @return {String} Package name
    */
   name() {
-    const getPackageBaseName = require('../utilities/get-package-base-name');
+    const getPackageBaseName = require("../utilities/get-package-base-name");
 
     return getPackageBaseName(this.pkg.name);
   }
@@ -206,7 +208,9 @@ class Project {
     @return {Boolean} Whether this is an Ember CLI project
    */
   isEmberCLIProject() {
-    return (this.cli ? this.cli.npmPackage : 'ember-cli') in this.dependencies();
+    return (
+      (this.cli ? this.cli.npmPackage : "ember-cli") in this.dependencies()
+    );
   }
 
   /**
@@ -216,7 +220,7 @@ class Project {
     @return {Boolean} Whether or not this is an Ember CLI Addon.
    */
   isEmberCLIAddon() {
-    return !!this.pkg.keywords && this.pkg.keywords.indexOf('ember-addon') > -1;
+    return !!this.pkg.keywords && this.pkg.keywords.indexOf("ember-addon") > -1;
   }
 
   /**
@@ -227,7 +231,7 @@ class Project {
     */
   isModuleUnification() {
     if (experiments.MODULE_UNIFICATION) {
-      return this.has('src');
+      return this.has("src");
     } else {
       return false;
     }
@@ -241,13 +245,13 @@ class Project {
     @return {String} Configuration path
    */
   configPath() {
-    let configPath = 'config';
+    let configPath = "config";
 
-    if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
-      configPath = this.pkg['ember-addon']['configPath'];
+    if (this.pkg["ember-addon"] && this.pkg["ember-addon"]["configPath"]) {
+      configPath = this.pkg["ember-addon"]["configPath"];
     }
 
-    return path.join(this.root, configPath, 'environment');
+    return path.join(this.root, configPath, "environment");
   }
 
   /**
@@ -298,18 +302,18 @@ class Project {
     if (this._targets) {
       return this._targets;
     }
-    let configPath = 'config';
+    let configPath = "config";
 
-    if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
-      configPath = this.pkg['ember-addon']['configPath'];
+    if (this.pkg["ember-addon"] && this.pkg["ember-addon"]["configPath"]) {
+      configPath = this.pkg["ember-addon"]["configPath"];
     }
 
-    let targetsPath = path.join(this.root, configPath, 'targets');
+    let targetsPath = path.join(this.root, configPath, "targets");
 
     if (existsSync(`${targetsPath}.js`)) {
       this._targets = this.require(targetsPath);
     } else {
-      this._targets = require('../utilities/default-targets');
+      this._targets = require("../utilities/default-targets");
     }
     return this._targets;
   }
@@ -346,7 +350,10 @@ class Project {
     @return {Boolean}      Whether or not the file is present
    */
   has(file) {
-    return existsSync(path.join(this.root, file)) || existsSync(path.join(this.root, `${file}.js`));
+    return (
+      existsSync(path.join(this.root, file)) ||
+      existsSync(path.join(this.root, `${file}.js`))
+    );
   }
 
   /**
@@ -359,7 +366,7 @@ class Project {
    */
   resolveSync(file) {
     return resolve.sync(file, {
-      basedir: process.env.EMBER_NODE_PATH || this.root,
+      basedir: process.env.EMBER_NODE_PATH || this.root
     });
   }
 
@@ -390,12 +397,12 @@ class Project {
   dependencies(pkg, excludeDevDeps) {
     pkg = pkg || this.pkg || {};
 
-    let devDependencies = pkg['devDependencies'];
+    let devDependencies = pkg["devDependencies"];
     if (excludeDevDeps) {
       devDependencies = {};
     }
 
-    return Object.assign({}, devDependencies, pkg['dependencies']);
+    return Object.assign({}, devDependencies, pkg["dependencies"]);
   }
 
   /**
@@ -408,10 +415,10 @@ class Project {
    */
   bowerDependencies(bower) {
     if (!bower) {
-      let bowerPath = path.join(this.root, 'bower.json');
-      bower = (existsSync(bowerPath)) ? require(bowerPath) : {};
+      let bowerPath = path.join(this.root, "bower.json");
+      bower = existsSync(bowerPath) ? require(bowerPath) : {};
     }
-    return Object.assign({}, bower['devDependencies'], bower['dependencies']);
+    return Object.assign({}, bower["devDependencies"], bower["dependencies"]);
   }
 
   /**
@@ -422,19 +429,24 @@ class Project {
     @method supportedInternalAddonPaths
   */
   supportedInternalAddonPaths() {
-    if (!this.root) { return []; }
+    if (!this.root) {
+      return [];
+    }
 
-    let internalMiddlewarePath = path.join(__dirname, '../tasks/server/middleware');
-    let internalTransformPath = path.join(__dirname, '../tasks/transforms');
+    let internalMiddlewarePath = path.join(
+      __dirname,
+      "../tasks/server/middleware"
+    );
+    let internalTransformPath = path.join(__dirname, "../tasks/transforms");
 
     return [
-      path.join(internalMiddlewarePath, 'testem-url-rewriter'),
-      path.join(internalMiddlewarePath, 'tests-server'),
-      path.join(internalMiddlewarePath, 'history-support'),
-      path.join(internalMiddlewarePath, 'broccoli-watcher'),
-      path.join(internalMiddlewarePath, 'broccoli-serve-files'),
-      path.join(internalMiddlewarePath, 'proxy-server'),
-      path.join(internalTransformPath, 'amd'),
+      path.join(internalMiddlewarePath, "testem-url-rewriter"),
+      path.join(internalMiddlewarePath, "tests-server"),
+      path.join(internalMiddlewarePath, "history-support"),
+      path.join(internalMiddlewarePath, "broccoli-watcher"),
+      path.join(internalMiddlewarePath, "broccoli-serve-files"),
+      path.join(internalMiddlewarePath, "proxy-server"),
+      path.join(internalTransformPath, "amd")
     ];
   }
 
@@ -453,10 +465,12 @@ class Project {
     let addonPackageList = [];
 
     if (this.isEmberCLIAddon()) {
-        addonPackageList.push(projectPackageInfo);
+      addonPackageList.push(projectPackageInfo);
     }
-    
-    let cliInRepoAddons = (projectPackageInfo.cliEntry ? projectPackageInfo.cliEntry.inRepoAddons : null);
+
+    let cliInRepoAddons = projectPackageInfo.cliEntry
+      ? projectPackageInfo.cliEntry.inRepoAddons
+      : null;
     if (cliInRepoAddons) {
       addonPackageList.push(...cliInRepoAddons);
     }
@@ -468,16 +482,18 @@ class Project {
     // The 'dependencyPackages' object contains ALL dependencies, not just those
     // that are addons. We want only the addons
     if (projectPackageInfo.dependencyPackages) {
-      let addonPkgs = Object.values(projectPackageInfo.dependencyPackages)
-          .filter(packageInfo => packageInfo.isAddon());
+      let addonPkgs = Object.values(
+        projectPackageInfo.dependencyPackages
+      ).filter(packageInfo => packageInfo.isAddon());
       addonPackageList.push(...addonPkgs);
     }
 
     // The 'devDependencyPackages' object contains ALL devDependencies, not just those
     // that are addons. We want only the addons.
     if (projectPackageInfo.devDependencyPackages) {
-      let addonPkgs = Object.values(projectPackageInfo.devDependencyPackages)
-          .filter(packageInfo => packageInfo.isAddon());
+      let addonPkgs = Object.values(
+        projectPackageInfo.devDependencyPackages
+      ).filter(packageInfo => packageInfo.isAddon());
       addonPackageList.push(...addonPkgs);
     }
 
@@ -489,8 +505,12 @@ class Project {
 
     addonPackageList.forEach(packageInfo => {
       let relpath = path.relative(this.root, packageInfo.realPath);
-      this.addonPackages[packageInfo.name] = new AddonInfo(packageInfo.name, packageInfo.realPath, packageInfo.pkg);
-    }); 
+      this.addonPackages[packageInfo.name] = new AddonInfo(
+        packageInfo.name,
+        packageInfo.realPath,
+        packageInfo.pkg
+      );
+    });
   }
 
   /**
@@ -505,14 +525,14 @@ class Project {
     }
     this._addonsInitialized = true;
 
-    logger.info('initializeAddons for: %s', this.pkg.name);
+    logger.info("initializeAddons for: %s", this.pkg.name);
 
     this.discoverAddons();
 
     this.addons = this.addonsFactory.initializeAddons(this.addonPackages);
 
     this.addons.forEach(addon => {
-      logger.info('addon: %s', addon.name);
+      logger.info("addon: %s", addon.name);
     });
   }
 
@@ -525,24 +545,26 @@ class Project {
     @return {Object} Addon names and command maps as key-value pairs
    */
   addonCommands() {
-    const Command = require('../models/command');
+    const Command = require("../models/command");
 
     let commands = Object.create(null);
 
     this.addons.forEach(addon => {
-      if (!addon.includedCommands) { return; }
+      if (!addon.includedCommands) {
+        return;
+      }
 
       let token = heimdall.start({
         name: `lookup-commands: ${addon.name}`,
         addonName: addon.name,
-        addonCommandInitialization: true,
+        addonCommandInitialization: true
       });
 
       let includedCommands = addon.includedCommands();
       let addonCommands = Object.create(null);
 
       for (let key in includedCommands) {
-        if (typeof includedCommands[key] === 'function') {
+        if (typeof includedCommands[key] === "function") {
           addonCommands[key] = includedCommands[key];
         } else {
           addonCommands[key] = Command.extend(includedCommands[key]);
@@ -576,7 +598,9 @@ class Project {
       this.initializeAddons();
       let addonCommands = this.addonCommands();
 
-      _.forOwn(addonCommands, (commands, addonName) => callback(addonName, commands));
+      _.forOwn(addonCommands, (commands, addonName) =>
+        callback(addonName, commands)
+      );
     }
   }
 
@@ -588,7 +612,7 @@ class Project {
     @return {String} Path to blueprints
    */
   localBlueprintLookupPath() {
-    return path.join(this.root, 'blueprints');
+    return path.join(this.root, "blueprints");
   }
 
   /**
@@ -617,13 +641,17 @@ class Project {
     @return {Array} List of paths
    */
   addonBlueprintLookupPaths() {
-    let addonPaths = this.addons.reduce((sum, addon) => {
-      if (addon.blueprintsPath) {
-        let val = addon.blueprintsPath();
-        if (val) { sum.push(val); }
-      }
-      return sum;
-    }, []).reverse();
+    let addonPaths = this.addons
+      .reduce((sum, addon) => {
+        if (addon.blueprintsPath) {
+          let val = addon.blueprintsPath();
+          if (val) {
+            sum.push(val);
+          }
+        }
+        return sum;
+      }, [])
+      .reverse();
 
     return addonPaths;
   }
@@ -636,7 +664,7 @@ class Project {
     @return {Object} Package content
    */
   reloadPkg() {
-    let pkgPath = path.join(this.root, 'package.json');
+    let pkgPath = path.join(this.root, "package.json");
 
     // We use readFileSync instead of require to avoid the require cache.
     this.pkg = fs.readJsonSync(pkgPath);
@@ -683,7 +711,8 @@ class Project {
     @return {String} The test file content
    */
   generateTestFile() {
-    let message = 'Please install an Ember.js test framework addon or update your dependencies.';
+    let message =
+      "Please install an Ember.js test framework addon or update your dependencies.";
 
     if (this.ui) {
       this.ui.writeDeprecateLine(message);
@@ -691,7 +720,7 @@ class Project {
       console.warn(message);
     }
 
-    return '';
+    return "";
   }
 
   /**
@@ -706,24 +735,28 @@ class Project {
     @return {Project}         Project instance
    */
   static closestSync(pathName, _ui, _cli) {
-    logger.info('looking for package.json starting at %s', pathName);
+    logger.info("looking for package.json starting at %s", pathName);
 
     let ui = ensureUI(_ui);
 
     let directory = findupPath(pathName);
-    logger.info('found package.json at %s', directory);
+    logger.info("found package.json at %s", directory);
 
     let relative = path.relative(directory, pathName);
-    if (relative.indexOf('tmp') === 0) {
-      logger.info('ignoring parent project since we are in the tmp folder of the project');
+    if (relative.indexOf("tmp") === 0) {
+      logger.info(
+        "ignoring parent project since we are in the tmp folder of the project"
+      );
       return Project.nullProject(_ui, _cli);
     }
 
-    let pkg = fs.readJsonSync(path.join(directory, 'package.json'));
-    logger.info('project name: %s', pkg && pkg.name);
+    let pkg = fs.readJsonSync(path.join(directory, "package.json"));
+    logger.info("project name: %s", pkg && pkg.name);
 
     if (!isEmberCliProject(pkg)) {
-      logger.info('ignoring parent project since it is not an ember-cli project');
+      logger.info(
+        "ignoring parent project since it is not an ember-cli project"
+      );
       return Project.nullProject(_ui, _cli);
     }
 
@@ -762,21 +795,24 @@ class Project {
     @return {String} The project root directory
    */
   static getProjectRoot() {
-    let packagePath = findup.sync('package.json');
+    let packagePath = findup.sync("package.json");
     if (!packagePath) {
-      logger.info('getProjectRoot: not found. Will use cwd: %s', process.cwd());
+      logger.info("getProjectRoot: not found. Will use cwd: %s", process.cwd());
       return process.cwd();
     }
 
     let directory = path.dirname(packagePath);
     const pkg = require(packagePath);
 
-    if (pkg && pkg.name === 'ember-cli') {
-      logger.info('getProjectRoot: named \'ember-cli\'. Will use cwd: %s', process.cwd());
+    if (pkg && pkg.name === "ember-cli") {
+      logger.info(
+        "getProjectRoot: named 'ember-cli'. Will use cwd: %s",
+        process.cwd()
+      );
       return process.cwd();
     }
 
-    logger.info('getProjectRoot %s -> %s', process.cwd(), directory);
+    logger.info("getProjectRoot %s -> %s", process.cwd(), directory);
     return directory;
   }
 }
@@ -784,8 +820,8 @@ class Project {
 class NotFoundError extends Error {
   constructor(message) {
     super(message);
-    this.name = 'NotFoundError';
-    this.stack = (new Error()).stack;
+    this.name = "NotFoundError";
+    this.stack = new Error().stack;
   }
 }
 
@@ -799,7 +835,7 @@ function ensureInstrumentation(cli, ui) {
   // Instrumentation `require` needs to occur inline due to circular dependencies between
   // Instrumentation => getConfig => Project => Instrumentation. getConfig is used in Project to
   // get the project root.
-  let Instrumentation = require('./instrumentation');
+  let Instrumentation = require("./instrumentation");
   // created without a `cli` object (possibly from deprecated `Brocfile.js`)
   return new Instrumentation({ ui, initInstrumentation: null });
 }
@@ -809,12 +845,12 @@ function ensureUI(_ui) {
 
   if (!ui) {
     // TODO: one UI (lib/cli/index.js also has one for now...)
-    const UI = require('console-ui');
+    const UI = require("console-ui");
     ui = new UI({
       inputStream: process.stdin,
       outputStream: process.stdout,
-      ci: process.env.CI || (/^(dumb|emacs)$/).test(process.env.TERM),
-      writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
+      ci: process.env.CI || /^(dumb|emacs)$/.test(process.env.TERM),
+      writeLevel: process.argv.indexOf("--silent") !== -1 ? "ERROR" : undefined
     });
   }
 
@@ -822,7 +858,7 @@ function ensureUI(_ui) {
 }
 
 function findupPath(pathName) {
-  let pkgPath = findup.sync('package.json', { cwd: pathName });
+  let pkgPath = findup.sync("package.json", { cwd: pathName });
   if (!pkgPath) {
     throw new NotFoundError(`No project found at or up from: \`${pathName}\``);
   }
@@ -831,9 +867,12 @@ function findupPath(pathName) {
 }
 
 function isEmberCliProject(pkg) {
-  return pkg && (
-    (pkg.dependencies && Object.keys(pkg.dependencies).indexOf('ember-cli') !== -1) ||
-    (pkg.devDependencies && Object.keys(pkg.devDependencies).indexOf('ember-cli') !== -1)
+  return (
+    pkg &&
+    ((pkg.dependencies &&
+      Object.keys(pkg.dependencies).indexOf("ember-cli") !== -1) ||
+      (pkg.devDependencies &&
+        Object.keys(pkg.devDependencies).indexOf("ember-cli") !== -1))
   );
 }
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -88,7 +88,7 @@ class Project {
     if (this.isEmberCLIProject()) {
       this._packageInfoCache = cli._packageInfoCache;
     } else {
-      this._packageInfoCache = new PackageInfoCache();
+      this._packageInfoCache = new PackageInfoCache(this.ui);
     }
 
     this._packageInfo = this._packageInfoCache.loadProject(this);

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -16,8 +16,12 @@ const emberCLIVersion = versionUtils.emberCLIVersion;
 const findAddonByName = require('../utilities/find-addon-by-name');
 const heimdall = require('heimdalljs');
 const experiments = require('../experiments');
+const AddonDiscovery = require('../models/addon-discovery');  // singleton, stateless
+const AddonInfo = require('../models/addon-info');
+const PackageInfoCache = require('../models/package-info-cache');
 
 let processCwd = process.cwd();
+
 // ensure NULL_PROJECT is a singleton
 let NULL_PROJECT;
 
@@ -76,7 +80,30 @@ class Project {
     instrumentation.project = this;
 
     this.emberCLIVersion = emberCLIVersion;
+
+    // XXX Can this be removed?
     this._nodeModulesPath = null;
+
+    if (this.isEmberCLIProject()) {
+      this._packageInfoCache = cli._packageInfoCache;
+    } else {
+      this._packageInfoCache = new PackageInfoCache();
+    }
+
+    this._packageInfo = this._packageInfoCache.loadProject(this);
+    if (this._packageInfo) {
+      // we at least got the project included in the cache.
+      // We cannot do much of anything without it.
+      this.root = this._packageInfo.realPath;
+    }
+
+    // XXX Need to decide what to do here about showing errors. For
+    // a non-CLI project the cache is local and probably should. For
+    // a CLI project the cache is there, but not sure when we'll know
+    // about all the errors, because there may be multiple projects.
+    if (this._packageInfoCache.hasErrors()) {
+      this._packageInfoCache.showErrors();
+    }
   }
 
   /**
@@ -113,6 +140,9 @@ class Project {
       // Blueprint tests set this flag.
       return true;
     }
+
+    // look for all the dependencies by name, returning true if
+    // found, false if not. 
     for (let depName in this.dependencies()) {
       try {
         this.resolveSync(`${depName}/package.json`);
@@ -226,7 +256,7 @@ class Project {
     @public
     @method config
     @param  {String} env Environment name
-    @return {Object}     Merged confiration object
+    @return {Object}     Merged configuration object
    */
   config(env) {
     let key = `${this.configPath()}|${env}`;
@@ -416,9 +446,54 @@ class Project {
     @method discoverAddons
    */
   discoverAddons() {
-    let addonsList = this.addonDiscovery.discoverProjectAddons(this);
+    console.log(" ");
+    console.log(`discoverAddons for root ${this.root}, pkg ${this.pkg.name}.`);
+    let cache = this._packageInfoCache;
 
-    this.addonPackages = this.addonDiscovery.addonPackages(addonsList);
+    let projectPackageInfo = cache.getEntry(this.root);
+
+    let addonPackageList = [];
+
+    if (this.isEmberCLIAddon()) {
+        addonPackageList.push(projectPackageInfo);
+    }
+    
+    let cliInRepoAddons = (projectPackageInfo.cliEntry ? projectPackageInfo.cliEntry.inRepoAddons : null);
+    if (cliInRepoAddons) {
+      addonPackageList.push(...cliInRepoAddons);
+    }
+
+    if (projectPackageInfo.internalAddons) {
+      addonPackageList.push(...projectPackageInfo.internalAddons);
+    }
+
+    // The 'dependencyPackages' object contains ALL dependencies, not just those
+    // that are addons. We want only the addons
+    if (projectPackageInfo.dependencyPackages) {
+      let addonPkgs = Object.values(projectPackageInfo.dependencyPackages)
+          .filter(packageInfo => packageInfo.isAddon());
+      addonPackageList.push(...addonPkgs);
+    }
+
+    // The 'devDependencyPackages' object contains ALL devDependencies, not just those
+    // that are addons. We want only the addons.
+    if (projectPackageInfo.devDependencyPackages) {
+      let addonPkgs = Object.values(projectPackageInfo.devDependencyPackages)
+          .filter(packageInfo => packageInfo.isAddon());
+      addonPackageList.push(...addonPkgs);
+    }
+
+    if (projectPackageInfo.inRepoAddons) {
+      addonPackageList.push(...projectPackageInfo.inRepoAddons);
+    }
+
+    this.addonPackages = {};
+
+    addonPackageList.forEach(packageInfo => {
+      let relpath = path.relative(this.root, packageInfo.realPath);
+      console.log(`  ${packageInfo.name}: relpath: ${relpath}`);
+      this.addonPackages[packageInfo.name] = new AddonInfo(packageInfo.name, packageInfo.realPath, packageInfo.pkg);
+    }); 
   }
 
   /**
@@ -433,7 +508,7 @@ class Project {
     }
     this._addonsInitialized = true;
 
-    logger.info('initializeAddons for: %s', this.name());
+    logger.info('initializeAddons for: %s', this.pkg.name);
 
     this.discoverAddons();
 


### PR DESCRIPTION
This is near completion, but I wanted to get a WIP version in before the final attempt so that @stefanpenner and @rwjblue could take a look and suggest improvements. (NOTE: this is being entered against master, but original development was against 3.0.1.) Here's the feature description:

Doing profiling of build time processing for a large project at LinkedIn found that the addon discovery process was taking over 50 seconds just to determine all where all the addon packages were on disk and read and parse their package.json files. I found that much of this was due to repeated validation of the path to the addon package.json and index.js files (fs.realpathSync turns out to be fairly expensive when done a lot, and the project was calling it something like 80K times). The implementation was already re-reading the package information and then throwing it away many times.

This PR creates a new PackageInfoCache class, with a singleton instance added to either CLI (if the build is being done through the CLI or an individual project (if the build is done on a single project but not through the CLI). If a build, like ours here at LinkedIn, includes multiple projects, the fact the instance is in CLI means they all take advantage of the same cache (I'll call it PIC from here out) and don't need to rediscover any packages.

When a Project (ember-cli/lib/models/project) is constructed, a reference to a local or CLI version of PIC is made and PIC.loadProject(projectPath) is called. loadProject then creates an internal instance of a PackageInfo class for the project. It parses the package.json file, then creates separate ProjectInfo instances for all internal addons, all CLI in-repo addons and all 'dependency' and 'devDependency' entries. In the process of that it does the same thing that the node resolution algorithm does to find package.json files, but tries as much as possible to not use 'fs.realpathSync' more than once per file path, caching the result of each path resolution for speed. 

Because of the cache, reading all the dependencies, parsing their package.json files, determining the addons and collecting information about them (prior to addon-instantiation), current performance on my Mac Pro machine (new 2017 model) has gone from 54 seconds down to 900 milliseconds. Obviously the precise performance will differ based on machine size, but overall it's about a 60x increase.

The result of all the above processing is that the PackageInfoCache contains a number of entries, one per package for each real file path (i.e. its cache entries are keyed on the real path for a package's root directory--all symlinks and .. entries are resolved). A PackageInfo object contains the following fields of interest:

* pkg - the object resulting from the package.json file
* realPath - (string) the resolved path for the package's root directory
* cache - a reference to the PIC object that contains the packageInfo instance
* errors - an ErrorList object containing ErrorEntry objects, one per error discovered during the processing of the package and all its various dependencies. When a packageInfo object is being created, if the package itself is bad (e.g. no or malformed package.json file) the error is created and put in the parent. If the package is generally constructed correctly, anything wrong with the contents of the object itself (e.g. one of its dependencies cannot be found), the error is registered with the object. The PIC has a method 'showErrors' to dump a list of all the errors in all the PackageInfo objects. The caller could then decide if any of those errors is enough to fail the build.

Various types of PackageInfo objects can have other fields:
* addonConstructor - filled out but not yet used, this would replace part of addons-factory so that constructing an instance of an addon would be done through the PIC/PackageInfo, simplifying the code
* addonMainPath - for an addon package, the real path to the package's 'main' file
* inRepoAddons - an array of PackageInfo objects, one per in-repo package definition (note that the in-repo addon definition is included in the PIC-level cache by its file path already, this is just a reference to that same set of objects)
* internalAddons - same as above, but for internal addons (project only)
* cliInfo - same as above, but for the package that corresponds to the path <pkg>.cli.root
* dependencyPackages - a JS object keyed by dependency name of references to PackageInfo objects, one per entry in the package's 'dependency' attribute list)
* devDependencyPackages - similar, but for the 'devDependency' attribute list
* nodeModules - a NodeModulesList object (basically contains an array of PackageInfo and other NodeModulesList objects) of all packages and subdirectories in a node_modules directory.