### PR TITLE
Update `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,9 +2369,9 @@ fs-extra@^4.0.0, fs-extra@^4.0.2, fs-extra@^4.0.3:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+fs-extra@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.0.tgz#0f0afb290bb3deb87978da816fcd3c7797f3a817"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"


### PR DESCRIPTION
For some reason, `yarn.lock` contained an older resolved version of
`fs-extra@5.0.0` whereas our `package.json` speficies `6.0.0`