### PR TITLE
testem: Improve Chrome command line flags

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -13,9 +13,11 @@ module.exports = {
       args: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
-
-        '--disable-gpu',
         '--headless',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ].filter(Boolean)


### PR DESCRIPTION
Some better testem config defaults for headless chrome.

Context for --disable-dev-shm-usage -> https://bugs.chromium.org/p/chromium/issues/detail?id=736452#c64

cc @step2yeung thoughts?