### PR TITLE
Passing defaultOptions to testem to prevent the cwd and config_dir set in testem.js from being overridden by ember-cli

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -8,9 +8,9 @@ const SilentError = require('silent-error');
 class TestServerTask extends TestTask {
   invokeTestem(options) {
     let task = this;
-
     return new Promise((resolve, reject) => {
-      task.testem.startDev(task.testemOptions(options), (exitCode, error) => {
+      task.testem.setDefaultOptions(task.testemOptions(options));
+      task.testem.startDev(options, (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {
@@ -39,7 +39,6 @@ class TestServerTask extends TestTask {
 
       let watcher = options.watcher;
       let started = false;
-
       // Wait for a build and then either start or restart testem
       watcher.on('change', () => {
         try {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -15,7 +15,8 @@ class TestTask extends Task {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      testem.startCI(task.testemOptions(options), (exitCode, error) => {
+      testem.setDefaultOptions(task.testemOptions(options));
+      testem.startCI(options, (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "sort-package-json": "^1.4.0",
     "symlink-or-copy": "^1.1.8",
     "temp": "0.8.3",
-    "testem": "^2.0.0",
+    "testem": "^2.2.0",
     "tiny-lr": "^1.0.3",
     "tree-sync": "^1.2.1",
     "uuid": "^3.0.0",

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -10,7 +10,7 @@ const MockWatcher = require('../../helpers/mock-watcher');
 describe('test server', function() {
   let subject;
 
-  it('transforms the options and invokes testem properly', function(done) {
+  it('transforms and sets defaultOptions in testem and invokes testem properly', function() {
     let ui = new MockUI();
     let watcher = new MockWatcher();
 
@@ -21,28 +21,33 @@ describe('test server', function() {
         return ['middleware1', 'middleware2'];
       },
       testem: {
-        startDev(options) {
-          expect(options.host).to.equal('greatwebsite.com');
-          expect(options.port).to.equal(123324);
-          expect(options.cwd).to.equal('blerpy-derpy');
-          expect(options.reporter).to.equal('xunit');
-          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
-          expect(options.test_page).to.equal('http://my/test/page');
-          expect(options.config_dir).to.be.an('string');
-          done();
+        setDefaultOptions(options) {
+          this.defaultOptions = options;
+        },
+        startDev(options, finalizer) {
+          this.config.setDefaultOptions(options);
+          finalizer(0);
+        },
+        config: {
+          setDefaultOptions(options) {
+            this.defaultOptions = options;
+          },
         },
       },
     });
 
-    subject.run({
+    let runResult = subject.run({
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',
       outputPath: 'blerpy-derpy',
       watcher,
       testPage: 'http://my/test/page',
+    }).then(function(value) {
+      expect(value, 'expected exist status of 0').to.eql(0);
     });
     watcher.emit('change');
+    return runResult;
   });
 
   describe('completion', function() {
@@ -76,6 +81,9 @@ describe('test server', function() {
     describe('firstRun', function() {
       it('rejects with testem exceptions', function() {
         let error = new Error('OMG');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(1, error);
@@ -92,6 +100,9 @@ describe('test server', function() {
 
       it('rejects with exit status (1)', function() {
         let error = new SilentError('Testem finished with non-zero exit code. Tests failed.');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(1);
@@ -102,11 +113,14 @@ describe('test server', function() {
         });
 
         watcher.emit('change');
-
         return runResult;
       });
 
       it('resolves with exit status (0)', function() {
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
+
         subject.testem.startDev = function(options, finalizer) {
           finalizer(0);
         };
@@ -124,6 +138,9 @@ describe('test server', function() {
     describe('restart', function() {
       it('rejects with testem exceptions', function() {
         let error = new Error('OMG');
+        subject.testem.setDefaultOptions = function(options) {
+          this.defaultOptions = options;
+        };
 
         subject.testem.startDev = function(options, finalizer) {
           finalizer(0);


### PR DESCRIPTION
When ember-cli invokes testem it provides defaultOptions for testem to use as a fallback option. But currently, the fallback option from ember-cli is used as progOptions in testem. And since progOptions has higher priority than fileOptions, the cwd being set in the testem.js file of an ember app is being overridden by ember-cli's fallbackOption.

Solution is to add defaultOptions as a sibling to progOptions and fileOptions in testem. And ember-cli can set defaultOptions invoke testem.

Related work in testem is in the below PR.
testem/testem#1219