### PR TITLE
Ensure livereload proxy is scoped to only live reload prefix.

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -7,6 +7,7 @@ const FSTree = require('fs-tree-diff');
 const logger = require('heimdalljs-logger')('ember-cli:live-reload:');
 const fs = require('fs');
 const Promise = require('rsvp').Promise;
+const cleanBaseUrl = require('clean-base-url');
 
 function isNotRemoved(entryTuple) {
   let operation = entryTuple[0];
@@ -74,10 +75,11 @@ module.exports = class LiveReloadServer {
         this.liveReloadServer = new Server({
           app: this.app,
           dashboard: 'false',
-          prefix: options.liveReloadPrefix,
+          prefix: '/',
           port: options.port,
         });
       }
+      this.liveReloadPrefix = cleanBaseUrl(options.liveReloadPrefix);
       this.start();
     } else {
       this.ui.writeWarnLine('Livereload server manually disabled.');
@@ -103,7 +105,7 @@ module.exports = class LiveReloadServer {
     this.httpServer.on('upgrade', this.liveReloadServer.websocketify.bind(this.liveReloadServer));
     this.httpServer.on('error', this.liveReloadServer.error.bind(this.liveReloadServer));
     this.httpServer.on('close', this.liveReloadServer.close.bind(this.liveReloadServer));
-    this.app.use(this.liveReloadServer.handler.bind(this.liveReloadServer));
+    this.app.use(this.liveReloadPrefix, this.liveReloadServer.handler.bind(this.liveReloadServer));
   }
 
   createHttpsServer(options, Server) {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -43,6 +43,8 @@ function readSSLandCert(sslKey, sslCert) {
   return { key, cert };
 }
 
+const DEFAULT_PREFIX = '/';
+
 module.exports = class LiveReloadServer {
   constructor({ app, watcher, ui, project, analytics, httpServer }) {
     this.app = app;
@@ -51,11 +53,16 @@ module.exports = class LiveReloadServer {
     this.project = project;
     this.analytics = analytics;
     this.httpServer = httpServer;
+    this.liveReloadPrefix = DEFAULT_PREFIX;
   }
 
   setupMiddleware(options) {
     const tinylr = require('tiny-lr');
     const Server = tinylr.Server;
+
+    if (options.liveReloadPrefix) {
+      this.liveReloadPrefix = cleanBaseUrl(options.liveReloadPrefix);
+    }
 
     if (options.liveReload) {
       if (options.liveReloadPort && options.port !== options.liveReloadPort) {
@@ -75,11 +82,10 @@ module.exports = class LiveReloadServer {
         this.liveReloadServer = new Server({
           app: this.app,
           dashboard: 'false',
-          prefix: '/',
+          prefix: DEFAULT_PREFIX,
           port: options.port,
         });
       }
-      this.liveReloadPrefix = cleanBaseUrl(options.liveReloadPrefix);
       this.start();
     } else {
       this.ui.writeWarnLine('Livereload server manually disabled.');

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -589,9 +589,11 @@ describe('livereload-server', function() {
 
     describe('specific files', function() {
       let reloadedFiles;
+      let changedOptions;
 
       let stubbedChanged = function(options) {
         reloadedFiles = options.body.files;
+        changedOptions = options;
       };
 
       beforeEach(function() {
@@ -655,13 +657,6 @@ describe('livereload-server', function() {
       });
 
       it('triggers livereload with "LiveReload files" if no results.directory was provided', function() {
-        let changedOptions;
-        subject.liveReloadServer = {
-          changed(options) {
-            changedOptions = options;
-          },
-        };
-
         subject.didChange({});
 
         expect(changedOptions).to.deep.equal({


### PR DESCRIPTION
Fixes #8037 
Fixes #8035 
Fixes #8029 

This unblocks 3.4.2 release, but needs to be followed up with more tests (for the regressions introduced)...