### PR TITLE
fix #7726 attach project to blueprint

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -90,10 +90,14 @@ class GenerateTask extends Task {
   }
 
   lookupBlueprint(name, ignoreMissing) {
-    return Blueprint.lookup(name, {
+    let blueprint = Blueprint.lookup(name, {
       paths: this.project.blueprintLookupPaths(),
       ignoreMissing,
     });
+    if (blueprint) {
+      blueprint.project = this.project;
+    }
+    return blueprint;
   }
 }
 


### PR DESCRIPTION
#7726 
This is manually tested:
```
MODULE_UNIFICATION=true bin/ember new foo
cd foo
// modify package.json: "ember-cli": "github:xg-wang/ember-cli",
ember g component foo-bar
```

output:
```
installing component
  create src/ui/components/foo-bar2/component.js
  create src/ui/components/foo-bar2/template.hbs
installing component-test
  create src/ui/components/foo-bar2/component-test.js
```

ember.js has [test](https://github.com/emberjs/ember.js/blob/master/node-tests/blueprints/component-test.js#L398) for component in module unification, once ember.js consumes newer version of ember-cli, the test should works correct ([link](https://github.com/emberjs/ember.js/blob/400ec6ee69265ce45538e07ace9523926569f805/package.json#L110)).

cc @GavinJoyce 