### PR TITLE
[FEATURE] Namespace(in subfolder) MU addon styles

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1073,19 +1073,20 @@ class EmberApp {
    * @return {BroccoliTree}
   */
   getStyles() {
-    let styles;
+    let styles = [];
     if (this.trees.styles) {
-      styles = new Funnel(this.trees.styles, {
-        srcDir: '/',
-        destDir: '/app/styles',
-        annotation: 'Funnel (styles)',
-      });
+      styles.push(this.trees.styles);
     }
     let addons = this.addonTreesFor('styles');
-
-    return mergeTrees(addons.concat(styles), {
+    styles = styles.concat(addons);
+    let mergedAddonStyles = mergeTrees(styles, {
       overwrite: true,
-      annotation: 'Styles',
+      annotation: 'Addon Styles',
+    });
+
+    return new Funnel(mergedAddonStyles, {
+      allowEmpty: true,
+      destDir: isExperimentEnabled('MODULE_UNIFICATION') ? 'src/ui/styles' : `app/styles`,
     });
   }
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -216,6 +216,10 @@ let addonProto = {
       public: 'public',
     };
 
+    if (this.isModuleUnification()) {
+      this.treePaths.styles = 'src/ui/styles';
+    }
+
     this.treeForMethods = defaultsDeep({}, DEFAULT_TREE_FOR_METHODS);
 
     if (this.parent) {
@@ -873,15 +877,37 @@ let addonProto = {
     @return {Tree} The return tree has the same contents as the input tree, but is moved so that the `app/styles/` path is preserved.
   */
   treeForStyles(tree) {
+
+    if (!this.name || this.name === 'superFn') {
+      throw new Error('needs to call _super.treeForStyles.call(...)');
+    }
+
     this._requireBuildPackages();
 
     if (!tree) {
       return tree;
     }
 
-    return new Funnel(tree, {
-      destDir: 'app/styles',
-      annotation: `Addon#treeForStyles (${this.name})`,
+    const name = this.moduleName();
+    const namespaceStyles = this.project.config().namespaceStyles || {};
+    if (namespaceStyles.all === undefined && this.project.isModuleUnification() && this.isModuleUnification()) {
+      namespaceStyles.all = true;
+    }
+    const destDir = (namespaceStyles.all || namespaceStyles[name]) ? name : '.';
+
+    const addonStyles = new Funnel(tree, {
+      allowEmpty: true,
+      srcDir: this.treePaths.styles,
+      destDir,
+    });
+
+    const customStyles = new Funnel(tree, {
+      exclude: [this.treePaths.styles],
+      destDir,
+    });
+
+    return mergeTrees([addonStyles, customStyles], {
+      annotation: `Addon#treeForStyles (${name})`,
     });
   },
 

--- a/tests/fixtures/addon/with-mu-styles/package.json
+++ b/tests/fixtures/addon/with-mu-styles/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+    "something-else": "latest"
+  },
+  "ember-addon": {
+    "paths": ["./lib/ember-super-button"]
+  },
+    "devDependencies": {
+    "ember-resolver": "^5.0.1",
+    "ember-cli": "latest",
+    "ember-random-addon": "latest",
+    "ember-non-root-addon": "latest",
+    "ember-generated-with-export-addon": "latest",
+    "non-ember-thingy": "latest",
+    "ember-before-blueprint-addon": "latest",
+    "ember-after-blueprint-addon": "latest",
+    "ember-devDeps-addon": "latest",
+    "ember-addon-with-dependencies": "latest"
+  }
+}

--- a/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
+++ b/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
@@ -1,0 +1,1 @@
+/* app/styles/foo-bar.css contents */

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -17,6 +17,28 @@ const { isExperimentEnabled } = require('../../../lib/experiments');
 const mergeTrees = require('../../../lib/broccoli/merge-trees');
 
 let EmberApp = require('../../../lib/broccoli/ember-app');
+const Addon = require('../../../lib/models/addon');
+
+
+function createAddon({ name, app, project, styles, isMu }) {
+  const AddonFoo = Addon.extend({
+    root: name,
+    name,
+    isModuleUnification() {
+      return isMu;
+    },
+    _treeFor(name) {
+      let treeForMethod = this.treeForMethods[name];
+      let tree = styles.path();
+      if (this[treeForMethod]) {
+        tree = this[treeForMethod](tree);
+      }
+      return tree;
+    },
+  });
+  return new AddonFoo(app, project);
+}
+
 
 function mockTemplateRegistry(app) {
   let oldLoad = app.registry.load;
@@ -165,7 +187,7 @@ describe('EmberApp', function() {
 
         let outputFiles = output.read();
 
-        expect(outputFiles).to.deep.equal({
+        const result = {
           'addon-tree-output': {},
           fake: {
             dist: {
@@ -190,7 +212,18 @@ describe('EmberApp', function() {
           vendor: {
             '.gitkeep': '',
           },
-        });
+        };
+        if (isExperimentEnabled('MODULE_UNIFICATION')) {
+          result.src = {
+            ui: {
+              styles: {
+                'app.css': '// css styles',
+              },
+            },
+          };
+          delete result.app;
+        }
+        expect(outputFiles).to.deep.equal(result);
       }));
 
       it('prints a warning if `package` is not a function and falls back to default packaging', co.wrap(function *() {
@@ -265,9 +298,6 @@ describe('EmberApp', function() {
   describe('getStyles()', function() {
     it('can handle empty styles folders', co.wrap(function *() {
       let appStyles = yield createTempDir();
-      appStyles.write({
-        'app.css': '// css styles',
-      });
 
       let app = new EmberApp({
         project,
@@ -276,27 +306,30 @@ describe('EmberApp', function() {
         },
       });
 
-      app.addonTreesFor = () => [];
-
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        app: {
-          styles: {
-            'app.css': '// css styles',
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {},
           },
-        },
-      });
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {},
+          },
+        });
+      }
 
       yield output.dispose();
     }));
 
-    it('returns add-ons styles files', co.wrap(function *() {
+    it('flattens `app/styles` folder from add-ons', co.wrap(function *() {
       let addonFooStyles = yield createTempDir();
-      let addonBarStyles = yield createTempDir();
 
-      // `ember-basic-dropdown`
+      // `ember-cli-tailwind`
       addonFooStyles.write({
         app: {
           styles: {
@@ -304,6 +337,62 @@ describe('EmberApp', function() {
           },
         },
       });
+
+      let app = new EmberApp({
+        project,
+      });
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      app.project.addons.push(addonFoo);
+
+      let output = yield buildOutput(app.getStyles());
+      let outputFiles = output.read();
+
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        });
+      }
+
+      yield output.dispose();
+    }));
+
+    it('returns add-ons styles files', co.wrap(function *() {
+      let addonFooStyles = yield createTempDir();
+      let addonBarStyles = yield createTempDir();
+      let addonMUStyles = yield createTempDir();
+
+      // `ember-basic-dropdown`
+      addonFooStyles.write({
+        'bar.css': 'bar',
+        app: {
+          styles: {
+            'foo.css': 'foo',
+          },
+        },
+      });
+
+      addonMUStyles.write({
+        src: {
+          ui: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        },
+      });
+
       // `ember-bootstrap`
       addonBarStyles.write({
         baztrap: {
@@ -314,42 +403,80 @@ describe('EmberApp', function() {
       let app = new EmberApp({
         project,
       });
-      app.addonTreesFor = function() {
-        return [
-          addonFooStyles.path(),
-          addonBarStyles.path(),
-        ];
+
+      const oldMuFn = project.isModuleUnification;
+      project.isModuleUnification = function() {
+        return true;
       };
+
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      let addonBar = createAddon({ name: 'bar', app, project, styles: addonBarStyles });
+      let addonMu = createAddon({ name: 'mu', app, project, styles: addonMUStyles, isMu: true });
+      app.project.addons.push(addonFoo, addonBar, addonMu);
 
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        app: {
-          styles: {
-            'foo.css': 'foo',
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {
+              "mu": {
+                "foo.css": "foo",
+              },
+              'foo.css': 'foo',
+              'bar.css': 'bar',
+              baztrap: {
+                'baztrap.css': '// baztrap.css',
+              },
+            },
           },
-        },
-        baztrap: {
-          'baztrap.css': '// baztrap.css',
-        },
-      });
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {
+              "mu": {
+                "foo.css": "foo",
+              },
+              'foo.css': 'foo',
+              'bar.css': 'bar',
+              baztrap: {
+                'baztrap.css': '// baztrap.css',
+              },
+            },
+          },
+        });
+      }
 
       yield addonFooStyles.dispose();
       yield addonBarStyles.dispose();
       yield output.dispose();
+      project.isModuleUnification = oldMuFn;
     }));
 
     it('does not fail if add-ons do not export styles', co.wrap(function *() {
       let app = new EmberApp({
         project,
       });
-      app.addonTreesFor = () => [];
+      let addonFooStyles = yield createTempDir();
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      app.project.addons.push(addonFoo);
 
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({});
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: { styles: { } },
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {},
+          },
+        });
+      }
 
       yield output.dispose();
     }));

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -735,17 +735,33 @@ describe('models/addon.js', function() {
 
   describe('treeForStyles', function() {
     let builder, addon;
+    const { isExperimentEnabled } = require('../../../lib/experiments');
 
     beforeEach(function() {
-      projectPath = path.resolve(fixturePath, 'with-app-styles');
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        projectPath = path.resolve(fixturePath, 'with-mu-styles');
+      } else {
+        projectPath = path.resolve(fixturePath, 'with-app-styles');
+      }
       const packageContents = require(path.join(projectPath, 'package.json'));
       let cli = new MockCLI();
 
       project = new Project(projectPath, packageContents, cli.ui, cli);
+      project.isModuleUnification = function() {
+        if (isExperimentEnabled('MODULE_UNIFICATION')) {
+          return true;
+        }
+      };
 
       let BaseAddon = Addon.extend({
         name: 'test-project',
         root: projectPath,
+        isModuleUnification() {
+          const { isExperimentEnabled } = require('../../../lib/experiments');
+          if (isExperimentEnabled('MODULE_UNIFICATION')) {
+            return true;
+          }
+        },
       });
 
       addon = new BaseAddon(project, project);
@@ -757,7 +773,7 @@ describe('models/addon.js', function() {
       }
     });
 
-    it('should move files in the root of the addons app/styles tree into the app/styles path', function() {
+    it('should move files in the root of the addons app/styles tree', function() {
       builder = new broccoli.Builder(addon.treeFor('styles'));
 
       return builder.build()
@@ -765,10 +781,16 @@ describe('models/addon.js', function() {
           let outputPath = results.directory;
 
           let expected = [
-            'app/',
-            'app/styles/',
-            'app/styles/foo-bar.css',
+            'foo-bar.css',
           ];
+
+          if (isExperimentEnabled('MODULE_UNIFICATION')) {
+            expected = [
+              'test-project/',
+              'test-project/foo-bar.css',
+            ];
+          }
+
 
           expect(walkSync(outputPath)).to.eql(expected);
         });


### PR DESCRIPTION

This is to prevent style file name clashes between MU addons, since with MU addons we dont expect it to be merged with the main app. 

Therefore the style files will be moved into a subdir named after their addon.

Also Improved the tests to have more real behaviour. Which I extracted into a separate PR: #8146
