### PR TITLE
Fix for style processing

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1078,7 +1078,8 @@ class EmberApp {
     });
 
     return new Funnel(mergedAddonStyles, {
-      destDir: this.name,
+      allowEmpty: true,
+      destDir: `${this.name}/styles`,
     });
   }
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -146,6 +146,7 @@ describe('EmberApp', function() {
             javascript: '// javascript.js',
           },
           'test-project': {
+            styles: {},
             templates: {},
           },
           tests: {
@@ -231,10 +232,28 @@ describe('EmberApp', function() {
   }
 
   describe('getAddonStyles()', function() {
+    it('can handle empty styles folders', co.wrap(function *() {
+      let app = new EmberApp({
+        project,
+      });
+
+      app.addonTreesFor = () => [];
+
+      let output = yield buildOutput(app.getAddonStyles());
+      let outputFiles = output.read();
+
+      expect(outputFiles['test-project']).to.deep.equal({
+        styles: { },
+      });
+
+      yield output.dispose();
+    }));
+
     it('returns add-ons styles files', co.wrap(function *() {
       let addonFooStyles = yield createTempDir();
       let addonBarStyles = yield createTempDir();
 
+      // `ember-basic-dropdown`
       addonFooStyles.write({
         app: {
           styles: {
@@ -242,11 +261,10 @@ describe('EmberApp', function() {
           },
         },
       });
+      // `ember-bootstrap`
       addonBarStyles.write({
-        app: {
-          styles: {
-            'bar.css': 'bar',
-          },
+        baztrap: {
+          'baztrap.css': '// baztrap.css',
         },
       });
 
@@ -264,10 +282,14 @@ describe('EmberApp', function() {
       let outputFiles = output.read();
 
       expect(outputFiles['test-project']).to.deep.equal({
-        app: {
-          styles: {
-            'foo.css': 'foo',
-            'bar.css': 'bar',
+        styles: {
+          app: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+          baztrap: {
+            'baztrap.css': '// baztrap.css',
           },
         },
       });


### PR DESCRIPTION
As Ember CLI gathers the trees from add-ons, it needs to properly place
them within its "working" directory for processing later (both JS and
SASS/LESS).

The root cause of the issue was that files returned from the add-ons
weren't properly moved, and will later cause transpilation failures as
preprocessing step couldn't find files it needed to resolve `@import`
statements within `app.scss`.

Related issue https://github.com/ember-cli/ember-cli/issues/7987