### PR TITLE
Skip running custom "*-addon" blueprint if module unification

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -15,16 +15,21 @@ class GenerateTask extends Task {
 
   run(options) {
     let name = options.args[0];
+    let isNotModuleUnification = !this.project.isModuleUnification();
     let noAddonBlueprint = ['mixin', 'blueprint-test'];
 
     let mainBlueprint = this.lookupBlueprint(name, options.ignoreMissingMain);
     let testBlueprint = this.lookupBlueprint(`${name}-test`, true);
+
     // lookup custom addon blueprint
-    let addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
+    let addonBlueprint;
+    if (isNotModuleUnification) {
+      addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
+    }
 
     // otherwise, use default addon-import
     if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && options.args[1]) {
-      let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && !this.project.isModuleUnification();
+      let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && isNotModuleUnification;
 
       if (mainBlueprintSupportsAddon) {
         addonBlueprint = this.lookupBlueprint('addon-import', true);

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -105,6 +105,45 @@ describe('Acceptance: ember generate in-addon', function() {
     expect(file('app/services/session.js')).to.not.exist;
   }));
 
+  it('runs a custom "*-addon" bluprint from a classic addon', co.wrap(function *() {
+    yield initAddon('my-addon');
+
+    yield outputFile(
+      'blueprints/service/files/__root__/__path__/__name__.js',
+      "import Service from '@ember/service';\n" +
+      'export default Service.extend({ });\n'
+    );
+
+    yield outputFile(
+      'blueprints/service-addon/files/app/services/session.js',
+      "export { default } from 'somewhere';\n"
+    );
+
+    yield ember(['generate', 'service', 'session']);
+
+    expect(file('app/services/session.js')).to.exist;
+  }));
+
+  it('skips a custom "*-addon" bluprint from a module unficiation addon', co.wrap(function *() {
+    yield initAddon('my-addon');
+    yield ensureDir('src');
+
+    yield outputFile(
+      'blueprints/service/files/__root__/__path__/__name__.js',
+      "import Service from '@ember/service';\n" +
+      'export default Service.extend({ });\n'
+    );
+
+    yield outputFile(
+      'blueprints/service-addon/files/app/services/session.js',
+      "export { default } from 'somewhere';\n"
+    );
+
+    yield ember(['generate', 'service', 'session']);
+
+    expect(file('app/services/session.js')).to.not.exist;
+  }));
+
   it('in-addon blueprint foo', co.wrap(function *() {
     yield generateInAddon(['blueprint', 'foo']);
 


### PR DESCRIPTION
Blueprints can define a custom `foo-addon` blueprint for addon exports. Examples:

 * https://github.com/emberjs/ember.js/tree/master/blueprints/route-addon
 * https://github.com/emberjs/ember.js/tree/master/blueprints/initializer-addon
 * https://github.com/emberjs/ember.js/tree/master/blueprints/instance-initializer-addon

We don't want to run these for module unification apps as MU uses a different mechanism for addon exports.

This PR will unblock work on blueprints such as https://github.com/emberjs/ember.js/pull/16492#issuecomment-381515742
 