### PR TITLE
Use colon in test commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - env: NAME=NODE_10
       node_js: 10
       script:
-        - yarn test-all:cover
+        - yarn test:cover
       after_success:
         - .travis/codecoverage.sh
 
@@ -76,4 +76,4 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 script:
-  - yarn test-all
+  - yarn test:all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ cache:
 test_script:
   # Output useful info for debugging.
   - git rev-parse HEAD
-  - cmd: yarn run test-all
+  - cmd: yarn run test:all
 
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
     "docs": "yuidoc",
     "lint": "node tests/runner lint",
     "test": "node tests/runner",
-    "test-all": "node tests/runner all",
-    "test-all:cover": "istanbul cover tests/runner.js all",
-    "test-all:debug": "node debug tests/runner all",
-    "test-slow": "node tests/runner slow",
+    "test:all": "node tests/runner all",
+    "test:cover": "istanbul cover tests/runner.js all",
+    "test:slow": "node tests/runner slow",
     "test:debug": "node debug tests/runner"
   },
   "dependencies": {


### PR DESCRIPTION
SwithIt is an unofficial standard to use a colon (`:`) for different flavours
of the same command (in node packages at least). For example,

```
yarn lint:js
yarn lint:css
```

This change also drops `test-all:debub` option since (practically
speaking) it is way to painful to debug slow tests this way locally.
Usually, during local debugging, one resorts to:

```
rm -rf tmp && node --inspect-brk ./node_modules/mocha/bin/_mocha debug tests/..
```