### PR TITLE
Add `yarn.lock` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@
 /.*
 *.log
 !/.travis.yml
+/yarn.lock


### PR DESCRIPTION
This should save ~190KB from the final package size