### PR TITLE
Use regex to parse /livereload urls

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -8,6 +8,7 @@ const logger = require('heimdalljs-logger')('ember-cli:live-reload:');
 const fs = require('fs');
 const Promise = require('rsvp').Promise;
 const cleanBaseUrl = require('clean-base-url');
+const isLiveReloadRequest = require('../../utilities/is-live-reload-request');
 
 function isNotRemoved(entryTuple) {
   let operation = entryTuple[0];
@@ -102,7 +103,7 @@ module.exports = class LiveReloadServer {
     // Reload on express server restarts
     this.app.on('restart', this.didRestart.bind(this));
     this.httpServer.on('upgrade', (req, socket, head) => {
-      if (req.url.indexOf('/livereload') === 0) {
+      if (isLiveReloadRequest(req.url, this.liveReloadPrefix)) {
         this.liveReloadServer.websocketify(req, socket, head);
       }
     });

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// eslint-disable-next-line
+const isLiveReloadRequest = require('../../../../utilities/is-live-reload-request');
+
 class ProxyServerAddon {
   constructor(project) {
     this.project = project;
@@ -32,7 +35,7 @@ class ProxyServerAddon {
       options.ui.writeLine(`Proxying to ${options.proxy}`);
 
       server.on('upgrade', (req, socket, head) => {
-        this.handleProxiedRequest(req, socket, head, options, proxy);
+        this.handleProxiedRequest({ req, socket, head, options, proxy });
       });
 
       app.use(morgan('dev'));
@@ -40,8 +43,8 @@ class ProxyServerAddon {
     }
   }
 
-  handleProxiedRequest(req, socket, head, options, proxy) {
-    if (req.url.indexOf('/livereload') === -1) {
+  handleProxiedRequest({ req, socket, head, options, proxy }) {
+    if (!isLiveReloadRequest(req.url, options.liveReloadPrefix)) {
       options.ui.writeLine(`Proxying websocket to ${req.url}`);
       proxy.ws(req, socket, head);
     }

--- a/lib/utilities/is-live-reload-request.js
+++ b/lib/utilities/is-live-reload-request.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const cleanBaseUrl = require('clean-base-url');
+module.exports = function isLiveReloadRequest(url, liveReloadPrefix) {
+  return url === `${cleanBaseUrl(liveReloadPrefix)}livereload`;
+};

--- a/lib/utilities/is-live-reload-request.js
+++ b/lib/utilities/is-live-reload-request.js
@@ -1,6 +1,17 @@
 'use strict';
 
 const cleanBaseUrl = require('clean-base-url');
+const deprecate = require('./deprecate');
+
 module.exports = function isLiveReloadRequest(url, liveReloadPrefix) {
-  return url === `${cleanBaseUrl(liveReloadPrefix)}livereload`;
+  let regex = /\/livereload$/gi;
+  if (url === `${cleanBaseUrl(liveReloadPrefix)}livereload`) {
+    return true;
+  } else if (regex.test(url)) {
+    //version needs to be updated according to the this PR (https://github.com/ember-cli/ember-cli-inject-live-reload/pull/55)
+    //in master of ember-cli-inject-live-reload.
+    deprecate(`Upgrade ember-cli-inject-live-reload version to 1.10.0 or above`, true);
+    return true;
+  }
+  return false;
 };

--- a/tests/unit/tasks/server/middleware/proxy-server-test.js
+++ b/tests/unit/tasks/server/middleware/proxy-server-test.js
@@ -13,9 +13,13 @@ describe('proxy-server', function() {
   });
 
   it(`bypass livereload request`, function() {
-    expect(proxyServer.handleProxiedRequest({
-      url: '/livereload',
-    })).to.undefined;
+    let options = {
+      liveReloadPrefix: 'test/',
+    };
+    let req = {
+      url: 'test/livereload',
+    };
+    expect(proxyServer.handleProxiedRequest({ req, options })).to.undefined;
   });
 });
 

--- a/tests/unit/utilities/is-live-reload-request-test.js
+++ b/tests/unit/utilities/is-live-reload-request-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const expect = require('chai').expect;
+const isLiveReloadRequest = require('../../../lib/utilities/is-live-reload-request');
+
+describe('isLiveReloadRequest()', function() {
+  it('/livereload', function() {
+    expect(isLiveReloadRequest('/livereload', '/')).to.be.true;
+  });
+  it('path/livereload', function() {
+    expect(isLiveReloadRequest('path/livereload', 'path/')).to.be.true;
+  });
+  it('path/path/livereload', function() {
+    expect(isLiveReloadRequest('path/path/livereload', 'path/path/')).to.be.true;
+  });
+  it('livereload', function() {
+    expect(isLiveReloadRequest('livereload', '/')).to.be.false;
+  });
+  it('livereload/path', function() {
+    expect(isLiveReloadRequest('livereload/path', '/')).to.be.false;
+  });
+  it('/livereload.js', function() {
+    expect(isLiveReloadRequest('/livereload.js', '/')).to.be.false;
+  });
+  it('path/livereload.js', function() {
+    expect(isLiveReloadRequest('path/livereload.js', 'path/')).to.be.false;
+  });
+  it('path/livereload/path', function() {
+    expect(isLiveReloadRequest('path/livereload/path', 'path/')).to.be.false;
+  });
+});


### PR DESCRIPTION
- Using strict `/livereload` matching is not very optimal.
- livereload takes `path` as an option which changes URL for upgrade requests. Ex `locahost:4200/path`. 
- LiveReload protocol insists `path` to end with `/livereload`. http://livereload.com/api/protocol/#basics
- The file `is-live-reload-request.js` can be an independent module like [clean-base-url](https://github.com/ember-cli/clean-base-url) which can be used by middlewares which listen for `upgrade` requests in ember-addons. This check is needed if we have listener for `upgrade` requests as we are now serving livereload and ember app on the same port.