### PR TITLE
Enable BROCCOLI_2 and SYSTEM_TEMP experiments by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,8 @@ jobs:
     - env: EMBER_CLI_PACKAGER=true
     - env: EMBER_CLI_MODULE_UNIFICATION=true
     - env: EMBER_CLI_DELAYED_TRANSPILATION=true
-    - env: EMBER_CLI_BROCCOLI_2=true
-    - env:
-      - EMBER_CLI_SYSTEM_TEMP=true
-      - EMBER_CLI_BROCCOLI_2=true
+    - env: EMBER_CLI_BROCCOLI_2=false
+    - env: EMBER_CLI_SYSTEM_TEMP=false
 
     - stage: deploy
       script: ./.travis/deploy.sh

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -15,7 +15,7 @@ const enabledExperiments = Object.freeze([
 ]);
 
 function isExperimentEnabled(experimentName) {
-  if (availableExperiments.indexOf(experimentName) < 0) {
+  if (!availableExperiments.includes(experimentName)) {
     return false;
   }
 
@@ -25,7 +25,7 @@ function isExperimentEnabled(experimentName) {
 
   let experimentEnvironmentVariable = `EMBER_CLI_${experimentName}`;
   let experimentValue = process.env[experimentEnvironmentVariable];
-  if (enabledExperiments.indexOf(experimentName) > -1) {
+  if (enabledExperiments.includes(experimentName)) {
     return experimentValue !== 'false';
   } else if (
     experimentName === 'SYSTEM_TEMP' &&

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -10,6 +10,9 @@ const availableExperiments = [
   'SYSTEM_TEMP',
 ];
 
+const enabledExperiments = [
+];
+
 function isExperimentEnabled(experimentName) {
   if (availableExperiments.indexOf(experimentName) < 0) {
     return false;
@@ -20,11 +23,18 @@ function isExperimentEnabled(experimentName) {
   }
 
   let experimentEnvironmentVariable = `EMBER_CLI_${experimentName}`;
-  if (process.env[experimentEnvironmentVariable]) {
+  let experimentValue = process.env[experimentEnvironmentVariable];
+  if (enabledExperiments.indexOf(experimentName) > -1) {
+    return experimentValue !== 'false';
+  } else if (
+    experimentName === 'SYSTEM_TEMP' &&
+    experimentValue === undefined &&
+    isExperimentEnabled('BROCCOLI_2')
+  ) {
     return true;
+  } else {
+    return experimentValue !== undefined && experimentValue !== 'false';
   }
-
-  return false;
 }
 
 // SYSTEM_TEMP can only be used with BROCCOLI_2

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -2,16 +2,17 @@
 
 const CliError = require('../errors/cli');
 
-const availableExperiments = [
+const availableExperiments = Object.freeze([
   'PACKAGER',
   'MODULE_UNIFICATION',
   'DELAYED_TRANSPILATION',
   'BROCCOLI_2',
   'SYSTEM_TEMP',
-];
+]);
 
-const enabledExperiments = [
-];
+const enabledExperiments = Object.freeze([
+  'BROCCOLI_2',
+]);
 
 function isExperimentEnabled(experimentName) {
   if (availableExperiments.indexOf(experimentName) < 0) {

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -27,9 +27,6 @@ class Builder extends CoreObject {
   constructor(options) {
     super(options);
 
-    this.broccoli2 = isExperimentEnabled('BROCCOLI_2');
-    this.systemTemp = isExperimentEnabled('SYSTEM_TEMP');
-
     this.setupBroccoliBuilder();
 
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
@@ -50,12 +47,12 @@ class Builder extends CoreObject {
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
 
     let broccoli, options = {};
-    if (this.broccoli2) {
+    if (isExperimentEnabled('BROCCOLI_2')) {
       broccoli = require('broccoli');
       let tmpDir;
 
       // If not using system temp dir, compatability mode with broccoli-builder, tmp in root
-      if (!this.systemTemp) {
+      if (!isExperimentEnabled('SYSTEM_TEMP')) {
         tmpDir = `${this.project.root}/tmp`;
         if (!fs.existsSync(tmpDir)) {
           fs.mkdir(tmpDir);
@@ -66,7 +63,7 @@ class Builder extends CoreObject {
       };
     } else {
       broccoli = require('broccoli-builder');
-      if (this.systemTemp) {
+      if (isExperimentEnabled('SYSTEM_TEMP')) {
         console.warn('EMBER_CLI_SYSTEM_TEMP only works in combination with EMBER_CLI_BROCCOLI_2');
       }
     }
@@ -173,18 +170,18 @@ class Builder extends CoreObject {
   build(addWatchDirCallback, resultAnnotation) {
     this.project._instrumentation.start('build');
 
-    if (!this.systemTemp) {
+    if (!isExperimentEnabled('SYSTEM_TEMP')) {
       attemptNeverIndex('tmp');
     }
 
-    if (addWatchDirCallback && this.broccoli2) {
+    if (addWatchDirCallback && isExperimentEnabled('BROCCOLI_2')) {
       for (let path of this.builder.watchedPaths) {
         addWatchDirCallback(path);
       }
     }
 
     return this.processAddonBuildSteps('preBuild')
-      .then(() => this.builder.build(this.broccoli2 ? null : addWatchDirCallback))
+      .then(() => this.builder.build(isExperimentEnabled('BROCCOLI_2') ? null : addWatchDirCallback))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
       .then(this.processBuildResult.bind(this))
@@ -271,7 +268,7 @@ class Builder extends CoreObject {
    * @param node The node returned from Broccoli builder
    */
   compatNode(node) {
-    if (this.broccoli2) {
+    if (isExperimentEnabled('BROCCOLI_2')) {
       return {
         directory: this.builder.outputPath,
         graph: this.builder.outputNodeWrapper,
@@ -304,7 +301,10 @@ class Builder extends CoreObject {
         };
       }
       if (!broccoliPayload.versions) {
-        let builderVersion = this.broccoli2 ? require('broccoli/package').version : require('broccoli-builder/package').version;
+        let builderVersion = isExperimentEnabled('BROCCOLI_2')
+          ? require('broccoli/package').version
+          : require('broccoli-builder/package').version;
+
         broccoliPayload.versions = {
           'broccoli-builder': builderVersion,
           node: process.version,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
     "bower-config": "^1.3.0",
     "bower-endpoint-parser": "0.2.2",
-    "broccoli": "^2.0.0-beta.3",
+    "broccoli": "^2.0.0",
     "broccoli-amd-funnel": "^2.0.1",
     "broccoli-babel-transpiler": "^6.5.0",
     "broccoli-builder": "^0.18.14",

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -25,10 +25,28 @@ describe('experiments', function() {
 
     beforeEach(function() {
       originalProcessEnv = Object.assign({}, process.env);
+
+      // reset all experiment flags for these tests, they will be restored in
+      // afterEach
+      delete process.env.EMBER_CLI_ENABLE_ALL_EXPERIMENTS;
+      delete process.env.EMBER_CLI_MODULE_UNIFICATION;
+      delete process.env.EMBER_CLI_PACKAGER;
+      delete process.env.EMBER_CLI_DELAYED_TRANSPILATION;
+      delete process.env.EMBER_CLI_BROCCOLI_2;
+      delete process.env.EMBER_CLI_SYSTEM_TEMP;
     });
 
     afterEach(function() {
       resetProcessEnv(originalProcessEnv);
+    });
+
+    it('should return true for all experiments when `EMBER_CLI_ENABLE_ALL_EXPERIMENTS` is set', function() {
+      process.env.EMBER_CLI_ENABLE_ALL_EXPERIMENTS = true;
+
+      expect(isExperimentEnabled('BROCCOLI_2')).to.be.true;
+      expect(isExperimentEnabled('PACKAGER')).to.be.true;
+      expect(isExperimentEnabled('SYSTEM_TEMP')).to.be.true;
+      expect(isExperimentEnabled('DELAYED_TRANSPILATION')).to.be.true;
     });
 
     it('should have BROCCOLI_2 enabled by default', function() {

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { isExperimentEnabled } = require('../../lib/experiments');
+
+describe('experiments', function() {
+  describe('isExperimentEnabled', function() {
+    let originalProcessEnv;
+
+    beforeEach(function() {
+      originalProcessEnv = Object.assign({}, process.env);
+    });
+
+    afterEach(function() {
+      process.env = originalProcessEnv;
+    });
+
+    it('should have BROCCOLI_2 enabled by default', function() {
+      expect(isExperimentEnabled('BROCCOLI_2')).to.be.true;
+    });
+
+    it('should have BROCCOLI_2 enabled when environment variable is set', function() {
+      process.env.EMBER_CLI_BROCCOLI_2 = 'true';
+      expect(isExperimentEnabled('BROCCOLI_2')).to.be.true;
+    });
+
+    it('should have BROCCOLI_2 disabled when environment variable is set to false', function() {
+      process.env.EMBER_CLI_BROCCOLI_2 = 'false';
+      expect(isExperimentEnabled('BROCCOLI_2')).to.be.false;
+    });
+
+    it('should have SYSTEM_TEMP disabled when BROCCOLI_2 is disabled', function() {
+      process.env.EMBER_CLI_BROCCOLI_2 = 'false';
+      expect(isExperimentEnabled('BROCCOLI_2')).to.be.false;
+      expect(isExperimentEnabled('SYSTEM_TEMP')).to.be.false;
+    });
+
+    it('should have SYSTEM_TEMP disabled when environment flag is present', function() {
+      process.env.EMBER_CLI_SYSTEM_TEMP = 'false';
+      expect(isExperimentEnabled('SYSTEM_TEMP')).to.be.false;
+    });
+
+    it('setting an already disabled feature to false does not enable it', function() {
+      process.env.EMBER_CLI_PACKAGER = 'false';
+      expect(isExperimentEnabled('PACKAGER')).to.be.false;
+    });
+
+    it('should have MODULE_UNIFICATION disabled by default', function() {
+      expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.false;
+    });
+
+    it('should have MODULE_UNIFICATION enabled when environment variable is set', function() {
+      process.env.EMBER_CLI_MODULE_UNIFICATION = 'true';
+      expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.true;
+    });
+  });
+});

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -3,6 +3,22 @@
 const expect = require('chai').expect;
 const { isExperimentEnabled } = require('../../lib/experiments');
 
+function resetProcessEnv(originalProcessEnv) {
+  for (let key in process.env) {
+    if (key in originalProcessEnv) {
+      process.env[key] = originalProcessEnv[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+
+  for (let key in originalProcessEnv) {
+    if (!(key in process.env)) {
+      process.env[key] = originalProcessEnv[key];
+    }
+  }
+}
+
 describe('experiments', function() {
   describe('isExperimentEnabled', function() {
     let originalProcessEnv;
@@ -12,7 +28,7 @@ describe('experiments', function() {
     });
 
     afterEach(function() {
-      process.env = originalProcessEnv;
+      resetProcessEnv(originalProcessEnv);
     });
 
     it('should have BROCCOLI_2 enabled by default', function() {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -27,7 +27,7 @@ describe('models/builder.js', function() {
   let addon, builder, buildResults, tmpdir;
 
   function setupBroccoliBuilder() {
-    if (this.broccoli2) {
+    if (isExperimentEnabled('BROCCOLI_2')) {
       this.builder = {
         outputPath: 'build results',
         outputNodeWrapper: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,10 +1090,10 @@ broccoli@^1.1.0:
     tmp "0.0.31"
     underscore.string "^3.2.2"
 
-broccoli@^2.0.0-beta.3:
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.0.0-beta.3.tgz#89fcd9fd5550c7a031b448b635a437d44323e416"
-  integrity sha1-ifzZ/VVQx6AxtEi2NaQ31EMj5BY=
+broccoli@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.0.0.tgz#7b95d6173865184697e4dab9f477591057b9410e"
+  integrity sha512-gCS1/nXaJpATboLpNeTPOgdqSSEauJ6bUS4+fNKNsf/m7CIxOS9MclT7DNn3VI9DARiGZxFi6hZmIEF1mD04eA==
   dependencies:
     broccoli-node-info "1.1.0"
     broccoli-slow-trees "^3.0.1"
@@ -1104,10 +1104,11 @@ broccoli@^2.0.0-beta.3:
     handlebars "^4.0.11"
     heimdalljs "^0.2.5"
     heimdalljs-logger "^0.1.9"
-    mime "^2.3.1"
+    mime-types "^2.1.19"
     promise.prototype.finally "^3.1.0"
+    resolve-path "^1.4.0"
     rimraf "^2.6.2"
-    sane "^2.2.0"
+    sane "^4.0.0"
     tmp "0.0.33"
     tree-sync "^1.2.2"
     underscore.string "^3.2.2"
@@ -4768,12 +4769,24 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
   integrity sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
 
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+  integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
+
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   integrity sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==
   dependencies:
     mime-db "~1.35.0"
+
+mime-types@^2.1.19:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
+  dependencies:
+    mime-db "~1.36.0"
 
 mime-types@~1.0.1:
   version "1.0.2"
@@ -4789,11 +4802,6 @@ mime@^1.2.11, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
-  integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
 
 mime@~1.2.11:
   version "1.2.11"
@@ -5418,7 +5426,7 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@1.0.1, path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -5859,6 +5867,14 @@ resolve-from@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
   integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
+resolve-path@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
+  integrity sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=
+  dependencies:
+    http-errors "~1.6.2"
+    path-is-absolute "1.0.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -5995,7 +6011,7 @@ sane@^1.4.1:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sane@^2.2.0, sane@^2.4.1:
+sane@^2.4.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
   integrity sha1-tNwYYcIbQn6SlQej51HiosuKs/o=


### PR DESCRIPTION
* Refactored `isExperimentEnabled` to account for "default enabled" experiments
* Add ability to turn off default enabled experiments (by setting the environment variable to `false`)
* Add tests for `isExperimentEnabled`
* Enable `BROCCOLI_2` by default
* Enable `SYSTEM_TEMP` by default
* Updated to latest broccoli@2
* Refactor usage of experiments in `lib/models/builder.js`