### PR TITLE
Update documentation for AddonInfo class

### DIFF
--- a/lib/models/addon-info.js
+++ b/lib/models/addon-info.js
@@ -1,10 +1,10 @@
 'use strict';
 
 /**
- * @module addon-info
- *
  * A simple class to store metadata info about an addon. This replaces a plain JS object
  * that used to be created with the same fields.
+ *
+ * @module ember-cli
  */
 
 class AddonInfo {


### PR DESCRIPTION
When running `yarn docs` to build the doc on my machine, I had this small issue:
![capture d ecran 2018-08-04 a 22 14 14](https://user-images.githubusercontent.com/6677373/43680140-cf24962e-9833-11e8-8d5b-3343e6e1026a.png)

Setting module to `ember-cli` fixes the issue.