### PR TITLE
compact code a bit so it's less effort to read

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1228,29 +1228,14 @@ let addonProto = {
       trees = trees.concat(lintAddonJsTrees, lintTemplateTrees);
     }
 
-    let addonTestSupportPath = this._treePathFor('addon-test-support');
-    if (fs.existsSync(addonTestSupportPath)) {
-      let addonTestSupportTree = new Funnel(addonTestSupportPath, { destDir: 'addon-test-support' });
-      let lintAddonTestSupportJsTrees = this._eachProjectAddonInvoke('lintTree', [
-        'addon-test-support',
-        addonTestSupportTree,
-      ]);
-      trees = trees.concat(lintAddonTestSupportJsTrees);
-    }
-
-    let appPath = this._treePathFor('app');
-    if (fs.existsSync(appPath)) {
-      let appTree = new Funnel(appPath, { destDir: 'app' });
-      let lintAppJsTrees = this._eachProjectAddonInvoke('lintTree', ['app', appTree]);
-      trees = trees.concat(lintAppJsTrees);
-    }
-
-    let testSupportPath = this._treePathFor('test-support');
-    if (fs.existsSync(testSupportPath)) {
-      let testSupportTree = new Funnel(testSupportPath, { destDir: 'test-support' });
-      let lintTestSupportJsTrees = this._eachProjectAddonInvoke('lintTree', ['test-support', testSupportTree]);
-      trees = trees.concat(lintTestSupportJsTrees);
-    }
+    ['test-support', 'app', 'addon-test-support'].forEach(treeName => {
+      let treePath = this._treePathFor(treeName);
+      if (fs.existsSync(treePath)) {
+        let tree = new Funnel(treePath, { destDir: treeName });
+        let lintTrees = this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+        trees = trees.concat(lintTrees);
+      }
+    });
 
     let lintTrees = trees.filter(Boolean);
     let lintedAddon = mergeTrees(lintTrees, {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1258,7 +1258,7 @@ let addonProto = {
       return;
     }
 
-    let tree = new Funnel(treePath, { type });
+    let tree = new Funnel(treePath, { destDir: type });
     return this._eachProjectAddonInvoke('lintTree', [type, tree]);
   },
   /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1228,10 +1228,11 @@ let addonProto = {
       lintTrees = lintTrees.concat(lintAddonJsTrees, lintTemplateTrees);
     }
 
-    lintTrees = lintTrees
-      .concat(this._lintTree('test-support'), this._lintTree('app'), this._lintTree('addon-test-support'))
-      .filter(Boolean);
+    lintTrees = lintTrees.concat(this._lintTree('addon-test-support'));
+    lintTrees = lintTrees.concat(this._lintTree('app'));
+    lintTrees = lintTrees.concat(this._lintTree('test-support'));
 
+    lintTrees = lintTrees.filter(Boolean);
     let lintedAddon = mergeTrees(lintTrees, {
       overwrite: true,
       annotation: 'TreeMerger (addon-lint)',

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1207,13 +1207,12 @@ let addonProto = {
     @return {Tree} Tree with JShint output (tests)
   */
   jshintAddonTree() {
-    this._requireBuildPackages();
     let lintTrees = [];
 
     let addonPath = this._treePathFor('addon');
     if (fs.existsSync(addonPath)) {
-      let addonJs = new Funnel(this.addonJsFiles(addonPath), {
-        srcDir: this.moduleName(),
+      let addonJs = new Funnel(addonPath, {
+        exclude: ['templates/**/*'],
         destDir: 'addon',
         allowEmpty: true,
       });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1226,20 +1226,12 @@ let addonProto = {
       });
       let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
 
-      lintTrees = lintTrees.concat(
-        lintAddonJsTrees,
-        lintTemplateTrees
-      );
-
+      lintTrees = lintTrees.concat(lintAddonJsTrees, lintTemplateTrees);
     }
 
-    lintTrees = lintTrees.concat(
-      this._lintTree('test-support'),
-      this._lintTree('app'),
-      this._lintTree('addon-test-support')
-    ).filter(Boolean);
-
-
+    lintTrees = lintTrees
+      .concat(this._lintTree('test-support'), this._lintTree('app'), this._lintTree('addon-test-support'))
+      .filter(Boolean);
 
     let lintedAddon = mergeTrees(lintTrees, {
       overwrite: true,

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1207,34 +1207,17 @@ let addonProto = {
     @return {Tree} Tree with JShint output (tests)
   */
   jshintAddonTree() {
-    let trees = [];
+    this._requireBuildPackages();
 
-    let addonPath = this._treePathFor('addon');
-    if (fs.existsSync(addonPath)) {
-      let addonJs = new Funnel(addonPath, {
-        exclude: ['templates/**/*'],
-        destDir: 'addon',
-        allowEmpty: true,
-      });
-
-      let addonTemplates = new Funnel(this._addonTemplateFiles(addonPath), {
-        srcDir: `${this.moduleName()}/templates`,
-        destDir: 'addon/templates',
-        allowEmpty: true,
-      });
-
-      trees.concat(
-        this._lintTree('addon', addonJs),
-        this._lintTree('templates', addonTemplates)
-      );
-    }
-    trees.concat(
+    let lintTrees = [
+      this._lintTree('addon', 'addon'),
+      this._lintTree('templates', 'addon-templates'),
       this._lintTree('test-support'),
       this._lintTree('app'),
-      this._lintTree('addon-test-support')
-    );
+      this._lintTree('addon-test-support'),
+    ].filter(Boolean);
 
-    let lintTrees = trees.filter(Boolean);
+
     let lintedAddon = mergeTrees(lintTrees, {
       overwrite: true,
       annotation: 'TreeMerger (addon-lint)',
@@ -1248,24 +1231,23 @@ let addonProto = {
   },
 
   /**
-    Returns a tree with tests output given tree.
-
+    Returns a tree with tests output given tree. if tree name is not passed it will use type to lookup tree
     @private
-    @param  {String} treeName will be fowarded to addon as type paramter, and is used to find path
-    @param  {Tree} tree optional if this paramter is passed it will not lookup tree using treeName, and pass this tree instead
+    @param  {String} type will be fowarded to addon as type paramter, and is used to find path
+    @param  {Tree} treeName optional if this paramter is passed it will not lookup tree using treeName, and pass this tree instead
     @method _lintTree
     @return {Tree} Tree with linter tests
   */
-  _lintTree(treeName, tree) {
-    if (!tree) {
-      let treePath = this._treePathFor(treeName);
-      if (fs.existsSync(tree)) {
-        tree = new Funnel(treePath, { destDir: treeName });
-      } else {
-        return;
-      }
+  _lintTree(type, treeName) {
+    treeName = treeName || type;
+    let treePath = this._treePathFor(treeName);
+    if (fs.existsSync(treePath)) {
+      let tree = new Funnel(treePath, { destDir: treeName });
+      return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+    } else {
+      return;
     }
-    return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+
   },
   /**
     Returns a tree containing the addon's js files

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1208,14 +1208,30 @@ let addonProto = {
   */
   jshintAddonTree() {
     this._requireBuildPackages();
+    let lintTrees = [];
 
-    let lintTrees = [
-      this._lintTree('addon', 'addon'),
-      this._lintTree('templates', 'addon-templates'),
+    let addonPath = this._treePathFor('addon');
+    if (fs.existsSync(addonPath)) {
+      let addonJs = new Funnel(this.addonJsFiles(addonPath), {
+        srcDir: this.moduleName(),
+        destDir: 'addon',
+        allowEmpty: true,
+      });
+      let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
+
+      lintTrees = lintTrees.concat(
+        lintAddonJsTrees,
+        this._lintTree('templates', 'addon-templates', 'addon/templates')
+      );
+
+    }
+
+    lintTrees = lintTrees.concat(
       this._lintTree('test-support'),
       this._lintTree('app'),
-      this._lintTree('addon-test-support'),
-    ].filter(Boolean);
+      this._lintTree('addon-test-support')
+    ).filter(Boolean);
+
 
 
     let lintedAddon = mergeTrees(lintTrees, {
@@ -1238,16 +1254,17 @@ let addonProto = {
     @method _lintTree
     @return {Tree} Tree with linter tests
   */
-  _lintTree(type, treeName) {
+  _lintTree(type, treeName, destDir) {
+    let tree = null;
     treeName = treeName || type;
+    destDir = destDir || treeName;
     let treePath = this._treePathFor(treeName);
     if (fs.existsSync(treePath)) {
-      let tree = new Funnel(treePath, { destDir: treeName });
-      return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+      tree = new Funnel(treePath, { destDir });
     } else {
       return;
     }
-
+    return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
   },
   /**
     Returns a tree containing the addon's js files

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1261,17 +1261,14 @@ let addonProto = {
     @method _lintTree
     @return {Tree} Tree with linter tests
   */
-  _lintTree(type, treeName, destDir) {
-    let tree = null;
-    treeName = treeName || type;
-    destDir = destDir || treeName;
-    let treePath = this._treePathFor(treeName);
-    if (fs.existsSync(treePath)) {
-      tree = new Funnel(treePath, { destDir });
-    } else {
+  _lintTree(type) {
+    let treePath = this._treePathFor(type);
+    if (!fs.existsSync(treePath)) {
       return;
     }
-    return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+
+    let tree = new Funnel(treePath, { type });
+    return this._eachProjectAddonInvoke('lintTree', [type, tree]);
   },
   /**
     Returns a tree containing the addon's js files

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1248,9 +1248,8 @@ let addonProto = {
   /**
     Returns a tree with tests output given tree. if tree name is not passed it will use type to lookup tree
     @private
-    @param  {String} type will be fowarded to addon as type paramter, and is used to find path
-    @param  {Tree} treeName optional if this paramter is passed it will not lookup tree using treeName, and pass this tree instead
     @method _lintTree
+    @param  {String} type will be forwarded to addon as type paramter, and is used to find path
     @return {Tree} Tree with linter tests
   */
   _lintTree(type) {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1216,26 +1216,23 @@ let addonProto = {
         destDir: 'addon',
         allowEmpty: true,
       });
-      let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
 
       let addonTemplates = new Funnel(this._addonTemplateFiles(addonPath), {
         srcDir: `${this.moduleName()}/templates`,
         destDir: 'addon/templates',
         allowEmpty: true,
       });
-      let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
 
-      trees = trees.concat(lintAddonJsTrees, lintTemplateTrees);
+      trees.concat(
+        this._lintTree('addon', addonJs),
+        this._lintTree('templates', addonTemplates)
+      );
     }
-
-    ['test-support', 'app', 'addon-test-support'].forEach(treeName => {
-      let treePath = this._treePathFor(treeName);
-      if (fs.existsSync(treePath)) {
-        let tree = new Funnel(treePath, { destDir: treeName });
-        let lintTrees = this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
-        trees = trees.concat(lintTrees);
-      }
-    });
+    trees.concat(
+      this._lintTree('test-support'),
+      this._lintTree('app'),
+      this._lintTree('addon-test-support')
+    );
 
     let lintTrees = trees.filter(Boolean);
     let lintedAddon = mergeTrees(lintTrees, {
@@ -1250,6 +1247,26 @@ let addonProto = {
     });
   },
 
+  /**
+    Returns a tree with tests output given tree.
+
+    @private
+    @param  {String} treeName will be fowarded to addon as type paramter, and is used to find path
+    @param  {Tree} tree optional if this paramter is passed it will not lookup tree using treeName, and pass this tree instead
+    @method _lintTree
+    @return {Tree} Tree with linter tests
+  */
+  _lintTree(treeName, tree) {
+    if (!tree) {
+      let treePath = this._treePathFor(treeName);
+      if (fs.existsSync(tree)) {
+        tree = new Funnel(treePath, { destDir: treeName });
+      } else {
+        return;
+      }
+    }
+    return this._eachProjectAddonInvoke('lintTree', [treeName, tree]);
+  },
   /**
     Returns a tree containing the addon's js files
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1219,9 +1219,16 @@ let addonProto = {
       });
       let lintAddonJsTrees = this._eachProjectAddonInvoke('lintTree', ['addon', addonJs]);
 
+      let addonTemplates = new Funnel(this._addonTemplateFiles(addonPath), {
+        srcDir: `${this.moduleName()}/templates`,
+        destDir: 'addon/templates',
+        allowEmpty: true,
+      });
+      let lintTemplateTrees = this._eachProjectAddonInvoke('lintTree', ['templates', addonTemplates]);
+
       lintTrees = lintTrees.concat(
         lintAddonJsTrees,
-        this._lintTree('templates', 'addon-templates', 'addon/templates')
+        lintTemplateTrees
       );
 
     }


### PR DESCRIPTION
Makes reading code easier, since it's more compact. uses existing trees, instead of creating new ones and shares code.

would like to know if maintainers are happy with this idea :) (tests are currently failing but will get them fixed)

I started here 1f1ea37a075699748fe657ff5805870bca476b5d then thought to myself maybe i can combine addons into this fbbca19ea74f9a7d27f2b1ab5a78fdb3596daf26, but that lead me to find out that some deeper refactoring would be required to make that happen. so i compromised with 15ad7c3fdffdf0eb39bc93d875253f1e8d22d929, but i feel like this should be easily possible ffbf04bd4dc3d75621235c4d10705ef3df3f8369
