### PR TITLE
Fix issues identified with "delayed transpilation" system.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -688,7 +688,7 @@ class EmberApp {
 
     if (defaultsForType.length > 1) {
       throw new Error(
-        `There are multiple preprocessor plugins marked as default that are registered for '${type}': ${defaultsForType.map(p => p.name).join(', ')}`
+        `There are multiple preprocessor plugins marked as default for '${type}': ${defaultsForType.map(p => p.name).join(', ')}`
       );
     }
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -688,7 +688,7 @@ class EmberApp {
 
     if (defaultsForType.length > 1) {
       throw new Error(
-        `There are multiple preprocessor plugins that are registered for '${type}': ${defaultsForType.map(p => p.name).join(', ')}`
+        `There are multiple preprocessor plugins marked as default that are registered for '${type}': ${defaultsForType.map(p => p.name).join(', ')}`
       );
     }
 
@@ -696,7 +696,7 @@ class EmberApp {
   }
 
   _compileAddonTemplates(tree) {
-    let defaultPluginForType = this._getDefaultPluginForType('js');
+    let defaultPluginForType = this._getDefaultPluginForType('template');
     let options = {
       annotation: `_compileAddonTemplates`,
       registry: this.registry,

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -682,20 +682,47 @@ class EmberApp {
     return this._addonTreesFor(type).map(addonBundle => addonBundle.tree);
   }
 
+  _getDefaultPluginForType(type) {
+    let plugins = this.registry.load(type);
+    let defaultsForType = plugins.filter(plugin => plugin.isDefaultForType);
+
+    if (defaultsForType.length > 1) {
+      throw new Error(
+        `There are multiple preprocessor plugins that are registered for '${type}': ${defaultsForType.map(p => p.name).join(', ')}`
+      );
+    }
+
+    return defaultsForType[0];
+  }
+
   _compileAddonTemplates(tree) {
-    tree = preprocessTemplates(tree, {
+    let defaultPluginForType = this._getDefaultPluginForType('js');
+    let options = {
       annotation: `_compileAddonTemplates`,
       registry: this.registry,
-    });
+    };
+
+    if (defaultPluginForType) {
+      tree = defaultPluginForType.toTree(tree, options);
+    } else {
+      tree = preprocessTemplates(tree, options);
+    }
 
     return tree;
   }
 
   _compileAddonJs(tree) {
-    tree = preprocessJs(tree, '/', '/', {
-      annotation: `_compileAddonJs`,
+    let defaultPluginForType = this._getDefaultPluginForType('js');
+    let options = {
+      annotation: '_compileAddonJs',
       registry: this.registry,
-    });
+    };
+
+    if (defaultPluginForType) {
+      tree = defaultPluginForType.toTree(tree, options);
+    } else {
+      tree = preprocessJs(tree, '/', '/', options);
+    }
 
     return tree;
   }

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -682,35 +682,20 @@ class EmberApp {
     return this._addonTreesFor(type).map(addonBundle => addonBundle.tree);
   }
 
-  _getDefaultCompiler(type) {
-    // since we are now using the app's registry to compile addon code,
-    // we could get into the case where the app has multiple compilers (coffeescript, emblem, etc.)
-    // operating on addon code where there weren't previously.
-    // This prevents that by using the default app compiler only.
-    let plugins = this.registry.load(type);
-    return plugins[plugins.length - 1];
-  }
-
   _compileAddonTemplates(tree) {
-    let plugin = this._getDefaultCompiler('template');
-    if (plugin) {
-      tree = plugin.toTree(tree, {
-        annotation: `_compileAddonTemplates`,
-        registry: this.registry,
-      });
-    }
+    tree = preprocessTemplates(tree, {
+      annotation: `_compileAddonTemplates`,
+      registry: this.registry,
+    });
 
     return tree;
   }
 
   _compileAddonJs(tree) {
-    let plugin = this._getDefaultCompiler('js');
-    if (plugin) {
-      tree = plugin.toTree(tree, '/', '/', {
-        annotation: `_compileAddonJs`,
-        registry: this.registry,
-      });
-    }
+    tree = preprocessJs(tree, '/', '/', {
+      annotation: `_compileAddonJs`,
+      registry: this.registry,
+    });
 
     return tree;
   }

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -754,7 +754,7 @@ let addonProto = {
     @return
   */
   treeForSrc(rawSrcTree) {
-    if (!experiments.MODULE_UNIFICATION) {
+    if (!experiments.MODULE_UNIFICATION || !this.isModuleUnification()) {
       return null;
     }
     if (!rawSrcTree) { return null; }

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -754,7 +754,7 @@ let addonProto = {
     @return
   */
   treeForSrc(rawSrcTree) {
-    if (!experiments.MODULE_UNIFICATION || !this.isModuleUnification()) {
+    if (!experiments.MODULE_UNIFICATION) {
       return null;
     }
     if (!rawSrcTree) { return null; }


### PR DESCRIPTION
This PR includes two specific fixes (discovered during pairing session with @twokul this morning).

---

Ensure `treeForSrc` does nothing when `isModuleUnification` is falsey.

An earlier change made `isModuleUnification` a manual opt-in (due to the breaking change of detecting `src/` and assuming it was module unification), however the `treeForSrc` implementation was not properly leveraging `this.isModuleUnification()` to determine if it should even do any work.

This adds an additional conditional to the short curcuit, and ensures that `treeForSrc` does _nothing_ when a given addon is not opting in to module unification.

---

Cleanup the mechanism to determine the default plugin for a given type.

Instead of using the previous heuristics we require that a plugin declare itself as the default for type. This would look like:

```js
registry.add('js', {
 name: 'ember-cli-babel',
 ext: 'js',
 isDefaultForType: true,
 toTree: (tree) => this.transpileTree(tree)
});
```

If no plugins declare that they are the default for a given type, all plugins will be used (since choosing the default arbitrarily is not a valid option).