### PR TITLE
Remove default value for `ember addon --yarn`

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -13,7 +13,7 @@ module.exports = NewCommand.extend({
     { name: 'skip-npm',   type: Boolean, default: false,   aliases: ['sn'] },
     { name: 'skip-bower', type: Boolean, default: false,   aliases: ['sb'] },
     { name: 'skip-git',   type: Boolean, default: false,   aliases: ['sg'] },
-    { name: 'yarn',       type: Boolean, default: false },
+    { name: 'yarn',       type: Boolean }, // no default means use yarn if the blueprint has a yarn.lock
     { name: 'directory',  type: String,                    aliases: ['dir'] },
   ],
 

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -16,7 +16,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
-  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -61,7 +61,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -16,7 +16,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
     \u001b[90maliases: -sb\u001b[39m
   \u001b[36m--skip-git\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -sg\u001b[39m
-  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
+  \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
 

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -61,7 +61,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -61,7 +61,6 @@ module.exports = {
         },
         {
           name: 'yarn',
-          default: false,
           key: 'yarn',
           required: false
         },


### PR DESCRIPTION
Like `ember new`, `ember addon` should not have a default value for the `--yarn` option so that it will search for a yarn.lock or Yarn workspace root unless the option is specified exactly.