### PR TITLE
More native promise usage

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -9,8 +9,8 @@ const loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
 const Instrumentation = require('../models/instrumentation');
 const PackageInfoCache = require('../models/package-info-cache');
 const heimdall = require('heimdalljs');
+const promiseFinally = require('promise.prototype.finally');
 
-const Promise = RSVP.Promise;
 const onProcessInterrupt = require('../utilities/will-interrupt-process');
 
 class CLI {
@@ -89,7 +89,7 @@ class CLI {
   run(environment) {
     let shutdownOnExit = null;
 
-    return RSVP.hash(environment).then(environment => {
+    let theRun = RSVP.hash(environment).then(environment => {
       let args = environment.cliArgs.slice();
       let commandName = args.shift();
       let commandArgs = args;
@@ -180,7 +180,9 @@ class CLI {
         onProcessInterrupt.removeHandler(onCommandInterrupt);
 
         return result;
-      }).finally(() => {
+      });
+
+      runPromise = promiseFinally(runPromise, () => {
         instrumentation.start('shutdown');
         shutdownOnExit = function() {
           instrumentation.stopAndReport('shutdown');
@@ -219,7 +221,9 @@ class CLI {
           .then(() => runPromise);
 
       return runPromise;
-    }).finally(() => {
+    });
+
+    return promiseFinally(theRun, () => {
       if (shutdownOnExit) {
         shutdownOnExit();
       }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -4,6 +4,7 @@ const willInterruptProcess = require('../utilities/will-interrupt-process');
 const instrumentation = require('../utilities/instrumentation');
 const getConfig = require('../utilities/get-config');
 const ciInfo = require('ci-info');
+const promiseFinally = require('promise.prototype.finally');
 
 let initInstrumentation;
 if (instrumentation.instrumentationEnabled()) {
@@ -148,5 +149,5 @@ module.exports = function(options) {
     settings: merge(defaultUpdateCheckerOptions, config.getAll()),
   };
 
-  return cli.run(environment).finally(() => willInterruptProcess.release());
+  return promiseFinally(cli.run(environment), () => willInterruptProcess.release());
 };

--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Command = require('../models/command');
-const Promise = require('rsvp').Promise;
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 const merge = require('ember-cli-lodash-subset').merge;
 const SilentError = require('silent-error');

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -2,7 +2,6 @@
 
 const chalk = require('chalk');
 const Command = require('../models/command');
-const Promise = require('rsvp').Promise;
 const Blueprint = require('../models/blueprint');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 const _ = require('ember-cli-lodash-subset');

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -3,7 +3,6 @@
 const clone = require('ember-cli-lodash-subset').clone;
 const merge = require('ember-cli-lodash-subset').merge;
 const Command = require('../models/command');
-const Promise = require('rsvp').Promise;
 const SilentError = require('silent-error');
 const validProjectName = require('../utilities/valid-project-name');
 const normalizeBlueprint = require('../utilities/normalize-blueprint-option');

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -2,7 +2,6 @@
 
 const Command = require('../models/command');
 const SilentError = require('silent-error');
-const Promise = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'install',

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -12,7 +12,6 @@ const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 const experiments = require('../experiments');
 
 const rmdir = RSVP.denodeify(fs.remove);
-const Promise = RSVP.Promise;
 
 module.exports = Command.extend({
   name: 'new',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -7,8 +7,6 @@ const PortFinder = require('portfinder');
 const Win = require('../utilities/windows-admin');
 const EOL = require('os').EOL;
 
-const Promise = RSVP.Promise;
-
 PortFinder.basePort = 7020;
 
 let getPort = RSVP.denodeify(PortFinder.getPort);

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,6 +7,7 @@ const SilentError = require('silent-error');
 const path = require('path');
 const Win = require('../utilities/windows-admin');
 const fs = require('fs');
+const promiseFinally = require('promise.prototype.finally');
 
 require('express').static.mime.define({ 'application/wasm': ['wasm'] });
 
@@ -144,7 +145,7 @@ module.exports = Command.extend({
             verbose: false,
             options: commandOptions,
           }));
-          session = this.runTask('TestServer', testOptions).finally(() => builder.cleanup());
+          session = promiseFinally(this.runTask('TestServer', testOptions), () => builder.cleanup());
         }
       } else if (hasBuild) {
         session = this.runTask('Test', testOptions);
@@ -157,7 +158,7 @@ module.exports = Command.extend({
           .then(() => this.runTask('Test', testOptions));
       }
 
-      return session.finally(this.rmTmp.bind(this));
+      return promiseFinally(session, this.rmTmp.bind(this));
     });
   },
 

--- a/lib/commands/uninstall-npm.js
+++ b/lib/commands/uninstall-npm.js
@@ -2,7 +2,6 @@
 
 const Command = require('../models/command');
 const SilentError = require('silent-error');
-const Promise = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'uninstall:npm',

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -24,8 +24,8 @@ const EOL = require('os').EOL;
 const bowEpParser = require('bower-endpoint-parser');
 const logger = require('heimdalljs-logger')('ember-cli:blueprint');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const promiseFinally = require('promise.prototype.finally');
 
-const Promise = RSVP.Promise;
 const stat = RSVP.denodeify(fs.stat);
 const writeFile = RSVP.denodeify(fs.outputFile);
 
@@ -442,8 +442,8 @@ let Blueprint = CoreObject.extend({
 
     logger.info('START: processing blueprint: `%s`', this.name);
     let start = new Date();
-    return this._process(options, this.beforeInstall, this.processFiles, this.afterInstall)
-      .finally(() => logger.info('END: processing blueprint: `%s` in (%dms)', this.name, new Date() - start));
+    return promiseFinally(this._process(options, this.beforeInstall, this.processFiles, this.afterInstall),
+      () => logger.info('END: processing blueprint: `%s` in (%dms)', this.name, new Date() - start));
   },
 
   /**

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -2,7 +2,6 @@
 const onProcessInterrupt = require('../utilities/will-interrupt-process');
 const fs = require('fs-extra');
 const path = require('path');
-const Promise = require('rsvp').Promise;
 const CoreObject = require('core-object');
 const SilentError = require('silent-error');
 const chalk = require('chalk');
@@ -12,6 +11,7 @@ const _resetTreeCache = require('./addon')._resetTreeCache;
 const Sync = require('tree-sync');
 const heimdall = require('heimdalljs');
 const experiments = require('../experiments/index');
+const promiseFinally = require('promise.prototype.finally');
 
 /**
  * Wrapper for the Broccoli [Builder](https://github.com/broccolijs/broccoli/blob/master/lib/builder.js) class.
@@ -183,7 +183,7 @@ class Builder extends CoreObject {
       }
     }
 
-    return this.processAddonBuildSteps('preBuild')
+    let preBuild = this.processAddonBuildSteps('preBuild')
       .then(() => this.builder.build(this.broccoli2 ? null : addWatchDirCallback))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
@@ -200,8 +200,9 @@ class Builder extends CoreObject {
       .catch(error => {
         this.processAddonBuildSteps('buildError', error);
         throw error;
-      })
-      .finally(this.finalizeBuild.bind(this));
+      });
+
+    return promiseFinally(preBuild, this.finalizeBuild.bind(this));
   }
 
   /**
@@ -224,15 +225,13 @@ class Builder extends CoreObject {
 
       let node = heimdall.start({ name: 'Builder Cleanup' });
 
-      this._cleanupPromise = Promise.resolve()
-        .then(() => this.builder.cleanup())
-        .finally(() => {
-          ui.stopProgress();
-          node.stop();
-        }).catch(err => {
-          ui.writeLine(chalk.red('Cleanup error.'));
-          ui.writeError(err);
-        });
+      this._cleanupPromise = promiseFinally(this.builder.cleanup(), () => {
+        ui.stopProgress();
+        node.stop();
+      }).catch(err => {
+        ui.writeLine(chalk.red('Cleanup error.'));
+        ui.writeError(err);
+      });
     }
 
     return this._cleanupPromise;

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -7,7 +7,6 @@ const isGitRepo = require('is-git-url');
 const camelize = require('ember-cli-string-utils').camelize;
 const getCallerFile = require('get-caller-file');
 const printCommand = require('../utilities/print-command');
-const Promise = require('rsvp').Promise;
 const _ = require('ember-cli-lodash-subset');
 const EOL = require('os').EOL;
 const CoreObject = require('core-object');
@@ -17,6 +16,7 @@ const SilentError = require('silent-error');
 const execSync = require('child_process').execSync;
 const fs = require('fs');
 const isYarnProject = require('../utilities/is-yarn-project');
+const promiseFinally = require('promise.prototype.finally');
 
 let cache = {};
 
@@ -240,15 +240,14 @@ let Command = CoreObject.extend({
 
     this._currentTask = task;
 
-    return Promise.resolve().then(() => task.run(options))
+    let run = Promise.resolve().then(() => task.run(options))
       .catch(error => {
         logger.info(`An error occurred running \`${name}\` from the \`${this.name}\` command.`, error.stack);
 
         throw error;
-      })
-      .finally(() => {
-        delete this._currentTask;
       });
+
+    return promiseFinally(run, () => delete this._currentTask);
   },
 
   /**

--- a/lib/models/edit-file-diff.js
+++ b/lib/models/edit-file-diff.js
@@ -7,9 +7,9 @@ const quickTemp = require('quick-temp');
 const path = require('path');
 const SilentError = require('silent-error');
 const openEditor = require('../utilities/open-editor');
-
 const readFile = RSVP.denodeify(fs.readFile);
 const writeFile = RSVP.denodeify(fs.writeFile);
+const promiseFinally = require('promise.prototype.finally');
 
 class EditFileDiff {
   constructor(options) {
@@ -19,13 +19,14 @@ class EditFileDiff {
   }
 
   edit() {
-    return RSVP.hash({
+    const edit = RSVP.hash({
       input: this.info.render(),
       output: readFile(this.info.outputPath),
     })
       .then(this.invokeEditor.bind(this))
-      .then(this.applyPatch.bind(this))
-      .finally(this.cleanUp.bind(this));
+      .then(this.applyPatch.bind(this));
+
+    return promiseFinally(edit, this.cleanUp.bind(this));
   }
 
   cleanUp() {

--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -4,7 +4,7 @@ const Task = require('../models/task');
 const SilentError = require('silent-error');
 const merge = require('ember-cli-lodash-subset').merge;
 const getPackageBaseName = require('../utilities/get-package-base-name');
-const Promise = require('rsvp').Promise;
+const promiseFinally = require('promise.prototype.finally');
 
 class AddonInstallTask extends Task {
   constructor(options) {
@@ -36,15 +36,16 @@ class AddonInstallTask extends Task {
 
     ui.startProgress(chalk.green('Installing addon package'), chalk.green('.'));
 
-    return npmInstall.run({
+    let run = npmInstall.run({
       'packages': packageNames,
       'save': commandOptions.save,
       'save-dev': !commandOptions.save,
       'save-exact': commandOptions.saveExact,
       useYarn: commandOptions.yarn,
     }).then(() => this.project.reloadAddons())
-      .then(() => this.installBlueprint(blueprintInstall, packageNames, blueprintOptions))
-      .finally(() => ui.stopProgress())
+      .then(() => this.installBlueprint(blueprintInstall, packageNames, blueprintOptions));
+
+    return promiseFinally(run, () => ui.stopProgress())
       .then(() => ui.writeLine(chalk.green('Installed addon package.')));
   }
 

--- a/lib/tasks/bower-install.js
+++ b/lib/tasks/bower-install.js
@@ -6,12 +6,12 @@ const path = require('path');
 const execa = require('../utilities/execa');
 const RSVP = require('rsvp');
 const SilentError = require('silent-error');
+const promiseFinally = require('promise.prototype.finally');
 const Task = require('../models/task');
 const formatPackageList = require('../utilities/format-package-list');
 
 const logger = require('heimdalljs-logger')('ember-cli:tasks:bower-install');
 
-const Promise = RSVP.Promise;
 const resolve = RSVP.denodeify(require('resolve'));
 const writeJson = RSVP.denodeify(fs.writeJson);
 
@@ -53,8 +53,7 @@ class BowerInstallTask extends Task {
 
     ui.startProgress(chalk.green('npm: Installing bower ...'));
 
-    return execa('npm', ['install', 'bower@^1.3.12'], { cwd: cliPath })
-      .finally(() => ui.stopProgress())
+    return promiseFinally(execa('npm', ['install', 'bower@^1.3.12'], { cwd: cliPath }), () => ui.stopProgress())
       .catch(error => this.handleInstallBowerError(error))
       .then(() => ui.writeLine(chalk.green('npm: Installed bower')));
   }
@@ -132,14 +131,15 @@ class BowerInstallTask extends Task {
       let config = bowerConfig.read();
       config.interactive = true;
 
-      return new Promise((resolve, reject) => {
+      let promise = new Promise((resolve, reject) => {
         this.bower.commands.install(packages, installOptions, config) // Packages, options, config
           .on('log', logBowerMessage)
           .on('prompt', ui.prompt.bind(ui))
           .on('error', reject)
           .on('end', resolve);
-      })
-        .finally(() => ui.stopProgress())
+      });
+
+      return promiseFinally(promise, () => ui.stopProgress())
         .then(() => ui.writeLine(chalk.green(completeMessage)));
 
       function logBowerMessage(message) {

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const Task = require('../models/task');
 const Builder = require('../models/builder');
+const promiseFinally = require('promise.prototype.finally');
 
 class BuildTask extends Task {
   // Options: String outputPath
@@ -28,7 +29,7 @@ class BuildTask extends Task {
       changedFiles: [],
     };
 
-    return builder.build(null, annotation)
+    let build = builder.build(null, annotation)
       .then(results => {
         let totalTime = results.totalTime / 1e6;
 
@@ -49,12 +50,12 @@ class BuildTask extends Task {
           label: 'broccoli build time',
           value: parseInt(totalTime, 10),
         });
-      })
-      .finally(() => {
-        ui.stopProgress();
-        return builder.cleanup();
-      })
-      .then(() => ui.writeLine(chalk.green(`Built project successfully. Stored in "${options.outputPath}".`)))
+      });
+
+    return promiseFinally(build, () => {
+      ui.stopProgress();
+      return builder.cleanup();
+    }).then(() => ui.writeLine(chalk.green(`Built project successfully. Stored in "${options.outputPath}".`)))
       .catch(err => {
         ui.writeLine(chalk.red('Build failed.'));
 

--- a/lib/tasks/create-and-step-into-directory.js
+++ b/lib/tasks/create-and-step-into-directory.js
@@ -8,7 +8,6 @@ const fs = require('fs');
 const Task = require('../models/task');
 const SilentError = require('silent-error');
 
-const Promise = RSVP.Promise;
 const mkdir = RSVP.denodeify(fs.mkdir);
 
 class CreateTask extends Task {

--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('rsvp').Promise;
 const Blueprint = require('../models/blueprint');
 const Task = require('../models/task');
 const parseOptions = require('../utilities/parse-options');

--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -1,13 +1,10 @@
 'use strict';
 
-const RSVP = require('rsvp');
 const Task = require('../models/task');
 const path = require('path');
 const pkg = require('../../package.json');
 const fs = require('fs');
 const execa = require('../utilities/execa');
-
-const Promise = RSVP.Promise;
 
 module.exports = class GitInitTask extends Task {
 

--- a/lib/tasks/npm-install.js
+++ b/lib/tasks/npm-install.js
@@ -5,7 +5,6 @@ const path = require('path');
 const fs = require('fs');
 const NpmTask = require('./npm-task');
 const formatPackageList = require('../utilities/format-package-list');
-const Promise = require('rsvp').Promise;
 
 class NpmInstallTask extends NpmTask {
   constructor(options) {

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -7,6 +7,7 @@ const execa = require('../utilities/execa');
 const semver = require('semver');
 const SilentError = require('silent-error');
 const isYarnProject = require('../utilities/is-yarn-project');
+const promiseFinally = require('promise.prototype.finally');
 
 const logger = require('heimdalljs-logger')('ember-cli:npm-task');
 
@@ -153,8 +154,7 @@ class NpmTask extends Task {
         promise = this.npm(args);
       }
 
-      return promise
-        .finally(() => ui.stopProgress())
+      return promiseFinally(promise, () => ui.stopProgress())
         .then(() => ui.writeLine(chalk.green(completeMessage)));
     });
   }

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const ExpressServer = require('./server/express-server');
-const RSVP = require('rsvp');
 const Task = require('../models/task');
 const Watcher = require('../models/watcher');
 const ServerWatcher = require('../models/server-watcher');
@@ -53,8 +52,12 @@ class ServeTask extends Task {
       serverWatcher,
     });
 
+    this._runDeferred = { };
+    this._runDeferred.promise = new Promise((resolve, reject) => {
+      this._runDeferred.resolve = resolve;
+      this._runDeferred.reject = reject;
+    });
     /* hang until the user exits */
-    this._runDeferred = RSVP.defer();
 
     return expressServer.start(options)
       .then(() => this._runDeferred.promise);

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -6,10 +6,10 @@ const chalk = require('chalk');
 const fs = require('fs');
 const debounce = require('ember-cli-lodash-subset').debounce;
 const mapSeries = require('promise-map-series');
-const Promise = require('rsvp').Promise;
 const Task = require('../../models/task');
 const SilentError = require('silent-error');
 const LiveReloadServer = require('./livereload-server');
+const promiseFinally = require('promise.prototype.finally');
 
 class ExpressServerTask extends Task {
   constructor(options) {
@@ -158,7 +158,9 @@ class ExpressServerTask extends Task {
         this.ui.writeLine('');
       }).catch(err => {
         this.ui.writeError(err);
-      }).finally(() => {
+      });
+
+      this.serverRestartPromise = promiseFinally(this.serverRestartPromise, () => {
         this.serverRestartPromise = null;
       });
 

--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const cleanBaseURL = require('clean-base-url');
+const promiseFinally = require('promise.prototype.finally');
 
 class HistorySupportAddon {
   /**
@@ -48,7 +49,7 @@ class HistorySupportAddon {
     let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
 
     app.use((req, res, next) => {
-      watcher.then(results => {
+      promiseFinally(watcher.then(results => {
         if (this.shouldHandleRequest(req, options)) {
           let assetPath = req.path.slice(baseURL.length);
           let isFile = false;
@@ -57,7 +58,7 @@ class HistorySupportAddon {
             req.serveUrl = `${baseURL}index.html`;
           }
         }
-      }).finally(next);
+      }), next);
     });
   }
 

--- a/lib/tasks/server/middleware/history-support/package.json
+++ b/lib/tasks/server/middleware/history-support/package.json
@@ -7,6 +7,7 @@
     "before": "broccoli-watcher"
   },
   "dependencies": {
-    "clean-base-url": "*"
+    "clean-base-url": "*",
+    "promise.prototype.finally": "*"
   }
 }

--- a/lib/tasks/server/middleware/tests-server/index.js
+++ b/lib/tasks/server/middleware/tests-server/index.js
@@ -4,6 +4,7 @@ const cleanBaseURL = require('clean-base-url');
 const path = require('path');
 const fs = require('fs');
 const logger = require('heimdalljs-logger')('ember-cli:test-server');
+const promiseFinally = require('promise.prototype.finally');
 
 class TestsServerAddon {
   /**
@@ -27,7 +28,7 @@ class TestsServerAddon {
     let testsPath = `${baseURL}tests`;
 
     app.use((req, res, next) => {
-      watcher.then(results => {
+      let watched = watcher.then(results => {
         let acceptHeaders = req.headers.accept || [];
         let hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
         let hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
@@ -48,8 +49,9 @@ class TestsServerAddon {
             req.url = newURL;
           }
         }
+      });
 
-      }).finally(next).finally(() => {
+      promiseFinally(promiseFinally(watched, next), () => {
         if (config.finally) {
           config.finally();
         }

--- a/lib/tasks/server/middleware/tests-server/package.json
+++ b/lib/tasks/server/middleware/tests-server/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "clean-base-url": "*",
     "exists-sync": "*",
-    "heimdalljs-logger": "*"
+    "heimdalljs-logger": "*",
+    "promise.prototype.finally": "*"
   }
 }

--- a/lib/tasks/test-server.js
+++ b/lib/tasks/test-server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const TestTask = require('./test');
-const Promise = require('rsvp').Promise;
 const chalk = require('chalk');
 const SilentError = require('silent-error');
 

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Task = require('../models/task');
-const Promise = require('rsvp').Promise;
 const SilentError = require('silent-error');
 
 class TestTask extends Task {

--- a/lib/utilities/clean-remove.js
+++ b/lib/utilities/clean-remove.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra');
 const RSVP = require('rsvp');
 const walkUp = require('./walk-up-path');
 
-const Promise = RSVP.Promise;
 const stat = RSVP.denodeify(fs.stat);
 const remove = RSVP.denodeify(fs.remove);
 const readdir = RSVP.denodeify(fs.readdir);

--- a/lib/utilities/execa.js
+++ b/lib/utilities/execa.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const execa = require('execa');
-const RSVP = require('rsvp');
 const logger = require('heimdalljs-logger')('ember-cli:execa');
 
 function _execa(cmd, args, opts) {
   logger.info('execa(%j, %j)', cmd, args);
-  return RSVP.resolve(execa(cmd, args, opts)).then(result => {
+  return execa(cmd, args, opts).then(result => {
     logger.info('execa(%j, %j) -> code: %d', cmd, args, result.code);
     return result;
   });

--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra');
 const EOL = require('os').EOL;
 const RSVP = require('rsvp');
 
-const Promise = RSVP.Promise;
 const writeFile = RSVP.denodeify(fs.outputFile);
 
 /**

--- a/lib/utilities/open-editor.js
+++ b/lib/utilities/open-editor.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('rsvp').Promise;
 const spawn = require('child_process').spawn;
 
 function openEditor(file) {

--- a/lib/utilities/sequence.js
+++ b/lib/utilities/sequence.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('rsvp').Promise;
 /*
  *
  * given an array of functions, that may or may not return promises sequence

--- a/lib/utilities/windows-admin.js
+++ b/lib/utilities/windows-admin.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('rsvp').Promise;
 const chalk = require('chalk');
 
 class WindowsSymlinkChecker {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "npm-package-arg": "^6.0.0",
     "portfinder": "^1.0.7",
     "promise-map-series": "^0.2.1",
+    "promise.prototype.finally": "^3.1.0",
     "quick-temp": "^0.1.8",
     "resolve": "^1.3.0",
     "rsvp": "^4.7.0",

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const co = require('co');
-const Promise = require('rsvp').Promise;
 const path = require('path');
 const fs = require('fs-extra');
 const spawn = require('child_process').spawn;

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -7,6 +7,8 @@ const crypto = require('crypto');
 const walkSync = require('walk-sync');
 const EOL = require('os').EOL;
 
+const promiseFinally = require('promise.prototype.finally');
+
 const experiments = require('../../lib/experiments');
 const runCommand = require('../helpers/run-command');
 const acceptance = require('../helpers/acceptance');
@@ -146,7 +148,7 @@ describe('Acceptance: smoke-test', function() {
       };
     }(originalWrite));
 
-    let result = yield ember(['test', '--path=dist']).finally(() => {
+    let result = yield promiseFinally(ember(['test', '--path=dist']), () => {
       process.stdout.write = originalWrite;
     });
 
@@ -174,7 +176,7 @@ describe('Acceptance: smoke-test', function() {
       };
     }(originalWrite));
 
-    let result = yield ember(['test', '--path=dist']).finally(() => {
+    let result = yield promiseFinally(ember(['test', '--path=dist']), () => {
       process.stdout.write = originalWrite;
     });
 
@@ -224,13 +226,11 @@ describe('Acceptance: smoke-test', function() {
   it('ember build generates instrumentation files when viz is enabled', co.wrap(function *() {
     process.env.BROCCOLI_VIZ = '1';
 
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
+    yield promiseFinally(runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', {
       env: {
         BROCCOLI_VIZ: '1',
       },
-    }).finally(() => {
-      delete process.env.BROCCOLI_VIZ;
-    });
+    }), () => delete process.env.BROCCOLI_VIZ);
 
     [
       'instrumentation.build.0.json',

--- a/tests/fixtures/blueprints/basic/index.js
+++ b/tests/fixtures/blueprints/basic/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Blueprint = require('../../../../lib/models/blueprint');
-const Promise = require('rsvp').Promise;
 
 module.exports = Blueprint.extend({
   description: 'A basic blueprint',

--- a/tests/helpers/run-command.js
+++ b/tests/helpers/run-command.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('rsvp').Promise;
 const chalk = require('chalk');
 const spawn = require('child_process').spawn;
 const defaults = require('ember-cli-lodash-subset').defaults;

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -17,7 +17,6 @@ const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 const td = require('testdouble');
 const Blueprint = require('../../../lib/models/blueprint');
 
-const Promise = RSVP.Promise;
 const remove = RSVP.denodeify(fs.remove);
 
 let localsCalled;

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -5,7 +5,6 @@ captureExit.captureExit();
 
 const glob = require('glob');
 const Mocha = require('mocha');
-const RSVP = require('rsvp');
 const fs = require('fs-extra');
 
 if (process.env.EOLNEWLINE) {
@@ -60,7 +59,7 @@ function runMocha() {
   });
 }
 
-RSVP.resolve()
+Promise.resolve()
   .then(() => runMocha())
   .catch(error => {
     console.error(error);

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -5,7 +5,7 @@ const MockUI = require('console-ui/mock');
 const MockAnalytics = require('../../helpers/mock-analytics');
 const td = require('testdouble');
 const Command = require('../../../lib/models/command');
-const Promise = require('rsvp').Promise;
+const promiseFinally = require('promise.prototype.finally');
 
 let ui;
 let analytics;
@@ -261,7 +261,7 @@ describe('Unit: CLI', function() {
     it('cleans up handler after command finished', function() {
       stubValidateAndRun('serve');
 
-      return ember(['serve']).finally(function() {
+      return promiseFinally(ember(['serve']), function() {
         td.verify(willInterruptProcess.removeHandler(onCommandInterrupt));
       });
     });

--- a/tests/unit/commands/destroy-test.js
+++ b/tests/unit/commands/destroy-test.js
@@ -5,7 +5,6 @@ const EOL = require('os').EOL;
 const MockProject = require('../../helpers/mock-project');
 const processHelpString = require('../../helpers/process-help-string');
 const commandOptions = require('../../factories/command-options');
-const Promise = require('rsvp').Promise;
 const Task = require('../../../lib/models/task');
 const DestroyCommand = require('../../../lib/commands/destroy');
 

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -5,7 +5,6 @@ const EOL = require('os').EOL;
 const commandOptions = require('../../factories/command-options');
 const processHelpString = require('../../helpers/process-help-string');
 const MockProject = require('../../helpers/mock-project');
-const Promise = require('rsvp').Promise;
 const Task = require('../../../lib/models/task');
 const Blueprint = require('../../../lib/models/blueprint');
 const GenerateCommand = require('../../../lib/commands/generate');

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -7,7 +7,6 @@ const expect = require('../../chai').expect;
 const map = require('ember-cli-lodash-subset').map;
 const MockUI = require('console-ui/mock');
 const MockAnalytics = require('../../helpers/mock-analytics');
-const Promise = require('rsvp').Promise;
 const Blueprint = require('../../../lib/models/blueprint');
 const Project = require('../../../lib/models/project');
 const Task = require('../../../lib/models/task');

--- a/tests/unit/commands/install-test.js
+++ b/tests/unit/commands/install-test.js
@@ -4,7 +4,6 @@ const expect = require('../../chai').expect;
 const MockProject = require('../../helpers/mock-project');
 const commandOptions = require('../../factories/command-options');
 const Task = require('../../../lib/models/task');
-const Promise = require('rsvp').Promise;
 const AddonInstall = require('../../../lib/tasks/addon-install');
 const InstallCommand = require('../../../lib/commands/install');
 const td = require('testdouble');

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -4,7 +4,6 @@ const expect = require('../../chai').expect;
 const map = require('ember-cli-lodash-subset').map;
 const commandOptions = require('../../factories/command-options');
 const NewCommand = require('../../../lib/commands/new');
-const Promise = require('rsvp').Promise;
 const Blueprint = require('../../../lib/models/blueprint');
 const Command = require('../../../lib/models/command');
 const Task = require('../../../lib/models/task');

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -8,8 +8,8 @@ const RSVP = require('rsvp');
 const td = require('testdouble');
 const PortFinder = require('portfinder');
 
-const Promise = RSVP.Promise;
 const getPort = RSVP.denodeify(PortFinder.getPort);
+const promiseFinally = require('promise.prototype.finally');
 
 const ServeCommand = require('../../../lib/commands/serve');
 
@@ -81,11 +81,13 @@ describe('serve command', function() {
 
     let testServer = function(opts, test) {
       let server = require('http').createServer(function() {});
-      return new Promise(function(resolve) {
+      let promise = new Promise(function(resolve) {
         server.listen(opts.port, opts.host, function() {
           resolve(test(opts, server));
         });
-      }).finally(function() {
+      });
+
+      return promiseFinally(promise, function() {
         return new Promise(function(resolve) {
           server.close(function() { resolve(); });
         });

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -5,10 +5,10 @@ const CoreObject = require('core-object');
 const expect = require('../../chai').expect;
 const MockProject = require('../../helpers/mock-project');
 const commandOptions = require('../../factories/command-options');
-const Promise = require('rsvp').Promise;
 const Task = require('../../../lib/models/task');
 const TestCommand = require('../../../lib/commands/test');
 const td = require('testdouble');
+const promiseFinally = require('promise.prototype.finally');
 
 describe('test command', function() {
   this.timeout(30000);
@@ -179,23 +179,23 @@ describe('test command', function() {
     });
 
     it('builds a watcher with verbose set to false', function() {
-      return command.validateAndRun(['--server']).then(function() {
+      return promiseFinally(command.validateAndRun(['--server']).then(function() {
         let captor = td.matchers.captor();
 
         td.verify(tasks.TestServer.prototype.run(captor.capture()));
         expect(captor.value.watcher.verbose).to.be.false;
-      }).finally(function() {
+      }), function() {
         expect(buildCleanupWasCalled).to.be.true;
       });
     });
 
     it('builds a watcher with options.watcher set to value provided', function() {
-      return command.validateAndRun(['--server', '--watcher=polling']).then(function() {
+      return promiseFinally(command.validateAndRun(['--server', '--watcher=polling']).then(function() {
         let captor = td.matchers.captor();
 
         td.verify(tasks.TestServer.prototype.run(captor.capture()));
         expect(captor.value.watcher.options.watcher).to.equal('polling');
-      }).finally(function() {
+      }), function() {
         expect(buildCleanupWasCalled).to.be.true;
       });
     });

--- a/tests/unit/models/asset-size-printer-test.js
+++ b/tests/unit/models/asset-size-printer-test.js
@@ -10,7 +10,6 @@ let root = process.cwd();
 const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 let tmpRoot = path.join(root, 'tmp');
 
-const Promise = RSVP.Promise;
 const remove = RSVP.denodeify(fs.remove);
 
 describe('models/asset-size-printer', function() {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -20,7 +20,6 @@ let tmproot = path.join(root, 'tmp');
 
 let Builder;
 
-const Promise = RSVP.Promise;
 const remove = RSVP.denodeify(fs.remove);
 
 describe('models/builder.js', function() {

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -6,8 +6,6 @@ const processHelpString = require('../../helpers/process-help-string');
 const Yam = require('yam');
 const EOL = require('os').EOL;
 const td = require('testdouble');
-const RSVP = require('rsvp');
-const Promise = RSVP.Promise;
 
 let Task = require('../../../lib/models/task');
 let Command = require('../../../lib/models/command');

--- a/tests/unit/models/file-info-test.js
+++ b/tests/unit/models/file-info-test.js
@@ -10,7 +10,6 @@ const RSVP = require('rsvp');
 const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
 const td = require('testdouble');
 
-const Promise = RSVP.Promise;
 const writeFile = RSVP.denodeify(fs.writeFile);
 
 let root = process.cwd();

--- a/tests/unit/tasks/addon-install-test.js
+++ b/tests/unit/tasks/addon-install-test.js
@@ -3,7 +3,6 @@
 const AddonInstallTask = require('../../../lib/tasks/addon-install');
 const expect = require('chai').expect;
 const CoreObject = require('core-object');
-const Promise = require('rsvp').Promise;
 
 describe('addon install task', function() {
   let ui;

--- a/tests/unit/tasks/bower-install-test.js
+++ b/tests/unit/tasks/bower-install-test.js
@@ -2,7 +2,6 @@
 
 const BowerInstallTask = require('../../../lib/tasks/bower-install');
 const MockUI = require('console-ui/mock');
-const Promise = require('rsvp').Promise;
 const expect = require('../../chai').expect;
 const td = require('testdouble');
 

--- a/tests/unit/tasks/build-watch-test.js
+++ b/tests/unit/tasks/build-watch-test.js
@@ -6,8 +6,6 @@ const Builder = require('../../../lib/models/builder');
 const MockProject = require('../../helpers/mock-project');
 const expect = require('chai').expect;
 
-const Promise = RSVP.Promise;
-
 describe('build-watch task', function() {
   let task, ui;
 

--- a/tests/unit/tasks/serve-test.js
+++ b/tests/unit/tasks/serve-test.js
@@ -6,8 +6,6 @@ const Builder = require('../../../lib/models/builder');
 const MockProject = require('../../helpers/mock-project');
 const expect = require('chai').expect;
 
-const Promise = RSVP.Promise;
-
 describe('serve task', function() {
   let task, ui;
 

--- a/tests/unit/tasks/server/middleware/tests-server-test.js
+++ b/tests/unit/tasks/server/middleware/tests-server-test.js
@@ -2,7 +2,6 @@
 
 const expect = require('chai').expect;
 const TestsServerAddon = require('../../../../../lib/tasks/server/middleware/tests-server');
-const Promise = require('rsvp').Promise;
 
 describe('TestServerAddon', function() {
   describe('.serverMiddleware', function() {


### PR DESCRIPTION
The goal here is to improve debugging experiences. Unfortunately `finally` is not available pre node 10, and polyfiling has some downsides. Those downsides include, needing to ensure the polyfil is used in every file `finally` is used, as users can easily require any file, so a single entry point isn't available... @rwjblue brainstormed on this, and made the call the best of the worst options was the `promiseFinally` helper.

Someday we can drop the `promiseFinally` helper.

Another alternative would be to use `co` and `yield` to utilize syntax `finally`... But that felt much more invasive.