### PR TITLE
Use non-greedy pattern for `{{content-for}}`

### DIFF
--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -170,7 +170,7 @@ function configReplacePatterns(options) {
       return convertObjectToString(config.EmberENV);
     },
   }, {
-    match: /{{content-for ['"](.+)["']}}/g,
+    match: /{{content-for ['"](.+?)["']}}/g,
     replacement(config, match, type) {
       return contentFor(config, match, type, options);
     },

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -7,6 +7,7 @@ const expect = require('chai').expect;
 const emberAppUtils = require('../../../lib/utilities/ember-app-utils');
 
 const contentFor = emberAppUtils.contentFor;
+const configReplacePatterns = emberAppUtils.configReplacePatterns;
 const normalizeUrl = emberAppUtils.normalizeUrl;
 const calculateBaseTag = emberAppUtils.calculateBaseTag;
 const convertObjectToString = emberAppUtils.convertObjectToString;
@@ -25,6 +26,22 @@ describe('ember-app-utils', function() {
       addons: [],
       isModuleUnification: false,
     };
+
+    it('`content-for` regex returns all matches presents in a same line', function() {
+      const contentForRegex = configReplacePatterns(defaultOptions)[2].match;
+      const content = '{{content-for \'foo\'}} {{content-for \'bar\'}}';
+      const results = [];
+      let match;
+
+      while((match = contentForRegex.exec(content)) !== null) {
+        results.push(match);
+      }
+
+      expect(results).to.deep.equal([
+        ['{{content-for \'foo\'}}', 'foo'],
+        ['{{content-for \'bar\'}}', 'bar']
+      ]);
+    });
 
     it('returns an empty string if invalid type is specified', function() {
       expect(contentFor(config, defaultMatch, 'foo', defaultOptions)).to.equal('');

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -33,13 +33,13 @@ describe('ember-app-utils', function() {
       const results = [];
       let match;
 
-      while((match = contentForRegex.exec(content)) !== null) {
+      while ((match = contentForRegex.exec(content)) !== null) {
         results.push(match);
       }
 
       expect(results).to.deep.equal([
         ['{{content-for \'foo\'}}', 'foo'],
-        ['{{content-for \'bar\'}}', 'bar']
+        ['{{content-for \'bar\'}}', 'bar'],
       ]);
     });
 


### PR DESCRIPTION
Hello,

If you use two {{content-for '...'}} on the same line, they are not replace. Ex:

```
<head>
  ...
  {{content-for 'head'}} {{content-for 'head-footer'}}
</head>
```
Here, the first `content-for` has a type `"head'}} {{content-for 'head-footer"`.

This PR fix this.