### PR TITLE
blueprints/addon: Add `yarn.lock` file to `.npmignore`

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -14,6 +14,7 @@
 bower.json
 ember-cli-build.js
 testem.js
+yarn.lock
 
 # ember-try
 .node_modules.ember-try/


### PR DESCRIPTION
see https://github.com/emberjs/ember-qunit/pull/329

@rwjblue should we target `release` or `beta` instead of `master` for this?