### PR TITLE
Modify development server compression behaviors.

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -35,6 +35,7 @@ module.exports = Command.extend({
     { name: 'ssl',                  type: Boolean, default: false },
     { name: 'ssl-key',              type: String,  default: 'ssl/server.key' },
     { name: 'ssl-cert',             type: String,  default: 'ssl/server.crt' },
+    { name: 'compression',          type: Boolean, default: true,                                                                              description: 'Set to false to disable compression' },
   ],
 
   run(commandOptions) {

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -191,17 +191,19 @@ class ExpressServerTask extends Task {
 
   startHttpServer() {
     this.app = this.express();
-    const compression = require('compression');
-    this.app.use(compression({
-      filter(req, res) {
-        if (res.getHeader('x-no-compression')) {
-          // don't compress responses with this response header
-          return false;
-        } else {
-          return compression.filter(req, res);
-        }
-      },
-    }));
+    if (this.startOptions.compression) {
+      const compression = require('compression');
+      this.app.use(compression({
+        filter(req, res) {
+          if (res.getHeader('x-no-compression')) {
+            // don't compress responses with this response header
+            return false;
+          } else {
+            return compression.filter(req, res);
+          }
+        },
+      }));
+    }
 
     this.setupHttpServer();
 

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -154,6 +154,7 @@ ember serve \u001b[36m<options...>\u001b[39m
   \u001b[36m--ssl\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--ssl-key\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: ssl/server.key)\u001b[39m
   \u001b[36m--ssl-cert\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: ssl/server.crt)\u001b[39m
+  \u001b[36m--compression\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to disable compression
 
 ember test \u001b[36m<options...>\u001b[39m
   Runs your app's test suite.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -639,6 +639,13 @@ module.exports = {
           default: 'ssl/server.crt',
           key: 'sslCert',
           required: false
+        },
+        {
+          default: true,
+          description: 'Set to false to disable compression',
+          key: 'compression',
+          name: 'compression',
+          required: false
         }
       ],
       anonymousOptions: []

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -154,6 +154,7 @@ ember serve \u001b[36m<options...>\u001b[39m
   \u001b[36m--ssl\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
   \u001b[36m--ssl-key\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: ssl/server.key)\u001b[39m
   \u001b[36m--ssl-cert\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: ssl/server.crt)\u001b[39m
+  \u001b[36m--compression\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: true)\u001b[39m Set to false to disable compression
 
 ember test \u001b[36m<options...>\u001b[39m
   Runs your app's test suite.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -671,6 +671,13 @@ module.exports = {
           default: 'ssl/server.crt',
           key: 'sslCert',
           required: false
+        },
+        {
+          default: true,
+          description: 'Set to false to disable compression',
+          key: 'compression',
+          name: 'compression',
+          required: false
         }
       ],
       anonymousOptions: []

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -639,6 +639,13 @@ module.exports = {
           default: 'ssl/server.crt',
           key: 'sslCert',
           required: false
+        },
+        {
+          default: true,
+          description: 'Set to false to disable compression',
+          key: 'compression',
+          name: 'compression',
+          required: false
         }
       ],
       anonymousOptions: []


### PR DESCRIPTION
* Allow opting out of compression via `ember serve --no-compression`
* Avoid adding compression for server sent events

---

From the `compression` packages README:

> Because of the nature of compression this module does not work out of the box with server-sent events. To compress content, a window of the output needs to be buffered up in order to get good compression.  Typically when using server-sent events, there are certain block of data that need to reach the client.

There are work arounds to this (every middleware that handles SSE's would have to immediately call `res.flush()`), but they do not work when proxying (because it is impossible for the proxy itself to know when `.flush()` should be called.

This change updates the compression code to simply disable itself for `text/event-stream` (which is what SSE uses as its mime type).