### PR TITLE
adding flag to stop repeated dumping of same package errors

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -40,6 +40,8 @@ class PackageInfo {
     // Missing dependencies will not be considered an error, since they may
     // not actually be used.
     this.valid = true;
+
+    this._hasDumpedInvalidAddonPackages = false;
   }
 
   // Make various fields of the pkg object available.
@@ -291,6 +293,9 @@ class PackageInfo {
   }
 
   dumpInvalidAddonPackages(addonPackageList) {
+    if (this._hasDumpedInvalidAddonPackages) { return; }
+    this._hasDumpedInvalidAddonPackages = true;
+
     let invalidPackages = this.getInvalidPackages(addonPackageList);
 
     let ui = this.cache.ui;


### PR DESCRIPTION
When package-info-cache dumps errors, this will prevent the same addon package from dumping its errors to the console log more than once, regardless of how many different other addons/projects refer to that same addon package.