### PR TITLE
Reject when command args validation fails

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -266,7 +266,7 @@ let Command = CoreObject.extend({
     @return {Promise}
   */
   validateAndRun(args) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       let commandOptions = this.parseArgs(args);
       // if the help option was passed, resolve with 'callHelp' to call help command
       if (commandOptions && (commandOptions.options.help || commandOptions.options.h)) {
@@ -280,7 +280,7 @@ let Command = CoreObject.extend({
       });
 
       if (commandOptions === null) {
-        return resolve();
+        return reject();
       }
 
       if (this.works === 'outsideProject' && this.isWithinProject) {

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -166,8 +166,8 @@ describe('models/command.js', function() {
 
   describe('#validateAndRun', function() {
 
-    it('should print a message if a required option is missing.', function() {
-      return new DevelopEmberCLICommand(options).validateAndRun([]).then(function() {
+    it('should reject and print a message if a required option is missing.', function() {
+      return new DevelopEmberCLICommand(options).validateAndRun([]).catch(function() {
         expect(ui.output).to.match(/requires the option.*package-name/);
       });
     });


### PR DESCRIPTION
When required argument is missing, then exit code should be non-zero value.