### PR TITLE
blueprints/app: Use a valid `package.json` file as input

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -11,12 +11,13 @@ const sortPackageJson = require('sort-package-json');
 let date = new Date();
 
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const adjustPackageJson = require('../app/adjust-pkg');
 const stringifyAndNormalize = require('../../lib/utilities/stringify-and-normalize');
 const FileInfo = require('../../lib/models/file-info');
 
 const replacers = {
   'package.json'(content) {
-    return this.updatePackageJson(content);
+    return this.updatePackageJson(adjustPackageJson.call(this, content));
   },
 };
 
@@ -37,7 +38,6 @@ module.exports = {
   updatePackageJson(content) {
     let contents = JSON.parse(content);
 
-    contents.name = this.locals(this.options).addonName;
     contents.description = this.description;
     delete contents.private;
     contents.scripts = contents.scripts || {};

--- a/blueprints/app/adjust-pkg.js
+++ b/blueprints/app/adjust-pkg.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const sortPackageJson = require('sort-package-json');
+
+const stringifyAndNormalize = require('../../lib/utilities/stringify-and-normalize');
+
+module.exports = function adjustPackageJson(content) {
+  let locals = this.locals(this.options);
+
+  let pkg = JSON.parse(content);
+
+  pkg.name = locals.addonName || locals.name;
+  pkg.devDependencies['ember-cli'] = `~${locals.emberCLIVersion}`;
+
+  if (!locals.welcome) {
+    delete pkg.devDependencies['ember-welcome-page'];
+  }
+
+  return stringifyAndNormalize(sortPackageJson(pkg));
+};

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= name %>",
+  "name": "my-app",
   "version": "0.0.0",
   "private": true,
   "description": "Small description for <%= name %> goes here",
@@ -22,7 +22,7 @@
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.1.0",
-    "ember-cli": "~<%= emberCLIVersion %>",
+    "ember-cli": "*",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^6.16.0",
     "ember-cli-dependency-checker": "^3.0.0",
@@ -39,8 +39,8 @@
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.5.0-beta.1<% if (welcome) { %>",
-    "ember-welcome-page": "^3.2.0<% } %>",
+    "ember-source": "~3.5.0-beta.1",
+    "ember-welcome-page": "^3.2.0",
     "eslint-plugin-ember": "^5.2.0",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.7.1"

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');
+const Blueprint = require('../../lib/models/blueprint');
+const adjustPackageJson = require('./adjust-pkg');
 
 module.exports = {
   description: 'The default blueprint for ember-cli projects.',
@@ -29,5 +31,15 @@ module.exports = {
       welcome: options.welcome,
       blueprint: 'app',
     };
+  },
+
+  buildFileInfo(intoDir, templateVariables, file) {
+    let fileInfo = Blueprint.prototype.buildFileInfo.apply(this, arguments);
+
+    if (file === 'package.json') {
+      fileInfo.replacer = adjustPackageJson.bind(this);
+    }
+
+    return fileInfo;
   },
 };


### PR DESCRIPTION
This might enable us to use e.g. dependabot to automatically update the dependencies specified in this file. Might still not work due to tests failing because of missing fixture updates then, but at least we might get a PR notification 🤔 