### PR TITLE
Allow specifying environment variables in .ember-cli

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -77,6 +77,14 @@ module.exports = function(options) {
   const Project = require('../models/project');
   let config = getConfig(options.Yam);
 
+  let envVariables = config.get('environment') || {};
+  for (let key in envVariables) {
+    // env variables in process.env should have more priority over the ones specified in .ember-cli.
+    if (!(key in process.env)) {
+      process.env[key] = envVariables[key];
+    }
+  }
+
   configureLogger(process.env);
 
   // TODO: one UI (lib/models/project.js also has one for now...)

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -17,7 +17,6 @@ const heimdall = require('heimdalljs');
 const PackageInfoCache = require('../models/package-info-cache');
 
 const instantiateAddons = require('../models/instantiate-addons');
-const experiments = require('../experiments');
 
 let processCwd = process.cwd();
 
@@ -216,6 +215,7 @@ class Project {
      @return {Boolean} Whether this is using a module unification format.
     */
   isModuleUnification() {
+    const experiments = require('../experiments');
     if (experiments.MODULE_UNIFICATION) {
       return this.has('src');
     } else {

--- a/tests/unit/settings-file/env-variables-test.js
+++ b/tests/unit/settings-file/env-variables-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const co = require('co');
+const expect = require('chai').expect;
+const MockUI = require('console-ui/mock');
+const Yam = require('yam');
+const cliEntry = require('../../../lib/cli');
+const broccoliTestHelper = require('broccoli-test-helper');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('.ember-cli environment options', function() {
+  let sampleApp;
+
+  beforeEach(co.wrap(function *() {
+    process.env.SHOULDNT_BE_THERE = 'Normal';
+
+    sampleApp = yield createTempDir();
+    sampleApp.write({
+      '.ember-cli': JSON.stringify({
+        environment: {
+          'MY_ENV_VARIABLE': 'Yayy',
+          'SHOULDNT_BE_THERE': 'Strange',
+        },
+      }),
+    });
+
+    let primaryPath = sampleApp.path();
+
+    yield buildOutput(primaryPath);
+
+    let mockedYam = new Yam('ember-cli', {
+      primary: primaryPath,
+    });
+
+    cliEntry({
+      UI: MockUI,
+      Yam: mockedYam,
+    });
+  }));
+
+  afterEach(co.wrap(function *() {
+    delete process.env.MY_ENV_VARIABLE;
+    delete process.env.SHOULDNT_BE_THERE;
+
+    yield sampleApp.dispose();
+  }));
+
+  it('should assign environment variables in .ember-cli to process.env', function() {
+    expect(process.env.MY_ENV_VARIABLE).to.equal('Yayy');
+    expect(process.env.SHOULDNT_BE_THERE).to.equal('Normal');
+  });
+});


### PR DESCRIPTION
Addresses #7896.

Makes it possible to specify environment variables in `.ember-cli` like

```javascript
     {
          "environment": {
               "EMBER_CLI_MODULE_UNIFICATION": true
          }
     }
```
