### PR TITLE
Pass resultAnnotation object to build function

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -188,7 +188,7 @@ class Builder extends CoreObject {
 
       if (this.broccoliBuilderFallback) {
         try {
-          buildResults = await this.builder.build(addWatchDirCallback);
+          buildResults = await this.builder.build(addWatchDirCallback, resultAnnotation);
         } catch (error) {
           this.throwFormattedBroccoliError(error);
         }


### PR DESCRIPTION
Pass resultAnnotation object to build function to allow custom caching strategies.
example: https://github.com/ember-cli/broccoli-builder/pull/30
This trick produce 4x pefrormance improvements on windows mashines