### PR TITLE
Align PackageInfoCache platform specific path usage with the rest of …

### DIFF
--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -665,7 +665,8 @@ class PackageInfoCache {
    *  to read the package.json from and process the contents and create a
    *  new cache entry or entries.
    */
-  _readNodeModulesList(nodeModulesDir) {
+  _readNodeModulesList(_nodeModulesDir) {
+    let nodeModulesDir = path.normalize(_nodeModulesDir);
     // Much of the time, normalizedNodeModulesDir is already a real path (i.e.
     // fs.realpathSync will return the same value as normalizedNodeModulesDir, if
     // the directory actually exists). Because of that, we'll assume
@@ -687,7 +688,7 @@ class PackageInfoCache {
 
     // realPath may be different than the original normalizedNodeModulesDir, so
     // we need to check the cache again.
-    if (realPath !== path.normalize(nodeModulesDir)) {
+    if (realPath !== nodeModulesDir) {
       nodeModulesList = this.getEntry(realPath);
       if (nodeModulesList) {
         return nodeModulesList;

--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -67,9 +67,10 @@ function getRealFilePath(filePath) {
  */
 function getRealDirectoryPath(directoryPath) {
   let realPath;
+  let normalizedDirectoryPath = path.posix.normalize(directoryPath);
 
   try {
-    realPath = realDirectoryPathCache[directoryPath];
+    realPath = realDirectoryPathCache[normalizedDirectoryPath];
 
     if (realPath) {
       return realPath;
@@ -92,7 +93,7 @@ function getRealDirectoryPath(directoryPath) {
     }
   }
 
-  realDirectoryPathCache[directoryPath] = realPath;
+  realDirectoryPathCache[normalizedDirectoryPath] = realPath;
 
   return realPath;
 }
@@ -371,8 +372,8 @@ class PackageInfoCache {
    * @private
    * @method _addEntry
    */
-  _addEntry(path, entry) {
-    this.entries[path] = entry;
+  _addEntry(thePath, entry) {
+    this.entries[path.posix.resolve(thePath)] = entry;
   }
 
   /**
@@ -383,8 +384,8 @@ class PackageInfoCache {
    * @param {String} path the real path whose PackageInfo or NodeModulesList is desired.
    * @return {PackageInfo} or {NodeModulesList} the desired entry.
    */
-  getEntry(path) {
-    return this.entries[path];
+  getEntry(thePath) {
+    return this.entries[path.posix.resolve(thePath)];
   }
 
   /**
@@ -395,8 +396,8 @@ class PackageInfoCache {
    * @param {String} path the real path to check for in the cache.
    * @return true if the entry is present for the given path, false otherwise.
    */
-  contains(path) {
-    return this.entries[path] !== undefined;
+  contains(thePath) {
+    return this.entries[path.posix.resolve(thePath)] !== undefined;
   }
 
   _getPackageInfos() {
@@ -445,7 +446,7 @@ class PackageInfoCache {
 
       let nodeModulesPath = endsWithNodeModules
         ? currPath
-        : `${currPath}${path.sep}node_modules`;
+        : `${currPath}/node_modules`;
 
       let nodeModulesList = this._readNodeModulesList(nodeModulesPath);
 
@@ -634,7 +635,7 @@ class PackageInfoCache {
       // directory from lower down in the project tree, and we want to get
       // the data into the cache ASAP. It may not necessarily be a 'real' error
       // if we find an issue, if nobody below is actually invoking the addon.
-      let nodeModules = this._readNodeModulesList(path.join(realPath, 'node_modules'));
+      let nodeModules = this._readNodeModulesList(`${realPath}/node_modules`);
 
       if (nodeModules) {
         pkgInfo.nodeModules = nodeModules;
@@ -665,13 +666,11 @@ class PackageInfoCache {
    *  new cache entry or entries.
    */
   _readNodeModulesList(nodeModulesDir) {
-    let normalizedNodeModulesDir = path.normalize(nodeModulesDir);
-
     // Much of the time, normalizedNodeModulesDir is already a real path (i.e.
     // fs.realpathSync will return the same value as normalizedNodeModulesDir, if
     // the directory actually exists). Because of that, we'll assume
     // we can test for normalizedNodeModulesDir first and return if we find it.
-    let nodeModulesList = this.getEntry(normalizedNodeModulesDir);
+    let nodeModulesList = this.getEntry(nodeModulesDir);
     if (nodeModulesList) {
       return nodeModulesList;
     }
@@ -680,7 +679,7 @@ class PackageInfoCache {
     // directories that may not exist, we'll just return null here if the
     // directory is not real. If it actually is an error in some case,
     // the caller can create the error there.
-    let realPath = getRealDirectoryPath(normalizedNodeModulesDir);
+    let realPath = getRealDirectoryPath(nodeModulesDir);
 
     if (!realPath) {
       return null;
@@ -688,7 +687,7 @@ class PackageInfoCache {
 
     // realPath may be different than the original normalizedNodeModulesDir, so
     // we need to check the cache again.
-    if (realPath !== normalizedNodeModulesDir) {
+    if (realPath !== path.normalize(nodeModulesDir)) {
       nodeModulesList = this.getEntry(realPath);
       if (nodeModulesList) {
         return nodeModulesList;


### PR DESCRIPTION
…the code-base.

In general, ember-cli avoids unnecessary path normalization.
Typically, passing user input un-normalized to fs methods, the exceptions
are when we perform string mutation or path comparisons.

The goal here, is to ensure all API’s can handle both posix and win32 paths,
and that internal data-structures are consistent regardless of which platform
they are run on.


Related #8006 #8002 #7998