### PR TITLE
Catch InvalidNodeError for Broccoli 2.0 and fallback to broccoli-builder

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -27,6 +27,8 @@ class Builder extends CoreObject {
   constructor(options) {
     super(options);
 
+    // Use Broccoli 2.0 by default, if this fails due to .read/.rebuild API, fallback to broccoli-builder
+    this.broccoliBuilderFallback = false;
     this.setupBroccoliBuilder();
 
     this._instantiationStack = (new Error()).stack.replace(/[^\n]*\n/, '');
@@ -40,11 +42,28 @@ class Builder extends CoreObject {
 
   /**
    * @private
+   * @method readBuildFile
+   * @param path The file path to read the build file from
+   */
+  readBuildFile(path) {
+    // Load the build file
+    let buildFile = findBuildFile('ember-cli-build.js', path);
+    if (buildFile) {
+      return buildFile({ project: this.project });
+    }
+
+    throw new SilentError('No ember-cli-build.js found.');
+  }
+
+  /**
+   * @private
    * @method setupBroccoliBuilder
    */
   setupBroccoliBuilder() {
     this.environment = this.environment || 'development';
     process.env.EMBER_ENV = process.env.EMBER_ENV || this.environment;
+
+    this.tree = this.readBuildFile(this.project.root);
 
     let broccoli, options = {};
     if (isExperimentEnabled('BROCCOLI_2')) {
@@ -61,20 +80,33 @@ class Builder extends CoreObject {
       options = {
         tmpdir: tmpDir,
       };
-    } else {
-      broccoli = require('broccoli-builder');
-      if (isExperimentEnabled('SYSTEM_TEMP')) {
-        console.warn('EMBER_CLI_SYSTEM_TEMP only works in combination with EMBER_CLI_BROCCOLI_2');
+
+      try {
+        this.builder = new broccoli.Builder(this.tree, options);
+        return;
+      } catch (e) {
+        // Catch here to trap InvalidNodeError. If this is thrown, it's because the node provided is not valid
+        // and likely uses the old .read/.rebuild API, so fallback to broccoli-builder that supports that API
+        if (
+          !(e instanceof broccoli.Builder.InvalidNodeError) ||
+          e.message.indexOf('The .read/.rebuild API is no longer supported as of Broccoli 1.0') === -1
+        ) {
+          throw e;
+        }
+
+        // Fallback to broccoli-builder
+        let error = `Invalid Broccoli2 node detected, falling back to broccoli-builder. Broccoli error:\n`
+        error += `---------------\n`;
+        error += e.message;
+        error += `---------------\n`;
+        this.ui.writeWarnLine(error);
       }
+    } else if (isExperimentEnabled('SYSTEM_TEMP')) {
+      this.ui.writeWarnLine('EMBER_CLI_SYSTEM_TEMP only works in combination with EMBER_CLI_BROCCOLI_2');
     }
 
-    let buildFile = findBuildFile('ember-cli-build.js', this.project.root);
-    if (buildFile) {
-      this.tree = buildFile({ project: this.project });
-    } else {
-      throw new SilentError('No ember-cli-build.js found.');
-    }
-
+    broccoli = require('broccoli-builder');
+    this.broccoliBuilderFallback = true;
     this.builder = new broccoli.Builder(this.tree, options);
   }
 
@@ -174,14 +206,14 @@ class Builder extends CoreObject {
       attemptNeverIndex('tmp');
     }
 
-    if (addWatchDirCallback && isExperimentEnabled('BROCCOLI_2')) {
+    if (addWatchDirCallback && !this.broccoliBuilderFallback) {
       for (let path of this.builder.watchedPaths) {
         addWatchDirCallback(path);
       }
     }
 
     return this.processAddonBuildSteps('preBuild')
-      .then(() => this.builder.build(isExperimentEnabled('BROCCOLI_2') ? null : addWatchDirCallback))
+      .then(() => this.builder.build(this.broccoliBuilderFallback ? addWatchDirCallback : null))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))
       .then(this.processAddonBuildSteps.bind(this, 'postBuild'))
       .then(this.processBuildResult.bind(this))
@@ -268,7 +300,7 @@ class Builder extends CoreObject {
    * @param node The node returned from Broccoli builder
    */
   compatNode(node) {
-    if (isExperimentEnabled('BROCCOLI_2')) {
+    if (!this.broccoliBuilderFallback) {
       return {
         directory: this.builder.outputPath,
         graph: this.builder.outputNodeWrapper,
@@ -301,9 +333,9 @@ class Builder extends CoreObject {
         };
       }
       if (!broccoliPayload.versions) {
-        let builderVersion = isExperimentEnabled('BROCCOLI_2')
-          ? require('broccoli/package').version
-          : require('broccoli-builder/package').version;
+        let builderVersion = this.broccoliBuilderFallback
+          ? require('broccoli-builder/package').version
+          : require('broccoli/package').version;
 
         broccoliPayload.versions = {
           'broccoli-builder': builderVersion,

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -7,10 +7,10 @@ const MockUI = require('console-ui/mock');
 // eslint-disable-next-line node/no-unpublished-require
 
 class MockProject extends Project {
-  constructor() {
-    let root = process.cwd();
-    let pkg = {};
-    let ui = new MockUI();
+  constructor(options = {}) {
+    let root = options.root || process.cwd();
+    let pkg = options.pkg || {};
+    let ui = options.ui || new MockUI();
     let instr = new Instrumentation({
       ui,
       initInstrumentation: {
@@ -18,7 +18,7 @@ class MockProject extends Project {
         node: null,
       },
     });
-    let cli = {
+    let cli = options.cli || {
       instrumentation: instr,
     };
 

--- a/tests/unit/broccoli/builder-test.js
+++ b/tests/unit/broccoli/builder-test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const co = require('co');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+
+const MockProject = require('../../helpers/mock-project');
+const Builder = require('../../../lib/models/builder');
+
+const { createTempDir, fromBuilder } = broccoliTestHelper;
+const ROOT = process.cwd();
+
+describe('Builder - broccoli tests', function() {
+  let projectRoot, builderOutputPath, output, project, builder;
+
+  beforeEach(co.wrap(function *() {
+    projectRoot = yield createTempDir();
+    builderOutputPath = yield createTempDir();
+
+    project = new MockProject({ root: projectRoot.path() });
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield projectRoot.dispose();
+    yield builderOutputPath.dispose();
+    yield output.dispose();
+
+    // this is needed because lib/utilities/find-build-file.js does a
+    // `process.chdir` when it looks for the `ember-cli-build.js`
+    process.chdir(ROOT);
+  }));
+
+  it('falls back to broccoli-builder@0.18 when legacy plugins exist in build', co.wrap(function *() {
+    projectRoot.write({
+      'ember-cli-build.js': `
+        const fs = require('fs');
+        const os = require('os');
+        const crypto = require('crypto');
+
+        function randomString() {
+          return crypto
+            .randomBytes(20)
+            .toString('base64')
+            .replace('+', '0')
+            .replace('/', '0');
+        }
+
+        function LegacyPlugin (inputTree) {
+          this.inputTree = inputTree;
+          this.tmpDestDir = os.tmpdir() + '/' + randomString();
+        }
+
+        LegacyPlugin.prototype.read = function(readTree) {
+          fs.mkdirSync(this.tmpDestDir); // doesn't handle rebuilds, yolo
+
+          return readTree(this.inputTree).then(inputDir => {
+            let sourceFile = inputDir + '/hello.txt';
+            let destFile = this.tmpDestDir + '/hello.txt';
+            let sourceContent = fs.readFileSync(sourceFile, 'utf-8');
+
+            fs.writeFileSync(destFile, sourceContent);
+
+            return this.tmpDestDir;
+          });
+        }
+
+        module.exports = function () {
+          return new LegacyPlugin(__dirname + '/app');
+        }
+      `,
+      app: {
+        'hello.txt': '// hello!',
+      },
+    });
+
+    builder = new Builder({
+      project,
+      ui: project.ui,
+      onProcessInterrupt: {
+        addHandler() {},
+        removeHandler() {},
+      },
+      outputPath: builderOutputPath.path(),
+    });
+
+    output = fromBuilder(builder);
+    yield output.build();
+
+    expect(output.read()).to.deep.equal({
+      'hello.txt': '// hello!',
+    });
+    expect(builder.broccoliBuilderFallback).to.be.true;
+    expect(builder.ui.output).to.include('WARNING: Invalid Broccoli2 node detected, falling back to broccoli-builder. Broccoli error:');
+    expect(builder.ui.output).to.include("LegacyPlugin: The .read/.rebuild API is no longer supported as of Broccoli 1.0. Plugins must now derive from broccoli-plugin. https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md");
+  }));
+});

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -28,6 +28,7 @@ describe('models/builder.js', function() {
 
   function setupBroccoliBuilder() {
     if (isExperimentEnabled('BROCCOLI_2')) {
+      this.broccoliBuilderFallback = false;
       this.builder = {
         outputPath: 'build results',
         outputNodeWrapper: {
@@ -45,6 +46,7 @@ describe('models/builder.js', function() {
         },
       };
     } else {
+      this.broccoliBuilderFallback = true;
       this.builder = {
         build() {
           return Promise.resolve({
@@ -80,9 +82,11 @@ describe('models/builder.js', function() {
     beforeEach(function() {
       return mkTmpDirIn(tmproot).then(function(dir) {
         tmpdir = dir;
+        let project = new MockProject();
         builder = new Builder({
+          project,
+          ui: project.ui,
           setupBroccoliBuilder,
-          project: new MockProject(),
         });
       });
     });
@@ -98,65 +102,70 @@ describe('models/builder.js', function() {
       expect(file(path.join(builder.outputPath, 'files', 'foo.txt'))).to.exist;
     });
 
-    let command;
+    describe('build command', function() {
+      let command;
+      let parentPath = `..${path.sep}..${path.sep}`;
 
-    let parentPath = `..${path.sep}..${path.sep}`;
+      beforeEach(function() {
+        command = new BuildCommand(commandOptions());
 
-    before(function() {
-      command = new BuildCommand(commandOptions());
-
-      builder = new Builder({
-        setupBroccoliBuilder,
-        project: new MockProject(),
+        let project = new MockProject();
+        builder = new Builder({
+          project,
+          ui: project.ui,
+          setupBroccoliBuilder,
+        });
       });
-    });
 
-    it('when outputPath is root directory ie., `--output-path=/` or `--output-path=C:`', function() {
-      let outputPathArg = '--output-path=.';
-      let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
-      outputPath = outputPath.split(path.sep)[0] + path.sep;
-      builder.outputPath = outputPath;
+      it('when outputPath is root directory ie., `--output-path=/` or `--output-path=C:`', function() {
+        let outputPathArg = '--output-path=.';
+        let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+        outputPath = outputPath.split(path.sep)[0] + path.sep;
+        builder.outputPath = outputPath;
 
-      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
-    });
+        expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
+      });
 
-    it('when outputPath is project root ie., `--output-path=.`', function() {
-      let outputPathArg = '--output-path=.';
-      let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
-      builder.outputPath = outputPath;
+      it('when outputPath is project root ie., `--output-path=.`', function() {
+        let outputPathArg = '--output-path=.';
+        let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+        builder.outputPath = outputPath;
 
-      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
-    });
+        expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
+      });
 
-    it(`when outputPath is a parent directory ie., \`--output-path=${parentPath}\``, function() {
-      let outputPathArg = `--output-path=${parentPath}`;
-      let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
-      builder.outputPath = outputPath;
+      it(`when outputPath is a parent directory ie., \`--output-path=${parentPath}\``, function() {
+        let outputPathArg = `--output-path=${parentPath}`;
+        let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+        builder.outputPath = outputPath;
 
-      expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
-    });
+        expect(builder.canDeleteOutputPath(outputPath)).to.equal(false);
+      });
 
-    it('allow outputPath to contain the root path as a substring, as long as it is not a parent', function() {
-      let outputPathArg = '--output-path=.';
-      let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
-      outputPath = outputPath.substr(0, outputPath.length - 1);
-      builder.outputPath = outputPath;
+      it('allow outputPath to contain the root path as a substring, as long as it is not a parent', function() {
+        let outputPathArg = '--output-path=.';
+        let outputPath = command.parseArgs([outputPathArg]).options.outputPath;
+        outputPath = outputPath.substr(0, outputPath.length - 1);
+        builder.outputPath = outputPath;
 
-      expect(builder.canDeleteOutputPath(outputPath)).to.equal(true);
+        expect(builder.canDeleteOutputPath(outputPath)).to.equal(true);
+      });
     });
   });
 
   describe('build', function() {
     let instrumentationStart;
     let instrumentationStop;
-    let cwd;
+    let cwd, project;
 
     beforeEach(function() {
       // Cache cwd to reset after test
       cwd = process.cwd();
+      project = new MockProject();
       builder = new Builder({
+        project,
+        ui: project.ui,
         setupBroccoliBuilder,
-        project: new MockProject(),
         processBuildResult(buildResults) { return Promise.resolve(buildResults); },
       });
 
@@ -216,6 +225,7 @@ describe('models/builder.js', function() {
 
         builder = new Builder({
           project,
+          ui: project.ui,
           processBuildResult(buildResults) { return Promise.resolve(buildResults); },
         });
 
@@ -232,6 +242,7 @@ describe('models/builder.js', function() {
         expect(fs.existsSync(`${builder.project.root}/tmp`)).to.be.false;
         builder = new Builder({
           project,
+          ui: project.ui,
           processBuildResult(buildResults) { return Promise.resolve(buildResults); },
         });
 
@@ -249,6 +260,7 @@ describe('models/builder.js', function() {
       project.root += '/tests/fixtures/build/simple';
       const setup = () => new Builder({
         project,
+        ui: project.ui,
         processBuildResult(buildResults) { return Promise.resolve(buildResults); },
       });
 
@@ -263,6 +275,7 @@ describe('models/builder.js', function() {
 
       builder = new Builder({
         project,
+        ui: project.ui,
         processBuildResult(buildResults) { return Promise.resolve(buildResults); },
       });
 
@@ -280,9 +293,11 @@ describe('models/builder.js', function() {
 
   describe('cleanup', function() {
     beforeEach(function() {
+      let project = new MockProject();
       builder = new Builder({
+        project,
+        ui: project.ui,
         setupBroccoliBuilder,
-        project: new MockProject(),
         processBuildResult(buildResults) { return Promise.resolve(buildResults); },
       });
     });
@@ -498,4 +513,42 @@ describe('models/builder.js', function() {
       });
     });
   });
+
+  if (isExperimentEnabled('BROCCOLI_2')) {
+    describe('fallback from broccoli 2 to broccoli-builder', function() {
+      it('falls back to broccoli-builder if an InvalidNode error is thrown for read/rebuild api', function() {
+        let project = new MockProject();
+        const builder = new Builder({
+          project,
+          ui: project.ui,
+          readBuildFile() {
+            return {
+              read() {
+
+              },
+              rebuild() {
+
+              },
+            };
+          },
+        });
+
+        expect(builder.broccoliBuilderFallback).to.be.true;
+        
+        expect(project.ui.output).to.include('WARNING: Invalid Broccoli2 node detected, falling back to broccoli-builder. Broccoli error:');
+        expect(project.ui.output).to.include('Object: The .read/.rebuild API is no longer supported as of Broccoli 1.0. Plugins must now derive from broccoli-plugin. https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md');
+      });
+
+      it('errors for an invalid node', function() {
+        let project = new MockProject();
+        expect(() => new Builder({
+          project,
+          ui: project.ui,
+          readBuildFile() {
+            return {};
+          },
+        })).to.throw('[object Object] is not a Broccoli node\nused as output node');
+      });
+    });
+  }
 });


### PR DESCRIPTION
As the title says. This should provide a decent level of BC for users with old plugins.

This can be tested with a new ember project, and yarn linking this branch of `ember-cli` into the new project.

Then `ember install ember-browserify` which uses the old read/rebuild API

Then `ember build` results in:

![image](https://user-images.githubusercontent.com/1246671/46439930-f4d83300-c72f-11e8-8261-6b617a778771.png)

Now this might be *too much* output, perhaps we only need the `ERROR`, given that `broccoli-builder` also outputs the offending plugin.

Thoughts...
