### PR TITLE
Remove private `_filterAppTree` method

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -891,36 +891,6 @@ class EmberApp {
     });
   }
 
-  /**
-    Filters styles and templates from the `app` tree.
-
-    @private
-    @method _filterAppTree
-    @return {Tree}
-  */
-  _filterAppTree() {
-    if (!this.trees.app) {
-      return;
-    }
-
-    if (!this._cachedFilterAppTree) {
-      let podPatterns = this._podTemplatePatterns();
-      let excludePatterns = podPatterns.concat([
-        // note: do not use path.sep here Funnel uses
-        // walk-sync which always joins with `/` (not path.sep)
-        'styles/**/*',
-        'templates/**/*',
-      ]);
-
-      this._cachedFilterAppTree = new Funnel(this.trees.app, {
-        exclude: excludePatterns,
-        annotation: 'Funnel: Filtered App',
-      });
-    }
-
-    return this._cachedFilterAppTree;
-  }
-
   podTemplates() {
     return new Funnel(this.trees.app, {
       include: this._podTemplatePatterns(),
@@ -1022,7 +992,7 @@ class EmberApp {
   _processedAppTree() {
     let appTrees = [].concat(
       this.addonTreesFor('app'),
-      this._filterAppTree()
+      this.trees.app
     ).filter(Boolean);
 
     let mergedApp = mergeTrees(appTrees, {
@@ -1475,9 +1445,22 @@ class EmberApp {
   lintTestTrees() {
     let lintTrees = [];
 
-    let appTree = this._filterAppTree();
+    let appTree = this.trees.app;
     if (appTree) {
-      let lintedApp = this.addonLintTree('app', appTree);
+      let podPatterns = this._podTemplatePatterns();
+      let excludePatterns = podPatterns.concat([
+        // note: do not use path.sep here Funnel uses
+        // walk-sync which always joins with `/` (not path.sep)
+        'styles/**/*',
+        'templates/**/*',
+      ]);
+
+      let appTreeWithoutStylesAndTemplates = new Funnel(this.trees.app, {
+        exclude: excludePatterns,
+        annotation: 'Funnel: Filtered App',
+      });
+
+      let lintedApp = this.addonLintTree('app', appTreeWithoutStylesAndTemplates);
       lintedApp = processModulesOnly(new Funnel(lintedApp, {
         srcDir: '/',
         destDir: `${this.name}/tests/`,


### PR DESCRIPTION
`_filterAppTree` was used to exclude templates and styles from
application tree. This should only be done when linting files and could
be omitted altogether for constructing `dist` tree.