### PR TITLE
Attempt to fix CI with npm@5 and npm@6.

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -151,6 +151,20 @@ class NpmTask extends Task {
       } else {
         let args = this.toNpmArgs(this.command, options);
         promise = this.npm(args);
+
+        // as of 2018-10-09 npm 5 and 6 _break_ the heirarchy of `node_modules`
+        // after a `npm install foo` (deletes files/folders other than
+        // what was directly installed) in some circumstances, see:
+        //
+        // * https://github.com/npm/npm/issues/16853
+        // * https://github.com/npm/npm/issues/17379
+        //
+        // this ensures that we run a full `npm install` **after** any `npm
+        // install foo` runs to ensure that we have a fully functional
+        // node_modules heirarchy
+        if (semver.gte(this.npmVersion, '5.0.0')) {
+          promise = promise.then(() => this.npm(['install']));
+        }
       }
 
       return promise


### PR DESCRIPTION
As of 2018-10-09 npm 5 and 6 _break_ the heirarchy of `node_modules` after a `npm install foo` (deletes files/folders other than `node_modules/foo` that were not created by the `npm` client itself)`

This ensures that we run a full `npm install` **after** any `npm install foo` funs to ensure that we have a fully functional `node_modules` heirarchy.