### PR TITLE
Make sure `package` hook warning is shown properly

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1545,10 +1545,12 @@ class EmberApp {
       annotation: 'Full Application',
     });
 
-    if (experiments.PACKAGER && typeof this.package === 'function') {
-      return [this.package.call(this, fullTree)];
-    } else {
-      this.project.ui.writeWarnLine('`package` hook must be a function, falling back to default packaging.');
+    if (experiments.PACKAGER) {
+      if (typeof this.package === 'function') {
+        return [this.package.call(this, fullTree)];
+      } else {
+        this.project.ui.writeWarnLine('`package` hook must be a function, falling back to default packaging.');
+      }
     }
 
     let javascriptTree = this._defaultPackager.packageJavascript(fullTree);


### PR DESCRIPTION
Now, the warning is only shown when the feature is enabled and `package` hook
is a function.