### PR TITLE
(fix ci) assert no filters matched

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -168,6 +168,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
   }));
 
   it('addon trees are not jshinted', co.wrap(function *() {
+    let assertions = 0;
     yield copyFixtureFiles('brocfile-tests/jshint-addon');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -176,8 +177,14 @@ describe('Acceptance: brocfile-smoke-test', function() {
       paths: ['./lib/ember-random-thing'],
     };
     fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--filter=jshint');
+    try {
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--filter=jshint');
+    } catch (e) {
+      let outputMatch = e.output.join(' ').match(/(No tests matched the filter "jshint")/g).length;
+      chai.expect(outputMatch).to.equal(3);
+      assertions++;
+    }
+    chai.expect(assertions).to.equal(1);
   }));
 
   it('specifying custom output paths works properly', co.wrap(function *() {


### PR DESCRIPTION
From what i understand, the config of this test would cause jshint tests to not be generated, and so if we filter by jshints we expect to see no failing tests.

recently qunit started throwing errors if nothing matched the filter 
https://github.com/qunitjs/qunit/blame/fc1c3ce4f9a403e3cfbd987a29aefb076560bf2b/src/core/processing-queue.js#L157

I catch the error assert it happened ( the assertions are a bit fragile). if that assertion did not run the qunit matched tests filtered as jshint