### PR TITLE
Explicitly include `this.trees.styles`

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1608,6 +1608,7 @@ class EmberApp {
     return [
       this.getAppJavascript(this._isPackageHookSupplied),
       this.getAddonTemplates(),
+      this.trees.styles,
       this.getAddonStyles(),
       this.getTests(),
       this.getExternalTree(),


### PR DESCRIPTION
After packager work landed, there was no need to explicitly merge
`app.trees.styles` into a "full tree" as for classic model they would
be a part of "app" tree, for MU they would be a part of "src" tree.

As it turned out some developers relied on the fact that they could add
things to `app.trees.styles` so that packager changes turned out to be
breaking changes.

Since this behaviour manifested only when using MU *and* adding styles
to `app.trees.styles`, this is not critical.

Fix https://github.com/ember-cli/ember-cli/issues/7862