### PR TITLE
Don't try to use default addon-import if app is MU

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -25,14 +25,14 @@ class GenerateTask extends Task {
     let addonBlueprint;
     if (isNotModuleUnification) {
       addonBlueprint = this.lookupBlueprint(`${name}-addon`, true);
-    }
 
-    // otherwise, use default addon-import
-    if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && options.args[1]) {
-      let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && isNotModuleUnification;
+      // otherwise, use default addon-import
+      if (noAddonBlueprint.indexOf(name) < 0 && !addonBlueprint && options.args[1]) {
+        let mainBlueprintSupportsAddon = mainBlueprint && mainBlueprint.supportsAddon() && isNotModuleUnification;
 
-      if (mainBlueprintSupportsAddon) {
-        addonBlueprint = this.lookupBlueprint('addon-import', true);
+        if (mainBlueprintSupportsAddon) {
+          addonBlueprint = this.lookupBlueprint('addon-import', true);
+        }
       }
     }
 


### PR DESCRIPTION
This is the second time I've been bitten by this complex logic, the first was in https://github.com/ember-cli/ember-cli/pull/7731

I recently made [this change](https://github.com/ember-cli/ember-cli/pull/7764) to skip looking up custom `*-addon` blueprints when the app is MU. Doing so sometimes resulted in an extra call to `mainBlueprint.supportsAddon()` which causes the blueprint files to be calculated, which in turn causes an exception (as `this.project` is undefined). I noticed this when trying to [upgrade ember-cli in ember-source](https://github.com/emberjs/ember.js/pull/16525).

This continues to be brittle & complex code, but it will be removed one MU becomes the single ember app format so I don't think it's worth the cost of untangling this with a series of simplification refactor PRs. I also don't expect to be making more changes here to support MU