### PR TITLE
Fix codeclimate badge svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ember-cli
 [appveyor-badge-url]: https://ci.appveyor.com/project/embercli/ember-cli/branch/master
 [coveralls-badge]: https://img.shields.io/coveralls/ember-cli/ember-cli/master.svg
 [coveralls-badge-url]: https://coveralls.io/github/ember-cli/ember-cli
-[codeclimate-badge]: https://img.shields.io/codeclimate/github/ember-cli/ember-cli.svg
+[codeclimate-badge]: https://codeclimate.com/github/ember-cli/ember-cli/badges/gpa.svg
 [codeclimate-badge-url]: https://codeclimate.com/github/ember-cli/ember-cli
 
 The Ember.js command line utility.


### PR DESCRIPTION
For some reason, codeclimate badge was broken on the README. This micro PR fixes it :)

To have a look at the changes, just follow this link: https://github.com/dcyriller/ember-cli/tree/svg-badges