### PR TITLE
Ensure livereload support does not break proxied websockets.

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -123,7 +123,14 @@ module.exports = class LiveReloadServer {
       serverOptions.key = key;
       serverOptions.cert = cert;
     }
-    return new Server(serverOptions);
+    let lrServer = new Server(serverOptions);
+
+    // this is required to prevent tiny-lr from triggering an error
+    // when checking this.server._handle during its close handler
+    // here: https://git.io/fA7Tr
+    lrServer.server = this.httpServer;
+
+    return lrServer;
   }
 
   createServerforCustomPort(options, Server) {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -101,7 +101,11 @@ module.exports = class LiveReloadServer {
 
     // Reload on express server restarts
     this.app.on('restart', this.didRestart.bind(this));
-    this.httpServer.on('upgrade', this.liveReloadServer.websocketify.bind(this.liveReloadServer));
+    this.httpServer.on('upgrade', (req, socket, head) => {
+      if (req.url.indexOf('/livereload') === 0) {
+        this.liveReloadServer.websocketify(req, socket, head);
+      }
+    });
     this.httpServer.on('error', this.liveReloadServer.error.bind(this.liveReloadServer));
     this.httpServer.on('close', this.liveReloadServer.close.bind(this.liveReloadServer));
     this.app.use(this.liveReloadPrefix, this.liveReloadServer.handler.bind(this.liveReloadServer));

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "strip-ansi": "^4.0.0",
     "supertest": "^3.1.0",
     "testdouble": "^3.8.1",
+    "websocket": "^1.0.26",
     "yuidoc-ember-cli-theme": "^1.0.4",
     "yuidocjs": "0.10.2"
   },

--- a/tests/helpers/proxy-server.js
+++ b/tests/helpers/proxy-server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const http = require('http');
+const WebSocketServer = require('websocket').server;
 
 class ProxyServer {
   constructor() {
@@ -13,6 +14,29 @@ class ProxyServer {
       res.end('okay');
     });
     this.httpServer.listen(3001);
+
+    let wsServer = new WebSocketServer({
+      httpServer: this.httpServer,
+      autoAcceptConnections: true,
+    });
+
+    let websocketEvents = this.websocketEvents = [];
+    wsServer.on('connect', connection => {
+      websocketEvents.push('connect');
+
+      connection.on('message', message => {
+        websocketEvents.push(`message: ${message.utf8Data}`);
+        connection.sendUTF(message.utf8Data);
+      });
+
+      connection.on('error', error => {
+        websocketEvents.push(`error: ${error}`);
+      });
+
+      connection.on('close', () => {
+        websocketEvents.push(`close`);
+      });
+    });
   }
 }
 

--- a/tests/unit/tasks/server/middleware/proxy-server-test.js
+++ b/tests/unit/tasks/server/middleware/proxy-server-test.js
@@ -6,10 +6,12 @@ const expect = require('chai').expect;
 
 describe('proxy-server', function() {
   let project, proxyServer;
-  before(function() {
+
+  beforeEach(function() {
     project = new MockProject();
     proxyServer = new ProxyServerAddon(project);
   });
+
   it(`bypass livereload request`, function() {
     expect(proxyServer.handleProxiedRequest({
       url: '/livereload',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,10 @@ is-type@0.0.1:
   dependencies:
     core-util-is "~1.0.0"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -3856,6 +3860,10 @@ mute-stream@0.0.6:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.3.3:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 nan@^2.9.2:
   version "2.10.0"
@@ -5344,6 +5352,12 @@ type-is@~1.6.15, type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typedarray-to-buffer@^3.1.2:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -5533,6 +5547,15 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
+websocket@^1.0.26:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.26.tgz#a03a01299849c35268c83044aa919c6374be8194"
+  dependencies:
+    debug "^2.2.0"
+    nan "^2.3.3"
+    typedarray-to-buffer "^3.1.2"
+    yaeti "^0.0.6"
+
 which@^1.1.1, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -5608,6 +5631,10 @@ xmlhttprequest-ssl@~1.5.4:
 xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Prior to this change the tiny-lr server would intercept and attempt to process **all** websocket upgrade attempts even though it should only process the requests for its own paths.

This fix ensures that we only defer to tiny-lr's websocket handling for livereload requests.

Fixes https://github.com/ember-cli/ember-cli/issues/8045.