### PR TITLE
Prompt to perform `yarn` in case of missing deps and present yarn.lock

### DIFF
--- a/lib/models/installation-checker.js
+++ b/lib/models/installation-checker.js
@@ -25,8 +25,10 @@ class InstallationChecker {
 
     if (this.usingNpm() && this.npmDependenciesNotPresent()) {
       logger.info('npm dependencies not installed');
-      commands.push('`npm install`');
+      const command = this.usingYarn() ? '`yarn`' : '`npm install`';
+      commands.push(command);
     }
+
     if (this.usingBower() && this.bowerDependenciesNotPresent()) {
       logger.info('bower dependencies not installed');
       commands.push('`bower install`');
@@ -54,7 +56,15 @@ class InstallationChecker {
   }
 
   usingNpm() {
-    return fs.existsSync(path.join(this.project.root, 'package.json')) && this.hasNpmDeps();
+    return this.fileExistsInRoot('package.json') && this.hasNpmDeps();
+  }
+
+  usingYarn() {
+    return this.fileExistsInRoot('yarn.lock') && this.hasNpmDeps();
+  }
+
+  fileExistsInRoot(fileName) {
+    return fs.existsSync(path.join(this.project.root, fileName));
   }
 
   npmDependenciesNotPresent() {


### PR DESCRIPTION
I did not test this so far. I tried `yarn link` but it seems like the `installation-checker` gets executed from the global version of ember-cli, not the local one.