### PR TITLE
Fix livereload failure with ssl enabled and Add a test for livereload with prefix

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -76,15 +76,8 @@ module.exports = class LiveReloadServer {
               throw error;
             }
           });
-      } else if (options.ssl) {
-        this.liveReloadServer = this.createHttpsServer(options, Server);
       } else {
-        this.liveReloadServer = new Server({
-          app: this.app,
-          dashboard: 'false',
-          prefix: DEFAULT_PREFIX,
-          port: options.port,
-        });
+        this.liveReloadServer = this.createServer(options, Server);
       }
       this.start();
     } else {
@@ -114,16 +107,19 @@ module.exports = class LiveReloadServer {
     this.app.use(this.liveReloadPrefix, this.liveReloadServer.handler.bind(this.liveReloadServer));
   }
 
-  createHttpsServer(options, Server) {
-    let { key, cert } = readSSLandCert(options.sslKey, options.sslCert);
-    return new Server({
+  createServer(options, Server) {
+    let serverOptions = {
       app: this.app,
       dashboard: 'false',
-      prefix: options.liveReloadPrefix,
-      port: options.liveReloadPort,
-      key,
-      cert,
-    });
+      prefix: DEFAULT_PREFIX,
+      port: options.port,
+    };
+    if (options.ssl) {
+      let { key, cert } = readSSLandCert(options.sslKey, options.sslCert);
+      serverOptions.key = key;
+      serverOptions.cert = cert;
+    }
+    return new Server(serverOptions);
   }
 
   createServerforCustomPort(options, Server) {

--- a/tests/unit/tasks/server/livereload-server-test.js
+++ b/tests/unit/tasks/server/livereload-server-test.js
@@ -10,6 +10,7 @@ const path = require('path');
 const MockWatcher = require('../../../helpers/mock-watcher');
 const express = require('express');
 const FSTree = require('fs-tree-diff');
+const http = require('http');
 
 describe('livereload-server', function() {
   let subject;
@@ -81,6 +82,19 @@ describe('livereload-server', function() {
       }).then(function() {
         expect(subject.liveReloadServer.options.port).to.equal(1377);
         expect(subject.liveReloadServer.options.host).to.equal('127.0.0.1');
+      });
+    });
+    it('Livereload responds to livereload requests and returns livereload file', function(done) {
+      let server = app.listen(4200);
+      subject.setupMiddleware({
+        liveReload: true,
+        liveReloadPrefix: '_lr',
+        port: 4200,
+      }).then(function() {
+        http.get('http://localhost:4200/_lr/livereload.js', function(response) {
+          expect(response.statusCode).to.equal(200);
+          server.close(done);
+        });
       });
     });
   });


### PR DESCRIPTION
This commit has three tasks

- fix live reload issue with ssl enabled.

- Refactor livereload server creation.

- Add a test for livereload prefix