### PR TITLE
Config hook called too soon during serve

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -43,8 +43,6 @@ module.exports = Command.extend({
     return this._checkExpressPort(commandOptions)
       .then(this._autoFindLiveReloadPort.bind(this))
       .then(commandOptions => {
-        let config = this.project.config(commandOptions.environment);
-
         this.ui.writeDeprecateLine(
           'Using the `baseURL` setting is deprecated, use `rootURL` instead.',
           !(!('rootURL' in config) && config.baseURL));
@@ -52,11 +50,6 @@ module.exports = Command.extend({
         this.ui.writeWarnLine(
           'The `baseURL` and `rootURL` settings should not be used at the same time.',
           !(('rootURL' in config) && config.baseURL));
-
-        commandOptions = Object.assign({}, commandOptions, {
-          rootURL: config.rootURL,
-          baseURL: config.baseURL || '/',
-        });
 
         if (commandOptions.proxy) {
           if (!(/^(http:|https:)/).test(commandOptions.proxy)) {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -43,14 +43,6 @@ module.exports = Command.extend({
     return this._checkExpressPort(commandOptions)
       .then(this._autoFindLiveReloadPort.bind(this))
       .then(commandOptions => {
-        this.ui.writeDeprecateLine(
-          'Using the `baseURL` setting is deprecated, use `rootURL` instead.',
-          !(!('rootURL' in config) && config.baseURL));
-
-        this.ui.writeWarnLine(
-          'The `baseURL` and `rootURL` settings should not be used at the same time.',
-          !(('rootURL' in config) && config.baseURL));
-
         if (commandOptions.proxy) {
           if (!(/^(http:|https:)/).test(commandOptions.proxy)) {
             let message = `You need to include a protocol with the proxy URL.${EOL}Try --proxy http://${commandOptions.proxy}`;

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -48,7 +48,7 @@ class Watcher extends CoreObject {
 
     if (this.serving) {
       let options = this.options;
-      let config = this.options.project.config();
+      let config = this.options.project.config(options.environment);
 
       let baseURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || (config.baseURL || '/'));
       message += ` – Serving on http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -48,7 +48,9 @@ class Watcher extends CoreObject {
 
     if (this.serving) {
       let options = this.options;
-      let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+      let config = this.options.project.config();
+
+      let baseURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || (config.baseURL || '/'));
       message += ` – Serving on http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
     }
     this.ui.writeLine(message);

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -199,21 +199,6 @@ describe('serve command', function() {
     });
   });
 
-  it('uses baseURL of correct environment', function() {
-    options.project.config = function(env) {
-      return { baseURL: env };
-    };
-
-    return command.validateAndRun([
-      '--port', '0',
-      '--environment', 'test',
-    ]).then(function() {
-      let captor = td.matchers.captor();
-      td.verify(tasks.Serve.prototype.run(captor.capture()), { times: 1 });
-      expect(captor.value.baseURL).to.equal('test', 'Uses the correct environment.');
-    });
-  });
-
   it('host alias does not conflict with help alias', function() {
     return command.validateAndRun([
       '--port', '0',

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -119,7 +119,14 @@ describe('Watcher', function() {
           ssl: true,
           sslCert: 'tests/fixtures/ssl/server.crt',
           sslKey: 'tests/fixtures/ssl/server.key',
-          rootURL: '/',
+          environment: 'development',
+          project: {
+            config() {
+              return {
+                rootURL: '/',
+              };
+            },
+          },
         },
       });
 
@@ -141,7 +148,14 @@ describe('Watcher', function() {
         options: {
           host: undefined,
           port: '1337',
-          baseURL: '/foo',
+          environment: 'development',
+          project: {
+            config() {
+              return {
+                baseURL: '/foo',
+              };
+            },
+          },
         },
       });
 
@@ -164,7 +178,14 @@ describe('Watcher', function() {
         options: {
           host: undefined,
           port: '1337',
-          rootURL: '/foo',
+          environment: 'development',
+          project: {
+            config() {
+              return {
+                rootURL: '/foo',
+              };
+            },
+          },
         },
       });
 
@@ -189,6 +210,14 @@ describe('Watcher', function() {
           host: undefined,
           port: '1337',
           rootURL: '',
+          environment: 'development',
+          project: {
+            config() {
+              return {
+                rootURL: '',
+              };
+            },
+          },
         },
       });
 


### PR DESCRIPTION
The config hook gets called eagerly during the serve flow and that
leads to issues with the context of the config hooks not being set
up properly. An example of this is if you have:

```js
config() {
  return this.app && this.app.options[this.name];
}
```

`this.app` will be undefined but that same hook during a build will not be undefined.