### PR TITLE
Better handle ambiguity between package.json and index.js name field.

### DIFF
--- a/blueprints/addon/files/index.js
+++ b/blueprints/addon/files/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: '<%= addonModulePrefix %>'
+  name: require('./package').name
 };

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -128,7 +128,6 @@ module.exports = {
       modulePrefix: name,
       namespace,
       addonName,
-      addonModulePrefix: addonName,
       addonNamespace,
       emberCLIVersion: require('../../package').version,
       year: date.getFullYear(),

--- a/blueprints/in-repo-addon/files/__root__/__name__/index.js
+++ b/blueprints/in-repo-addon/files/__root__/__name__/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-  name: '<%= dasherizedModuleName %>',
+  name: require('./package').name,
 
   isDevelopingAddon() {
     return true;

--- a/blueprints/module-unification-addon/files/index.js
+++ b/blueprints/module-unification-addon/files/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: '<%= addonName %>'
+  name: require('./package').name
 };

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -366,7 +366,7 @@ let addonProto = {
 
       // Addon names in index.js and package.json should be the same at all times whether they have scope or not.
       if (this.root === this.parent.root) {
-        if (parentName !== this.name) {
+        if (parentName !== this.name && !process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH) {
           let pathToDisplay = process.cwd() === this.root ? process.cwd() : path.relative(process.cwd(), this.root);
 
           throw new SilentError(

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -366,12 +366,12 @@ let addonProto = {
 
       // Addon names in index.js and package.json should be the same at all times whether they have scope or not.
       if (this.root === this.parent.root) {
-        if (parentName !== this.name && !this._hasWarnedForMismatchedNames) {
-          this.ui.writeWarnLine(
-            'Your names in package.json and index.js should match. ' +
-            `You currently have ${parentName} in package.json and ${this.name} in index.js.`);
+        if (parentName !== this.name) {
+          let pathToDisplay = process.cwd() === this.root ? process.cwd() : path.relative(process.cwd(), this.root);
 
-          this._hasWarnedForMismatchedNames = true;
+          throw new SilentError(
+            'Your names in package.json and index.js should match. ' +
+            `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js.`);
         }
 
         return true;

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -36,7 +36,6 @@ const addonProcessTree = require('../utilities/addon-process-tree');
 const emberCLIBabelConfigKey = require('../utilities/ember-cli-babel-config-key');
 const semver = require('semver');
 const processModulesOnly = require('../broccoli/babel-process-modules-only');
-const npa = require('npm-package-arg');
 const registryHasPreprocessor = require('../utilities/registry-has-preprocessor');
 
 const BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS = Symbol('BUILD_BABEL_OPTIONS_FOR_PREPROCESSORS');
@@ -365,17 +364,12 @@ let addonProto = {
         return true;
       }
 
-      // If package.json and index.js names do not match, we should check for scoped vs non-scoped
-      const parsed = npa(parentName);
-      let parsedName = parsed.name;
-      if (parsed.scope) {
-        parsedName = parsedName.replace(parsed.scope, '').slice(1);
-      }
-      if (parsedName === this.name) {
-        if (!this._hasWarnedForMismatchedNames) {
+      // Addon names in index.js and package.json should be the same at all times whether they have scope or not.
+      if (this.root === this.parent.root) {
+        if (parentName !== this.name && !this._hasWarnedForMismatchedNames) {
           this.ui.writeWarnLine(
             'Your names in package.json and index.js should match. ' +
-            `You currently have ${parsed.name} in package.json and ${this.name} in index.js.`);
+            `You currently have ${parentName} in package.json and ${this.name} in index.js.`);
 
           this._hasWarnedForMismatchedNames = true;
         }

--- a/lib/models/instantiate-addons.js
+++ b/lib/models/instantiate-addons.js
@@ -42,7 +42,7 @@ function instantiateAddons(parent, project, addonPackages) {
   let graph = new DAGMap();
   let addonInfo, emberAddonConfig;
 
-  addonNames.forEach(name => {
+  addonNames.sort().forEach(name => {
     addonInfo = addonPackages[name];
     emberAddonConfig = addonInfo.pkg['ember-addon'];
 

--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -1,11 +1,50 @@
 'use strict';
 
-const find = require('ember-cli-lodash-subset').find;
-
-module.exports = function findAddonByName(addons, name) {
-  function matchAddon(name, addon) {
-    return name === addon.name || (addon.pkg && name === addon.pkg.name);
+function unscope(name) {
+  if (name[0] !== '@') {
+    return name;
   }
 
-  return find(addons, addon => matchAddon(name, addon));
+  return name.slice(name.indexOf('/') + 1);
+}
+
+/*
+  Finds an addon given a specific name. Due to older versions of ember-cli
+  not properly supporting scoped packages it was (at one point) common practice
+  to have `package.json` include a scoped name but `index.js` having an unscoped
+  name.
+
+  Changes to the blueprints and addon model (in ~ 3.4+) have made it much clearer
+  that both `package.json` and `index.js` `name`'s should match. At some point
+  this will be "forced" and no longer optional.
+
+  This function is attempting to prioritize matching across all of the combinations
+  (in this priority order):
+
+  - package.json name matches requested name exactly
+  - index.js name matches requested name exactly
+  - unscoped (leaf portion) index.js name matches unscoped requested name
+*/
+module.exports = function findAddonByName(addons, name) {
+  let unscopedName = unscope(name);
+  let exactMatchFromPkg = addons.find(addon => addon.pkg && addon.pkg.name === name);
+
+  if (exactMatchFromPkg) {
+    return exactMatchFromPkg;
+  }
+
+  let exactMatchFromIndex = addons.find(addon => addon.name === name);
+  if (exactMatchFromIndex) {
+    console.warn(`The addon at \`${exactMatchFromIndex.root}\` has different values in its addon index.js ('${exactMatchFromIndex.name}') and its package.json ('${exactMatchFromIndex.pkg.name}').`);
+    return exactMatchFromIndex;
+  }
+
+
+  let unscopedMatchFromIndex = addons.find(addon => addon.name && unscope(addon.name) === unscopedName);
+  if (unscopedMatchFromIndex) {
+    console.trace(`Finding a scoped addon via its unscoped name is deprecated. You searched for \`${name}\` which we found as \`${unscopedMatchFromIndex.name}\` in '${unscopedMatchFromIndex.root}'`);
+    return unscopedMatchFromIndex;
+  }
+
+  return null;
 };

--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -35,7 +35,8 @@ module.exports = function findAddonByName(addons, name) {
 
   let exactMatchFromIndex = addons.find(addon => addon.name === name);
   if (exactMatchFromIndex) {
-    console.warn(`The addon at \`${exactMatchFromIndex.root}\` has different values in its addon index.js ('${exactMatchFromIndex.name}') and its package.json ('${exactMatchFromIndex.pkg.name}').`);
+    const pkg = exactMatchFromIndex.pkg;
+    console.warn(`The addon at \`${exactMatchFromIndex.root}\` has different values in its addon index.js ('${exactMatchFromIndex.name}') and its package.json ('${pkg && pkg.name}').`);
     return exactMatchFromIndex;
   }
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-mocha": "^4.8.0",
     "eslint-plugin-node": "^6.0.1",
+    "fixturify-project": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^5.0.0",
     "mocha-eslint": "^4.1.0",

--- a/tests/fixtures/addon/component-with-template/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/component-with-template/addon/components/basic-thing.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from '../templates/components/basic-thing';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/content-for-head/index.js
+++ b/tests/fixtures/addon/content-for-head/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'content-for-head',
+  name: require('./package').name,
 
   contentFor(type, config) {
     return '"SOME AWESOME STUFF"';

--- a/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
+++ b/tests/fixtures/addon/developing-addon/addon/components/simple-component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/simple-component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/tests/fixtures/addon/developing-addon/index.js
+++ b/tests/fixtures/addon/developing-addon/index.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 module.exports = {
-  name: 'developing-addon',
+  name: require('./package').name,
 
   isDevelopingAddon() {
     return true;

--- a/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/index.js
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-foo-env-addon/index.js
@@ -1,5 +1,6 @@
 module.exports = {
-  name: 'ember-foo-env-addon',
+  name: require('./package').name,
+
   isEnabled() {
     return this.app.env === 'foo';
   }

--- a/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/env-addons/node_modules/ember-random-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Random Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/external-dependency/index.js
+++ b/tests/fixtures/addon/external-dependency/index.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 module.exports = {
-  name: 'external-dependency',
+  name: require('./package').name,
 
   isDevelopingAddon() {
     return true;

--- a/tests/fixtures/addon/kitchen-sink-mu/index.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'basic-thing',
+  name: require('./package').name,
 
   contentFor(type, config) {
     if (type === 'head') {

--- a/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/main/component.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/main/component.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
 });
+
+

--- a/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/my-component/component.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/src/ui/components/my-component/component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from './template';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/kitchen-sink-mu/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink-mu/tests/acceptance/main-test.js
@@ -1,6 +1,6 @@
 import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
-// import truthyHelper from 'kitchen-sink/test-support/helper';
+// import truthyHelper from 'some-cool-addon/test-support/helper';
 import { module, test } from 'qunit';
 
 module('Acceptance', function(hooks) {

--- a/tests/fixtures/addon/kitchen-sink/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/kitchen-sink/addon/components/basic-thing.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import template from '../templates/components/basic-thing';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/kitchen-sink/addon/components/my-component/component.js
+++ b/tests/fixtures/addon/kitchen-sink/addon/components/my-component/component.js
@@ -1,6 +1,7 @@
-import Ember from 'ember';
-import template from './template';
 
-export default Ember.Component.extend({
+import template from './template';
+import Component from '@ember/component';
+
+export default Component.extend({
   layout: template
 });

--- a/tests/fixtures/addon/kitchen-sink/app/components/basic-thing.js
+++ b/tests/fixtures/addon/kitchen-sink/app/components/basic-thing.js
@@ -1,2 +1,2 @@
-import BasicThing from 'kitchen-sink/components/basic-thing';
+import BasicThing from 'some-cool-addon/components/basic-thing';
 export default BasicThing;

--- a/tests/fixtures/addon/kitchen-sink/index.js
+++ b/tests/fixtures/addon/kitchen-sink/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'kitchen-sink',
+  name: require('./package').name,
 
   contentFor(type, config) {
     if (type === 'head') {

--- a/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
@@ -1,6 +1,6 @@
 import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
-import truthyHelper from 'kitchen-sink/test-support/helper';
+import truthyHelper from 'some-cool-addon/test-support/helper';
 import { module, test } from 'qunit';
 
 module('Acceptance', function(hooks) {

--- a/tests/fixtures/addon/kitchen-sink/tests/dummy/app/components/second-thing.js
+++ b/tests/fixtures/addon/kitchen-sink/tests/dummy/app/components/second-thing.js
@@ -1,4 +1,4 @@
-import BasicThing from 'kitchen-sink/components/basic-thing';
+import BasicThing from 'some-cool-addon/components/basic-thing';
 
 export default BasicThing.extend({
   classNames: ['second-thing']

--- a/tests/fixtures/addon/simple/lib/ember-super-button/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Super Button',
+  name: require('./package').name,
 };

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-ng/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-ng/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Ng'
+  name: require('./package').name,
 };

--- a/tests/fixtures/addon/simple/lib/ember-super-button/node_modules/ember-yagni/index.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/node_modules/ember-yagni/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Yagni'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-addon-with-dependencies/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'Ember Addon With Dependencies'
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-after-blueprint-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-after-blueprint-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember After Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-before-blueprint-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-before-blueprint-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Before Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-devDeps-addon/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: "ember-devDeps-addon"
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-generated-with-export-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-generated-with-export-addon/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'Ember CLI Generated with export'
+  name: require('./package').name
 }

--- a/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/ember-index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-non-root-addon/ember-index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Non Root Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/addon/simple/node_modules/ember-random-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Random Addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
+++ b/tests/fixtures/addon/with-blueprint-override/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,5 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 <%= importTemplate %>
-export default Ember.Component.extend({<%= contents %>
+
+export default Component.extend({<%= contents %>
 });
 //generated component successfully

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-top-addon'
+  name: require('./package').name
 };
 

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Inner Addon',
+  name: require('./package').name,
   included(app) {
     app.import('vendor/inner.js');
   }

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon2/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/ember-inner-addon2/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Inner Addon 2',
+  name: require('./package').name,
   included() {
     this.import('vendor/inner2.js');
   }

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon/index.js
@@ -3,7 +3,7 @@
 const stew = require('broccoli-stew');
 
 module.exports = {
-  name: 'postprocesstree-addon',
+  name: require('./package').name,
 
   postprocessTree(type, tree) {
     return stew.map(tree, contents => contents.replace('PREPROCESSED', 'POSTPROCESSED'));

--- a/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/index.js
+++ b/tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon/index.js
@@ -3,7 +3,7 @@
 const stew = require('broccoli-stew');
 
 module.exports = {
-  name: 'preprocesstree-addon',
+  name: require('./package').name,
 
   preprocessTree(type, tree) {
     return stew.map(tree, contents => contents.replace('RAW', 'PREPROCESSED'));

--- a/tests/fixtures/brocfile-tests/app-import-custom-transform/node_modules/ember-transform-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-import-custom-transform/node_modules/ember-transform-addon/index.js
@@ -3,7 +3,7 @@
 const map = require('broccoli-stew').map;
 
 module.exports = {
-  name: 'Ember Transform Addon',
+  name: require('./package').name,
 
   importTransforms: () => {
     return {

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-bad-addon/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Random Addon',
+  name: require('./package').name,
 
   included(app) {
     this._super.included(app);

--- a/tests/fixtures/brocfile-tests/app-import/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-import/node_modules/ember-random-addon/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'Ember Random Addon',
+  name: require('./package').name,
 
   included(app) {
     this._super.included(app);

--- a/tests/fixtures/brocfile-tests/app-test-import/node_modules/ember-test-addon/index.js
+++ b/tests/fixtures/brocfile-tests/app-test-import/node_modules/ember-test-addon/index.js
@@ -21,7 +21,7 @@ AddCustomFile.prototype.build = function() {
 var customTestFilePath = 'my-custom-test-assets/test-dependency.js';
 
 module.exports = {
-  name: 'Ember Test Addon',
+  name: require('./package').name,
 
   included(app) {
     this._super.included(app);

--- a/tests/fixtures/brocfile-tests/jshint-addon/lib/ember-random-thing/index.js
+++ b/tests/fixtures/brocfile-tests/jshint-addon/lib/ember-random-thing/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-random-thing'
+  name: require('./package').name
 }

--- a/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/ember-cli-sass/index.js
+++ b/tests/fixtures/brocfile-tests/multiple-sass-files/node_modules/ember-cli-sass/index.js
@@ -29,7 +29,7 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
 };
 
 module.exports = {
-  name: 'ember-cli-sass',
+  name: require('./package').name,
 
   setupPreprocessorRegistry(type, registry) {
     registry.add('css', new SASSPlugin());

--- a/tests/fixtures/brocfile-tests/public-tree/node_modules/ember-random-addon/index.js
+++ b/tests/fixtures/brocfile-tests/public-tree/node_modules/ember-random-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-random-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/missing-before-addon/lib/sample-addon/index.js
+++ b/tests/fixtures/missing-before-addon/lib/sample-addon/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'sample-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/module-unification-addon/index.js
+++ b/tests/fixtures/module-unification-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'foo'
+  name: require('./package').name
 };

--- a/tests/fixtures/preprocessor-tests/app-registry-ordering/app/components/should-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-registry-ordering/app/components/should-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: /__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__/
 });

--- a/tests/fixtures/preprocessor-tests/app-registry-ordering/node_modules/first-dummy-preprocessor/index.js
+++ b/tests/fixtures/preprocessor-tests/app-registry-ordering/node_modules/first-dummy-preprocessor/index.js
@@ -17,7 +17,7 @@ DummyFilter.prototype.processString = function (string, relativePath) {
 };
 
 module.exports = {
-  name: 'first-dummy-preprocessor',
+  name: require('./package').name,
   setupPreprocessorRegistry(type, registry) {
     if (type !== 'parent') { return; }
     var plugin = {

--- a/tests/fixtures/preprocessor-tests/app-registry-ordering/node_modules/second-dummy-preprocessor/index.js
+++ b/tests/fixtures/preprocessor-tests/app-registry-ordering/node_modules/second-dummy-preprocessor/index.js
@@ -17,7 +17,7 @@ DummyFilter.prototype.processString = function (string, relativePath) {
 };
 
 module.exports = {
-  name: 'second-dummy-preprocessor',
+  name: require('./package').name,
   setupPreprocessorRegistry(type, registry) {
     if (type !== 'parent') { return; }
     var plugin = {

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/app/components/should-not-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/app/components/should-not-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/addon/components/clitest-example.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/addon/components/clitest-example.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cool-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/node_modules/dummy-preprocessor/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-2/node_modules/ember-cool-addon/node_modules/dummy-preprocessor/index.js
@@ -21,7 +21,7 @@ DummyFilter.prototype.processString = function (string, relativePath) {
 };
 
 module.exports = {
-  name: 'dummy-preprocessor',
+  name: require('./package').name,
   setupPreprocessorRegistry(type, registry) {
     if (type !== 'parent') { return; }
     var plugin = {

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/app/components/should-not-be-preprocessed.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/app/components/should-not-be-preprocessed.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   foo: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-shallow-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/addon/components/clitest-deep-example.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/addon/components/clitest-deep-example.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   deep: __PREPROCESSOR_REPLACEMENT_TOKEN__
 });

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-deep-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/node_modules/dummy-preprocessor/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors-3/node_modules/ember-shallow-addon/node_modules/ember-deep-addon/node_modules/dummy-preprocessor/index.js
@@ -21,7 +21,7 @@ DummyFilter.prototype.processString = function (string, relativePath) {
 };
 
 module.exports = {
-  name: 'dummy-preprocessor',
+  name: require('./package').name,
   setupPreprocessorRegistry(type, registry) {
     if (type !== 'parent') { return; }
     var plugin = {

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cli-sass/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cli-sass/index.js
@@ -29,7 +29,7 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
 };
 
 module.exports = {
-  name: 'ember-cli-sass',
+  name: require('./package').name,
 
   setupPreprocessorRegistry(type, registry) {
     registry.add('css', new SASSPlugin());

--- a/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-with-preprocessors/node_modules/ember-cool-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cool-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/index.js
+++ b/tests/fixtures/preprocessor-tests/app-with-addon-without-preprocessors/node_modules/ember-cool-addon/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cool-addon'
+  name: require('./package').name
 };

--- a/tests/fixtures/smoke-tests/with-template-failing-linting/node_modules/fake-template-linter/index.js
+++ b/tests/fixtures/smoke-tests/with-template-failing-linting/node_modules/fake-template-linter/index.js
@@ -6,7 +6,7 @@ const Plugin = require('broccoli-plugin');
 const walkSync = require('walk-sync');
 
 module.exports = {
-  name: 'fake-template-linter',
+  name: require('./package').name,
 
   lintTree(type, tree) {
     if (type === 'templates') {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -159,7 +159,7 @@ describe('models/addon.js', function() {
 
     describe('generated addon', function() {
       beforeEach(function() {
-        addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+        addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
 
         // Clear the caches
         delete addon._moduleName;
@@ -273,7 +273,7 @@ describe('models/addon.js', function() {
 
     describe('addon with dependencies', function() {
       beforeEach(function() {
-        addon = findWhere(project.addons, { name: 'Ember Addon With Dependencies' });
+        addon = findWhere(project.addons, { name: 'ember-addon-with-dependencies' });
       });
 
       it('returns a listing of all dependencies in the addon\'s package.json', function() {
@@ -563,7 +563,7 @@ describe('models/addon.js', function() {
 
       project.initializeAddons();
 
-      addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+      addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
     });
 
     it('should not throw an error if addon/templates is present but empty', function() {
@@ -585,7 +585,7 @@ describe('models/addon.js', function() {
 
       project.initializeAddons();
 
-      addon = findWhere(project.addons, { name: 'Ember CLI Generated with export' });
+      addon = findWhere(project.addons, { name: 'ember-generated-with-export-addon' });
     });
 
     it('should not call _getAddonTemplatesTreeFiles when default treePath is used', function() {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -148,7 +148,7 @@ describe('models/addon.js', function() {
 
   describe('initialized addon', function() {
     this.timeout(40000);
-    before(function() {
+    beforeEach(function() {
       projectPath = path.resolve(fixturePath, 'simple');
       const packageContents = require(path.join(projectPath, 'package.json'));
       let ui = new MockUI();
@@ -328,21 +328,20 @@ describe('models/addon.js', function() {
         expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
       });
 
-      it('returns true when the addon name is prefixed in package.json and not in index.js', function() {
+      it('throws when the addon name is prefixed in package.json and not in index.js', function() {
         process.env.EMBER_ADDON_ENV = 'development';
         project.root = 'foo';
         project.name = () => ('@foo/my-addon');
         addon.name = 'my-addon';
-        expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
+        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
       });
 
-      it('displays warning if addon name is different in package.json and index.js ', function() {
+      it('throws an error if addon name is different in package.json and index.js ', function() {
         process.env.EMBER_ADDON_ENV = 'development';
         project.root = 'foo';
         project.name = () => ('foo-my-addon');
         addon.name = 'my-addon';
-        addon.isDevelopingAddon();
-        expect(project.ui.output).to.match(/WARNING: Your names in package.json and index.js should match*/);
+        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {
@@ -734,7 +733,7 @@ describe('models/addon.js', function() {
       project = new Project(projectPath, packageContents, cli.ui, cli);
 
       let BaseAddon = Addon.extend({
-        name: 'base-addon',
+        name: 'test-project',
         root: projectPath,
       });
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -320,6 +320,8 @@ describe('models/addon.js', function() {
         } else {
           process.env.EMBER_ADDON_ENV = originalEnvValue;
         }
+
+        delete process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH;
       });
 
       it('returns true when `EMBER_ADDON_ENV` is set to development', function() {
@@ -334,6 +336,15 @@ describe('models/addon.js', function() {
         project.name = () => ('@foo/my-addon');
         addon.name = 'my-addon';
         expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
+      });
+
+      it('does not throw for a mismatched addon name when process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH is set', function() {
+        process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH = 'true';
+        process.env.EMBER_ADDON_ENV = 'development';
+        project.root = 'foo';
+        project.name = () => ('@foo/my-addon');
+        addon.name = 'my-addon';
+        expect(addon.isDevelopingAddon()).to.eql(true);
       });
 
       it('throws an error if addon name is different in package.json and index.js ', function() {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -330,10 +330,19 @@ describe('models/addon.js', function() {
 
       it('returns true when the addon name is prefixed in package.json and not in index.js', function() {
         process.env.EMBER_ADDON_ENV = 'development';
-
+        project.root = 'foo';
         project.name = () => ('@foo/my-addon');
         addon.name = 'my-addon';
         expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
+      });
+
+      it('displays warning if addon name is different in package.json and index.js ', function() {
+        process.env.EMBER_ADDON_ENV = 'development';
+        project.root = 'foo';
+        project.name = () => ('foo-my-addon');
+        addon.name = 'my-addon';
+        addon.isDevelopingAddon();
+        expect(project.ui.output).to.match(/WARNING: Your names in package.json and index.js should match*/);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {

--- a/tests/unit/models/instantiate-addons-test.js
+++ b/tests/unit/models/instantiate-addons-test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const FixturifyProject = require('fixturify-project');
+const Project = require('../../../lib/models/project');
+const expect = require('chai').expect;
+const MockCLI = require('../../helpers/mock-cli');
+const { createTempDir } = require('broccoli-test-helper');
+
+class EmberCLIFixturifyProject extends FixturifyProject {
+  addAddon(name, version, cb) {
+    let addon = this.addDependency(name, version);
+    addon.pkg.keywords.push('ember-addon');
+    addon.pkg['ember-addon'] = { };
+    addon.files['index.js'] = 'module.exports = { name: require("./package").name };';
+
+    if (cb) {
+      cb(addon);
+    }
+
+    return addon;
+  }
+}
+
+// used in these tests to ensure we are only
+// operating on the addons added here
+class ProjectWithoutInternalAddons extends Project {
+  supportedInternalAddonPaths() {
+    return [];
+  }
+}
+
+describe('models/instatiate-addons.js', function() {
+  let project, fixturifyProject, projectDir;
+
+  function bootProject() {
+    let cli = new MockCLI();
+    project = new ProjectWithoutInternalAddons(projectDir.path(fixturifyProject.name), fixturifyProject.pkg, cli.ui, cli);
+  }
+
+  beforeEach(function() {
+    return createTempDir().then(tmpdir => {
+      projectDir = tmpdir;
+
+      fixturifyProject = new EmberCLIFixturifyProject('awesome-proj', '0.0.0');
+      fixturifyProject.addDevDependency('ember-cli', '*');
+    });
+  });
+
+  afterEach(function() {
+    if (project) { project = null; }
+    return projectDir.dispose();
+  });
+
+  it('ordering without before/after', function() {
+    fixturifyProject.addAddon('foo', '1.0.0');
+    fixturifyProject.addAddon('bar', '1.0.0');
+    fixturifyProject.addAddon('qux', '1.0.0');
+
+    fixturifyProject.writeSync(projectDir.path());
+    bootProject();
+
+    project.initializeAddons();
+
+    expect(project.addons.map(a => a.name)).to.deep.eql([
+      'foo',
+      'bar',
+      'qux',
+    ]);
+  });
+
+  it('ordering with before specified', function() {
+    fixturifyProject.addAddon('foo', '1.0.0');
+    fixturifyProject.addAddon('bar', '1.0.0');
+    fixturifyProject.addAddon('qux', '1.0.0', a => a.pkg['ember-addon'].before = 'foo');
+
+    fixturifyProject.writeSync(projectDir.path());
+    bootProject();
+
+    project.initializeAddons();
+
+    expect(project.addons.map(a => a.name)).to.deep.eql([
+      'qux',
+      'foo',
+      'bar',
+    ]);
+  });
+
+  it('ordering with after specified', function() {
+    fixturifyProject.addAddon('foo', '1.0.0');
+    fixturifyProject.addAddon('bar', '1.0.0');
+    fixturifyProject.addAddon('qux', '1.0.0', a => a.pkg['ember-addon'].after = 'foo');
+
+    fixturifyProject.writeSync(projectDir.path());
+    bootProject();
+
+    project.initializeAddons();
+
+    expect(project.addons.map(a => a.name)).to.deep.eql([
+      'bar',
+      'foo',
+      'qux',
+    ]);
+  });
+
+  it('ordering always matches package.json name (index.js name is ignored)', function() {
+    let foo = fixturifyProject.addAddon('lol', '1.0.0');
+    foo.files['index.js'] = 'module.exports = { name: "foo" };';
+    fixturifyProject.addAddon('qux', '1.0.0', a => a.pkg['ember-addon'].before = 'foo');
+
+    fixturifyProject.writeSync(projectDir.path());
+    bootProject();
+
+    project.initializeAddons();
+
+    expect(project.addons.map(a => a.name)).to.deep.eql([
+      'foo',
+      'qux',
+    ]);
+  });
+
+  it('errors when there is a cycle detected', function() {
+    fixturifyProject.addAddon('foo', '1.0.0', a => a.pkg['ember-addon'].after = 'qux');
+    fixturifyProject.addAddon('qux', '1.0.0', a => a.pkg['ember-addon'].after = 'foo');
+
+    fixturifyProject.writeSync(projectDir.path());
+    bootProject();
+
+    expect(() => project.initializeAddons()).to.throw(/cycle detected/);
+  });
+});

--- a/tests/unit/models/instantiate-addons-test.js
+++ b/tests/unit/models/instantiate-addons-test.js
@@ -62,8 +62,8 @@ describe('models/instatiate-addons.js', function() {
     project.initializeAddons();
 
     expect(project.addons.map(a => a.name)).to.deep.eql([
-      'foo',
       'bar',
+      'foo',
       'qux',
     ]);
   });
@@ -79,9 +79,9 @@ describe('models/instatiate-addons.js', function() {
     project.initializeAddons();
 
     expect(project.addons.map(a => a.name)).to.deep.eql([
+      'bar',
       'qux',
       'foo',
-      'bar',
     ]);
   });
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -330,10 +330,10 @@ describe('models/project.js', function() {
     it('returns instances of the addons', function() {
       let addons = project.addons;
 
-      expect(addons[8].name).to.equal('Ember Non Root Addon');
-      expect(addons[14].name).to.equal('Ember Super Button');
-      expect(addons[14].addons[0].name).to.equal('Ember Yagni');
-      expect(addons[14].addons[1].name).to.equal('Ember Ng');
+      expect(addons[8].name).to.equal('ember-non-root-addon');
+      expect(addons[14].name).to.equal('ember-super-button');
+      expect(addons[14].addons[0].name).to.equal('ember-yagni');
+      expect(addons[14].addons[1].name).to.equal('ember-ng');
     });
 
     it('addons get passed the project instance', function() {
@@ -345,7 +345,7 @@ describe('models/project.js', function() {
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       let addons = project.addons;
 
-      expect(addons[10].name).to.equal('Ember Random Addon');
+      expect(addons[10].name).to.equal('ember-random-addon');
     });
 
     it('returns the default blueprints path', function() {
@@ -406,7 +406,7 @@ describe('models/project.js', function() {
       let addons = project.addons;
 
       expect(addons[7] instanceof Addon).to.equal(true);
-      expect(addons[7].name).to.equal('Ember CLI Generated with export');
+      expect(addons[7].name).to.equal('ember-generated-with-export-addon');
     });
 
     it('adds the project itself if it is an addon', function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -324,28 +324,30 @@ describe('models/project.js', function() {
         'ember-before-blueprint-addon', 'ember-after-blueprint-addon',
         'ember-devDeps-addon', 'ember-addon-with-dependencies', 'ember-super-button',
       ];
-      expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
+      expect(Object.keys(project.addonPackages)).to.deep.eql(expected);
     });
 
     it('returns instances of the addons', function() {
       let addons = project.addons;
 
-      expect(addons[8].name).to.equal('ember-non-root-addon');
-      expect(addons[14].name).to.equal('ember-super-button');
-      expect(addons[14].addons[0].name).to.equal('ember-yagni');
-      expect(addons[14].addons[1].name).to.equal('ember-ng');
+      expect(addons.find(a => a.name === 'ember-non-root-addon')).to.be;
+
+      let superButton = addons.find(a => a.name === 'ember-super-button');
+      expect(!!superButton).to.be;
+      expect(superButton.addons.find(a => a.name === 'ember-yagni')).to.be;
+      expect(superButton.addons.find(a => a.name === 'ember-ng')).to.be;
     });
 
     it('addons get passed the project instance', function() {
       let addons = project.addons;
 
-      expect(addons[1].project).to.equal(project);
+      addons.forEach(addon => expect(addon.project).to.eql(project));
     });
 
     it('returns an instance of an addon that uses `ember-addon-main`', function() {
       let addons = project.addons;
 
-      expect(addons[10].name).to.equal('ember-random-addon');
+      expect(!!addons.find(a => a.name === 'ember-random-addon')).to.be;
     });
 
     it('returns the default blueprints path', function() {
@@ -405,8 +407,8 @@ describe('models/project.js', function() {
     it('returns an instance of an addon with an object export', function() {
       let addons = project.addons;
 
-      expect(addons[7] instanceof Addon).to.equal(true);
-      expect(addons[7].name).to.equal('ember-generated-with-export-addon');
+      let addon = addons.find(a => a.name === 'ember-generated-with-export-addon');
+      expect(addon instanceof Addon).to.equal(true);
     });
 
     it('adds the project itself if it is an addon', function() {

--- a/tests/unit/utilities/find-addon-by-name-test.js
+++ b/tests/unit/utilities/find-addon-by-name-test.js
@@ -14,6 +14,15 @@ describe('findAddonByName', function() {
     }, {
       name: 'foo-bar',
       pkg: { name: 'foo-bar' },
+    }, {
+      name: '@scoped/foo-bar',
+      pkg: { name: '@scoped/foo-bar' },
+    }, {
+      name: 'thing',
+      pkg: { name: '@scope/thing' },
+    }, {
+      name: '@scoped/other',
+      pkg: { name: '@scoped/other' },
     }];
   });
 
@@ -32,18 +41,33 @@ describe('findAddonByName', function() {
     expect(addon.pkg.name).to.equal('bar-pkg', 'should have found the bar-pkg addon');
   });
 
-  it('should return undefined if addon doesn\'t exist', function() {
+  it('should return null if addon doesn\'t exist', function() {
     let addon = findAddonByName(addons, 'not-an-addon');
-    expect(addon).to.equal(undefined, 'not found addon should be undefined');
+    expect(addon).to.equal(null, 'not found addon should be null');
   });
 
   it('should not return an addon that is a substring of requested name', function() {
     let addon = findAddonByName(addons, 'foo-ba');
-    expect(addon).to.equal(undefined, 'foo-ba should not be found');
+    expect(addon).to.equal(null, 'foo-ba should not be found');
   });
 
   it('should not guess addon name from string with slashes', function() {
     let addon = findAddonByName(addons, 'qux/foo');
-    expect(addon).to.equal(undefined, 'should not have found the foo addon');
+    expect(addon).to.equal(null, 'should not have found the foo addon');
+  });
+
+  it('matches scoped packages when names match exactly', function() {
+    let addon = findAddonByName(addons, '@scoped/other');
+    expect(addon.pkg.name).to.equal('@scoped/other');
+  });
+
+  it('matches unscoped name of scoped package when no exact match is found', function() {
+    let addon = findAddonByName(addons, 'other');
+    expect(addon.pkg.name).to.equal('@scoped/other');
+  });
+
+  it('if exact match is found, it "wins" over unscoped matches', function() {
+    let addon = findAddonByName(addons, 'foo-bar');
+    expect(addon.pkg.name).to.equal('foo-bar');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,7 +2247,13 @@ fireworm@^0.7.0:
     lodash.flatten "^3.0.2"
     minimatch "^3.0.2"
 
-fixturify@^0.3.2:
+fixturify-project@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fixturify-project/-/fixturify-project-1.0.0.tgz#c723fc21ce229bc1124eaae874e938bd1f46dc4b"
+  dependencies:
+    fixturify "^0.3.4"
+
+fixturify@^0.3.2, fixturify@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"
   dependencies:


### PR DESCRIPTION
* Backports #7929 which added a warning if the `name` property in an addon's `index.js` doesn't match the package.json` value
* Changes the `addon` blueprint to ensure `name` property just references the `package.json`'s `name`
* Updates changes originally from #7929 to be a hard error when locally developing an addon whose `package.json` name differs from `index.js` name.
  * Ensure error message includes the offending addon's path (either `process.cwd()` or `path.relative(process.cwd(), addon.root)`)
* Updates `Project.prototype.findAddonByName` / `Addon.prototype.findAddonByName` to handle the changes to mentioned above. Specifically, `findAddonByName` will prefer exact matches to the `package.json` name over exact matches in `index.js` name.