### PR TITLE
[BUGFIX release] Fix crash when tree objects are used in config

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -214,7 +214,10 @@ class EmberApp {
   */
   _initOptions(options) {
     let resolvePathFor = (defaultPath, specified) => {
-      let path = specified || defaultPath;
+      let path = defaultPath;
+      if (specified && typeof specified === 'string') {
+        path = specified;
+      }
       let resolvedPath = this._resolveLocal(path);
 
       return resolvedPath;


### PR DESCRIPTION
When I run `ember serve` on my project, I get a crash after updating to ember-cli@3.3.0:

```sh
$ npx ember serve
The "path" argument must be of type string. Received type object
```

The trigger is my `ember-cli-build.js` configuration, where I create my own broccoli tree object for the `tree.styles` `EmberApp` option.

This error was introduced with 0ab09675e476dd270968c31af8dd5b58126c4bc4, which incorrectly assumes that the `tree.styles` option always return a plain path.

This patch fixes this, by not resolving a path to non-strings.

<details>
  <summary>Log</summary>

```
=================================================================================

ENV Summary:

  TIME: Thu Aug 02 2018 16:49:59 GMT+0200 (Central European Summer Time)
  TITLE: ember
  ARGV:
  - /Users/gil/.nvm/versions/node/v10.5.0/bin/node
  - /Users/gil/Development/mtv-client/mtv-client-www/node_modules/.bin/ember
  - serve
  EXEC_PATH: /Users/gil/.nvm/versions/node/v10.5.0/bin/node
  TMPDIR: /var/folders/b_/p03d2tvn475ffq5my1572cn80000gn/T
  SHELL: /bin/bash
  PATH:
  - /Users/gil/Development/mtv-client/mtv-client-www/node_modules/.bin
  - /Users/gil/.nvm/versions/node/v10.5.0/bin
  - /usr/local/share/npm/bin
  - /usr/local/opt/ruby/bin
  - /usr/local/bin
  - /usr/local/sbin
  - /usr/local/bin
  - /usr/bin
  - /bin
  - /usr/sbin
  - /sbin
  - /Users/gil/go/bin
  - /usr/local/Cellar/go/1.2/libexec/bin
  - /Users/gil/Library/Android/sdk/platform-tools
  - /Users/gil/Library/Android/sdk/tools
  PLATFORM: darwin x64
  FREEMEM: 24690688
  TOTALMEM: 17179869184
  UPTIME: 283013
  LOADAVG: 10.3369140625,6.4638671875,4.8466796875
  CPUS:
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  - Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz - 2900
  ENDIANNESS: LE
  VERSIONS:
  - ares: 1.14.0
  - cldr: 33.0
  - http_parser: 2.8.0
  - icu: 61.1
  - modules: 64
  - napi: 3
  - nghttp2: 1.32.0
  - node: 10.5.0
  - openssl: 1.1.0h
  - tz: 2018c
  - unicode: 10.0
  - uv: 1.20.3
  - v8: 6.7.288.46-node.8
  - zlib: 1.2.11

ERROR Summary:

  - broccoliBuilderErrorStack: [undefined]
  - codeFrame: [undefined]
  - errorMessage: The "path" argument must be of type string. Received type object
  - errorType: [undefined]
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
  - message: The "path" argument must be of type string. Received type object
  - name: TypeError [ERR_INVALID_ARG_TYPE]
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at assertPath (path.js:39:11)
    at Object.join (path.js:1157:7)
    at EmberApp._resolveLocal (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/broccoli/ember-app.js:364:17)
    at resolvePathFor (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/broccoli/ember-app.js:218:31)
    at EmberApp._initOptions (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/broccoli/ember-app.js:255:26)
    at new EmberApp (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/broccoli/ember-app.js:128:10)
    at module.exports (/Users/gil/Development/mtv-client/mtv-client-www/ember-cli-build.js:20:13)
    at Builder.setupBroccoliBuilder (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/models/builder.js:51:19)
    at new Builder (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/models/builder.js:29:10)
    at ServeTask.run (/Users/gil/Development/mtv-client/mtv-client-www/node_modules/ember-cli/lib/tasks/serve.js:24:55)

=================================================================================
```
</details>