### PR TITLE
updated count expected in package-info-cache test 

### DIFF
--- a/tests/unit/models/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache-test.js
@@ -111,11 +111,11 @@ describe('models/package-info-cache.js', function() {
       expect(internalAddons.length).to.equal(7);
     });
 
-    it('shows projectPackageInfo has 9 node-module entries', function() {
+    it('shows projectPackageInfo has 10 node-module entries', function() {
       let nodeModules = projectPackageInfo.nodeModules;
       expect(nodeModules).to.exist;
       expect(nodeModules.entries).to.exist;
-      expect(Object.keys(nodeModules.entries).length).to.equal(9);
+      expect(Object.keys(nodeModules.entries).length).to.equal(10);
     });
 
   });


### PR DESCRIPTION
Because the test actually tries to look at files expected in ember-cli's package dependencies, the count expected changes from version to version of ember-cli. This is fixed for 3.2.0.