### PR TITLE
no ambiguously named addons

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -331,11 +331,12 @@ class PackageInfo {
       ctor = module;
       ctor.prototype.root = ctor.prototype.root || mainDir;
       ctor.prototype.pkg = ctor.prototype.pkg || this.pkg;
+      ctor.prototype.name = this.pkg.name; // pkg.name is the source of truth for the name
     } else {
       const Addon = require('../addon'); // done here because of circular dependency
 
       ctor = Addon.extend(
-        Object.assign({ root: mainDir, pkg: this.pkg }, module)
+        Object.assign({ root: mainDir, pkg: this.pkg }, module, { name: this.pkg.name })
       );
     }
 

--- a/tests/fixtures/addon/simple/lib/ember-super-button/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Super Button',
+  name: require('./package').name,
 };

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-ng/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-ng/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Ng'
+  name: require('./package').name,
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'Ember Addon With Dependencies'
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-after-blueprint-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-after-blueprint-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember After Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-before-blueprint-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-before-blueprint-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Before Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: "ember-devDeps-addon"
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-generated-with-export-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-generated-with-export-addon/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'Ember CLI Generated with export'
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Random Addon'
+  name: require('./package').name
 };

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -159,7 +159,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon', function() {
       beforeEach(function() {
-        addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+        addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
 
         // Clear the caches
         delete addon._moduleName;
@@ -273,7 +273,7 @@ describe('models/addon.js', function() {
 
     describe('addon with dependencies', function() {
       beforeEach(function() {
-        addon = findWhere(project.addons, { name: 'Ember Addon With Dependencies' });
+        addon = findWhere(project.addons, { name: 'ember-addon-with-dependencies' });
       });
 
       it('returns a listing of all dependencies in the addon\'s package.json', function() {
@@ -564,7 +564,7 @@ describe('models/addon.js', function() {
 
       project.initializeAddons();
 
-      addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+      addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
     });
 
     it('should not throw an error if addon/templates is present but empty', function() {
@@ -586,7 +586,7 @@ describe('models/addon.js', function() {
 
       project.initializeAddons();
 
-      addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+      addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
     });
 
     it('should not call _getAddonTemplatesTreeFiles when default treePath is used', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -330,10 +330,10 @@ describe('models/project.js', function() {
     it('returns instances of the addons', function() {
       let addons = project.addons;
 
-      expect(addons[8].name).to.equal('Ember Non Root Addon');
-      expect(addons[14].name).to.equal('Ember Super Button');
-      expect(addons[14].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[14].addons[1].name).to.equal('Ember Ng');
+      expect(addons[8].name).to.equal('ember-non-root-addon');
+      expect(addons[14].name).to.equal('ember-super-button');
+      expect(addons[14].addons[0].name).to.equal('ember-yagni');
+      expect(addons[14].addons[1].name).to.equal('ember-ng');
     });
 
     it('addons get passed the project instance', function() {
@@ -345,7 +345,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       let addons = project.addons;
 
-      expect(addons[10].name).to.equal('Ember Random Addon');
+      expect(addons[10].name).to.equal('ember-random-addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -406,7 +406,7 @@ describe('models/project.js', function() {
       let addons = project.addons;
 
       expect(addons[7] instanceof Addon).to.equal(true);
-      expect(addons[7].name).to.equal('Ember CLI Generated with export');
+      expect(addons[7].name).to.equal('ember-generated-with-export-addon');
     });
 
     it('adds the project itself if it is an addon', function() {


### PR DESCRIPTION
This is kinda heavy handed, but forces `package.json#name` to being `addon.name`