### PR TITLE
Use default system `npm` in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,6 @@ jobs:
 before_install:
   # prevent the npm loading indicator
   - npm config --global set spin false
-  # if npm version is less than 3.0.0, upgrade to 3
-  - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
-  # if npm version is newer than 4, downgrade to 4
-  - if [[ $(npm -v | cut -d '.' -f 1) -gt 4 ]]; then npm i -g npm@^4; fi
 
   # travis currently includes yarn v0.17.8 (20170705)
   # this isn't new enough for our use of --non-interactive

--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -26,7 +26,7 @@ class NpmTask extends Task {
     // The command to run: can be 'install' or 'uninstall'
     this.command = '';
 
-    this.versionConstraints = '3 || 4 || 5';
+    this.versionConstraints = '3 || 4 || 5 || 6';
   }
 
   npm(args) {

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -26,7 +26,7 @@ describe('NpmTask', function() {
     });
 
     it('resolves with warning when a newer version is found', function() {
-      td.when(task.npm(['--version'])).thenResolve({ stdout: '6.0.0' });
+      td.when(task.npm(['--version'])).thenResolve({ stdout: '7.0.0' });
 
       return expect(task.checkNpmVersion()).to.be.fulfilled.then(() => {
         expect(ui.output).to.contain('WARNING');


### PR DESCRIPTION
Now that we no longer support Node 4, we also no longer have to support `npm@2`. This removes the CI configuration for forcing either `npm@3` or `npm@4`, and begins to allow us to test `npm@5` / `npm@6` as appropriate.

Fixes https://github.com/ember-cli/ember-cli/issues/7213