### PR TITLE
Make use of `ci-info` for detecting CI environments

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -1,12 +1,12 @@
 'use strict';
 
+const { isCI } = require('ci-info');
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions'
 ];
 
-const isCI = !!process.env.CI;
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {

--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { isCI } = require('ci-info');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -11,7 +15,7 @@ module.exports = {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.CI ? '--no-sandbox' : null,
+        isCI ? '--no-sandbox' : null,
         '--headless',
         '--disable-gpu',
         '--disable-dev-shm-usage',

--- a/blueprints/module-unification-app/files/testem.js
+++ b/blueprints/module-unification-app/files/testem.js
@@ -1,3 +1,5 @@
+const { isCI } = require('ci-info');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -12,7 +14,7 @@ module.exports = {
       mode: 'ci',
       args: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
+        isCI ? '--no-sandbox' : null,
 
         '--disable-gpu',
         '--headless',

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,7 +3,7 @@
 const willInterruptProcess = require('../utilities/will-interrupt-process');
 const instrumentation = require('../utilities/instrumentation');
 const getConfig = require('../utilities/get-config');
-const ciInfo = require('ci-info');
+const { isCI } = require('ci-info');
 
 let initInstrumentation;
 if (instrumentation.instrumentationEnabled()) {
@@ -85,7 +85,7 @@ module.exports = function(options) {
     outputStream: options.outputStream,
     errorStream: options.errorStream || process.stderr,
     errorLog: options.errorLog || [],
-    ci: ciInfo.isCI || (/^(dumb|emacs)$/).test(process.env.TERM),
+    ci: isCI || (/^(dumb|emacs)$/).test(process.env.TERM),
     writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
   });
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -20,6 +20,8 @@ const instantiateAddons = require('../models/instantiate-addons');
 
 let processCwd = process.cwd();
 
+const { isCI } = require('ci-info');
+
 // ensure NULL_PROJECT is a singleton
 let NULL_PROJECT;
 
@@ -769,7 +771,7 @@ function ensureUI(_ui) {
     ui = new UI({
       inputStream: process.stdin,
       outputStream: process.stdout,
-      ci: process.env.CI || (/^(dumb|emacs)$/).test(process.env.TERM),
+      ci: isCI || (/^(dumb|emacs)$/).test(process.env.TERM),
       writeLevel: (process.argv.indexOf('--silent') !== -1) ? 'ERROR' : undefined,
     });
   }

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -20,24 +20,22 @@ const forEach = require('ember-cli-lodash-subset').forEach;
 const assertVersionLock = require('../helpers/assert-version-lock');
 const { isExperimentEnabled } = require('../../lib/experiments');
 
+let ci = require('ci-info');
+
 let tmpDir = './tmp/new-test';
 
 describe('Acceptance: ember new', function() {
   this.timeout(10000);
-  let ORIGINAL_PROCESS_ENV_CI;
+  let originalIsCI;
 
   beforeEach(co.wrap(function *() {
     yield tmp.setup(tmpDir);
     process.chdir(tmpDir);
-    ORIGINAL_PROCESS_ENV_CI = process.env.CI;
+    originalIsCI = ci.isCI;
   }));
 
   afterEach(function() {
-    if (ORIGINAL_PROCESS_ENV_CI === undefined) {
-      delete process.env.CI;
-    } else {
-      process.env.CI = ORIGINAL_PROCESS_ENV_CI;
-    }
+    ci.isCI = originalIsCI;
     return tmp.teardown(tmpDir);
   });
 
@@ -138,7 +136,7 @@ describe('Acceptance: ember new', function() {
       '--skip-bower',
     ]);
 
-    process.env.CI = true;
+    ci.isCI = true;
     const defaultTargets = require('../../lib/utilities/default-targets').browsers;
     const blueprintTargets = require(path.resolve('config/targets.js')).browsers;
     expect(blueprintTargets).to.have.same.deep.members(defaultTargets);

--- a/tests/fixtures/module-unification-addon/testem.js
+++ b/tests/fixtures/module-unification-addon/testem.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { isCI } = require('ci-info');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -12,7 +16,7 @@ module.exports = {
       mode: 'ci',
       args: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
+        isCI ? '--no-sandbox' : null,
 
         '--disable-gpu',
         '--headless',

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -1,4 +1,8 @@
+'use strict';
+
 console.log('***CUSTOM_TESTEM_JS**');
+
+const { isCI } = require('ci-info');
 
 module.exports = {
   "framework": "qunit",
@@ -13,7 +17,7 @@ module.exports = {
   "browser_args": {
     "Chrome": [
       // --no-sandbox is needed when running Chrome inside a container
-      process.env.TRAVIS ? '--no-sandbox' : null,
+      isCI ? '--no-sandbox' : null,
 
       "--disable-gpu",
       "--headless",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -8,6 +8,8 @@ const Mocha = require('mocha');
 const RSVP = require('rsvp');
 const fs = require('fs-extra');
 
+const { isCI } = require('ci-info');
+
 if (process.env.EOLNEWLINE) {
   require('os').EOL = '\n';
 }
@@ -17,7 +19,7 @@ fs.removeSync('.deps-tmp');
 let root = 'tests/{unit,integration,acceptance}';
 let optionOrFile = process.argv[2];
 // default to `tap` reporter in CI otherwise default to `spec`
-let reporter = process.env.MOCHA_REPORTER || (process.env.CI ? 'tap' : 'spec');
+let reporter = process.env.MOCHA_REPORTER || (isCI ? 'tap' : 'spec');
 let mocha = new Mocha({
   timeout: 5000,
   reporter,


### PR DESCRIPTION
Fixed #8093 

Replaced the usage of `process.env.CI` and `process.env.TRAVIS` with `require('ci-info').isCI`