### PR TITLE
Allowing cwd to be passed to testem without being overridden by ember-cli

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -8,9 +8,10 @@ const SilentError = require('silent-error');
 class TestServerTask extends TestTask {
   invokeTestem(options) {
     let task = this;
+
     return new Promise((resolve, reject) => {
-      task.testem.setDefaultOptions(task.testemOptions(options));
-      task.testem.startDev(options, (exitCode, error) => {
+      task.testem.setDefaultOptions(task.defaultOptions(options));
+      task.testem.startDev(task.transformOptions(options), (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {
@@ -39,6 +40,7 @@ class TestServerTask extends TestTask {
 
       let watcher = options.watcher;
       let started = false;
+
       // Wait for a build and then either start or restart testem
       watcher.on('change', () => {
         try {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -15,8 +15,8 @@ class TestTask extends Task {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      testem.setDefaultOptions(task.testemOptions(options));
-      testem.startCI(options, (exitCode, error) => {
+      testem.setDefaultOptions(task.defaultOptions(options));
+      testem.startCI(task.transformOptions(options), (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {
@@ -40,18 +40,25 @@ class TestTask extends Task {
     }, []);
   }
 
-  testemOptions(options) {
+  defaultOptions(options) {
+    let defaultOptions = this.transformOptions(options);
+    defaultOptions.cwd = options.outputPath;
+    /* eslint-disable camelcase */
+    defaultOptions.config_dir = process.cwd();
+    /* eslint-enable camelcase */
+    return defaultOptions;
+  }
+
+    transformOptions(options) {
     return {
       host: options.host,
       port: options.port,
-      cwd: options.outputPath,
       debug: options.testemDebug,
       reporter: options.reporter,
       middleware: this.addonMiddlewares(),
       launch: options.launch,
       file: options.configFile,
       /* eslint-disable camelcase */
-      config_dir: process.cwd(),
       test_page: options.testPage,
       query_params: options.queryString,
       /* eslint-enable camelcase */

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -49,7 +49,7 @@ class TestTask extends Task {
     return defaultOptions;
   }
 
-    transformOptions(options) {
+  transformOptions(options) {
     return {
       host: options.host,
       port: options.port,

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -25,13 +25,16 @@ describe('test server', function() {
           this.defaultOptions = options;
         },
         startDev(options, finalizer) {
-          this.config.setDefaultOptions(options);
+          expect(options.host).to.equal('greatwebsite.com');
+          expect(options.port).to.equal(123324);
+          expect(options.reporter).to.equal('xunit');
+          expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
+          expect(options.test_page).to.equal('http://my/test/page');
+          expect(options.cwd).to.be.undefined;
+          expect(options.config_dir).to.be.undefined;
+          expect(this.defaultOptions.cwd).to.equal('blerpy-derpy');
+          expect(this.defaultOptions.config_dir).to.be.an('string');
           finalizer(0);
-        },
-        config: {
-          setDefaultOptions(options) {
-            this.defaultOptions = options;
-          },
         },
       },
     });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -15,17 +15,26 @@ describe('test task test', function() {
       },
 
       invokeTestem(options) {
-        let testemOptions = this.testemOptions(options);
-
+        // cwd and config_dir are not passed to testem progOptions
+        let testemOptions = this.transformOptions(options);
         expect(testemOptions.host).to.equal('greatwebsite.com');
         expect(testemOptions.port).to.equal(123324);
-        expect(testemOptions.cwd).to.equal('blerpy-derpy');
+        expect(testemOptions.cwd).to.be.undefined;
         expect(testemOptions.reporter).to.equal('xunit');
         expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
         expect(testemOptions.test_page).to.equal('http://my/test/page');
-        expect(testemOptions.debug).to.equal('testem.log');
-        expect(testemOptions.config_dir).to.be.an('string');
-        expect(testemOptions.file).to.equal('custom-testem-config.json');
+        expect(testemOptions.config_dir).to.be.undefined;
+
+        // cwd and config_dir are present as part of default options.
+        let defaultOptions = this.defaultOptions(options);
+        expect(defaultOptions.host).to.equal('greatwebsite.com');
+        expect(defaultOptions.port).to.equal(123324);
+        expect(defaultOptions.cwd).to.equal('blerpy-derpy');
+        expect(defaultOptions.reporter).to.equal('xunit');
+        expect(defaultOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
+        expect(defaultOptions.test_page).to.equal('http://my/test/page');
+        expect(defaultOptions.config_dir).to.be.an('string');
+
       },
     });
 


### PR DESCRIPTION
When ember-cli invokes testem it provides defaultOptions for testem to use as a fallback option. But currently, the fallback option from ember-cli is used as progOptions in testem. And since progOptions has higher priority than fileOptions, the cwd being set in the testem.js file of an ember app is being overridden by ember-cli's fallbackOption.

Solution is to add defaultOptions as a sibling to progOptions and fileOptions in testem. And ember-cli can set defaultOptions invoke testem.

Related work in testem is in the below PR.
testem/testem#1219

Previously this commit caused the tests to run in only 1 partition because when ember-cli was passing progOptions to testem, it didnt transform the option's property names like testPage to test_page which has partition information from ember exam. Hence by default it ran in 1 partition.
ember exam does not fail if it is asked to run in multiple partitions but it ran only in 1 partition.