### PR TITLE
Don’t produce duplicate warnings when invoking findAddonByName with a…

### DIFF
--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -8,6 +8,8 @@ function unscope(name) {
   return name.slice(name.indexOf('/') + 1);
 }
 
+const HAS_FOUND_ADDON_BY_NAME = Object.create(null);
+const HAS_FOUND_ADDON_BY_UNSCOPED_NAME = Object.create(null);
 /*
   Finds an addon given a specific name. Due to older versions of ember-cli
   not properly supporting scoped packages it was (at one point) common practice
@@ -34,7 +36,8 @@ module.exports = function findAddonByName(addons, name) {
   }
 
   let exactMatchFromIndex = addons.find(addon => addon.name === name);
-  if (exactMatchFromIndex) {
+  if (exactMatchFromIndex && HAS_FOUND_ADDON_BY_NAME[name] !== true) {
+    HAS_FOUND_ADDON_BY_NAME[name] = true;
     const pkg = exactMatchFromIndex.pkg;
     console.warn(`The addon at \`${exactMatchFromIndex.root}\` has different values in its addon index.js ('${exactMatchFromIndex.name}') and its package.json ('${pkg && pkg.name}').`);
     return exactMatchFromIndex;
@@ -42,7 +45,8 @@ module.exports = function findAddonByName(addons, name) {
 
 
   let unscopedMatchFromIndex = addons.find(addon => addon.name && unscope(addon.name) === unscopedName);
-  if (unscopedMatchFromIndex) {
+  if (unscopedMatchFromIndex && HAS_FOUND_ADDON_BY_NAME[name] !== true) {
+    HAS_FOUND_ADDON_BY_UNSCOPED_NAME[name] = true;
     console.trace(`Finding a scoped addon via its unscoped name is deprecated. You searched for \`${name}\` which we found as \`${unscopedMatchFromIndex.name}\` in '${unscopedMatchFromIndex.root}'`);
     return unscopedMatchFromIndex;
   }


### PR DESCRIPTION
…n ambiguous add-on name