### PR TITLE
[WIP] allow ability to override the module-prefix for tests

### DIFF
--- a/lib/broccoli/tests-suffix.js
+++ b/lib/broccoli/tests-suffix.js
@@ -1,2 +1,2 @@
-require('{{MODULE_PREFIX}}/tests/test-helper');
+require('{{TEST_MODULE_PREFIX}}/tests/test-helper');
 EmberENV.TESTS_FILE_LOADED = true;

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -179,6 +179,11 @@ function configReplacePatterns(options) {
     replacement(config) {
       return config.modulePrefix;
     },
+  }, {
+    match: /{{TEST_MODULE_PREFIX}}/g,
+    replacement(config) {
+      return config.testModulePrefix || config.modulePrefix;
+    },
   }];
 }
 


### PR DESCRIPTION
This is part of the ongoing effort to enable multiple dummy apps to enable testing of addons in classic and Module Unification apps in the same codebase.

This is being used in https://github.com/mansona/testing-mu and seems to be working quite well 🎉 I'm going to keep discussing this with the MU strike team and hopefully bring it to the ember-cli team meeting at some point 😂 