### PR TITLE
Filter out blacklisted addons before calling included hook

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -536,13 +536,15 @@ class EmberApp {
       });
     }
 
-    this.project.addons = this.project.addons.filter(addon => {
-      if (this.shouldIncludeAddon(addon)) {
-        if (addon.included) {
-          addon.included(this);
-        }
+    // the addons must be filtered before the `included` hook is called
+    // in case an addon caches the project.addons list
+    this.project.addons = this.project.addons.filter(
+      addon => this.shouldIncludeAddon(addon)
+    );
 
-        return addon;
+    this.project.addons.forEach(addon => {
+      if (addon.included) {
+        addon.included(this);
       }
     });
   }


### PR DESCRIPTION
The `ember-engines` caches the host addons (the `app.project.addons` list) on the first addon hook callback, which is `included`. This is generally OK, except in the case when `EmberApp` blacklists some of the addons.

Because the list of the addons is actually filtered after the hook is called, `ember-engines` deduplication algorithm is using the incorrect list of parent addons, because it has cached the list on the first hook call - `included`). This leads to `ember-engines` deduplicating dependencies, which are not actually available in the app.
