### PR TITLE
move old packager to single function

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1617,6 +1617,10 @@ class EmberApp {
       }
     }
 
+    return this._legacyPackager(fullTree);
+  }
+
+  _legacyPackager(fullTree) {
     let javascriptTree = this._defaultPackager.packageJavascript(fullTree);
     let stylesTree = this._defaultPackager.packageStyles(fullTree);
     let appIndex = this._defaultPackager.processIndex(fullTree);


### PR DESCRIPTION
This will allow custom packagers to start moving ASAP while ember-cli-default-packager is still getting built. It will make all of this https://github.com/kellyselden/ember-cli-rollup-packager/blob/da856d4c09763acec54169dee7d02b0c36a65cd1/test/fixtures/my-app/ember-cli-build.js#L15-L33 go away.