### PR TITLE
Fix `ember serve` throwing .replace of undefined

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -213,9 +213,15 @@ class ExpressServerTask extends Task {
     let options = this.startOptions;
     options.httpServer = this.httpServer;
 
+    const config = this.project.config(options.environment);
+    const middlewareOptions = Object.assign({}, options, {
+      rootURL: config.rootURL,
+      baseURL: config.baseURL || '/',
+    });
+
     return Promise.resolve()
-      .then(() => this.processAppMiddlewares(options))
-      .then(() => this.processAddonMiddlewares(options))
+      .then(() => this.processAppMiddlewares(middlewareOptions))
+      .then(() => this.processAddonMiddlewares(middlewareOptions))
       .then(() => this.listen(options.port, options.host)
         .catch(() => {
           throw new SilentError(`Could not serve on http://${this.displayHost(options.host)}:${options.port}. ` +

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -530,6 +530,7 @@ describe('express-server', function() {
     describe('without proxy', function() {
       function startServer(rootURL) {
         return subject.start({
+          environment: 'development',
           host: undefined,
           port: '1337',
           rootURL: rootURL || '/',
@@ -732,6 +733,10 @@ describe('express-server', function() {
       });
 
       it('serves static asset up from build output without a period in name (with rootURL)', function(done) {
+        project._config = {
+          rootURL: '/foo',
+        };
+
         startServer('/foo')
           .then(function() {
             request(subject.app)
@@ -894,18 +899,22 @@ describe('express-server', function() {
 
       it('calls processAppMiddlewares upon start', function() {
         let realOptions = {
+          baseURL: '/',
+          rootURL: undefined,
           host: undefined,
           port: '1337',
         };
 
         return subject.start(realOptions).then(function() {
-          expect(passedOptions === realOptions).to.equal(true);
+          expect(passedOptions).to.deep.equal(realOptions);
           expect(calls).to.equal(1);
         });
       });
 
       it('calls processAppMiddlewares upon restart', function() {
         let realOptions = {
+          baseURL: '/',
+          rootURL: undefined,
           host: undefined,
           port: '1337',
         };
@@ -921,7 +930,7 @@ describe('express-server', function() {
           .then(function() {
             expect(subject.app).to.be.ok;
             expect(originalApp).to.not.equal(subject.app);
-            expect(passedOptions === realOptions).to.equal(true);
+            expect(passedOptions).to.deep.equal(realOptions);
             expect(calls).to.equal(2);
           });
       });

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -16,6 +16,10 @@ const nock = require('nock');
 const express = require('express');
 const co = require('co');
 
+function checkMiddlewareOptions(options) {
+  expect(options).to.satisfy(option => option.baseURL || option.rootURL);
+}
+
 describe('express-server', function() {
   let subject, ui, project, proxy, nockProxy;
   nock.enableNetConnect();
@@ -751,7 +755,8 @@ describe('express-server', function() {
       beforeEach(function() {
         calls = 0;
 
-        subject.processAddonMiddlewares = function() {
+        subject.processAddonMiddlewares = function(options) {
+          checkMiddlewareOptions(options);
           calls++;
         };
       });
@@ -775,11 +780,13 @@ describe('express-server', function() {
 
         project.initializeAddons = function() { };
         project.addons = [{
-          serverMiddleware() {
+          serverMiddleware({ options }) {
+            checkMiddlewareOptions(options);
             firstCalls++;
           },
         }, {
-          serverMiddleware() {
+          serverMiddleware({ options }) {
+            checkMiddlewareOptions(options);
             secondCalls++;
           },
         }, {


### PR DESCRIPTION
This issue was that the options param changed after: https://github.com/ember-cli/ember-cli/pull/7861. Specifically that rootURL and baseURL were taken off of commandOptions. This had a problem where the express-server when passing down the options into addons `serverMiddleware` hook would not contain those properties. An example https://github.com/ember-cli/ember-cli-inject-live-reload/blob/master/index.js#L37