### PR TITLE
Add @ember/jquery and @ember/optional-features by default.

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -32,6 +32,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 matrix:
   fast_finish: true

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -64,6 +64,19 @@ module.exports = function() {
           npm: {
             devDependencies: {}
           }
+        },
+        {
+          name: 'ember-default-with-jquery',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true,
+            }),
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1'
+            }
+          }
         }
       ]
     };

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -69,8 +69,8 @@ module.exports = function() {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
+              'jquery-integration': true
+            })
           },
           npm: {
             devDependencies: {

--- a/blueprints/addon/files/config/optional-features.json
+++ b/blueprints/addon/files/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": false
+}

--- a/blueprints/addon/files/ember-cli-build.js
+++ b/blueprints/addon/files/ember-cli-build.js
@@ -4,13 +4,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    /* 
-      Leave jQuery out of this addon's own test suite & dummy app by default, 
-      so that the addon can be used in apps without jQuery. If you really need 
-      jQuery, it's safe to remove this line.
-    */
-    vendorFiles: { 'jquery.js': null, 'app-shims.js': null }
-    
     // Add options here
   });
 

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -56,6 +56,9 @@ module.exports = {
     // 100% of addons don't need ember-cli-app-version, make it opt-in instead
     delete contents.devDependencies['ember-cli-app-version'];
 
+    // addons should test _without_ jquery by default
+    delete contents.devDependencies['@ember/jquery'];
+
     if (contents.keywords.indexOf('ember-addon') === -1) {
       contents.keywords.push('ember-addon');
     }

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -70,7 +70,7 @@ module.exports = {
     contents.devDependencies['eslint-plugin-node'] = '^6.0.1';
 
     // add ember-try
-    contents.devDependencies['ember-try'] = '^0.2.23';
+    contents.devDependencies['ember-try'] = '^1.0.0-beta.3';
 
     // add ember-source-channel-url
     contents.devDependencies['ember-source-channel-url'] = '^1.0.1';

--- a/blueprints/app/files/config/optional-features.json
+++ b/blueprints/app/files/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": true
+}

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -29,6 +29,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 matrix:
   fast_finish: true

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -63,6 +63,19 @@ module.exports = function() {
           npm: {
             devDependencies: {}
           }
+        },
+        {
+          name: 'ember-default-with-jquery',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true,
+            }),
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1'
+            }
+          }
         }
       ]
     };

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -68,8 +68,8 @@ module.exports = function() {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
+              'jquery-integration': true
+            })
           },
           npm: {
             devDependencies: {

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -23,6 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -42,7 +42,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.2.0-beta.2",
     "ember-source-channel-url": "^1.0.1",
-    "ember-try": "^0.2.23",
+    "ember-try": "^1.0.0-beta.3",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -28,6 +28,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 matrix:
   fast_finish: true

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -64,6 +64,19 @@ module.exports = function() {
           npm: {
             devDependencies: {}
           }
+        },
+        {
+          name: 'ember-default-with-jquery',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true,
+            }),
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1'
+            }
+          }
         }
       ]
     };

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -69,8 +69,8 @@ module.exports = function() {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
+              'jquery-integration': true
+            })
           },
           npm: {
             devDependencies: {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -23,6 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -42,7 +42,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.2.0-beta.2",
     "ember-source-channel-url": "^1.0.1",
-    "ember-try": "^0.2.23",
+    "ember-try": "^1.0.0-beta.3",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/module-unification-addon/package.json
+++ b/tests/fixtures/module-unification-addon/package.json
@@ -23,6 +23,7 @@
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -17,6 +17,8 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/jquery": "^0.5.1",
+    "@ember/optional-features": "^0.6.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -77,7 +77,7 @@ describe('blueprint - addon', function() {
   "devDependencies": {\n\
     "ember-disable-prototype-extensions": "^1.1.2",\n\
     "ember-source-channel-url": "^1.0.1",\n\
-    "ember-try": "^0.2.23",\n\
+    "ember-try": "^1.0.0-beta.3",\n\
     "eslint-plugin-node": "^6.0.1"\n\
   },\n\
   "ember-addon": {\n\


### PR DESCRIPTION
* Apps get `@ember/jquery` for backwards compatibility
* Addons do not include `@ember/jquery`
* All projects include `@ember/optional-features` and either opt-in or
  out as appropriate.
* Update to ember-try 1.0.0-beta.3
* Make default scenario run without jQuery
* Add `default-with-jquery` ember-try scenario