### PR TITLE
remove config caching

### DIFF
--- a/lib/utilities/get-config.js
+++ b/lib/utilities/get-config.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let config;
 let Yam = require('yam');
 let Project = require('../models/project');
 
@@ -10,14 +9,10 @@ function generateConfig() {
   });
 }
 
-module.exports = function getConfig(configOverride) {
-  if (configOverride) {
-    return configOverride;
+module.exports = function getConfig(override) {
+  if (override) {
+    return override;
   }
 
-  if (config === undefined) {
-    config = generateConfig();
-  }
-
-  return config;
+  return generateConfig();
 };


### PR DESCRIPTION
Config caching was added as part of https://github.com/ember-cli/ember-cli/pull/7491, but it resulted in a bunch of blueprint test failures for tests in ember-source, see [this discussion](https://github.com/emberjs/ember.js/pull/16465#discussion_r179132445).

Removing this will unblock the MU blueprint work.