### PR TITLE
Allowing cwd to be passed to testem without being overridden by ember-cli

### DIFF
--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -10,7 +10,8 @@ class TestServerTask extends TestTask {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      task.testem.startDev(task.testemOptions(options), (exitCode, error) => {
+      task.testem.setDefaultOptions(task.defaultOptions(options));
+      task.testem.startDev(task.transformOptions(options), (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -15,7 +15,8 @@ class TestTask extends Task {
     let task = this;
 
     return new Promise((resolve, reject) => {
-      testem.startCI(task.testemOptions(options), (exitCode, error) => {
+      testem.setDefaultOptions(task.defaultOptions(options));
+      testem.startCI(task.transformOptions(options), (exitCode, error) => {
         if (error) {
           reject(error);
         } else if (exitCode !== 0) {
@@ -39,18 +40,25 @@ class TestTask extends Task {
     }, []);
   }
 
-  testemOptions(options) {
+  defaultOptions(options) {
+    let defaultOptions = this.transformOptions(options);
+    defaultOptions.cwd = options.outputPath;
+    /* eslint-disable camelcase */
+    defaultOptions.config_dir = process.cwd();
+    /* eslint-enable camelcase */
+    return defaultOptions;
+  }
+
+  transformOptions(options) {
     return {
       host: options.host,
       port: options.port,
-      cwd: options.outputPath,
       debug: options.testemDebug,
       reporter: options.reporter,
       middleware: this.addonMiddlewares(),
       launch: options.launch,
       file: options.configFile,
       /* eslint-disable camelcase */
-      config_dir: process.cwd(),
       test_page: options.testPage,
       query_params: options.queryString,
       /* eslint-enable camelcase */

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -21,15 +21,20 @@ describe('test server', function() {
         return ['middleware1', 'middleware2'];
       },
       testem: {
-        startDev(options) {
+        setDefaultOptions(options) {
+          this.defaultOptions = options;
+        },
+        startDev(options, finalizer) {
           expect(options.host).to.equal('greatwebsite.com');
           expect(options.port).to.equal(123324);
-          expect(options.cwd).to.equal('blerpy-derpy');
           expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           expect(options.test_page).to.equal('http://my/test/page');
-          expect(options.config_dir).to.be.an('string');
-          done();
+          expect(options.cwd).to.be.undefined;
+          expect(options.config_dir).to.be.undefined;
+          expect(this.defaultOptions.cwd).to.equal('blerpy-derpy');
+          expect(this.defaultOptions.config_dir).to.be.an('string');
+          finalizer(0);
         },
       },
     });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -15,17 +15,26 @@ describe('test task test', function() {
       },
 
       invokeTestem(options) {
-        let testemOptions = this.testemOptions(options);
-
+        // cwd and config_dir are not passed to testem progOptions
+        let testemOptions = this.transformOptions(options);
         expect(testemOptions.host).to.equal('greatwebsite.com');
         expect(testemOptions.port).to.equal(123324);
-        expect(testemOptions.cwd).to.equal('blerpy-derpy');
+        expect(testemOptions.cwd).to.be.undefined;
         expect(testemOptions.reporter).to.equal('xunit');
         expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
         expect(testemOptions.test_page).to.equal('http://my/test/page');
-        expect(testemOptions.debug).to.equal('testem.log');
-        expect(testemOptions.config_dir).to.be.an('string');
-        expect(testemOptions.file).to.equal('custom-testem-config.json');
+        expect(testemOptions.config_dir).to.be.undefined;
+
+        // cwd and config_dir are present as part of default options.
+        let defaultOptions = this.defaultOptions(options);
+        expect(defaultOptions.host).to.equal('greatwebsite.com');
+        expect(defaultOptions.port).to.equal(123324);
+        expect(defaultOptions.cwd).to.equal('blerpy-derpy');
+        expect(defaultOptions.reporter).to.equal('xunit');
+        expect(defaultOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
+        expect(defaultOptions.test_page).to.equal('http://my/test/page');
+        expect(defaultOptions.config_dir).to.be.an('string');
+
       },
     });
 


### PR DESCRIPTION
Back-porting https://github.com/ember-cli/ember-cli/pull/7758 to ember-cli 3.1.4