### PR TITLE
add blueprints to linting coverage

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -75,7 +75,7 @@ module.exports = {
     contents.scripts['test:all'] = 'ember try:each';
 
     // add addon specific directories to lint:js script
-    contents.scripts['lint:js'] = 'eslint ./*.js addon addon-test-support app config lib server test-support tests';
+    contents.scripts['lint:js'] = 'eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests';
 
     contents['ember-addon'] = contents['ember-addon'] || {};
     contents['ember-addon'].configPath = 'tests/dummy/config';

--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -1,0 +1,1 @@
+/blueprints/*/files/**/*.js

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',<% if (blueprint !== 'app') { %>
         'index.js',<% } %>
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js'<% if (blueprint === 'app') { %>,
         'lib/*/index.js'<% } %><% if (blueprint !== 'app') { %>,
         'tests/dummy/config/**/*.js'<% } %>

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -14,7 +14,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each"

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -14,7 +14,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each"

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
       files: [
         'ember-cli-build.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'lib/*/index.js'
       ],

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
       files: [
         'ember-cli-build.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'lib/*/index.js'
       ],

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/tests/fixtures/module-unification-app/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/npm/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/tests/fixtures/module-unification-app/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/yarn/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -12,7 +12,7 @@
   "repository": "",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "ember serve",
     "test": "ember test"
   },

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -70,7 +70,7 @@ describe('blueprint - addon', function() {
     "ember-addon"\n\
   ],\n\
   "scripts": {\n\
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",\n\
+    "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",\n\
     "test:all": "ember try:each"\n\
   },\n\
   "dependencies": {},\n\


### PR DESCRIPTION
We got burned by the "node/no-unpublished-require" in blueprint files, so lets add it to lint coverage. I also exclude the templated files from eslint.