### PR TITLE
Less restrictive blueprints - change how addons are identified

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1513,7 +1513,17 @@ function findAddonByName(addonOrProject, name) {
 }
 
 function ensureTargetDirIsAddon(addonPath) {
-  const projectInfo = require(path.join(addonPath, 'package.json'));
+  let projectInfo;
+
+  try {
+    projectInfo = require(path.join(addonPath, 'package.json'));
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error(`The directory ${addonPath} does not appear to be a valid addon directory.`);
+    } else {
+      throw err;
+    }
+  }
 
   return isAddon(projectInfo.keywords);
 }

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -24,6 +24,7 @@ const EOL = require('os').EOL;
 const bowEpParser = require('bower-endpoint-parser');
 const logger = require('heimdalljs-logger')('ember-cli:blueprint');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const isAddon = require('../utilities/is-addon');
 
 const Promise = RSVP.Promise;
 const stat = RSVP.denodeify(fs.stat);
@@ -400,9 +401,7 @@ let Blueprint = CoreObject.extend({
     }
 
     if (options.in) {
-      addon = findAddonByPath(this.project, options.in);
-
-      if (!addon) {
+      if (!ensureTargetDirIsAddon(options.in)) {
         throw new SilentError(`You specified the 'in' flag, but the ` +
           `in repo addon '${options.in}' does not exist. Please check the name and try again.`);
       }
@@ -1513,8 +1512,10 @@ function findAddonByName(addonOrProject, name) {
   return addonOrProject.addons.find(addon => findAddonByName(addon, name));
 }
 
-function findAddonByPath(project, addonPath) {
-  return project.addons.find(addon => addon.root === addonPath);
+function ensureTargetDirIsAddon(addonPath) {
+  const projectInfo = require(path.join(addonPath, 'package.json'));
+
+  return isAddon(projectInfo.keywords);
 }
 
 /**

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -4,6 +4,7 @@ const path = require('path');
 const ErrorList = require('./error-list');
 const Errors = require('./errors');
 const AddonInfo = require('../addon-info');
+const isAddon = require('../../utilities/is-addon');
 
 function lexicographically(a, b) {
   const aIsString = typeof a.name === 'string';
@@ -218,10 +219,7 @@ class PackageInfo {
   }
 
   isAddon() {
-    let val =
-      Array.isArray(this.pkg.keywords) &&
-      this.pkg.keywords.indexOf('ember-addon') >= 0;
-    return val;
+    return isAddon(this.pkg.keywords);
   }
 
   /**

--- a/lib/utilities/is-addon.js
+++ b/lib/utilities/is-addon.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function isAddon(keywords) {
+  return Array.isArray(keywords) &&
+    keywords.indexOf('ember-addon') >= 0;
+};

--- a/tests/acceptance/in-option-generate-test.js
+++ b/tests/acceptance/in-option-generate-test.js
@@ -39,6 +39,15 @@ describe('Acceptance: ember generate with --in option', function() {
     return remove(tmproot);
   });
 
+  function removeAddonPath() {
+    let packageJsonPath = path.join(process.cwd(), 'package.json');
+    let packageJson = fs.readJsonSync(packageJsonPath);
+
+    delete packageJson['ember-addon'].paths;
+
+    return fs.writeJsonSync(packageJsonPath, packageJson);
+  }
+
   it('generate blueprint foo using lib', function() {
     // build an app with an in-repo addon in a non-standard path
     return initApp()
@@ -95,11 +104,13 @@ describe('Acceptance: ember generate with --in option', function() {
       );
   });
 
-  it('generate blueprint foo using sibling path', function() {
+  it.only('generate blueprint foo using sibling path', function() {
     // build an app with an in-repo addon in a non-standard path
     return initApp()
       .then(() => fs.mkdirp('../sibling'))
       .then(() => generateUtils.inRepoAddon('../sibling'))
+      // we want to ensure the project has no awareness of the in-repo addon via `ember-addon.paths`, so we remove it
+      .then(removeAddonPath)
       // generate in project blueprint to allow easier testing of in-repo generation
       .then(() => generateUtils.tempBlueprint())
       // confirm that we can generate into the non-lib path

--- a/tests/acceptance/in-option-generate-test.js
+++ b/tests/acceptance/in-option-generate-test.js
@@ -104,7 +104,7 @@ describe('Acceptance: ember generate with --in option', function() {
       );
   });
 
-  it.only('generate blueprint foo using sibling path', function() {
+  it('generate blueprint foo using sibling path', function() {
     // build an app with an in-repo addon in a non-standard path
     return initApp()
       .then(() => fs.mkdirp('../sibling'))

--- a/tests/acceptance/in-option-generate-test.js
+++ b/tests/acceptance/in-option-generate-test.js
@@ -94,4 +94,19 @@ describe('Acceptance: ember generate with --in option', function() {
         })
       );
   });
+
+  it('generate blueprint foo using sibling path', function() {
+    // build an app with an in-repo addon in a non-standard path
+    return initApp()
+      .then(() => fs.mkdirp('../sibling'))
+      .then(() => generateUtils.inRepoAddon('../sibling'))
+      // generate in project blueprint to allow easier testing of in-repo generation
+      .then(() => generateUtils.tempBlueprint())
+      // confirm that we can generate into the non-lib path
+      .then(() =>
+        ember(['generate', 'foo', 'bar', '--in=../sibling']).then(function() {
+          expect(file('../sibling/addon/foos/bar.js')).to.exist;
+        })
+      );
+  });
 });


### PR DESCRIPTION
The current logic used to evaluate whether a directory is an addon for the `--in` and `--in-repo-addon` options is fairly restrictive. It uses a project's discovered addons, a pre-identified list of direct addon depencencies, to evaluate whether one can run blueprints against a particular directory. This works well for most conventional cases, but in cases where a project uses an unconventional structure (I can hear you all saying "convention over configuration as I type this), such as a **monorepo**, this breaks down. 

In order to satisfy current uses cases while allowing more unconventional uses cases, this PR proposes slightly altering the logic of how an in-repo addon is evaluated. It merely uses the heuristic of whether a directory _resembles_ an addon, specifically if its package.json contains the addon keyword. This allows both current, _conventional_ use cases to work in addition to _unconventional_ use cases. Everyone is happy; we all celebrate 🎉 .

Existing tests should cover this change in internal behavior.