### PR TITLE
Upgrade ember-source to master in `new` blueprint

### DIFF
--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "description": "Small description for <%= name %> goes here",
+  "repository": "",
   "license": "MIT",
   "author": "",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
@@ -18,33 +18,34 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/jquery": "^0.5.1",
-    "@ember/optional-features": "^0.6.1",
+    "@ember/jquery": "^0.5.2",
+    "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^3.0.0",
+    "ember-ajax": "^3.1.0",
     "ember-cli": "github:ember-cli/ember-cli",
-    "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.6.0",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^6.16.0",
     "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-eslint": "^4.2.1",
+    "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-qunit": "^4.3.2",
-    "ember-cli-sri": "^2.1.0",
+    "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
-    "ember-cli-uglify": "^2.0.0",
-    "ember-data": "~3.1.1",
+    "ember-cli-uglify": "^2.1.0",
+    "ember-data": "~3.4.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz<% if (welcome) { %>",
-    "ember-welcome-page": "^3.0.0<% } %>",
-    "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/49e58e45604bd63ac1001cb491195c032c050053.tgz<% if (welcome) { %>",
+    "ember-welcome-page": "^3.2.0<% } %>",
+    "eslint-plugin-ember": "^5.2.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.7.1"
   },
   "engines": {
-    "node": "6.* || >= 8.*"
+    "node": "6.* || 8.* || >= 10.*"
   }
 }

--- a/tests/fixtures/module-unification-addon/package.json
+++ b/tests/fixtures/module-unification-addon/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/49e58e45604bd63ac1001cb491195c032c050053.tgz",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "description": "Small description for foo goes here",
+  "repository": "",
   "license": "MIT",
   "author": "",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
@@ -18,32 +18,33 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/jquery": "^0.5.1",
-    "@ember/optional-features": "^0.6.1",
+    "@ember/jquery": "^0.5.2",
+    "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^3.0.0",
+    "ember-ajax": "^3.1.0",
     "ember-cli": "github:ember-cli/ember-cli",
-    "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.6.0",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^6.16.0",
     "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-eslint": "^4.2.1",
+    "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-qunit": "^4.3.2",
-    "ember-cli-sri": "^2.1.0",
+    "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
-    "ember-cli-uglify": "^2.0.0",
-    "ember-data": "~3.1.1",
+    "ember-cli-uglify": "^2.1.0",
+    "ember-data": "~3.4.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
-    "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/49e58e45604bd63ac1001cb491195c032c050053.tgz",
+    "eslint-plugin-ember": "^5.2.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.7.1"
   },
   "engines": {
-    "node": "6.* || >= 8.*"
+    "node": "6.* || 8.* || >= 10.*"
   }
 }

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "description": "Small description for foo goes here",
+  "repository": "",
   "license": "MIT",
   "author": "",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
@@ -18,33 +18,34 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/jquery": "^0.5.1",
-    "@ember/optional-features": "^0.6.1",
+    "@ember/jquery": "^0.5.2",
+    "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^3.0.0",
+    "ember-ajax": "^3.1.0",
     "ember-cli": "github:ember-cli/ember-cli",
-    "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.6.0",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^6.16.0",
     "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-eslint": "^4.2.1",
+    "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-qunit": "^4.3.2",
-    "ember-cli-sri": "^2.1.0",
+    "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
-    "ember-cli-uglify": "^2.0.0",
-    "ember-data": "~3.1.1",
+    "ember-cli-uglify": "^2.1.0",
+    "ember-data": "~3.4.0-beta.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
-    "ember-welcome-page": "^3.0.0",
-    "eslint-plugin-ember": "^5.0.0",
-    "loader.js": "^4.2.3"
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/49e58e45604bd63ac1001cb491195c032c050053.tgz",
+    "ember-welcome-page": "^3.2.0",
+    "eslint-plugin-ember": "^5.2.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.7.1"
   },
   "engines": {
-    "node": "6.* || >= 8.*"
+    "node": "6.* || 8.* || >= 10.*"
   }
 }


### PR DESCRIPTION
This fixes a bug some MU experimenters ran into.

**How to reproduce**
Create a new MU app with latest `ember-cli` and generate a route / service.

When doing `EMBER_CLI_MODULE_UNIFICATION=true ember new my-app`, users get a project with an outdated version of `ember-source` (from March). 

Then, `EMBER_CLI_MODULE_UNIFICATION=true ember generate route foo` do not have the expected behavior, it generates the files inside `app` directory.