### PR TITLE
Only import jquery if `@ember/jquery` is a dependency

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -465,19 +465,22 @@ class EmberApp {
   }
 
   _addJqueryInLegacyEmber() {
-    let emberJQuery = this.project.findAddonByName('@ember/jquery');
-    if (emberJQuery) {
-      this.vendorFiles['jquery.js'] = emberJQuery.paths.jquery;
-    } else {
-      let ember = this.project.findAddonByName('ember-source');
-      if (ember) {
-        if (semver.lt(this.project.addonPackages['ember-source'].pkg.version, '3.3.0')) {
-          this.vendorFiles['jquery.js'] = ember.paths.jquery;
-        }
-      } else {
-        this.vendorFiles['jquery.js'] = `${this.bowerDirectory}/jquery/dist/jquery.js`;
-      }
+    if (this.project.findAddonByName('@ember/jquery')) {
+      return;
     }
+    let ember = this.project.findAddonByName('ember-source');
+    let jqueryPath;
+    if (ember) {
+      let optionFeatures = this.project.findAddonByName('@ember/optional-features');
+      if (optionFeatures && !optionFeatures.isFeatureEnabled('jquery-integration')) {
+        return;
+      }
+      this.project.ui.writeDeprecateLine('Ember will stop including jQuery by default in an upcoming version. If you wish keep using jQuery in your application explicitly add `@ember/jquery` to your package.json');
+      jqueryPath = ember.paths.jquery;
+    } else {
+      jqueryPath = `${this.bowerDirectory}/jquery/dist/jquery.js`;
+    }
+    this.vendorFiles = merge({ 'jquery.js': jqueryPath }, this.vendorFiles);
   }
 
   /**

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -387,17 +387,13 @@ class EmberApp {
     let productionEmber;
     let emberTesting;
     let emberShims = null;
-    let jquery;
 
     if (ember) {
       developmentEmber = ember.paths.debug;
       productionEmber = ember.paths.prod;
       emberTesting = ember.paths.testing;
       emberShims = ember.paths.shims;
-      jquery = ember.paths.jquery;
     } else {
-      jquery = `${this.bowerDirectory}/jquery/dist/jquery.js`;
-
       if (bowerEmberCliShims) {
         emberShims = `${this.bowerDirectory}/ember-cli-shims/app-shims.js`;
       }
@@ -423,7 +419,6 @@ class EmberApp {
     }
 
     this.vendorFiles = omitBy(merge({
-      'jquery.js': jquery,
       'handlebars.js': handlebarsVendorFiles,
       'ember.js': {
         development: developmentEmber,
@@ -442,6 +437,8 @@ class EmberApp {
         },
       ],
     }, this.options.vendorFiles), isNull);
+
+    this._addJqueryInLegacyEmber();
 
     if (this._addonInstalled('ember-resolver') || !bowerDeps['ember-resolver']) {
       // if the project is using `ember-resolver` as an addon
@@ -464,6 +461,22 @@ class EmberApp {
     // of Ember older than 1.8.0 (when ember-testing.js was incldued in ember.js itself)
     if (!ember && this.vendorFiles['ember-testing.js'] && !fs.existsSync(this.vendorFiles['ember-testing.js'][0])) {
       delete this.vendorFiles['ember-testing.js'];
+    }
+  }
+
+  _addJqueryInLegacyEmber() {
+    let emberJQuery = this.project.findAddonByName('@ember/jquery');
+    if (emberJQuery) {
+      this.vendorFiles['jquery.js'] = emberJQuery.paths.jquery;
+    } else {
+      let ember = this.project.findAddonByName('ember-source');
+      if (ember) {
+        if (semver.lt(this.project.addonPackages['ember-source'].pkg.version, '3.3.0')) {
+          this.vendorFiles['jquery.js'] = ember.paths.jquery;
+        }
+      } else {
+        this.vendorFiles['jquery.js'] = `${this.bowerDirectory}/jquery/dist/jquery.js`;
+      }
     }
   }
 

--- a/tests/helpers/default-packager.js
+++ b/tests/helpers/default-packager.js
@@ -54,7 +54,7 @@ const DEFAULT_NODE_MODULES = {
       `,
     'package.json': JSON.stringify({
       name: 'ember-source',
-      version: '~3.0.0-beta.1',
+      version: '3.0.0-beta.1',
       keywords: ['ember-addon'],
       paths: {
         debug: 'vendor/ember/ember.debug.js',

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1088,9 +1088,9 @@ describe('EmberApp', function() {
 
   describe('vendorFiles', function() {
     let defaultVendorFiles = [
+      'jquery.js',
       'ember.js',
       'app-shims.js',
-      'jquery.js',
     ];
 
     describe('handlebars.js', function() {
@@ -1152,6 +1152,35 @@ describe('EmberApp', function() {
         },
       });
       expect(Object.keys(app.vendorFiles)).to.deep.equal(defaultVendorFiles);
+    });
+
+    it('does not include jquery if the app has `@ember/jquery` installed', function() {
+      project.initializeAddons = function() {
+        this.addons = [{ name: '@ember/jquery' }];
+      };
+      app = new EmberApp({ project });
+      let filesWithoutJQuery = defaultVendorFiles.filter(e => e !== 'jquery.js');
+      expect(Object.keys(app.vendorFiles)).to.deep.equal(filesWithoutJQuery);
+    });
+
+    it('does not include jquery if the app has `@ember/optional-features` with the `jquery-integration` FF turned off', function() {
+      project.initializeAddons = function() {
+        this.addons = [
+          {
+            name: 'ember-source',
+            paths: { jquery: 'foo', testing: null },
+          },
+          {
+            name: '@ember/optional-features',
+            isFeatureEnabled() {
+              return false;
+            },
+          },
+        ];
+      };
+      app = new EmberApp({ project, vendorFiles: { 'ember-testing.js': null } });
+      let filesWithoutJQuery = defaultVendorFiles.filter(e => e !== 'jquery.js');
+      expect(Object.keys(app.vendorFiles)).to.deep.equal(filesWithoutJQuery);
     });
 
     it('removes dependency in vendorFiles', function() {

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1088,9 +1088,9 @@ describe('EmberApp', function() {
 
   describe('vendorFiles', function() {
     let defaultVendorFiles = [
-      'jquery.js',
       'ember.js',
       'app-shims.js',
+      'jquery.js',
     ];
 
     describe('handlebars.js', function() {


### PR DESCRIPTION
This will only works for ember-source >= 3.3.0

The logic is:
1. If `@ember/jquery` is present, exit. The addon will know better.
2. If the app is NOT using `ember-source` means it's an old version using bower, so import jquery from bower path.
3. If the app is using `ember-source` but it's not using `@ember/optional-features`, add jquery.
4. If the app is using `ember-source`, it's also using `@ember/optional-features` and the jquery flag is enabled, also add jquery.
5. In the cases where jquery is added by ember-cli, a deprecation message is shown asking users to install `@ember/jquery`

**TODO:** Add tests.