### PR TITLE
account for filePath overrides in blueprint linting

### DIFF
--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -1,5 +1,5 @@
 # unconventional js
-/blueprints/*/files/
+/blueprints/*/*/
 /vendor/
 
 # compiled output

--- a/blueprints/module-unification-app/files/.eslintignore
+++ b/blueprints/module-unification-app/files/.eslintignore
@@ -1,5 +1,5 @@
 # unconventional js
-/blueprints/*/files/
+/blueprints/*/*/
 /vendor/
 
 # compiled output


### PR DESCRIPTION
I've discovered that /files/ is not good enough for linting ignore because a `filePath` override can be anything. This new rule covers that.