### PR TITLE
Make styles first class lint citizens

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1475,7 +1475,7 @@ class EmberApp {
   }
 
   /**
-    Runs the `app`, `tests` and `templates` trees through the chain of addons that produces lint trees.
+    Runs the `app`, `tests` and `templates`, `styles` trees through the chain of addons that produces lint trees.
 
     Those lint trees are afterwards funneled into the `tests` folder, babel-ified and returned as an array.
 
@@ -1510,7 +1510,14 @@ class EmberApp {
     }
 
     let lintedTests = this.addonLintTree('tests', this.trees.tests);
+    let lintedStyles = this.addonLintTree('styles', this.trees.styles);
     let lintedTemplates = this.addonLintTree('templates', this._templatesTree());
+
+    lintedStyles = processModulesOnly(new Funnel(lintedStyles, {
+      srcDir: '/',
+      destDir: `${this.name}/tests/`,
+      annotation: 'Funnel (lint styles)',
+    }), 'Babel: lintTree(styles)');
 
     lintedTests = processModulesOnly(new Funnel(lintedTests, {
       srcDir: '/',
@@ -1524,7 +1531,7 @@ class EmberApp {
       annotation: 'Funnel (lint templates)',
     }), 'Babel: lintTree(templates)');
 
-    return [lintedTests, lintedTemplates].concat(lintTrees);
+    return [lintedTests, lintedTemplates, lintedStyles].concat(lintTrees);
   }
 
   /**


### PR DESCRIPTION
Currently styles are not first class lint citizens, and this causes a bunch of problems that i will try to describe.

type=='app' only contains javascript
![image](https://user-images.githubusercontent.com/1640136/38138410-5cc818f6-345d-11e8-8eb3-145161d52f47.png)

so i have been doing the following

```
if(type == 'app'){
  return StyleLinter.create(this.app.trees.app, this.styleLintOptions)
}
```

for addons that value maps to `tests/dummy` directory
for apps that value maps to `app` directory

but some addon's want to lint `app` directory as well.

so stylelinters use a config called `included paths`

```
    let toBeLinted = [ this.app.trees.app ];
    if (this.styleLintOptions.includePaths) {
      toBeLinted.push.apply(toBeLinted, this.styleLintOptions.includePaths);
    }
    
    let linted = toBeLinted.map(function(tree) {
      let filteredTreeToBeLinted = new Funnel(tree, {
        exclude: ['**/*.js']
      });
      return StyleLinter.create(tree, this.styleLintOptions)
```

but the issue is if you have multiple addons in your app or you are developing an addon type=='app' gets called multiple times.

![image](https://user-images.githubusercontent.com/1640136/38132899-8b5e045a-343f-11e8-99ba-72a65896c90d.png)

In order to rectify this we need each lint method the auxillary one and the main one to use `type=='styles'`

that way each time type==`styles` we can be sure that it is a unique branch of the code so unique addon/engine/ or the main app (it seems like the main `app` directory is considered an addon for addon repositories. and stylelinters can be stable 😍 

examples of work arounds
- https://github.com/billybonks/ember-cli-stylelint/blob/master/index.js#L64
- https://github.com/tomasbasham/ember-cli-scss-lint/blob/master/index.js#L54