### PR TITLE
[Doc] Fix API doc deployment

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -12,11 +12,6 @@ if [[ $TRAVIS_BRANCH != "release" ]]; then
   exit 0
 fi
 
-if [[ $TRAVIS_NODE_VERSION != "6" ]]; then
-  echo "not publishing because we only publish on the Node 4.x build."
-  exit 0
-fi
-
 eval "$(ssh-agent -s)"
 
 openssl aes-256-cbc -K $encrypted_c177ff031535_key -iv $encrypted_c177ff031535_iv -in .travis/deploy_key.pem.enc -out .travis/deploy_key.pem -d


### PR DESCRIPTION
ember-cli's API doc has not been deployed in the latest releases. This PR should fix this.

@Turbo87 do you think it's ok to remove the check on node 6 version? 

Here an example of exiting travis script https://travis-ci.org/ember-cli/ember-cli/jobs/432214197