### PR TITLE
restore `addon-import` logic

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -23,9 +23,12 @@ class GenerateTask extends Task {
     let addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
 
     // otherwise, use default addon-import
-    let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && !this.project.isModuleUnification();
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && mainBlueprintSupportsAddon && options.args[1]) {
-      addonBlueprint = this.lookupBlueprint('addon-import', true);
+    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && options.args[1]) {
+      let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && !this.project.isModuleUnification();
+
+      if (mainBlueprintSupportsAddon) {
+        addonBlueprint = this.lookupBlueprint('addon-import', true);
+      }
     }
 
     if (options.ignoreMissingMain && !mainBlueprint) {


### PR DESCRIPTION
Fixes https://github.com/ember-cli/ember-cli/issues/7726

In my attempt to simplify a quite complex piece of code while adding an additional condition, I inadvertently modified the logic such that  `mainBlueprint.supportsAddon()` was called in more cases that before my change. It seems that calling [`blueprint.supportsAddon()`](https://github.com/ember-cli/ember-cli/blob/e23c2ef653cffa4a95db8dad78214cef20222b79/lib/models/blueprint.js#L775) has some side-effects (as it calls `blueprint.files()`) which resulted in some blueprint code executing without having a reference to `this.project`: https://github.com/ember-cli/ember-cli/issues/7726

Here is the original logic:

```js
if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && (mainBlueprint && mainBlueprint.supportsAddon()) && options.args[1]) {
  addonBlueprint = this.lookupBlueprint('addon-import', true);
}
```

This is all quite brittle, but as this code will be removed once MU takes over the world, I think it's ok to leave as is.

