### PR TITLE
removing extra `app` folder check and error message

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -241,9 +241,6 @@ class EmberApp {
 
     let srcTree = buildTreeFor('src', trees.src);
     let appTree = buildTreeFor('app', trees.app);
-    if (!appTree && !experiments.MODULE_UNIFICATION) {
-      throw new SilentError('You must have an `app` directory!');
-    }
 
     let testsPath = typeof trees.tests === 'string' ? resolvePathFor('tests', trees.tests) : null;
     let testsTree = buildTreeFor('tests', trees.tests);


### PR DESCRIPTION
This is reverting a small change that was introduced in this commit https://github.com/ember-cli/ember-cli/commit/0ab09675e476dd270968c31af8dd5b58126c4bc4#diff-392bb207fea8bcbeb4a084bb445f7cc7R253

After a discussion today with @rwjblue and @mixonic we decided that we would re-introduce this check on master because there are a few other things that will need to be improved/changed at the same time and we didn't want to introduce this on the beta branch.