### PR TITLE
throw error on `window.find` in tests

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -46,6 +46,21 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })<% } %>
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js']<% if (blueprint !== 'app') { %>,
+      excludedFiles: ['tests/dummy/**']<% } %>,
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -43,6 +43,21 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -35,6 +35,21 @@ module.exports = {
         browser: false,
         node: true
       }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -45,6 +45,21 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -45,6 +45,21 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -34,6 +34,20 @@ module.exports = {
         browser: false,
         node: true
       }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -34,6 +34,20 @@ module.exports = {
         browser: false,
         node: true
       }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -43,6 +43,21 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/npm/.eslintrc.js
@@ -35,6 +35,21 @@ module.exports = {
         browser: false,
         node: true
       }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/yarn/.eslintrc.js
@@ -35,6 +35,21 @@ module.exports = {
         browser: false,
         node: true
       }
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'find',
+            message: 'You forgot to import `find`, and we are preventing accidental usage of `window.find`.'
+          },
+        ]
+      }
     }
   ]
 };


### PR DESCRIPTION
Solves https://github.com/emberjs/ember-test-helpers/pull/369#issuecomment-392975541 with a linter change rather than a code hack.

The upside of it being here instead of the eslint-plugin-ember recommended is it can target tests only.

Sister https://github.com/ember-cli/eslint-plugin-ember/pull/258