### PR TITLE
Extract url construction in watcher

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -38,6 +38,14 @@ class Watcher extends CoreObject {
     return this.watcher.then.apply(this.watcher, arguments);
   }
 
+  serverURL() {
+    let options = this.options;
+    let config = this.options.project.config(options.environment);
+
+    let baseURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || (config.baseURL || '/'));
+    return `http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
+  }
+
   didChange(results) {
     logger.info('didChange %o', results);
 
@@ -47,12 +55,9 @@ class Watcher extends CoreObject {
     this.ui.writeLine('');
 
     if (this.serving) {
-      let options = this.options;
-      let config = this.options.project.config(options.environment);
-
-      let baseURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || (config.baseURL || '/'));
-      message += ` – Serving on http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
+      message += ` – Serving on ${this.serverURL()}`;
     }
+
     this.ui.writeLine(message);
 
     this.analytics.track({


### PR DESCRIPTION
It would be really nice if we could customize the output that is displayed once the express server is setup. Today, there is a one-to-one coupling between the port/host combination passed to express and what is printed. After talking to @rwjblue we feel this is minimal change that gives override access to what gets printed. However, it is pretty clear that there needs to be a DSL type interface on top of `UI` that allows you to customize the output. Another use case is being able to squelch deprecations for ember-cli-deprecation-workflow.