### PR TITLE
[BUGFIX] Continue to use jQuery in Ember 2.x scenarios

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -12,25 +12,25 @@ module.exports = function() {
       <% if (yarn) { %>useYarn: true,
       <% } %>scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.16',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.16.0'
             }
           }
         },
         {
           name: 'ember-lts-2.18',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.18.0'
             }
           }

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -11,25 +11,25 @@ module.exports = function() {
     return {
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.16',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.16.0'
             }
           }
         },
         {
           name: 'ember-lts-2.18',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.18.0'
             }
           }

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -12,25 +12,25 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.16',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.16.0'
             }
           }
         },
         {
           name: 'ember-lts-2.18',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.18.0'
             }
           }


### PR DESCRIPTION
It turns out the default blueprint for addons generates an addon whose 2.X scenarios in ember-try fail by default.

In https://github.com/ember-cli/ember-cli/commit/ca68ba3a5c5f8781a3650b553cf2050afc8b69f7#diff-d2dc84345b41f0668236a56410bcc7bc addons began to be tested without jQuery by default, which is great, but in Ember 2.X we **also** need to install the `ember-native-dom-event-dispatcher`.

I still suspect this may not help the tests for Ember 2.12, but let's start from here.

