### PR TITLE
Changed the condition to check if addon name is same in index.js and package.json to be generic

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -36,7 +36,6 @@ const addonProcessTree = require('../utilities/addon-process-tree');
 const emberCLIBabelConfigKey = require('../utilities/ember-cli-babel-config-key');
 const semver = require('semver');
 const processModulesOnly = require('../broccoli/babel-process-modules-only');
-const npa = require('npm-package-arg');
 const registryHasPreprocessor = require('../utilities/registry-has-preprocessor');
 
 const BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS = Symbol('BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS');
@@ -365,17 +364,12 @@ let addonProto = {
         return true;
       }
 
-      // If package.json and index.js names do not match, we should check for scoped vs non-scoped
-      const parsed = npa(parentName);
-      let parsedName = parsed.name;
-      if (parsed.scope) {
-        parsedName = parsedName.replace(parsed.scope, '').slice(1);
-      }
-      if (parsedName === this.name) {
-        if (!this._hasWarnedForMismatchedNames) {
+      // Addon names in index.js and package.json should be the same at all times whether they have scope or not.
+      if (this.root === this.parent.root) {
+        if (parentName !== this.name && !this._hasWarnedForMismatchedNames) {
           this.ui.writeWarnLine(
             'Your names in package.json and index.js should match. ' +
-            `You currently have ${parsed.name} in package.json and ${this.name} in index.js.`);
+            `You currently have ${parentName} in package.json and ${this.name} in index.js.`);
 
           this._hasWarnedForMismatchedNames = true;
         }

--- a/tests/fixtures/addon/component-with-template/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/component-with-template/addon/components/basic-thing.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from '../templates/components/basic-thing';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
+++ b/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/simple-component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/main/component.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/main/component.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
 });
+
+

--- a/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/my-component/component.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/my-component/component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from './template';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/kitchen-sink/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/kitchen-sink/addon/components/basic-thing.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from '../templates/components/basic-thing';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/kitchen-sink/addon/components/my-component/component.js
+++ b/tests/fixtures/addon/kitchen-sink/addon/components/my-component/component.js
@@ -1,6 +1,7 @@
-import Ember from 'ember';
-import template from './template';
 
-export default Ember.Component.extend({
+import template from './template';
+import Component from '@ember/component';
+
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
+++ b/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,5 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 <%= importTemplate %>
-export default Ember.Component.extend({<%= contents %>
+
+export default Component.extend({<%= contents %>
 });
 //generated component successfully

--- a/tests/fixtures/preprocessor-tests/app-registry-ordering/app/components/should-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-registry-ordering/app/components/should-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: /__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__/
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/app/components/should-not-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/app/components/should-not-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/addon/components/clitest-example.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/addon/components/clitest-example.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/app/components/should-not-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/app/components/should-not-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/addon/components/clitest-deep-example.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/addon/components/clitest-deep-example.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   deep: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -330,10 +330,19 @@ describe('models/addon.js', function() {
 
       it('returns true when the addon name is prefixed in package.json and not in index.js', function() {
         process.env.EMBER_ADDON_ENV = 'development';
-
+        project.root = 'foo';
         project.name = () => ('@foo/my-addon');
         addon.name = 'my-addon';
         expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
+      });
+
+      it('displays warning if addon name is different in package.json and index.js ', function() {
+        process.env.EMBER_ADDON_ENV = 'development';
+        project.root = 'foo';
+        project.name = () => ('foo-my-addon');
+        addon.name = 'my-addon';
+        addon.isDevelopingAddon();
+        expect(project.ui.output).to.match(/WARNING: Your names in package.json and index.js should match*/);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {


### PR DESCRIPTION
Earlier the warning was displayed for addon's with different names only if the addon's had scopes in their names. 