### PR TITLE
Remove private `javascript` method

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -364,6 +364,9 @@ module.exports = class DefaultPackager {
   */
   packageJavascript(tree) {
     if (this._cachedJavascript === null) {
+      let vendorFilePath = this.distPaths.vendorJsFile;
+      this.scriptOutputFiles[vendorFilePath].unshift('vendor/ember-cli/vendor-prefix.js');
+
       let appJs = this.packageApplicationJs(tree);
       let vendorJs = this.packageVendorJs(tree);
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1527,23 +1527,6 @@ class EmberApp {
   }
 
   /**
-    Returns the tree for javascript files
-
-    @private
-    @method javascript
-    @return {Tree} Merged tree
-  */
-  javascript() {
-    let applicationJs = this.appAndDependencies();
-
-    let vendorFilePath = this.options.outputPaths.vendor.js;
-
-    this._scriptOutputFiles[vendorFilePath].unshift('vendor/ember-cli/vendor-prefix.js');
-
-    return this._defaultPackager.packageJavascript(applicationJs);
-  }
-
-  /**
     Returns the tree for styles
 
     @private
@@ -1899,9 +1882,12 @@ class EmberApp {
 
     let publicTree = this._defaultPackager.packagePublic(addonPublicTrees);
 
+    let applicationJs = this.appAndDependencies();
+    let javascriptTree = this._defaultPackager.packageJavascript(applicationJs);
+
     let sourceTrees = [
       this.index(),
-      this.javascript(),
+      javascriptTree,
       this.styles(),
       // undefined when `experiments.MODULE_UNIFICATION` is not available
       this._srcAfterStylePreprocessing,

--- a/tests/helpers/default-packager.js
+++ b/tests/helpers/default-packager.js
@@ -1,0 +1,254 @@
+'use strict';
+
+/*
+ * A list of "helper" functions to automate tedious tasks of generating and
+ * validating folder structures.
+*/
+
+const assert = require('assert');
+
+const DEFAULT_ADDON_MODULES = {
+  'ember-cli-foobar': '^1.0.0',
+};
+const DEFAULT_BOWER_COMPONENTS = {};
+
+const DEFAULT_NODE_MODULES = {
+  'broccoli-asset-rev': {
+    'index.js': 'module.exports = function() { return { name: "broccoli-asset-rev" }; };',
+    'package.json': JSON.stringify({
+      name: 'broccoli-asset-rev',
+      keywords: ['ember-addon'],
+    }),
+  },
+  'ember-cli-htmlbars': {
+    'index.js': `module.exports = {
+        name: 'ember-cli-htmlbars',
+        setupPreprocessorRegistry(type, registry) {
+          registry.add('template', {
+            name: 'ember-cli-htmlbars',
+            ext: 'hbs',
+            toTree(tree) { return tree; }
+          });
+        }
+      };
+      `,
+    'package.json': JSON.stringify({
+      name: 'ember-cli-htmlbars',
+      version: '2.0.1',
+      keywords: ['ember-addon'],
+    }),
+  },
+  'ember-source': {
+    'index.js': `module.exports = function() {
+        return {
+          name: 'ember-source',
+          paths: {
+            debug: 'vendor/ember/ember.debug.js',
+            prod: 'vendor/ember/ember.prod.js',
+            testing: 'vendor/ember/ember-testing.js',
+            shims: undefined,
+            jquery: 'vendor/ember/jquery/jquery.js',
+          }
+        };
+      };
+      `,
+    'package.json': JSON.stringify({
+      name: 'ember-source',
+      version: '~3.0.0-beta.1',
+      keywords: ['ember-addon'],
+      paths: {
+        debug: 'vendor/ember/ember.debug.js',
+        prod: 'vendor/ember/ember.prod.js',
+        testing: 'vendor/ember/ember-testing.js',
+        shims: undefined,
+        jquery: 'vendor/ember/jquery/jquery.js',
+      },
+    }),
+  },
+};
+
+const DEFAULT_VENDOR = {
+  'loader': {
+    'loader.js': 'W',
+  },
+  'ember': {
+    'jquery': {
+      'jquery.js': 'window.$ = function() {}',
+    },
+    'ember.js': 'window.Ember = {};',
+    'ember.debug.js': 'window.Ember = {};',
+  },
+  'ember-cli': {
+    'app-boot.js': '!!!',
+    'app-config.js': 'SPARTA',
+    'app-prefix.js': 'THIS',
+    'app-suffix.js': 'IS',
+    'test-support-prefix.js': 'If a clod be washed away by the sea,',
+    'test-support-suffix.js': 'Europe is the less.',
+    'tests-prefix.js': 'As well as if a promontory were.',
+    'tests-suffix.js': 'As well as if a manor of thine own',
+    'vendor-prefix.js': 'HELLO',
+    'vendor-suffix.js': '!',
+  },
+  'ember-cli-shims': {
+    'app-shims.js': 'L',
+  },
+  'ember-resolver': {
+    'legacy-shims.js': 'D',
+  },
+};
+
+const DEFAULT_SOURCE = {
+  'index.html': '<html></html>',
+  'router.js': 'export default class {}',
+  'resolver.js': `export default class {}`,
+  routes: {
+    'index.js': 'export default class {}',
+  },
+  styles: {
+    'app.css': 'html,body{height:100%}',
+  },
+  templates: {
+    'application.hbs': '{{outlet}}',
+  },
+  config: {
+    'environment.js': `module.exports = function() { return { modulePrefix: 'the-best-app-ever' }; };`,
+  },
+  'package.json': JSON.stringify({
+    name: 'the-best-app-ever',
+    'devDependencies': {
+      'broccoli-asset-rev': '^2.4.5',
+      'ember-ajax': '^3.0.0',
+      'ember-cli': '~3.0.0-beta.1',
+      'ember-cli-app-version': '^3.0.0',
+      'ember-cli-babel': '^6.6.0',
+      'ember-cli-dependency-checker': '^2.0.0',
+      'ember-cli-eslint': '^4.2.1',
+      'ember-cli-htmlbars': '^2.0.1',
+      'ember-cli-htmlbars-inline-precompile': '^1.0.0',
+      'ember-cli-inject-live-reload': '^1.4.1',
+      'ember-cli-qunit': '^4.1.1',
+      'ember-cli-sass': '^7.1.3',
+      'ember-cli-shims': '^1.2.0',
+      'ember-cli-sri': '^2.1.0',
+      'ember-cli-uglify': '^2.0.0',
+      'ember-data': '~3.0.0-beta.1',
+      'ember-export-application-global': '^2.0.0',
+      'ember-load-initializers': '^1.0.0',
+      'ember-resolver': '^4.0.0',
+      'ember-source': '~3.0.0-beta.1',
+      'loader.js': '^4.2.3',
+    },
+  }),
+  tests: {
+    'test-helper.js': '// test-helper.js',
+    integration: {
+      components: {
+        'foo-bar-test.js': '// foo-bar-test.js',
+      },
+    },
+  },
+};
+
+/*
+ * Generates an object that represents an unpackaged Ember application tree,
+ * including application source, addons, vendor, bower (empty) and node.js files.
+ *
+ * @param {String} name The name of the app
+ * @param {Object} options Customize output object
+ *
+ * @return {Object}
+*/
+function getDefaultUnpackagedDist(name, options) {
+  options = options || {};
+
+  const addonModules = Object.assign({}, DEFAULT_ADDON_MODULES, options.addonModules);
+  const bowerComponents = options.bowerComponents || DEFAULT_BOWER_COMPONENTS;
+  const nodeModules = options.nodeModules || DEFAULT_NODE_MODULES;
+  const application = Object.assign({}, DEFAULT_SOURCE, options.source);
+  const vendor = Object.assign({}, DEFAULT_VENDOR, options.vendor);
+
+  return {
+    'addon-modules': addonModules,
+    'bower_components': bowerComponents,
+    'node_modules': nodeModules,
+    [name]: application,
+    vendor,
+  };
+}
+
+/*
+ * Validates that passed-in object has the following shape:
+ *
+ * ```javascript
+ * {
+ *   assets: {
+ *     [name].js
+ *     [name].map
+ *     vendor.js
+ *     vendor.map
+ *   }
+ * }
+ * ```
+ *
+ * This shape corresponds to the "dist" folder structure that Ember CLI creates
+ * after the build.
+ *
+ * If the shape does not correspond to the expected value, it throws an
+ * exception.
+*/
+function validateDefaultPackagedDist(name, obj) {
+  if (obj !== undefined || obj.assets !== undefined) {
+    let result = Object.keys(obj.assets).sort();
+
+    let valid = [
+      `${name}.js`,
+      `${name}.map`,
+      'vendor.js',
+      'vendor.map',
+    ];
+
+    assert.deepEqual(result, valid, `Expected [${valid}] but got [${result}]`);
+  } else {
+    throw new Error('Validation Error: Packaged files must be nested under `assets` folder');
+  }
+}
+
+/*
+ * Generates an object that represents a "dependency" on the disk. Could be used
+ * both for generating bower and node dependencies.
+ *
+ * ```javascript
+ * getDependencyFor('moment', {
+ *   'file1.js: 'content',
+ *   'file2.js': 'content'
+ * });
+ * ```
+*/
+function getDependencyFor(key, value) {
+  return {
+    [key]: value,
+  };
+}
+
+function setupProject(rootPath) {
+  const path = require('path');
+  const Project = require('../../lib/models/project');
+  const MockCLI = require('./mock-cli');
+
+  const packageContents = require(path.join(rootPath, 'package.json'));
+  let cli = new MockCLI();
+
+  return new Project(rootPath, packageContents, cli.ui, cli);
+}
+
+module.exports = {
+  setupProject,
+  validateDefaultPackagedDist,
+  getDefaultUnpackagedDist,
+  getDependencyFor,
+  DEFAULT_SOURCE,
+  DEFAULT_VENDOR,
+  DEFAULT_NODE_MODULES,
+  DEFAULT_ADDON_MODULES,
+};

--- a/tests/unit/broccoli/ember-app/import-test.js
+++ b/tests/unit/broccoli/ember-app/import-test.js
@@ -1,236 +1,156 @@
 'use strict';
 
 const co = require('co');
-const fs = require('fs-extra');
+const path = require('path');
 const broccoliTestHelper = require('broccoli-test-helper');
 const expect = require('chai').expect;
+const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
 const EmberApp = require('../../../../lib/broccoli/ember-app');
-const MockCLI = require('../../../helpers/mock-cli');
-const Project = require('../../../../lib/models/project');
 
 const buildOutput = broccoliTestHelper.buildOutput;
 const createTempDir = broccoliTestHelper.createTempDir;
 
-const APPLICATION_BLUEPRINT = {
-  app: {
-    'app.js': '',
-  },
-  'bower_components': {
-    ember: {
-      'ember.js': 'window.Ember = { foo: "bar"; };',
-    },
-    jquery: {
-      dist: {
-        'jquery.js': 'window.$ = function() { console.log("this is jQuery!"); };',
-      },
-    },
-    moment: {
-      'moment.js': 'window.moment = "what does time even mean?";',
-      'moment.min.js': 'window.moment="verysmallmoment"',
-    },
-  },
-  config: {
-    'environment.js': `
-      'use strict';
-      module.exports = function(environment) {
-        return {
-          modulePrefix: 'app-import',
-          environment,
-        };
-      };
-    `,
-  },
-  'node_modules': {
-    moment: {
-      'package.json': '{}',
-      'moment.js': 'window.moment = "what does time even mean?";',
-      'moment.min.js': 'window.moment="verysmallmoment"',
-    },
-    '@scoped': {
-      private: {
-        'package.json': '{}',
-        'index.js': 'window.secret = "sssshhhhh";',
-      },
-    },
-  },
-  'package.json': JSON.stringify({
-    name: 'app-import',
-    devDependencies: {
-      'broccoli-asset-rev': '^2.7.0',
-      'ember-ajax': '^3.0.0',
-      'ember-cli': '~2.14.0-beta.1',
-      'ember-cli-app-version': '^3.0.0',
-      'ember-cli-babel': '^6.0.0',
-      'ember-cli-dependency-checker': '^1.3.0',
-      'ember-cli-eslint': '^3.0.0',
-      'ember-cli-htmlbars': '^1.1.1',
-      'ember-cli-htmlbars-inline-precompile': '^0.4.0',
-      'ember-cli-inject-live-reload': '^1.4.1',
-      'ember-cli-qunit': '^4.1.1',
-      'ember-cli-shims': '^1.2.0',
-      'ember-cli-sri': '^2.1.0',
-      'ember-cli-uglify': '^2.0.0',
-      'ember-data': '~2.13.0',
-      'ember-export-application-global': '^2.0.0',
-      'ember-load-initializers': '^1.1.0',
-      'ember-resolver': '^4.0.0',
-      'ember-source': '~2.14.0-beta.1',
-      'ember-welcome-page': '^3.0.0',
-      'loader.js': '^4.2.3',
-    },
-    engines: {
-      node: '>= 4',
-    },
-    private: true,
-  }),
-};
+const getDefaultUnpackagedDist = defaultPackagerHelpers.getDefaultUnpackagedDist;
+const getDependencyFor = defaultPackagerHelpers.getDependencyFor;
+const setupProject = defaultPackagerHelpers.setupProject;
+const validateDefaultPackagedDist = defaultPackagerHelpers.validateDefaultPackagedDist;
 
-describe('EmberApp.import()', function() {
-  let input, cwd;
+describe('EmberApp: Bower Dependencies', function() {
+  let applicationDirectory, output;
 
-  before(co.wrap(function *() {
-    cwd = process.cwd();
+  let moment = getDependencyFor('moment', {
+    'package.json': '{}',
+    'moment.js': 'window.moment = "what does time even mean?";',
+    'moment.min.js': 'window.moment = "verysmallmoment"',
+  });
 
-    input = yield createTempDir();
-    input.write(APPLICATION_BLUEPRINT);
+  beforeEach(co.wrap(function *() {
+    applicationDirectory = yield createTempDir();
   }));
 
-  after(co.wrap(function *() {
-    process.chdir(cwd);
-    yield input.dispose();
+  afterEach(co.wrap(function *() {
+    yield applicationDirectory.dispose();
+    yield output.dispose();
   }));
 
-  function createApp(options) {
-    options = options || {};
+  /*
+   * Both Ember.js and jQuery are packaged by default (when distriburted
+   * through bower). `ember-source` takes precedent over bower though.
+   */
+  it('are not packaged unless explicitly imported', co.wrap(function *() {
+    // Given
+    applicationDirectory.write(getDefaultUnpackagedDist('the-best-app-ever', {
+      bowerComponents: Object.assign({}, moment),
+    }));
 
-    let path = input.path();
-    process.chdir(path);
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(
+        path.join(applicationDirectory.path(), 'the-best-app-ever')
+      ),
+    });
 
-    let pkg = fs.readJsonSync(`${path}/package.json`);
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-    let cli = new MockCLI();
-    let project = new Project(path, pkg, cli.ui, cli);
+    // Then
+    output = yield buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-    EmberApp.env = function() {
-      return options.env || 'development';
-    };
-
-    let app = new EmberApp({
-      project,
-      _ignoreMissingLoader: true,
-      sourcemaps: { enabled: false },
-    }, options);
-
-    app._processedTemplatesTree = () => '';
-    app._compileAddonTemplates = tree => tree;
-
-    return app;
-  }
-
-  it('does not import bower dependencies if they are not explicitly imported', co.wrap(function *() {
-    let app = createApp();
-
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('window.Ember = {');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.$ = function() {');
-    expect(outputTree['assets']['vendor.js']).to.not.contain('window.moment');
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.Ember = {');
+    expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
+    expect(results.assets['vendor.js']).to.not.contain('window.moment');
   }));
 
-  it('can import bower dependencies into vendor.js', co.wrap(function *() {
-    let app = createApp();
+  it('are packaged when explicitly imported', co.wrap(function *() {
+    // Given
+    applicationDirectory.write(getDefaultUnpackagedDist('the-best-app-ever', {
+      bowerComponents: Object.assign({}, moment),
+    }));
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(
+        path.join(applicationDirectory.path(), 'the-best-app-ever')
+      ),
+    });
+    applicationInstance.import('bower_components/moment/moment.js');
 
-    app.import('bower_components/moment/moment.js');
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('window.Ember = {');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.$ = function() {');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.moment');
+    // Then
+    output = yield buildOutput(packagedApplicationJs);
+    let results = output.read();
+
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.Ember = {');
+    expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
+    expect(results.assets['vendor.js']).to.contain('window.moment');
   }));
 
-  it('handles imports with different environments (development)', co.wrap(function *() {
-    let app = createApp();
+  it('are packaged when explicitly imported for production', co.wrap(function *() {
+    // Given
+    applicationDirectory.write(getDefaultUnpackagedDist('the-best-app-ever', {
+      bowerComponents: Object.assign({}, moment),
+    }));
 
-    app.import({
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(
+        path.join(applicationDirectory.path(), 'the-best-app-ever')
+      ),
+    });
+    applicationInstance.env = 'production';
+    applicationInstance.import({
       development: 'bower_components/moment/moment.js',
       production: 'bower_components/moment/moment.min.js',
     });
 
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('window.moment = "');
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
+
+    // Then
+    output = yield buildOutput(packagedApplicationJs);
+    let results = output.read();
+
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('verysmallmoment');
   }));
 
-  it('handles imports with different environments (production)', co.wrap(function *() {
-    let app = createApp({
-      env: 'production',
+  it('are packaged when explicitly imported for development', co.wrap(function *() {
+    // Given
+    applicationDirectory.write(getDefaultUnpackagedDist('the-best-app-ever', {
+      bowerComponents: Object.assign({}, moment),
+    }));
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(
+        path.join(applicationDirectory.path(), 'the-best-app-ever')
+      ),
     });
-
-    app.import({
+    applicationInstance.import({
       development: 'bower_components/moment/moment.js',
       production: 'bower_components/moment/moment.min.js',
     });
 
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('verysmallmoment');
-  }));
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-  it('can import node dependencies into vendor.js', co.wrap(function *() {
-    let app = createApp();
+    // Then
+    output = yield buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-    app.import('node_modules/moment/moment.js');
-    app.import('node_modules/@scoped/private/index.js');
-
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('window.Ember = {');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.$ = function() {');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.moment');
-    expect(outputTree['assets']['vendor.js']).to.contain('window.secret');
-  }));
-
-  it('handles imports from node with different environments (development)', co.wrap(function *() {
-    let app = createApp();
-
-    app.import({
-      development: 'node_modules/moment/moment.js',
-      production: 'node_modules/moment/moment.min.js',
-    });
-
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('window.moment = "');
-  }));
-
-  it('handles imports from node with different environments (production)', co.wrap(function *() {
-    let app = createApp({
-      env: 'production',
-    });
-
-    app.import({
-      development: 'node_modules/moment/moment.js',
-      production: 'node_modules/moment/moment.min.js',
-    });
-
-    let output = yield buildOutput(app.javascript());
-    let outputTree = output.read();
-    expect(Object.keys(outputTree)).to.deep.equal(['assets']);
-    expect(Object.keys(outputTree['assets']).sort()).to.deep.equal(['app-import.js', 'vendor.js']);
-    expect(outputTree['assets']['vendor.js']).to.contain('verysmallmoment');
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.moment');
   }));
 });


### PR DESCRIPTION
+ Introduce new packager helpers
+ Convert `app.import` tests to use packager

This is a commit from https://github.com/ember-cli/ember-cli/pull/7562 as it's much easier to land things one-by-one rather than in one big PR.