### PR TITLE
Bypass proxy-server from handling livereload requests

### DIFF
--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -216,7 +216,11 @@ class ExpressServerTask extends Task {
     options.httpServer = this.httpServer;
     let liveReloadServer = null;
 
-    if (!options.path) {
+    if (options.path) {
+      liveReloadServer = {
+        setupMiddleware() {},
+      };
+    } else {
       liveReloadServer = new LiveReloadServer({
         app: this.app,
         ui: options.ui,
@@ -234,9 +238,9 @@ class ExpressServerTask extends Task {
     });
 
     return Promise.resolve()
+      .then(() => liveReloadServer.setupMiddleware(this.startOptions))
       .then(() => this.processAppMiddlewares(middlewareOptions))
       .then(() => this.processAddonMiddlewares(middlewareOptions))
-      .then(() => liveReloadServer && liveReloadServer.setupMiddleware(this.startOptions))
       .then(() => this.listen(options.port, options.host)
         .catch(() => {
           throw new SilentError(`Could not serve on http://${this.displayHost(options.host)}:${options.port}. ` +

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -30,12 +30,18 @@ class ProxyServerAddon {
       options.ui.writeLine(`Proxying to ${options.proxy}`);
 
       server.on('upgrade', (req, socket, head) => {
-        options.ui.writeLine(`Proxying websocket to ${req.url}`);
-        proxy.ws(req, socket, head);
+        this.handleProxiedRequest(req, socket, head, options, proxy);
       });
 
       app.use(morgan('dev'));
       app.use((req, res) => proxy.web(req, res));
+    }
+  }
+
+  handleProxiedRequest(req, socket, head, options, proxy) {
+    if (req.url.indexOf('/livereload') === -1) {
+      options.ui.writeLine(`Proxying websocket to ${req.url}`);
+      proxy.ws(req, socket, head);
     }
   }
 }

--- a/tests/unit/tasks/server/middleware/proxy-server-test.js
+++ b/tests/unit/tasks/server/middleware/proxy-server-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const MockProject = require('../../../../helpers/mock-project');
+const ProxyServerAddon = require('../../../../../lib/tasks/server/middleware/proxy-server');
+const expect = require('chai').expect;
+
+describe('proxy-server', function() {
+  let project, proxyServer;
+  before(function() {
+    project = new MockProject();
+    proxyServer = new ProxyServerAddon(project);
+  });
+  it(`bypass livereload request`, function() {
+    expect(proxyServer.handleProxiedRequest({
+      url: '/livereload',
+    })).to.undefined;
+  });
+});
+


### PR DESCRIPTION
When livereload and ember serve uses same port following things happen,

- Livereload server needs to be set up before other addon middlewares were set up so that livereload server responds to for the reload requests.
- Livereload requests must be bypassed from the proxy server so that proxy server doesn't respond to requests.