### PR TITLE
replace TRAVIS with CI

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -12,7 +12,7 @@ module.exports = {
       mode: 'ci',
       args: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
+        process.env.CI ? '--no-sandbox' : null,
 
         '--disable-gpu',
         '--headless',


### PR DESCRIPTION
This affects our gitlab runner too, and since we already use `process.env.CI` in the "targets.js" file, it also makes sense to be consistent.