### PR TITLE
add fast_finish to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
+    - fast_finish: true
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "9"


### PR DESCRIPTION
Try to match Travis build stages' speed by failing fast in appveyor. It's the best we can do, since appveyor doesn't have build stages (yet).