### PR TITLE
Fix bugs in package hook

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -179,6 +179,7 @@ class EmberApp {
       },
     });
 
+    this._isPackageHookSupplied = typeof this.options.package === 'function';
     this._cachedAddonBundles = {};
   }
 
@@ -1604,11 +1605,8 @@ class EmberApp {
     @return {Array} An array of trees
    */
   toArray() {
-    // allows us to optimize if they aren't using the hook
-    let isPackageHookSupplied = typeof this.package === 'function';
-
-    let trees = [
-      this.getAppJavascript(isPackageHookSupplied),
+    return [
+      this.getAppJavascript(this._isPackageHookSupplied),
       this.getAddonTemplates(),
       this.getAddonStyles(),
       this.getTests(),
@@ -1616,23 +1614,6 @@ class EmberApp {
       this.getSrc(),
       this.getPublic(),
     ].filter(Boolean);
-
-    let fullTree = mergeTrees(trees, {
-      overwrite: true,
-      annotation: 'Full Application',
-    });
-
-    fullTree = this._debugTree(fullTree, 'prepackage');
-
-    if (experiments.PACKAGER) {
-      if (isPackageHookSupplied) {
-        return [this.package.call(this, fullTree)];
-      } else {
-        this.project.ui.writeWarnLine('`package` hook must be a function, falling back to default packaging.');
-      }
-    }
-
-    return this._legacyPackager(fullTree);
   }
 
   _legacyAddonCompile(type, outputDir, _options) {
@@ -1700,7 +1681,7 @@ class EmberApp {
     });
   }
 
-  _legacyPackager(fullTree) {
+  _legacyPackage(fullTree) {
     if (experiments.DELAYED_TRANSPILATION) {
       fullTree = mergeTrees(
         [
@@ -1740,7 +1721,10 @@ class EmberApp {
       sourceTrees.push(this._defaultPackager.packageTests(fullTree));
     }
 
-    return sourceTrees;
+    return mergeTrees(sourceTrees, {
+      overwrite: true,
+      annotation: 'Application Dist',
+    });
   }
 
   /**
@@ -1752,12 +1736,26 @@ class EmberApp {
     @return {Tree}                  Merged tree for this application
    */
   toTree(additionalTrees) {
-    let tree = mergeTrees(this.toArray().concat(additionalTrees || []), {
+    let packagedTree;
+    let trees = this.toArray().concat(additionalTrees || []);
+    let packageFn = this.options.package;
+
+    let fullTree = mergeTrees(trees, {
       overwrite: true,
-      annotation: 'TreeMerger (allTrees)',
+      annotation: 'Full Application',
     });
 
-    return this.addonPostprocessTree('all', tree);
+    fullTree = this._debugTree(fullTree, 'prepackage');
+
+    if (experiments.PACKAGER) {
+      if (this._isPackageHookSupplied) {
+        packagedTree = packageFn.call(this, fullTree);
+      } else {
+        this.project.ui.writeWarnLine('`package` hook must be a function, falling back to default packaging.');
+      }
+    }
+
+    return this.addonPostprocessTree('all', packagedTree || this._legacyPackage(fullTree));
   }
 }
 


### PR DESCRIPTION
Notable changes:

+ aligned `package` function behaviour with the one in RFC: `package`
function can now only be passed through `options` object to the `EmberApp`
constructor
+ `toArray` method now actually returns an array, not a broccoli tree
+ `_legacyPackager` renamed to `_legacyPackage`; since it's private API
and it wasn't announced or broadcasted (more over, it is behind a
feature flag and only used internally), name change should be fine
+ `addonPostprocessTree('all')` is now getting properly called (this bug
was surfaced whilst integrating with `ember-engines`)