### PR TITLE
Packager Experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
         - .travis/codecoverage.sh
 
     - env: EMBER_CLI_ENABLE_ALL_EXPERIMENTS=true
+    - env: EMBER_CLI_PACKAGER=true
     - env: EMBER_CLI_MODULE_UNIFICATION=true
     - env: EMBER_CLI_DELAYED_TRANSPILATION=true
 

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1545,14 +1545,22 @@ class EmberApp {
       annotation: 'Full Application',
     });
 
+    if (experiments.PACKAGER && typeof this.package === 'function') {
+      return [this.package.call(this, fullTree)];
+    } else {
+      this.project.ui.writeWarnLine('`package` hook must be a function, falling back to default packaging.');
+    }
+
     let javascriptTree = this._defaultPackager.packageJavascript(fullTree);
     let stylesTree = this._defaultPackager.packageStyles(fullTree);
+    let appIndex = this._defaultPackager.processIndex(fullTree);
+    let additionalAssets = this._defaultPackager.importAdditionalAssets(fullTree);
 
     let sourceTrees = [
-      this._defaultPackager.processIndex(fullTree),
+      appIndex,
       javascriptTree,
       stylesTree,
-      this._defaultPackager.importAdditionalAssets(fullTree),
+      additionalAssets,
       publicTree,
     ].filter(Boolean);
 

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -15,6 +15,7 @@ function isExperimentEnabled(experimentName) {
 }
 
 let experiments = {
+  PACKAGER: isExperimentEnabled('PACKAGER'),
   MODULE_UNIFICATION: isExperimentEnabled('MODULE_UNIFICATION'),
   DELAYED_TRANSPILATION: isExperimentEnabled('DELAYED_TRANSPILATION'),
 };


### PR DESCRIPTION
after this is merged, there some more work required mainly around the shape of the tree that is passed into `package` hook (ideally, we would throw a hard error in dev mode saying that a particular folder is missing and we can't proceed).