### PR TITLE
update broccoli-amd-funnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
     "broccoli": "^2.0.0-beta.3",
-    "broccoli-amd-funnel": "^2.0.0",
+    "broccoli-amd-funnel": "^2.0.1",
     "broccoli-babel-transpiler": "^6.0.0",
     "broccoli-builder": "^0.18.8",
     "broccoli-concat": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,9 +612,9 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-broccoli-amd-funnel@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-amd-funnel/-/broccoli-amd-funnel-2.0.0.tgz#00627161bab7f22b420ea85c81f48001f11843e8"
+broccoli-amd-funnel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-amd-funnel/-/broccoli-amd-funnel-2.0.1.tgz#dbdbfd28841731342d538126567c25bea3f15310"
   dependencies:
     broccoli-plugin "^1.3.0"
     symlink-or-copy "^1.2.0"


### PR DESCRIPTION
This fix is essential for scoped addons that do their own AMD compiling (vertical-collection)