### PR TITLE
`New` command respects module unification experiment

### DIFF
--- a/blueprints/module-unification-app/files/testem.js
+++ b/blueprints/module-unification-app/files/testem.js
@@ -8,11 +8,17 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+    Chrome: {
+      mode: 'ci',
+      args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
   }
 };

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -9,6 +9,7 @@ const SilentError = require('silent-error');
 const validProjectName = require('../utilities/valid-project-name');
 const normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+const experiments = require('../experiments');
 
 const rmdir = RSVP.denodeify(fs.remove);
 const Promise = RSVP.Promise;
@@ -37,7 +38,7 @@ module.exports = Command.extend({
   beforeRun: mergeBlueprintOptions,
 
   run(commandOptions, rawArgs) {
-    if (process.env.MODULE_UNIFICATION === 'true') {
+    if (experiments.MODULE_UNIFICATION) {
       if (commandOptions.blueprint === 'app') {
         commandOptions.blueprint = 'module-unification-app';
       } else if (commandOptions.blueprint === 'addon') {

--- a/tests/acceptance/addon-mu-smoke-test-slow.js
+++ b/tests/acceptance/addon-mu-smoke-test-slow.js
@@ -21,7 +21,7 @@ let addonName = 'some-cool-addon';
 let addonRoot;
 
 if (experiments.MODULE_UNIFICATION) {
-  describe('Acceptance: addon-mu-smoke-test', function() {
+  describe.skip('Acceptance: addon-mu-smoke-test', function() {
     this.timeout(450000);
 
     before(function() {

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra');
 const spawn = require('child_process').spawn;
 const chalk = require('chalk');
 
+const experiments = require('../../lib/experiments');
 const runCommand = require('../helpers/run-command');
 const ember = require('../helpers/ember');
 const copyFixtureFiles = require('../helpers/copy-fixture-files');
@@ -23,122 +24,124 @@ let dir = chai.dir;
 let addonName = 'some-cool-addon';
 let addonRoot;
 
-describe('Acceptance: addon-smoke-test', function() {
-  this.timeout(450000);
+if (!experiments.MODULE_UNIFICATION) {
+  describe('Acceptance: addon-smoke-test', function() {
+    this.timeout(450000);
 
-  before(function() {
-    return createTestTargets(addonName, {
-      command: 'addon',
+    before(function() {
+      return createTestTargets(addonName, {
+        command: 'addon',
+      });
     });
-  });
 
-  after(teardownTestTargets);
+    after(teardownTestTargets);
 
-  beforeEach(function() {
-    addonRoot = linkDependencies(addonName);
+    beforeEach(function() {
+      addonRoot = linkDependencies(addonName);
 
-    process.env.JOBS = '1';
-  });
+      process.env.JOBS = '1';
+    });
 
-  afterEach(function() {
-    // Cleans up a folder set up on the other side of a symlink.
-    fs.removeSync(path.join(addonRoot, 'node_modules', 'developing-addon'));
+    afterEach(function() {
+      // Cleans up a folder set up on the other side of a symlink.
+      fs.removeSync(path.join(addonRoot, 'node_modules', 'developing-addon'));
 
-    cleanupRun(addonName);
-    expect(dir(addonRoot)).to.not.exist;
+      cleanupRun(addonName);
+      expect(dir(addonRoot)).to.not.exist;
 
-    delete process.env.JOBS;
-  });
+      delete process.env.JOBS;
+    });
 
-  it('generates package.json with proper metadata', function() {
-    let packageContents = fs.readJsonSync('package.json');
+    it('generates package.json with proper metadata', function() {
+      let packageContents = fs.readJsonSync('package.json');
 
-    expect(packageContents.name).to.equal(addonName);
-    expect(packageContents.private).to.be.an('undefined');
-    expect(packageContents.keywords).to.deep.equal(['ember-addon']);
-    expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
-  });
+      expect(packageContents.name).to.equal(addonName);
+      expect(packageContents.private).to.be.an('undefined');
+      expect(packageContents.keywords).to.deep.equal(['ember-addon']);
+      expect(packageContents['ember-addon']).to.deep.equal({ 'configPath': 'tests/dummy/config' });
+    });
 
-  it('ember addon foo, clean from scratch', function() {
-    return ember(['test']);
-  });
+    it('ember addon foo, clean from scratch', function() {
+      return ember(['test']);
+    });
 
-  it('works in most common scenarios for an example addon', co.wrap(function *() {
-    yield copyFixtureFiles('addon/kitchen-sink');
+    it('works in most common scenarios for an example addon', co.wrap(function *() {
+      yield copyFixtureFiles('addon/kitchen-sink');
 
-    let packageJsonPath = path.join(addonRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
+      let packageJsonPath = path.join(addonRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
 
-    packageJson.dependencies = packageJson.dependencies || {};
-    // add HTMLBars for templates (generators do this automatically when components/templates are added)
-    packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
+      packageJson.dependencies = packageJson.dependencies || {};
+      // add HTMLBars for templates (generators do this automatically when components/templates are added)
+      packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
-    fs.writeJsonSync(packageJsonPath, packageJson);
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-    let result = yield runCommand('node_modules/ember-cli/bin/ember', 'build');
+      let result = yield runCommand('node_modules/ember-cli/bin/ember', 'build');
 
-    expect(result.code).to.eql(0);
-    let contents;
+      expect(result.code).to.eql(0);
+      let contents;
 
-    let indexPath = path.join(addonRoot, 'dist', 'index.html');
-    contents = fs.readFileSync(indexPath, { encoding: 'utf8' });
-    expect(contents).to.contain('"SOME AWESOME STUFF"');
+      let indexPath = path.join(addonRoot, 'dist', 'index.html');
+      contents = fs.readFileSync(indexPath, { encoding: 'utf8' });
+      expect(contents).to.contain('"SOME AWESOME STUFF"');
 
-    let cssPath = path.join(addonRoot, 'dist', 'assets', 'vendor.css');
-    contents = fs.readFileSync(cssPath, { encoding: 'utf8' });
-    expect(contents).to.contain('addon/styles/app.css is present');
+      let cssPath = path.join(addonRoot, 'dist', 'assets', 'vendor.css');
+      contents = fs.readFileSync(cssPath, { encoding: 'utf8' });
+      expect(contents).to.contain('addon/styles/app.css is present');
 
-    let robotsPath = path.join(addonRoot, 'dist', 'robots.txt');
-    contents = fs.readFileSync(robotsPath, { encoding: 'utf8' });
-    expect(contents).to.contain('tests/dummy/public/robots.txt is present');
+      let robotsPath = path.join(addonRoot, 'dist', 'robots.txt');
+      contents = fs.readFileSync(robotsPath, { encoding: 'utf8' });
+      expect(contents).to.contain('tests/dummy/public/robots.txt is present');
 
-    result = yield runCommand('node_modules/ember-cli/bin/ember', 'test');
+      result = yield runCommand('node_modules/ember-cli/bin/ember', 'test');
 
-    expect(result.code).to.eql(0);
-  }));
+      expect(result.code).to.eql(0);
+    }));
 
-  it('npm pack does not include unnecessary files', co.wrap(function *() {
-    let handleError = function(error, commandName) {
-      if (error.code === 'ENOENT') {
-        console.warn(chalk.yellow(`      Your system does not provide ${commandName} -> Skipped this test.`));
-      } else {
-        throw new Error(error);
+    it('npm pack does not include unnecessary files', co.wrap(function *() {
+      let handleError = function(error, commandName) {
+        if (error.code === 'ENOENT') {
+          console.warn(chalk.yellow(`      Your system does not provide ${commandName} -> Skipped this test.`));
+        } else {
+          throw new Error(error);
+        }
+      };
+
+      try {
+        yield npmPack();
+      } catch (error) {
+        return handleError(error, 'npm');
       }
-    };
 
-    try {
-      yield npmPack();
-    } catch (error) {
-      return handleError(error, 'npm');
-    }
+      let output;
+      try {
+        output = yield tar();
+      } catch (error) {
+        return handleError(error, 'tar');
+      }
 
-    let output;
-    try {
-      output = yield tar();
-    } catch (error) {
-      return handleError(error, 'tar');
-    }
+      let unnecessaryFiles = [
+        '.gitkeep',
+        '.travis.yml',
+        '.editorconfig',
+        'testem.js',
+        '.ember-cli',
+        'bower.json',
+        '.bowerrc',
+      ];
 
-    let unnecessaryFiles = [
-      '.gitkeep',
-      '.travis.yml',
-      '.editorconfig',
-      'testem.js',
-      '.ember-cli',
-      'bower.json',
-      '.bowerrc',
-    ];
+      let unnecessaryFolders = [
+        'tests/',
+        'bower_components/',
+      ];
 
-    let unnecessaryFolders = [
-      'tests/',
-      'bower_components/',
-    ];
-
-    let outputFiles = output.split('\n');
-    expect(outputFiles).to.not.contain(unnecessaryFiles);
-    expect(outputFiles).to.not.contain(unnecessaryFolders);
-  }));
-});
+      let outputFiles = output.split('\n');
+      expect(outputFiles).to.not.contain(unnecessaryFiles);
+      expect(outputFiles).to.not.contain(unnecessaryFolders);
+    }));
+  });
+}
 
 function npmPack() {
   return new Promise((resolve, reject) => {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -18,6 +18,7 @@ let file = chai.file;
 let dir = chai.dir;
 const forEach = require('ember-cli-lodash-subset').forEach;
 const assertVersionLock = require('../helpers/assert-version-lock');
+const experiments = require('../../lib/experiments');
 
 let tmpDir = './tmp/new-test';
 
@@ -50,8 +51,63 @@ describe('Acceptance: ember new', function() {
       .to.deep.equal(actual, `${EOL} expected: ${util.inspect(expected)}${EOL} but got: ${util.inspect(actual)}`);
   }
 
-  function confirmBlueprinted() {
+  function confirmBlueprintedApp() {
+    if (experiments.MODULE_UNIFICATION) {
+      return confirmBlueprintedForDir('blueprints/module-unification-app');
+    }
     return confirmBlueprintedForDir('blueprints/app');
+  }
+
+  if (experiments.MODULE_UNIFICATION) {
+    it('EMBER_CLI_MODULE_UNIFICATION: ember addon foo works', co.wrap(function *() {
+      yield ember([
+        'addon',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+      ]);
+
+      let expectedFiles = walkSync(path.join(__dirname, '../fixtures', 'module-unification-addon'))
+        .sort()
+        .filter(e => e !== '.DS_Store');
+      let actualFiles = walkSync('.').sort().filter(e => e !== '.DS_Store');
+      expect(actualFiles).to.deep.equal(expectedFiles);
+    }));
+  } else {
+    // TODO: this should pass in both MU and classic
+    it('ember new adds ember-welcome-page by default', co.wrap(function *() {
+      yield ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git',
+      ]);
+
+      expect(file('package.json'))
+        .to.match(/"ember-welcome-page"/);
+
+      expect(file('app/templates/application.hbs'))
+        .to.contain("{{welcome-page}}");
+    }));
+
+    // TODO: this should pass in both MU and classic
+    it('ember new --no-welcome skips installation of ember-welcome-page', co.wrap(function *() {
+      yield ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git',
+        '--no-welcome',
+      ]);
+
+      expect(file('package.json'))
+        .not.to.match(/"ember-welcome-page"/);
+
+      expect(file('app/templates/application.hbs'))
+        .to.contain("Welcome to Ember");
+    }));
   }
 
   it('ember new foo, where foo does not yet exist, works', co.wrap(function *() {
@@ -62,18 +118,7 @@ describe('Acceptance: ember new', function() {
       '--skip-bower',
     ]);
 
-    confirmBlueprinted();
-  }));
-
-  it('EMBER_CLI_MODULE_UNIFICATION: ember new foo works', co.wrap(function *() {
-    yield ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-bower',
-    ]);
-
-    confirmBlueprintedForDir('blueprints/module-unification-app');
+    confirmBlueprintedApp();
   }));
 
   it('ember new with empty app name fails with a warning', co.wrap(function *() {
@@ -162,7 +207,7 @@ describe('Acceptance: ember new', function() {
     expect(error.name).to.equal('SilentError');
     expect(error.message).to.equal(`You cannot use the ${chalk.green('new')} command inside an ember-cli project.`);
 
-    confirmBlueprinted();
+    confirmBlueprintedApp();
   }));
 
   it('ember new with blueprint uses the specified blueprint directory with a relative path', co.wrap(function *() {
@@ -320,21 +365,6 @@ describe('Acceptance: ember new', function() {
     expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
   }));
 
-  it('EMBER_CLI_MODULE_UNIFICATION: ember addon foo works', co.wrap(function *() {
-    yield ember([
-      'addon',
-      'foo',
-      '--skip-npm',
-      '--skip-bower',
-    ]);
-
-    let expectedFiles = walkSync(path.join(__dirname, '../fixtures', 'module-unification-addon'))
-      .sort()
-      .filter(e => e !== '.DS_Store');
-    let actualFiles = walkSync('.').sort().filter(e => e !== '.DS_Store');
-    expect(actualFiles).to.deep.equal(expectedFiles);
-  }));
-
   it('ember addon with --directory uses given directory name and has correct package name', co.wrap(function *() {
     let workdir = process.cwd();
 
@@ -356,39 +386,6 @@ describe('Acceptance: ember new', function() {
 
     let pkgJson = fs.readJsonSync('package.json');
     expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
-  }));
-
-  it('ember new adds ember-welcome-page by default', co.wrap(function *() {
-    yield ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-bower',
-      '--skip-git',
-    ]);
-
-    expect(file('package.json'))
-      .to.match(/"ember-welcome-page"/);
-
-    expect(file('app/templates/application.hbs'))
-      .to.contain("{{welcome-page}}");
-  }));
-
-  it('ember new --no-welcome skips installation of ember-welcome-page', co.wrap(function *() {
-    yield ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-bower',
-      '--skip-git',
-      '--no-welcome',
-    ]);
-
-    expect(file('package.json'))
-      .not.to.match(/"ember-welcome-page"/);
-
-    expect(file('app/templates/application.hbs'))
-      .to.contain("Welcome to Ember");
   }));
 
   describe('verify fixtures', function() {
@@ -454,103 +451,105 @@ describe('Acceptance: ember new', function() {
       checkPackageJson(fixturePath);
     }));
 
-    it('app + npm + !welcome', co.wrap(function *() {
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--no-welcome',
-      ]);
+    if (!experiments.MODULE_UNIFICATION) {
+      it('app + npm + !welcome', co.wrap(function *() {
+        yield ember([
+          'new',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+          '--no-welcome',
+        ]);
 
-      let fixturePath = 'app/npm';
-      [
-        'app/templates/application.hbs',
-        '.travis.yml',
-        'README.md',
-        '.eslintrc.js',
-      ].forEach(filePath => {
-        expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-      });
+        let fixturePath = 'app/npm';
+        [
+          'app/templates/application.hbs',
+          '.travis.yml',
+          'README.md',
+          '.eslintrc.js',
+        ].forEach(filePath => {
+          expect(file(filePath))
+            .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+        });
 
-      checkPackageJson(fixturePath);
-    }));
+        checkPackageJson(fixturePath);
+      }));
 
-    it('app + yarn + welcome', co.wrap(function *() {
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--yarn',
-      ]);
+      it('app + yarn + welcome', co.wrap(function *() {
+        yield ember([
+          'new',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+          '--yarn',
+        ]);
 
-      let fixturePath = 'app/yarn';
-      [
-        'app/templates/application.hbs',
-        '.travis.yml',
-        'README.md',
-        '.eslintrc.js',
-      ].forEach(filePath => {
-        expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-      });
+        let fixturePath = 'app/yarn';
+        [
+          'app/templates/application.hbs',
+          '.travis.yml',
+          'README.md',
+          '.eslintrc.js',
+        ].forEach(filePath => {
+          expect(file(filePath))
+            .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+        });
 
-      checkPackageJson(fixturePath);
-    }));
+        checkPackageJson(fixturePath);
+      }));
 
-    it('addon + npm + !welcome', co.wrap(function *() {
-      yield ember([
-        'addon',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-      ]);
+      it('addon + npm + !welcome', co.wrap(function *() {
+        yield ember([
+          'addon',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+        ]);
 
-      let fixturePath = 'addon/npm';
-      [
-        'config/ember-try.js',
-        'tests/dummy/app/templates/application.hbs',
-        '.travis.yml',
-        'README.md',
-        '.eslintrc.js',
-      ].forEach(filePath => {
-        expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-      });
+        let fixturePath = 'addon/npm';
+        [
+          'config/ember-try.js',
+          'tests/dummy/app/templates/application.hbs',
+          '.travis.yml',
+          'README.md',
+          '.eslintrc.js',
+        ].forEach(filePath => {
+          expect(file(filePath))
+            .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+        });
 
-      checkPackageJson(fixturePath);
-    }));
+        checkPackageJson(fixturePath);
+      }));
 
-    it('addon + yarn + welcome', co.wrap(function *() {
-      yield ember([
-        'addon',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--yarn',
-        '--welcome',
-      ]);
+      it('addon + yarn + welcome', co.wrap(function *() {
+        yield ember([
+          'addon',
+          'foo',
+          '--skip-npm',
+          '--skip-bower',
+          '--skip-git',
+          '--yarn',
+          '--welcome',
+        ]);
 
-      let fixturePath = 'addon/yarn';
-      [
-        'config/ember-try.js',
-        'tests/dummy/app/templates/application.hbs',
-        '.travis.yml',
-        'README.md',
-        '.eslintrc.js',
-      ].forEach(filePath => {
-        expect(file(filePath))
-          .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-      });
+        let fixturePath = 'addon/yarn';
+        [
+          'config/ember-try.js',
+          'tests/dummy/app/templates/application.hbs',
+          '.travis.yml',
+          'README.md',
+          '.eslintrc.js',
+        ].forEach(filePath => {
+          expect(file(filePath))
+            .to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+        });
 
-      checkPackageJson(fixturePath);
-    }));
+        checkPackageJson(fixturePath);
+      }));
+    }
   });
 
   describe('verify dependencies', function() {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -30,7 +30,6 @@ describe('Acceptance: ember new', function() {
   }));
 
   afterEach(function() {
-    process.env.MODULE_UNIFICATION = undefined;
     return tmp.teardown(tmpDir);
   });
 
@@ -66,8 +65,7 @@ describe('Acceptance: ember new', function() {
     confirmBlueprinted();
   }));
 
-  it('MODULE_UNIFICATION=true ember new foo works', co.wrap(function *() {
-    process.env.MODULE_UNIFICATION = 'true';
+  it('EMBER_CLI_MODULE_UNIFICATION: ember new foo works', co.wrap(function *() {
     yield ember([
       'new',
       'foo',
@@ -322,8 +320,7 @@ describe('Acceptance: ember new', function() {
     expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
   }));
 
-  it('MODULE_UNIFICATION=true ember addon foo works', co.wrap(function *() {
-    process.env.MODULE_UNIFICATION = 'true';
+  it('EMBER_CLI_MODULE_UNIFICATION: ember addon foo works', co.wrap(function *() {
     yield ember([
       'addon',
       'foo',

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -4,6 +4,7 @@ const co = require('co');
 const path = require('path');
 const fs = require('fs-extra');
 
+const experiments = require('../../lib/experiments');
 const runCommand = require('../helpers/run-command');
 const acceptance = require('../helpers/acceptance');
 const copyFixtureFiles = require('../helpers/copy-fixture-files');
@@ -20,125 +21,127 @@ let dir = chai.dir;
 let appName = 'some-cool-app';
 let appRoot;
 
-describe('Acceptance: preprocessor-smoke-test', function() {
-  this.timeout(360000);
+if (!experiments.MODULE_UNIFICATION) {
+  describe('Acceptance: preprocessor-smoke-test', function() {
+    this.timeout(360000);
 
-  before(function() {
-    return createTestTargets(appName);
+    before(function() {
+      return createTestTargets(appName);
+    });
+
+    after(teardownTestTargets);
+
+    beforeEach(function() {
+      appRoot = linkDependencies(appName);
+    });
+
+    afterEach(function() {
+      cleanupRun(appName);
+      expect(dir(appRoot)).to.not.exist;
+    });
+
+    it('addons with standard preprocessors compile correctly', co.wrap(function *() {
+      yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
+      expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
+    }));
+
+    it('addon registry entries are added in the proper order', co.wrap(function *() {
+      yield copyFixtureFiles('preprocessor-tests/app-registry-ordering');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
+      packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('replacedByPreprocessor', 'token should have been replaced in app bundle')
+        .to.not.contain('__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained')
+        .to.not.contain('__FIRST_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained');
+    }));
+
+    it('addons without preprocessors compile correctly', co.wrap(function *() {
+      yield copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
+      expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
+    }));
+
+    /*
+      [ app ]  -> [ addon ] -> [ preprocessor addon ]
+        |             |
+        |             |--- preprocessor applies to this
+        |
+        |-- preprocessor should not apply to this
+    */
+    it('addons depending on preprocessor addon preprocesses addon but not app', co.wrap(function *() {
+      yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-2');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
+        .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
+
+      expect(file('dist/assets/vendor.js'))
+        .to.contain('replacedByPreprocessor', 'token should have been replaced in vendor bundle')
+        .to.not.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in vendor bundle');
+    }));
+
+    /*
+      [ app ]  -> [ addon ] ->  [ addon ] -> [ preprocessor addon ]
+        |             |             |
+        |             |             |--- preprocessor applies to this
+        |             |
+        |             |-- preprocessor should not apply to this
+        |
+        |-- preprocessor should not apply to this
+    */
+    it('addon N levels deep depending on preprocessor preprocesses that parent addon only', co.wrap(function *() {
+      yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-3');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-shallow-addon'] = 'latest';
+
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
+        .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
+
+      expect(file('dist/assets/vendor.js'))
+        .to.contain('deep: "replacedByPreprocessor"', 'token should have been replaced in deep component')
+        .to.contain('shallow: __PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in shallow component')
+        .to.not.contain('deep: __PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in deep component')
+        .to.not.contain('shallow: "replacedByPreprocessor"', 'token should not have been replaced in shallow component');
+    }));
   });
-
-  after(teardownTestTargets);
-
-  beforeEach(function() {
-    appRoot = linkDependencies(appName);
-  });
-
-  afterEach(function() {
-    cleanupRun(appName);
-    expect(dir(appRoot)).to.not.exist;
-  });
-
-  it('addons with standard preprocessors compile correctly', co.wrap(function *() {
-    yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors');
-
-    let packageJsonPath = path.join(appRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.devDependencies['ember-cli-sass'] = 'latest';
-    packageJson.devDependencies['ember-cool-addon'] = 'latest';
-    fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
-    expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
-  }));
-
-  it('addon registry entries are added in the proper order', co.wrap(function *() {
-    yield copyFixtureFiles('preprocessor-tests/app-registry-ordering');
-
-    let packageJsonPath = path.join(appRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
-    packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
-    fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('dist/assets/some-cool-app.js'))
-      .to.contain('replacedByPreprocessor', 'token should have been replaced in app bundle')
-      .to.not.contain('__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained')
-      .to.not.contain('__FIRST_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained');
-  }));
-
-  it('addons without preprocessors compile correctly', co.wrap(function *() {
-    yield copyFixtureFiles('preprocessor-tests/app-with-addon-without-preprocessors');
-
-    let packageJsonPath = path.join(appRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.devDependencies['ember-cli-sass'] = 'latest';
-    packageJson.devDependencies['ember-cool-addon'] = 'latest';
-    fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
-    expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
-  }));
-
-  /*
-    [ app ]  -> [ addon ] -> [ preprocessor addon ]
-      |             |
-      |             |--- preprocessor applies to this
-      |
-      |-- preprocessor should not apply to this
-  */
-  it('addons depending on preprocessor addon preprocesses addon but not app', co.wrap(function *() {
-    yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-2');
-
-    let packageJsonPath = path.join(appRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.devDependencies['ember-cool-addon'] = 'latest';
-    fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('dist/assets/some-cool-app.js'))
-      .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
-      .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
-
-    expect(file('dist/assets/vendor.js'))
-      .to.contain('replacedByPreprocessor', 'token should have been replaced in vendor bundle')
-      .to.not.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in vendor bundle');
-  }));
-
-  /*
-    [ app ]  -> [ addon ] ->  [ addon ] -> [ preprocessor addon ]
-      |             |             |
-      |             |             |--- preprocessor applies to this
-      |             |
-      |             |-- preprocessor should not apply to this
-      |
-      |-- preprocessor should not apply to this
-  */
-  it('addon N levels deep depending on preprocessor preprocesses that parent addon only', co.wrap(function *() {
-    yield copyFixtureFiles('preprocessor-tests/app-with-addon-with-preprocessors-3');
-
-    let packageJsonPath = path.join(appRoot, 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.devDependencies['ember-shallow-addon'] = 'latest';
-
-    fs.writeJsonSync(packageJsonPath, packageJson);
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    expect(file('dist/assets/some-cool-app.js'))
-      .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
-      .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
-
-    expect(file('dist/assets/vendor.js'))
-      .to.contain('deep: "replacedByPreprocessor"', 'token should have been replaced in deep component')
-      .to.contain('shallow: __PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in shallow component')
-      .to.not.contain('deep: __PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in deep component')
-      .to.not.contain('shallow: "replacedByPreprocessor"', 'token should not have been replaced in shallow component');
-  }));
-});
+}

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const walkSync = require('walk-sync');
 const EOL = require('os').EOL;
 
+const experiments = require('../../lib/experiments');
 const runCommand = require('../helpers/run-command');
 const acceptance = require('../helpers/acceptance');
 const copyFixtureFiles = require('../helpers/copy-fixture-files');
@@ -47,30 +48,32 @@ describe('Acceptance: smoke-test', function() {
     return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
-  it('ember new foo, make sure addon template overwrites', co.wrap(function *() {
-    yield ember(['generate', 'template', 'foo']);
-    yield ember(['generate', 'in-repo-addon', 'my-addon']);
+  if (!experiments.MODULE_UNIFICATION) {
+    it('ember new foo, make sure addon template overwrites', co.wrap(function *() {
+      yield ember(['generate', 'template', 'foo']);
+      yield ember(['generate', 'in-repo-addon', 'my-addon']);
 
-    // this should work, but generating a template in an addon/in-repo-addon doesn't
-    // do the right thing: update once https://github.com/ember-cli/ember-cli/issues/5687
-    // is fixed
-    //return ember(['generate', 'template', 'foo', '--in-repo-addon=my-addon']);
+      // this should work, but generating a template in an addon/in-repo-addon doesn't
+      // do the right thing: update once https://github.com/ember-cli/ember-cli/issues/5687
+      // is fixed
+      //return ember(['generate', 'template', 'foo', '--in-repo-addon=my-addon']);
 
-    // temporary work around
-    let templatePath = path.join('lib', 'my-addon', 'app', 'templates', 'foo.hbs');
-    fs.mkdirsSync(path.dirname(templatePath));
-    fs.writeFileSync(templatePath, 'Hi, Mom!', { encoding: 'utf8' });
+      // temporary work around
+      let templatePath = path.join('lib', 'my-addon', 'app', 'templates', 'foo.hbs');
+      fs.mkdirsSync(path.dirname(templatePath));
+      fs.writeFileSync(templatePath, 'Hi, Mom!', { encoding: 'utf8' });
 
-    let packageJsonPath = path.join('lib', 'my-addon', 'package.json');
-    let packageJson = fs.readJsonSync(packageJsonPath);
-    packageJson.dependencies = packageJson.dependencies || {};
-    packageJson.dependencies['ember-cli-htmlbars'] = '*';
+      let packageJsonPath = path.join('lib', 'my-addon', 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.dependencies = packageJson.dependencies || {};
+      packageJson.dependencies['ember-cli-htmlbars'] = '*';
 
-    fs.writeJsonSync(packageJsonPath, packageJson);
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-    let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-    expect(result.code).to.equal(0);
-  }));
+      let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      expect(result.code).to.equal(0);
+    }));
+  }
 
   it('ember test still runs when a JavaScript testem config exists', co.wrap(function *() {
     yield copyFixtureFiles('smoke-tests/js-testem-config');
@@ -192,29 +195,31 @@ describe('Acceptance: smoke-test', function() {
     expect(paths).to.have.length.below(24, `expected fewer than 24 files in dist, found ${paths.length}`);
   }));
 
-  it('ember build exits with non-zero code when build fails', co.wrap(function *() {
-    let appJsPath = path.join(appRoot, 'app', 'app.js');
-    let ouputContainsBuildFailed = false;
+  if (!experiments.MODULE_UNIFICATION) {
+    it('ember build exits with non-zero code when build fails', co.wrap(function *() {
+      let appJsPath = path.join(appRoot, 'app', 'app.js');
+      let ouputContainsBuildFailed = false;
 
-    let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-    expect(result.code).to.equal(0, `expected exit code to be zero, but got ${result.code}`);
+      let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      expect(result.code).to.equal(0, `expected exit code to be zero, but got ${result.code}`);
 
-    // add something broken to the project to make build fail
-    fs.appendFileSync(appJsPath, '{(syntaxError>$@}{');
+      // add something broken to the project to make build fail
+      fs.appendFileSync(appJsPath, '{(syntaxError>$@}{');
 
-    result = yield expect(runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
-      onOutput(string) {
-        // discard output as there will be a lot of errors and a long stacktrace
-        // just mark that the output contains expected text
-        if (!ouputContainsBuildFailed && string.match(/Build failed/)) {
-          ouputContainsBuildFailed = true;
-        }
-      },
-    })).to.be.rejected;
+      result = yield expect(runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
+        onOutput(string) {
+          // discard output as there will be a lot of errors and a long stacktrace
+          // just mark that the output contains expected text
+          if (!ouputContainsBuildFailed && string.match(/Build failed/)) {
+            ouputContainsBuildFailed = true;
+          }
+        },
+      })).to.be.rejected;
 
-    expect(ouputContainsBuildFailed, 'command output must contain "Build failed" text').to.be.ok;
-    expect(result.code).to.not.equal(0, `expected exit code to be non-zero, but got ${result.code}`);
-  }));
+      expect(ouputContainsBuildFailed, 'command output must contain "Build failed" text').to.be.ok;
+      expect(result.code).to.not.equal(0, `expected exit code to be non-zero, but got ${result.code}`);
+    }));
+  }
 
   it('ember build generates instrumentation files when viz is enabled', co.wrap(function *() {
     process.env.BROCCOLI_VIZ = '1';
@@ -244,72 +249,74 @@ describe('Acceptance: smoke-test', function() {
     });
   }));
 
-  it('ember new foo, build --watch development, and verify rebuilt after change', co.wrap(function *() {
-    let touched = false;
-    let appJsPath = path.join(appRoot, 'app', 'app.js');
-    let builtJsPath = path.join(appRoot, 'dist', 'assets', 'some-cool-app.js');
-    let text = 'anotuhaonteuhanothunaothanoteh';
-    let line = `console.log("${text}");`;
+  if (!experiments.MODULE_UNIFICATION) {
+    it('ember new foo, build --watch development, and verify rebuilt after change', co.wrap(function *() {
+      let touched = false;
+      let appJsPath = path.join(appRoot, 'app', 'app.js');
+      let builtJsPath = path.join(appRoot, 'dist', 'assets', 'some-cool-app.js');
+      let text = 'anotuhaonteuhanothunaothanoteh';
+      let line = `console.log("${text}");`;
 
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--watch', {
-      onOutput(string, child) {
-        if (touched) {
-          if (string.match(/Build successful/)) {
-            // build after change to app.js
-            let contents = fs.readFileSync(builtJsPath).toString();
-            expect(contents).to.contain(text, 'must contain changed line after rebuild');
-            killCliProcess(child);
-          }
-        } else if (string.match(/Build successful/)) {
-          // first build
-          touched = true;
-          fs.appendFileSync(appJsPath, line);
-        }
-      },
-    }).catch(function() {
-      // swallowing because of SIGINT
-    });
-  }));
-
-  it('ember new foo, build --watch development, and verify rebuilt after multiple changes', co.wrap(function *() {
-    let buildCount = 0;
-    let touched = false;
-    let appJsPath = path.join(appRoot, 'app', 'app.js');
-    let builtJsPath = path.join(appRoot, 'dist', 'assets', 'some-cool-app.js');
-    let firstText = 'anotuhaonteuhanothunaothanoteh';
-    let firstLine = `console.log("${firstText}");`;
-    let secondText = 'aahsldfjlwioruoiiononociwewqwr';
-    let secondLine = `console.log("${secondText}");`;
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--watch', {
-      onOutput(string, child) {
-        if (buildCount === 0) {
-          if (string.match(/Build successful/)) {
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--watch', {
+        onOutput(string, child) {
+          if (touched) {
+            if (string.match(/Build successful/)) {
+              // build after change to app.js
+              let contents = fs.readFileSync(builtJsPath).toString();
+              expect(contents).to.contain(text, 'must contain changed line after rebuild');
+              killCliProcess(child);
+            }
+          } else if (string.match(/Build successful/)) {
             // first build
             touched = true;
-            buildCount = 1;
-            fs.appendFileSync(appJsPath, firstLine);
+            fs.appendFileSync(appJsPath, line);
           }
-        } else if (buildCount === 1) {
-          if (string.match(/Build successful/)) {
-            // second build
-            touched = true;
-            buildCount = 2;
-            fs.appendFileSync(appJsPath, secondLine);
+        },
+      }).catch(function() {
+        // swallowing because of SIGINT
+      });
+    }));
+
+    it('ember new foo, build --watch development, and verify rebuilt after multiple changes', co.wrap(function *() {
+      let buildCount = 0;
+      let touched = false;
+      let appJsPath = path.join(appRoot, 'app', 'app.js');
+      let builtJsPath = path.join(appRoot, 'dist', 'assets', 'some-cool-app.js');
+      let firstText = 'anotuhaonteuhanothunaothanoteh';
+      let firstLine = `console.log("${firstText}");`;
+      let secondText = 'aahsldfjlwioruoiiononociwewqwr';
+      let secondLine = `console.log("${secondText}");`;
+
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--watch', {
+        onOutput(string, child) {
+          if (buildCount === 0) {
+            if (string.match(/Build successful/)) {
+              // first build
+              touched = true;
+              buildCount = 1;
+              fs.appendFileSync(appJsPath, firstLine);
+            }
+          } else if (buildCount === 1) {
+            if (string.match(/Build successful/)) {
+              // second build
+              touched = true;
+              buildCount = 2;
+              fs.appendFileSync(appJsPath, secondLine);
+            }
+          } else if (touched && buildCount === 2) {
+            if (string.match(/Build successful/)) {
+              // build after change to app.js
+              let contents = fs.readFileSync(builtJsPath).toString();
+              expect(contents).to.contain(secondText, 'must contain second changed line after rebuild');
+              killCliProcess(child);
+            }
           }
-        } else if (touched && buildCount === 2) {
-          if (string.match(/Build successful/)) {
-            // build after change to app.js
-            let contents = fs.readFileSync(builtJsPath).toString();
-            expect(contents).to.contain(secondText, 'must contain second changed line after rebuild');
-            killCliProcess(child);
-          }
-        }
-      },
-    }).catch(function() {
-      // swallowing because of SIGINT
-    });
-  }));
+        },
+      }).catch(function() {
+        // swallowing because of SIGINT
+      });
+    }));
+  }
 
   it('ember new foo, server, SIGINT clears tmp/', co.wrap(function *() {
     let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'server', '--port=54323', '--live-reload=false', {
@@ -392,14 +399,16 @@ describe('Acceptance: smoke-test', function() {
     });
   }));
 
-  it('ember can override and reuse the built-in blueprints', co.wrap(function *() {
-    yield copyFixtureFiles('addon/with-blueprint-override');
+  if (!experiments.MODULE_UNIFICATION) {
+    it('ember can override and reuse the built-in blueprints', co.wrap(function *() {
+      yield copyFixtureFiles('addon/with-blueprint-override');
 
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'component', 'foo-bar', '-p');
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'component', 'foo-bar', '-p');
 
-    // because we're overriding, the fileMapTokens is default, sans 'component'
-    expect(file('app/foo-bar/component.js')).to.contain('generated component successfully');
-  }));
+      // because we're overriding, the fileMapTokens is default, sans 'component'
+      expect(file('app/foo-bar/component.js')).to.contain('generated component successfully');
+    }));
+  }
 
   it('template linting works properly for pods and classic structured templates', co.wrap(function *() {
     yield copyFixtureFiles('smoke-tests/with-template-failing-linting');

--- a/tests/fixtures/module-unification-addon/testem.js
+++ b/tests/fixtures/module-unification-addon/testem.js
@@ -8,11 +8,17 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+    Chrome: {
+      mode: 'ci',
+      args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
   }
 };

--- a/tests/unit/blueprints/in-repo-addon-test.js
+++ b/tests/unit/blueprints/in-repo-addon-test.js
@@ -18,46 +18,6 @@ describe('Acceptance: ember generate and destroy in-repo-addon', function() {
     cliPath: path.resolve(`${__dirname}/../../..`),
   });
 
-  describe('classic app', function() {
-    it('in-repo-addon fooBar', function() {
-      let args = ['in-repo-addon', 'fooBar'];
-
-      return emberNew()
-        .then(function() {
-          expect(fs.readJsonSync('package.json')['ember-addon']).to.be.undefined;
-        })
-        .then(function() {
-          return emberGenerate(args);
-        })
-        .then(function() {
-          expect(file('lib/foo-bar/package.json')).to.exist;
-          expect(file('lib/foo-bar/index.js')).to.exist;
-
-          expect(fs.readJsonSync('lib/foo-bar/package.json')).to.deep.equal({
-            "name": "foo-bar",
-            "keywords": [
-              "ember-addon",
-            ],
-          });
-
-          expect(fs.readJsonSync('package.json')['ember-addon']).to.deep.equal({
-            "paths": [
-              "lib/foo-bar",
-            ],
-          });
-        })
-        .then(function() {
-          return emberDestroy(args);
-        })
-        .then(function() {
-          expect(file('lib/foo-bar/package.json')).to.not.exist;
-          expect(file('lib/foo-bar/index.js')).to.not.exist;
-
-          expect(fs.readJsonSync('package.json')['ember-addon']['paths']).to.be.undefined;
-        });
-    });
-  });
-
   if (experiments.MODULE_UNIFICATION) {
     describe('module unification app', function() {
       it('in-repo-addon fooBar', function() {
@@ -101,8 +61,47 @@ describe('Acceptance: ember generate and destroy in-repo-addon', function() {
           });
       });
     });
-  }
+  } else {
+    describe('classic app', function() {
+      it('in-repo-addon fooBar', function() {
+        let args = ['in-repo-addon', 'fooBar'];
 
+        return emberNew()
+          .then(function() {
+            expect(fs.readJsonSync('package.json')['ember-addon']).to.be.undefined;
+          })
+          .then(function() {
+            return emberGenerate(args);
+          })
+          .then(function() {
+            expect(file('lib/foo-bar/package.json')).to.exist;
+            expect(file('lib/foo-bar/index.js')).to.exist;
+
+            expect(fs.readJsonSync('lib/foo-bar/package.json')).to.deep.equal({
+              "name": "foo-bar",
+              "keywords": [
+                "ember-addon",
+              ],
+            });
+
+            expect(fs.readJsonSync('package.json')['ember-addon']).to.deep.equal({
+              "paths": [
+                "lib/foo-bar",
+              ],
+            });
+          })
+          .then(function() {
+            return emberDestroy(args);
+          })
+          .then(function() {
+            expect(file('lib/foo-bar/package.json')).to.not.exist;
+            expect(file('lib/foo-bar/index.js')).to.not.exist;
+
+            expect(fs.readJsonSync('package.json')['ember-addon']['paths']).to.be.undefined;
+          });
+      });
+    });
+  }
 });
 
 describe('Unit: in-repo-addon blueprint', function() {

--- a/tests/unit/commands/addon-test.js
+++ b/tests/unit/commands/addon-test.js
@@ -5,6 +5,7 @@ const commandOptions = require('../../factories/command-options');
 const map = require('ember-cli-lodash-subset').map;
 const AddonCommand = require('../../../lib/commands/addon');
 const Blueprint = require('../../../lib/models/blueprint');
+const experiments = require('../../../lib/experiments');
 const td = require('testdouble');
 
 describe('addon command', function() {
@@ -71,11 +72,13 @@ describe('addon command', function() {
     });
   });
 
-  it('doesn\'t allow to create an addon when the name is a period', function() {
-    return expect(command.validateAndRun(['.'])).to.be.rejected.then(error => {
-      expect(error.message).to.equal('Trying to generate an addon structure in this directory? Use `ember init` instead.');
+  if (!experiments.MODULE_UNIFICATION) {
+    it('doesn\'t allow to create an addon when the name is a period', function() {
+      return expect(command.validateAndRun(['.'])).to.be.rejected.then(error => {
+        expect(error.message).to.equal('Trying to generate an addon structure in this directory? Use `ember init` instead.');
+      });
     });
-  });
+  }
 
   it('registers blueprint options in beforeRun', function() {
     td.replace(Blueprint, 'lookup', td.function());

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -8,6 +8,7 @@ const Promise = require('rsvp').Promise;
 const Blueprint = require('../../../lib/models/blueprint');
 const Command = require('../../../lib/models/command');
 const Task = require('../../../lib/models/task');
+const experiments = require('../../../lib/experiments');
 const td = require('testdouble');
 
 describe('new command', function() {
@@ -76,11 +77,13 @@ describe('new command', function() {
     });
   });
 
-  it('shows a suggestion messages when the application name is a period', function() {
-    return expect(command.validateAndRun(['.'])).to.be.rejected.then(error => {
-      expect(error.message).to.equal('Trying to generate an application structure in this directory? Use `ember init` instead.');
+  if (!experiments.MODULE_UNIFICATION) {
+    it('shows a suggestion messages when the application name is a period', function() {
+      return expect(command.validateAndRun(['.'])).to.be.rejected.then(error => {
+        expect(error.message).to.equal('Trying to generate an application structure in this directory? Use `ember init` instead.');
+      });
     });
-  });
+  }
 
   it('registers blueprint options in beforeRun', function() {
     td.when(Blueprint.lookup('app'), { ignoreExtraArgs: true }).thenReturn({


### PR DESCRIPTION
This [removes the need for specifying the additional `MODULE_UNIFICATION` env](https://github.com/emberjs/ember.js/issues/16373#issuecomment-389747683) for the `new` command by respecting the new [Experiments](https://github.com/ember-cli/ember-cli/blob/9a4c95608928c207e6fefc22a9ee0c7af652ecc8/docs/experiments.md) feature toggling.

It also exposes gaps in MU testing and some needed fixture verification. 

(Thank you @mixonic for your help today.)