### PR TITLE
Migrate test to `runCommand` to work around test state leakage.

### DIFF
--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -77,8 +77,14 @@ describe('Acceptance: smoke-test', function() {
 
   it('ember test still runs when a JavaScript testem config exists', co.wrap(function *() {
     yield copyFixtureFiles('smoke-tests/js-testem-config');
-    yield ember(['test']);
-    expect(process.env._TESTEM_CONFIG_JS_RAN).to.be.ok;
+
+    let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+
+    let exitCode = result.code;
+    let output = result.output.join(EOL);
+
+    expect(exitCode).to.eql(0);
+    expect(output).to.include('***CUSTOM_TESTEM_JS**');
   }));
 
   // there is a bug in here when running the entire suite on Travis

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -1,4 +1,4 @@
-process.env._TESTEM_CONFIG_JS_RAN = true;
+console.log('***CUSTOM_TESTEM_JS**');
 
 module.exports = {
   "framework": "qunit",


### PR DESCRIPTION
Using the shared `test/helpers/ember` currently ends up with module resolution failures (due to shared state between tests). This migrates to using `runCommand` (which spawns a process) to avoid that leakage.

Fixes https://github.com/ember-cli/ember-cli/issues/8098