### PR TITLE
Use `path.join` instead of `path.separator`

### DIFF
--- a/tests/unit/models/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache-test.js
@@ -208,7 +208,7 @@ describe('models/package-info-cache.js', function() {
         project = fixturifyProject.buildProjectModel(Project);
         project.discoverAddons();
         pic = project.packageInfoCache;
-        projectPackageInfo = pic.getEntry(`${fixturifyProject.root}${path.sep}simple-ember-app`);
+        projectPackageInfo = pic.getEntry(path.join(fixturifyProject.root, 'simple-ember-app'));
       });
 
       after(function() {
@@ -255,7 +255,7 @@ describe('models/package-info-cache.js', function() {
 
         expect(inRepoAddons).to.exist;
         expect(inRepoAddons.length).to.equal(1);
-        expect(inRepoAddons[0].realPath).to.contain(`simple-ember-app${path.sep}lib${path.sep}ember-super-button`);
+        expect(inRepoAddons[0].realPath).to.contain(path.join('simple-ember-app', 'lib', 'ember-super-button'));
         expect(inRepoAddons[0].pkg.name).to.equal('ember-super-button');
       });
 


### PR DESCRIPTION
@dcombslinkedin I'm going to land this fix for now. Following up on [your comment](https://github.com/ember-cli/ember-cli/pull/8002#issuecomment-417075305), if you could add normalize to `getEntry`, that'd be great. We might use something like [normalize-path](https://github.com/jonschlinkert/normalize-path) to ensure we have consistent path across platforms.