### PR TITLE
Remove `appAndDependencies` method

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -111,6 +111,7 @@ module.exports = class DefaultPackager {
     this._cachedProcessedTemplates = null;
     this._cachedProcessedJavascript = null;
     this._cachedEmberCliInternalTree = null;
+    this._cachedProcessedAppAndDependencies = null;
 
     this.options = options || {};
 
@@ -126,6 +127,64 @@ module.exports = class DefaultPackager {
     this.storeConfigInMeta = this.options.storeConfigInMeta;
     this.customTransformsMap = this.options.customTransformsMap;
     this.isModuleUnificationEnabled = this.options.isModuleUnificationEnabled;
+  }
+
+  /*
+   * Combines compiled javascript, external files (node modules, bower
+   * components), vendor files and processed configuration (based on the
+   * environment) into a single tree.
+   *
+   * Input tree:
+   *
+   * ```
+   * /
+   * ├── addon-tree-output/
+   * ├── the-best-app-ever/
+   * ├── bower_components/
+   * └── vendor/
+   * ```
+   *
+   * Changes are made "inline" so the output tree has the same structure.
+   *
+   * @private
+   * @method processAppAndDependencies
+   * @param {BroccoliTree}
+   * @return {BroccoliTree}
+  */
+  processAppAndDependencies(allTrees) {
+    if (this._cachedProcessedAppAndDependencies === null) {
+      let config = this.packageConfig();
+      let internal = this.packageEmberCliInternalFiles();
+      let templates = this.processTemplates(allTrees);
+
+      let trees = [
+        allTrees,
+        templates,
+        this.processSrc(allTrees),
+      ].filter(Boolean);
+
+      let mergedTree = mergeTrees(trees, {
+        annotation: 'TreeMerger (preprocessedApp & templates)',
+        overwrite: true,
+      });
+
+      let external = this.applyCustomTransforms(allTrees);
+      let postprocessedApp = this.processJavascript(mergedTree);
+
+      let sourceTrees = [
+        external,
+        postprocessedApp,
+        config,
+        internal,
+      ];
+
+      this._cachedProcessedAppAndDependencies = mergeTrees(sourceTrees, {
+        overwrite: true,
+        annotation: 'Processed Application and Dependencies',
+      });
+    }
+
+    return this._cachedProcessedAppAndDependencies;
   }
 
   /*
@@ -206,7 +265,7 @@ module.exports = class DefaultPackager {
         isModuleUnification: this.isModuleUnificationEnabled,
       });
 
-      let configTree = this.packageConfig(this.areTestsEnabled);
+      let configTree = this.packageConfig();
       let configPath = path.join(this.name, 'config', 'environments', `${this.env}.json`);
 
       let emberCLITree = new ConfigReplace(new UnwatchedDir(__dirname), configTree, {
@@ -232,12 +291,11 @@ module.exports = class DefaultPackager {
    * Given a tree:
    *
    * ```
-   * the-best-app-ever/
-   * └── templates
-   *     ├── application.hbs
-   *     ├── error.hbs
-   *     ├── index.hbs
-   *     └── loading.hbs
+   * /
+   * ├── addon-tree-output/
+   * ├── bower_components/
+   * ├── the-best-app-ever/
+   * └── vendor/
    * ```
    *
    * Returns:
@@ -258,15 +316,35 @@ module.exports = class DefaultPackager {
   */
   processTemplates(templates) {
     if (this._cachedProcessedTemplates === null) {
-      let options = {
-        registry: this.registry,
-      };
-      let preprocessedTemplatesFromAddons = callAddonsPreprocessTreeHook(this.project, 'template', templates);
+      let include = this.registry.extensionsForType('template')
+        .map(extension => `**/*/template.${extension}`);
+
+      let pods = new Funnel(templates, {
+        include,
+        exclude: ['templates/**/*'],
+        annotation: 'Pod Templates',
+      });
+      let classic = new Funnel(templates, {
+        srcDir: `${this.name}/templates`,
+        destDir: `${this.name}/templates`,
+        annotation: 'Classic Templates',
+      });
+      let mergedTemplates = mergeTrees([pods, classic], {
+        overwrite: true,
+        annotation: 'Pod & Classic Templates',
+      });
+      let preprocessedTemplatesFromAddons = callAddonsPreprocessTreeHook(
+        this.project,
+        'template',
+        mergedTemplates
+      );
 
       this._cachedProcessedTemplates = callAddonsPostprocessTreeHook(
         this.project,
         'template',
-        preprocessTemplates(preprocessedTemplatesFromAddons, options)
+        preprocessTemplates(preprocessedTemplatesFromAddons, {
+          registry: this.registry,
+        })
       );
     }
 
@@ -278,6 +356,16 @@ module.exports = class DefaultPackager {
    * tree with the processed javascript.
    *
    * Given a tree:
+   *
+   * ```
+   * /
+   * ├── addon-tree-output/
+   * ├── bower_components/
+   * ├── the-best-app-ever/
+   * └── vendor/
+   * ```
+   *
+   * Returns:
    *
    * ```
    * the-best-app-ever/
@@ -299,8 +387,6 @@ module.exports = class DefaultPackager {
    * ...
    * ```
    *
-   * Returns the tree with the same structure, but with processed files.
-   *
    * @private
    * @method processJavascript
    * @param {BroccoliTree} tree
@@ -308,13 +394,22 @@ module.exports = class DefaultPackager {
   */
   processJavascript(tree) {
     if (this._cachedProcessedJavascript === null) {
-      let app = callAddonsPreprocessTreeHook(this.project, 'js', tree);
+      let javascript = new Funnel(tree, {
+        srcDir: this.name,
+        destDir: this.name,
+        annotation: '',
+      });
+      let app = callAddonsPreprocessTreeHook(this.project, 'js', javascript);
 
       let preprocessedApp = preprocessJs(app, '/', this.name, {
         registry: this.registry,
       });
 
-      this._cachedProcessedJavascript = callAddonsPostprocessTreeHook(this.project, 'js', preprocessedApp);
+      this._cachedProcessedJavascript = callAddonsPostprocessTreeHook(
+        this.project,
+        'js',
+        preprocessedApp
+      );
     }
 
     return this._cachedProcessedJavascript;
@@ -352,8 +447,14 @@ module.exports = class DefaultPackager {
    * @return {BroccoliTree}
   */
   processSrc(tree) {
-    if (this._cachedProcessedSrc === null && tree !== null) {
-      let srcAfterPreprocessTreeHook = callAddonsPreprocessTreeHook(this.project, 'src', tree);
+    if (this._cachedProcessedSrc === null && this.isModuleUnificationEnabled) {
+      let src = new Funnel(tree, {
+        srcDir: 'src',
+        destDir: 'src',
+        annotation: 'Module Unification Src',
+      });
+
+      let srcAfterPreprocessTreeHook = callAddonsPreprocessTreeHook(this.project, 'src', src);
 
       let options = {
         outputPaths: this.distPaths.appCssFile,
@@ -362,18 +463,25 @@ module.exports = class DefaultPackager {
 
       // TODO: This isn't quite correct (but it does function properly in most cases),
       // and should be re-evaluated before enabling the `MODULE_UNIFICATION` feature
-      this._srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
+      let srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
 
       let srcAfterTemplatePreprocessing = preprocessTemplates(srcAfterPreprocessTreeHook, {
         registry: this.registry,
         annotation: 'Process Templates: src',
       });
 
-      let srcAfterPostprocessTreeHook = callAddonsPostprocessTreeHook(this.project, 'src', srcAfterTemplatePreprocessing);
+      let srcAfterPostprocessTreeHook = callAddonsPostprocessTreeHook(
+        this.project,
+        'src',
+        srcAfterTemplatePreprocessing
+      );
 
-      return new Funnel(srcAfterPostprocessTreeHook, {
+      return new Funnel(mergeTrees([
+        srcAfterPostprocessTreeHook,
+        srcAfterStylePreprocessing,
+      ], { ovewrite: true }), {
         srcDir: '/',
-        destDir: `${this.name}`,
+        destDir: this.name,
         annotation: 'Funnel: src',
       });
     }
@@ -584,7 +692,7 @@ module.exports = class DefaultPackager {
    * @param {Boolean} testsEnabled Boolean flag to control the inclusion of
    *                  `test.json` file in the resulting tree.
   */
-  packageConfig(testsEnabled) {
+  packageConfig() {
     let env = this.env;
     let name = this.name;
     let project = this.project;
@@ -593,7 +701,7 @@ module.exports = class DefaultPackager {
     if (this._cachedConfig === null) {
       let configTree = new ConfigLoader(path.dirname(configPath), {
         env,
-        tests: testsEnabled || false,
+        tests: this.areTestsEnabled || false,
         project,
       });
 
@@ -654,11 +762,13 @@ module.exports = class DefaultPackager {
   */
   packageJavascript(tree) {
     if (this._cachedJavascript === null) {
+      let applicationJs = this.processAppAndDependencies(tree);
+
       let vendorFilePath = this.distPaths.vendorJsFile;
       this.scriptOutputFiles[vendorFilePath].unshift('vendor/ember-cli/vendor-prefix.js');
 
-      let appJs = this.packageApplicationJs(tree);
-      let vendorJs = this.packageVendorJs(tree);
+      let appJs = this.packageApplicationJs(applicationJs);
+      let vendorJs = this.packageVendorJs(applicationJs);
 
       this._cachedJavascript = mergeTrees([appJs, vendorJs], {
         overwrite: true,

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -903,7 +903,7 @@ class EmberApp {
     return new Funnel(this.trees.app, {
       include: this._podTemplatePatterns(),
       exclude: ['templates/**/*'],
-      destDir: `${this.name}/`,
+      destDir: this.name,
       annotation: 'Funnel: Pod Templates',
     });
   }
@@ -1033,8 +1033,7 @@ class EmberApp {
   }
 
   /*
-   * Gather application and add-ons template files and return them in a single
-   * tree.
+   * Gather add-ons template files and return them in a single tree.
    *
    * Resulting tree:
    *
@@ -1051,10 +1050,10 @@ class EmberApp {
    * application.
    *
    * @private
-   * @method getTemplates
+   * @method getAddonTemplates
    * @return {BroccoliTree}
   */
-  getTemplates() {
+  getAddonTemplates() {
     let addonTrees = this.addonTreesFor('templates');
     let mergedTemplates = mergeTrees(addonTrees, {
       overwrite: true,
@@ -1067,13 +1066,7 @@ class EmberApp {
       annotation: 'ProcessedTemplateTree',
     });
 
-    return mergeTrees([
-      addonTemplates,
-      this._templatesTree(),
-    ], {
-      annotation: 'Application Templates',
-      overwrite: true,
-    });
+    return addonTemplates;
   }
 
   /**
@@ -1302,45 +1295,6 @@ class EmberApp {
     }
 
     return this._cachedTestAppConfigTree;
-  }
-
-  /**
-    Returns the tree for the app and its dependencies
-
-    @private
-    @method appAndDependencies
-    @return {Tree} Merged tree
-  */
-  appAndDependencies() {
-    let config = this._defaultPackager.packageConfig(this.tests);
-    let templates = this._defaultPackager.processTemplates(this.getTemplates());
-
-    let trees = [this.getAppJavascript(), templates];
-
-    if (experiments.MODULE_UNIFICATION) {
-      trees.push(this._defaultPackager.processSrc(this.getSrc()));
-    }
-
-    let mergedTree = mergeTrees(trees, {
-      annotation: 'TreeMerger (preprocessedApp & templates)',
-      overwrite: true,
-    });
-
-    let external = this._defaultPackager.applyCustomTransforms(this._debugTree(this.getExternalTree(), 'external'));
-    let postprocessedApp = this._defaultPackager.processJavascript(mergedTree);
-    let emberCLITree = this._defaultPackager.packageEmberCliInternalFiles();
-
-    let sourceTrees = [
-      external,
-      postprocessedApp,
-      config,
-      emberCLITree,
-    ];
-
-    return mergeTrees(sourceTrees, {
-      overwrite: true,
-      annotation: 'TreeMerger (appAndDependencies)',
-    });
   }
 
   test() {
@@ -1818,15 +1772,24 @@ class EmberApp {
 
     let publicTree = this._defaultPackager.packagePublic(addonPublicTrees);
 
-    let applicationJs = this.appAndDependencies();
-    let javascriptTree = this._defaultPackager.packageJavascript(applicationJs);
+    let trees = [
+      this.getAppJavascript(),
+      this.getAddonTemplates(),
+      this.getExternalTree(),
+      this.getSrc(),
+    ].filter(Boolean);
+
+    let allJs = mergeTrees(trees, {
+      overwrite: true,
+      annotation: 'Javascript',
+    });
+
+    let javascriptTree = this._defaultPackager.packageJavascript(allJs);
 
     let sourceTrees = [
       this.index(),
       javascriptTree,
       this.styles(),
-      // undefined when `experiments.MODULE_UNIFICATION` is not available
-      this._srcAfterStylePreprocessing,
       this.otherAssets(),
       publicTree,
     ].filter(Boolean);

--- a/tests/helpers/default-packager.js
+++ b/tests/helpers/default-packager.js
@@ -244,6 +244,14 @@ function getDependencyFor(key, value) {
 */
 function setupRegistryFor(registryType, fn) {
   return {
+    extensionsForType(type) {
+      if (type === registryType) {
+        return ['hbs'];
+      }
+
+      return [];
+    },
+
     load(type) {
       if (type === registryType) {
         return [{

--- a/tests/unit/broccoli/default-packager/config-test.js
+++ b/tests/unit/broccoli/default-packager/config-test.js
@@ -84,9 +84,10 @@ describe('Default Packager: Config', function() {
       name,
       project,
       env,
+      areTestsEnabled: true,
     });
 
-    output = yield buildOutput(defaultPackager.packageConfig(true));
+    output = yield buildOutput(defaultPackager.packageConfig());
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/javascript-test.js
+++ b/tests/unit/broccoli/default-packager/javascript-test.js
@@ -45,11 +45,15 @@ describe('Default Packager: Javascript', function() {
       'router.js': 'router.js',
       'app.js': 'app.js',
       'components': {
-        'x-foo.js': 'x-foo.js',
+        'x-foo.js': 'export default class {}',
+      },
+      'routes': {
+        'application.js': 'export default class {}',
       },
       'config': {
         'environment.js': 'environment.js',
       },
+      'templates': {},
     },
     'vendor': {
       'loader': {
@@ -81,6 +85,25 @@ describe('Default Packager: Javascript', function() {
       },
     },
   };
+  let project = {
+    configPath() {
+      return `${input.path()}/the-best-app-ever/config/environment`;
+    },
+
+    config() {
+      return { a: 1 };
+    },
+
+    registry: setupRegistryFor('template', function(tree) {
+      return new Funnel(tree, {
+        getDestinationPath(relativePath) {
+          return relativePath.replace(/hbs$/g, 'js');
+        },
+      });
+    }),
+
+    addons: [],
+  };
 
   before(co.wrap(function *() {
     input = yield createTempDir();
@@ -98,11 +121,26 @@ describe('Default Packager: Javascript', function() {
 
   it('caches packaged javascript tree', co.wrap(function *() {
     let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
       distPaths: {
         appJsFile: '/assets/the-best-app-ever.js',
         vendorJsFile: '/assets/vendor.js',
       },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
+      customTransformsMap: new Map(),
+
       scriptOutputFiles,
+      project,
     });
 
     expect(defaultPackager._cachedJavascript).to.equal(null);
@@ -115,11 +153,26 @@ describe('Default Packager: Javascript', function() {
 
   it('packages javascript files with sourcemaps on', co.wrap(function *() {
     let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
       distPaths: {
         appJsFile: '/assets/the-best-app-ever.js',
         vendorJsFile: '/assets/vendor.js',
       },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
+      customTransformsMap: new Map(),
+
       scriptOutputFiles,
+      project,
     });
 
     output = yield buildOutput(defaultPackager.packageJavascript(input.path()));
@@ -136,14 +189,30 @@ describe('Default Packager: Javascript', function() {
 
   it('packages javascript files with sourcemaps off', co.wrap(function *() {
     let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
       distPaths: {
         appJsFile: '/assets/the-best-app-ever.js',
         vendorJsFile: '/assets/vendor.js',
       },
-      scriptOutputFiles,
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
       sourcemaps: {
         enabled: false,
       },
+
+      customTransformsMap: new Map(),
+
+      scriptOutputFiles,
+      project,
     });
 
     output = yield buildOutput(defaultPackager.packageJavascript(input.path()));
@@ -180,7 +249,10 @@ describe('Default Packager: Javascript', function() {
     expect(outputFiles['the-best-app-ever']).to.deep.equal({
       'app.jsx': 'app.js',
       components: {
-        'x-foo.jsx': 'x-foo.js',
+        'x-foo.jsx': 'export default class {}',
+      },
+      routes: {
+        'application.jsx': 'export default class {}',
       },
       config: {
         'environment.jsx': 'environment.js',
@@ -239,22 +311,22 @@ describe('Default Packager: Javascript', function() {
           'main.js': '',
           'resolver.js': '',
           'router.js': '',
-        },
-        ui: {
-          components: {
-            'login-form': {
-              'component.js': '',
-              'template.hbs': '',
+          ui: {
+            components: {
+              'login-form': {
+                'component.js': '',
+                'template.hbs': '',
+              },
             },
-          },
-          'index.html': '',
-          routes: {
-            application: {
-              'template.hbs': '',
+            'index.html': '',
+            routes: {
+              application: {
+                'template.hbs': '',
+              },
             },
-          },
-          styles: {
-            'app.css': '',
+            styles: {
+              'app.css': '',
+            },
           },
         },
       };
@@ -275,6 +347,8 @@ describe('Default Packager: Javascript', function() {
             },
           }),
         }),
+
+        isModuleUnificationEnabled: true,
 
         // avoid using `testdouble.js` here on purpose; it does not have a "proxy"
         // option, where a function call would be registered and the original
@@ -317,26 +391,29 @@ describe('Default Packager: Javascript', function() {
         let outputFiles = output.read();
 
         expect(outputFiles['the-best-app-ever']).to.deep.equal({
+          assets: {
+            'app.css': '',
+          },
           src: {
             'main.js': '',
             'resolver.js': '',
             'router.js': '',
-          },
-          ui: {
-            components: {
-              'login-form': {
-                'component.js': '',
-                'template.js': '',
+            ui: {
+              components: {
+                'login-form': {
+                  'component.js': '',
+                  'template.js': '',
+                },
               },
-            },
-            'index.html': '',
-            routes: {
-              application: {
-                'template.js': '',
+              'index.html': '',
+              routes: {
+                application: {
+                  'template.js': '',
+                },
               },
-            },
-            styles: {
-              'app.css': '',
+              styles: {
+                'app.css': '',
+              },
             },
           },
         });

--- a/tests/unit/broccoli/default-packager/process-test.js
+++ b/tests/unit/broccoli/default-packager/process-test.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const co = require('co');
+const expect = require('chai').expect;
+const Funnel = require('broccoli-funnel');
+const DefaultPackager = require('../../../../lib/broccoli/default-packager');
+const broccoliTestHelper = require('broccoli-test-helper');
+const defaultPackagerHelpers = require('../../../helpers/default-packager');
+const experiments = require('../../../../lib/experiments');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
+
+describe('Default Packager: Process Javascript', function() {
+  let input, output;
+
+  let scriptOutputFiles = {
+    '/assets/vendor.js': [
+      'vendor/ember-cli/vendor-prefix.js',
+      'vendor/loader/loader.js',
+      'vendor/ember/jquery/jquery.js',
+      'vendor/ember-cli-shims/app-shims.js',
+      'vendor/ember-resolver/legacy-shims.js',
+      'vendor/ember/ember.debug.js',
+    ],
+  };
+  let MODULES = {
+    'addon-tree-output': {},
+    'the-best-app-ever': {
+      'router.js': 'router.js',
+      'app.js': 'app.js',
+      'components': {
+        'x-foo.js': 'export default class {}',
+      },
+      'routes': {
+        'application.js': 'export default class {}',
+      },
+      'config': {
+        'environment.js': 'environment.js',
+      },
+      'templates': {},
+    },
+    vendor: {},
+  };
+
+  let project = {
+    configPath() {
+      return `${input.path()}/the-best-app-ever/config/environment`;
+    },
+
+    config() {
+      return { a: 1 };
+    },
+
+    registry: setupRegistryFor('template', function(tree) {
+      return new Funnel(tree, {
+        getDestinationPath(relativePath) {
+          return relativePath.replace(/hbs$/g, 'js');
+        },
+      });
+    }),
+
+    addons: [{
+      treeForAddon(tree) {
+        const Funnel = require('broccoli-funnel');
+        return new Funnel(tree, {
+          destDir: 'modules/my-addon',
+        });
+      },
+    }],
+  };
+
+  before(co.wrap(function *() {
+    input = yield createTempDir();
+
+    input.write(MODULES);
+  }));
+
+  after(co.wrap(function *() {
+    yield input.dispose();
+  }));
+
+  afterEach(co.wrap(function *() {
+    if (output) {
+      yield output.dispose();
+    }
+  }));
+
+  it('caches packaged application tree', co.wrap(function *() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appJsFile: '/assets/the-best-app-ever.js',
+        vendorJsFile: '/assets/vendor.js',
+      },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
+      customTransformsMap: new Map(),
+
+      scriptOutputFiles,
+      project,
+    });
+
+    expect(defaultPackager._cachedProcessedAppAndDependencies).to.equal(null);
+
+    output = yield buildOutput(defaultPackager.processAppAndDependencies(input.path()));
+
+    expect(defaultPackager._cachedProcessedAppAndDependencies).to.not.equal(null);
+    expect(defaultPackager._cachedProcessedAppAndDependencies._annotation).to.equal('Processed Application and Dependencies');
+  }));
+
+  if (experiments.MODULE_UNIFICATION) {
+    it('merges src with with app', co.wrap(function *() {
+      let input = yield createTempDir();
+
+      input.write({
+        'addon-tree-output': {},
+        'the-best-app-ever': {
+          'router.js': 'router.js',
+          'app.js': 'app.js',
+          'components': {
+            'x-foo.js': 'export default class {}',
+          },
+          'routes': {
+            'application.js': 'export default class {}',
+          },
+          'config': {
+            'environment.js': 'environment.js',
+          },
+          'templates': {},
+        },
+        vendor: {},
+        src: {
+          'main.js': '',
+          'resolver.js': '',
+          'router.js': '',
+          ui: {
+            components: {
+              'login-form': {
+                'component.js': '',
+                'template.hbs': '',
+              },
+            },
+            'index.html': '',
+            routes: {
+              application: {
+                'template.hbs': '',
+              },
+            },
+            styles: {
+              'app.css': '',
+            },
+          },
+        },
+      });
+
+      let defaultPackager = new DefaultPackager({
+        name: 'the-best-app-ever',
+        env: 'development',
+
+        distPaths: {
+          appJsFile: '/assets/the-best-app-ever.js',
+          vendorJsFile: '/assets/vendor.js',
+        },
+
+        isModuleUnificationEnabled: true,
+
+        registry: setupRegistryFor('template', function(tree) {
+          return new Funnel(tree, {
+            getDestinationPath(relativePath) {
+              return relativePath.replace(/hbs$/g, 'js');
+            },
+          });
+        }),
+
+        customTransformsMap: new Map(),
+
+        scriptOutputFiles,
+        project,
+      });
+
+      output = yield buildOutput(defaultPackager.processAppAndDependencies(input.path()));
+
+      let outputFiles = output.read();
+
+      expect(Object.keys(outputFiles)).to.deep.equal([
+        'addon-tree-output',
+        'src',
+        'the-best-app-ever',
+        'vendor',
+      ]);
+
+      input.dispose();
+    }));
+  }
+});

--- a/tests/unit/broccoli/default-packager/templates-test.js
+++ b/tests/unit/broccoli/default-packager/templates-test.js
@@ -32,11 +32,15 @@ describe('Default Packager: Templates', function() {
   }));
 
   after(co.wrap(function *() {
-    yield input.dispose();
+    if (input) {
+      yield input.dispose();
+    }
   }));
 
   afterEach(co.wrap(function *() {
-    yield output.dispose();
+    if (output) {
+      yield output.dispose();
+    }
   }));
 
   it('caches processed templates tree', co.wrap(function *() {
@@ -82,12 +86,14 @@ describe('Default Packager: Templates', function() {
 
     let outputFiles = output.read();
 
-    expect(Object.keys(outputFiles['the-best-app-ever'].templates)).to.deep.equal([
-      'application.js',
-      'error.js',
-      'index.js',
-      'loading.js',
-    ]);
+    expect(outputFiles['the-best-app-ever']).to.deep.equal({
+      templates: {
+        'application.js': '',
+        'error.js': '',
+        'index.js': '',
+        'loading.js': '',
+      },
+    });
   }));
 
   it('runs pre/post-process add-on hooks', co.wrap(function *() {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -57,17 +57,12 @@ describe('EmberApp', function() {
     project = setupProject(projectPath);
   });
 
-  describe('getTemplates()', function() {
-    it('returns application and add-ons template files', co.wrap(function *() {
+  describe('getAddonTemplates()', function() {
+    it('returns add-ons template files', co.wrap(function *() {
       let input = yield createTempDir();
       let addonFooTemplates = yield createTempDir();
       let addonBarTemplates = yield createTempDir();
 
-      input.write({
-        'application.hbs': '',
-        'error.hbs': '',
-        'loading.hbs': '',
-      });
       addonFooTemplates.write({
         'foo.hbs': 'foo',
       });
@@ -86,13 +81,10 @@ describe('EmberApp', function() {
         ];
       };
 
-      let output = yield buildOutput(app.getTemplates());
+      let output = yield buildOutput(app.getAddonTemplates());
       let outputFiles = output.read();
 
       expect(outputFiles['test-project'].templates).to.deep.equal({
-        'application.hbs': '',
-        'error.hbs': '',
-        'loading.hbs': '',
         'foo.hbs': 'foo',
         'bar.hbs': 'bar',
       });

--- a/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
+++ b/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
@@ -88,96 +88,6 @@ describe('EmberApp#appAndDependencies', function() {
     });
   }
 
-  it('results in a tree containing final loose modules', co.wrap(function *() {
-    input.write({
-      'app': {
-        'index.html': 'foobar',
-        'routes': {
-          'application.js': 'export default class { }',
-        },
-        'templates': {
-          'application.hbs': 'hi hi',
-        },
-      },
-    });
-
-    let app = createApp();
-    output = yield buildOutput(app.appAndDependencies());
-    let actualFiles = getFiles(output.path());
-
-    expect(actualFiles).to.deep.equal([
-      'ember-app-test/config/environments/development.json',
-      'ember-app-test/config/environments/test.json',
-      'ember-app-test/index.html',
-      'ember-app-test/routes/application.js',
-      'ember-app-test/templates/application.hbs',
-    ]);
-  }));
-
-  if (experiments.MODULE_UNIFICATION) {
-    it('works properly without an app directory', co.wrap(function *() {
-      input.write({
-        'src': {
-          'ui': {
-            'index.html': 'foobar',
-            'routes': {
-              'application': {
-                'route.js': 'export default class { }',
-                'template.hbs': 'hi hi',
-              },
-            },
-          },
-        },
-      });
-
-      let app = createApp();
-      output = yield buildOutput(app.appAndDependencies());
-      let actualFiles = getFiles(output.path());
-
-      expect(actualFiles).to.deep.equal([
-        'ember-app-test/config/environments/development.json',
-        'ember-app-test/config/environments/test.json',
-        'ember-app-test/src/ui/index.html',
-        'ember-app-test/src/ui/routes/application/route.js',
-        'ember-app-test/src/ui/routes/application/template.hbs',
-      ]);
-    }));
-
-    it('merges src with with app', co.wrap(function *() {
-      input.write({
-        'app': {
-          'routes': {
-            'index.js': 'export default class {}',
-          },
-        },
-        'src': {
-          'ui': {
-            'index.html': 'foobar',
-            'routes': {
-              'application': {
-                'route.js': 'export default class { }',
-                'template.hbs': 'hi hi',
-              },
-            },
-          },
-        },
-      });
-
-      let app = createApp();
-      output = yield buildOutput(app.appAndDependencies());
-      let actualFiles = getFiles(output.path());
-
-      expect(actualFiles).to.deep.equal([
-        'ember-app-test/config/environments/development.json',
-        'ember-app-test/config/environments/test.json',
-        'ember-app-test/routes/index.js',
-        'ember-app-test/src/ui/index.html',
-        'ember-app-test/src/ui/routes/application/route.js',
-        'ember-app-test/src/ui/routes/application/template.hbs',
-      ]);
-    }));
-  }
-
   it('moduleNormalizerDisabled', co.wrap(function *() {
     input.write({
       'node_modules': {
@@ -216,7 +126,7 @@ describe('EmberApp#appAndDependencies', function() {
       });
     };
 
-    output = yield buildOutput(app.appAndDependencies());
+    output = yield buildOutput(app.getExternalTree());
     let actualFiles = getFiles(output.path());
 
     expect(actualFiles).to.contain(


### PR DESCRIPTION
All the processing logic for application files (javascript and
templates) and dependencies (import transforms) has moved to the
packager. That way `ember-app` is only responsible for providing
application and add-on files that are needed.

Because of that `appAndDependencies` method is no longer needed and
could be removed altogether. It's a private method so it is safe to do
so.