### PR TITLE
Update default broccoli-asset-rev

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/fixtures/module-unification-addon/package.json
+++ b/tests/fixtures/module-unification-addon/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/unit/broccoli/ember-app/import-test.js
+++ b/tests/unit/broccoli/ember-app/import-test.js
@@ -57,7 +57,7 @@ const APPLICATION_BLUEPRINT = {
   'package.json': JSON.stringify({
     name: 'app-import',
     devDependencies: {
-      'broccoli-asset-rev': '^2.4.5',
+      'broccoli-asset-rev': '^2.7.0',
       'ember-ajax': '^3.0.0',
       'ember-cli': '~2.14.0-beta.1',
       'ember-cli-app-version': '^3.0.0',


### PR DESCRIPTION
This includes bug fixes and performance improvements. I reviewed and don't see any expected public API breakage.

People on the default blueprint have been using broccoli-asset-rev 2.4.6, which is untagged, but appears to go with https://github.com/rickharrison/broccoli-asset-rev/commit/c453de7045110c6b2ac9783c3e3d66d54c35e8fc

Here's the commits in between: https://github.com/rickharrison/broccoli-asset-rev/compare/c453de7045110c6b2ac9783c3e3d66d54c35e8fc...v2.7.0