### PR TITLE
Add watched paths via callback

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -178,7 +178,7 @@ class Builder extends CoreObject {
     }
 
     if (addWatchDirCallback && this.broccoli2) {
-      for(let path of this.builder.watchedPaths) {
+      for (let path of this.builder.watchedPaths) {
         addWatchDirCallback(path);
       }
     }

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -170,21 +170,21 @@ class Builder extends CoreObject {
    * @method build
    * @return {Promise}
    */
-  build(willReadStringDir, resultAnnotation) {
+  build(addWatchDirCallback, resultAnnotation) {
     this.project._instrumentation.start('build');
 
     if (!this.systemTemp) {
       attemptNeverIndex('tmp');
     }
 
-    if (willReadStringDir && this.broccoli2) {
+    if (addWatchDirCallback && this.broccoli2) {
       for(let path of this.builder.watchedPaths) {
-        willReadStringDir(path);
+        addWatchDirCallback(path);
       }
     }
 
     return this.processAddonBuildSteps('preBuild')
-      .then(() => this.builder.build(this.broccoli2 ? null : willReadStringDir))
+      .then(() => this.builder.build(this.broccoli2 ? null : addWatchDirCallback))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
       .then(this.processBuildResult.bind(this))

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -177,8 +177,14 @@ class Builder extends CoreObject {
       attemptNeverIndex('tmp');
     }
 
+    if (willReadStringDir && this.broccoli2) {
+      for(let path of this.builder.watchedPaths) {
+        willReadStringDir(path);
+      }
+    }
+
     return this.processAddonBuildSteps('preBuild')
-      .then(() => this.builder.build(willReadStringDir))
+      .then(() => this.builder.build(this.broccoli2 ? null : willReadStringDir))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
       .then(this.processBuildResult.bind(this))


### PR DESCRIPTION
# What
Turns out that I didn't hook up the watched paths from Broccoli 2.0 builder to ember-cli, DOH.
This is done via the callback that is passed to the ember-cli builder `willReadStringDir` and executed here https://github.com/ember-cli/broccoli-builder/blob/0-18-x/lib/builder.js#L136 in `broccoli-builder`, however broccoli 2.0 uses a property called `watchedPaths` to store the watched paths once the brocfile.js has been parsed and the graph build.

Without this callback being run, no watched paths are added.

# Testing
Tested this with a brand new 3.3 app, using ember-cli master, and:
`DEBUG=broccoli-sane-watcher DEBUG_LEVEL=trace ember serve` to test master, which outputs the following:
```
  broccoli-sane-watcher initialize: { verbose: true, poll: false, watchman: true, node: false } +0ms
  broccoli-sane-watcher build: undefined +2ms
  broccoli-sane-watcher { type: 'initial', reason: 'watcher', primaryFile: undefined, changedFiles: [] } +0ms
building...
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#828 -> /Users/oli/Projects/ember-new/node_modules/ember-ajax/app#829] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-ajax/app +76ms
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#830 -> /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/app#831] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/app +7ms
  broccoli-sane-watcher [Addon#treeFor (ember-data - app)#832 -> WatchedDir#833 -> /Users/oli/Projects/ember-new/node_modules/ember-inflector/app#834] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/app +1ms
  broccoli-sane-watcher [Addon#treeFor (ember-data - app)#832 -> WatchedDir#835 -> /Users/oli/Projects/ember-new/node_modules/ember-data/app#836] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-data/app +0ms
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#839 -> /Users/oli/Projects/ember-new/node_modules/ember-export-application-global/app#840] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-export-application-global/app +3ms
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#841 -> /Users/oli/Projects/ember-new/node_modules/ember-resolver/app#842] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/app +0ms
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#843 -> /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/app#844] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/app +0ms
  broccoli-sane-watcher [TreeMerger (app)#827 -> WatchedDir#845 -> /Users/oli/Projects/ember-new/app#846] addWatchDir: /Users/oli/Projects/ember-new/app +1ms
  broccoli-sane-watcher [broccoli-persistent-filter:EslintValidationFilter#860 -> WatchedDir#861 -> /Users/oli/Projects/ember-new/tests#862] addWatchDir: /Users/oli/Projects/ember-new/tests +18ms
  broccoli-sane-watcher [Babel: ember-test-helpers#879 -> WatchedDir#880 -> /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/addon-test-support#881] addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/addon-test-support +238ms
  broccoli-sane-watcher [Addon#treeForTestSupport (ember-cli-test-loader)#886 -> WatchedDir#887 -> /Users/oli/Projects/ember-new/node_modules/ember-cli-test-loader/addon-test-support#888] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-test-loader/addon-test-support +82ms
  broccoli-sane-watcher [Babel: ember-qunit#891 -> WatchedDir#892 -> /Users/oli/Projects/ember-new/node_modules/ember-qunit/addon-test-support#893] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-qunit/addon-test-support +5ms
  broccoli-sane-watcher [Babel: ember-cli-qunit#898 -> WatchedDir#899 -> /Users/oli/Projects/ember-new/node_modules/ember-cli-qunit/addon-test-support#900] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-qunit/addon-test-support +15ms
  broccoli-sane-watcher [BroccoliMergeTrees#910 -> WatchedDir#911 -> /Users/oli/Projects/ember-new/node_modules/ember-cli-shims/vendor#912] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-shims/vendor +13ms
  broccoli-sane-watcher [Addon#treeFor (ember-data - vendor)#916 -> WatchedDir#917 -> /Users/oli/Projects/ember-new/node_modules/ember-inflector/vendor#918] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/vendor +4ms
  broccoli-sane-watcher [Addon#treeFor (ember-data - vendor)#916 -> WatchedDir#919 -> /Users/oli/Projects/ember-new/node_modules/ember-runtime-enumerable-includes-polyfill/vendor#920] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-runtime-enumerable-includes-polyfill/vendor +0ms
  broccoli-sane-watcher [TreeMerger (vendor)#909 -> WatchedDir#923 -> /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/vendor#924] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/vendor +1ms
  broccoli-sane-watcher [Funnel#925 -> WatchedDir#926 -> /Users/oli/Projects/ember-new/node_modules/regenerator-runtime#927] addWatchDir: /Users/oli/Projects/ember-new/node_modules/regenerator-runtime +1ms
  broccoli-sane-watcher [TreeMerger (vendor)#909 -> WatchedDir#928 -> /Users/oli/Projects/ember-new/node_modules/ember-resolver/vendor#929] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/vendor +3ms
  broccoli-sane-watcher [BroccoliMergeTrees#930 -> Funnel#931 -> /Users/oli/Projects/ember-new/node_modules/ember-source/dist#932] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-source/dist +2ms
  broccoli-sane-watcher [BroccoliMergeTrees#930 -> Funnel#935 -> /Users/oli/Projects/ember-new/node_modules/jquery/dist#936] addWatchDir: /Users/oli/Projects/ember-new/node_modules/jquery/dist +6ms
  broccoli-sane-watcher [TreeMerger (vendor)#909 -> WatchedDir#941 -> /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/vendor#942] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/vendor +9ms
  broccoli-sane-watcher [TreeMerger (vendor)#909 -> WatchedDir#943 -> /Users/oli/Projects/ember-new/node_modules/loader.js/dist#944] addWatchDir: /Users/oli/Projects/ember-new/node_modules/loader.js/dist +0ms
  broccoli-sane-watcher [Babel: ember-test-helpers#946 -> WatchedDir#947 -> /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/vendor#948] addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/vendor +3ms
  broccoli-sane-watcher [ember-qunit#treeForVendor#952 -> WatchedDir#953 -> /Users/oli/Projects/ember-new/node_modules/qunit/qunit#954] addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit/qunit +7ms
  broccoli-sane-watcher [BroccoliMergeTrees#951 -> WatchedDir#955 -> /Users/oli/Projects/ember-new/node_modules/ember-qunit/vendor#956] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-qunit/vendor +2ms
  broccoli-sane-watcher [BroccoliMergeTrees#961 -> WatchedDir#962 -> /Users/oli/Projects/ember-new/node_modules/qunit-dom/vendor#963] addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit-dom/vendor +5ms
  broccoli-sane-watcher [BroccoliMergeTrees#961 -> Funnel#964 -> /Users/oli/Projects/ember-new/node_modules/qunit-dom/dist#965] addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit-dom/dist +1ms
  broccoli-sane-watcher [TreeMerger (vendor)#909 -> WatchedDir#970 -> /Users/oli/Projects/ember-new/vendor#971] addWatchDir: /Users/oli/Projects/ember-new/vendor +7ms
  broccoli-sane-watcher [Funnel: Addon JS#977 -> WatchedDir#978 -> /Users/oli/Projects/ember-new/node_modules/ember-ajax/addon#979] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-ajax/addon +10ms
  broccoli-sane-watcher [Funnel: Addon JS#985 -> WatchedDir#986 -> /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/addon#987] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/addon +37ms
  broccoli-sane-watcher [Funnel: Addon JS#994 -> WatchedDir#995 -> /Users/oli/Projects/ember-new/node_modules/@ember/ordered-set/addon#996] addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/ordered-set/addon +6ms
  broccoli-sane-watcher [Funnel: Addon JS#1007 -> WatchedDir#1008 -> /Users/oli/Projects/ember-new/node_modules/ember-inflector/addon#1009] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/addon +28ms
  broccoli-sane-watcher [BroccoliMergeTrees#1018 -> WatchedDir#1019 -> /Users/oli/Projects/ember-new/node_modules/ember-data/addon#1020] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-data/addon +17ms
  broccoli-sane-watcher [Funnel: Addon JS#1053 -> WatchedDir#1054 -> /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/addon#1055] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/addon +507ms
  broccoli-sane-watcher [Funnel: Addon JS#1062 -> WatchedDir#1063 -> /Users/oli/Projects/ember-new/node_modules/ember-resolver/addon#1064] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/addon +83ms
  broccoli-sane-watcher [Funnel: Addon JS#1074 -> WatchedDir#1075 -> /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon#1076] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon +22ms
  broccoli-sane-watcher [Addon#_addonTemplateFiles (ember-welcome-page)#1083 -> WatchedDir#1084 -> /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon/templates#1085] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon/templates +7ms
  broccoli-sane-watcher [Addon#treeForPublic (ember-welcome-page)#1101 -> WatchedDir#1102 -> /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/public#1103] addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/public +34ms
  broccoli-sane-watcher [Public#1100 -> WatchedDir#1104 -> /Users/oli/Projects/ember-new/public#1105] addWatchDir: /Users/oli/Projects/ember-new/public +2ms
  broccoli-sane-watcher [Packaged Config#1112 -> ConfigLoader#1113 -> /Users/oli/Projects/ember-new/config#1114] addWatchDir: /Users/oli/Projects/ember-new/config +22ms
  broccoli-sane-watcher triggerChange +815ms
```
vs broccoli 2
`DEBUG=broccoli-sane-watcher DEBUG_LEVEL=trace EMBER_CLI_BROCCOLI_2=false ember serve`
```
  broccoli-sane-watcher initialize: { verbose: true, poll: false, watchman: true, node: false } +0ms
  broccoli-sane-watcher build: undefined +1ms
  broccoli-sane-watcher { type: 'initial', reason: 'watcher', primaryFile: undefined, changedFiles: [] } +0ms
building...
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-ajax/app +2ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/app +6ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/app +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-data/app +1ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-export-application-global/app +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/app +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/app +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/app +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/tests +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/addon-test-support +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-test-loader/addon-test-support +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-qunit/addon-test-support +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-qunit/addon-test-support +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-shims/vendor +1ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-runtime-enumerable-includes-polyfill/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/regenerator-runtime +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-source/dist +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/jquery/dist +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/loader.js/dist +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/test-helpers/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit/qunit +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-qunit/vendor +1ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit-dom/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/qunit-dom/dist +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/vendor +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-ajax/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-cli-app-version/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/@ember/ordered-set/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-inflector/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-data/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-load-initializers/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-resolver/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/addon/templates +1ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/node_modules/ember-welcome-page/public +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/public +0ms
  broccoli-sane-watcher addWatchDir: /Users/oli/Projects/ember-new/config +0ms
  broccoli-sane-watcher triggerChange +2s
```

Im not sure why the content of the log line is different, but the paths are consistent, and rebuilds now work correctly.

# Tests
Not sure where to add tests for this...