### PR TITLE
Only assert on fallback messaging when BROCCOLI_2 enabled.

### DIFF
--- a/tests/unit/broccoli/builder-test.js
+++ b/tests/unit/broccoli/builder-test.js
@@ -6,6 +6,7 @@ const expect = require('chai').expect;
 
 const MockProject = require('../../helpers/mock-project');
 const Builder = require('../../../lib/models/builder');
+const { isExperimentEnabled } = require('../../../lib/experiments');
 
 const { createTempDir, fromBuilder } = broccoliTestHelper;
 const ROOT = process.cwd();
@@ -89,8 +90,11 @@ describe('Builder - broccoli tests', function() {
     expect(output.read()).to.deep.equal({
       'hello.txt': '// hello!',
     });
-    expect(builder.broccoliBuilderFallback).to.be.true;
-    expect(builder.ui.output).to.include('WARNING: Invalid Broccoli2 node detected, falling back to broccoli-builder. Broccoli error:');
-    expect(builder.ui.output).to.include("LegacyPlugin: The .read/.rebuild API is no longer supported as of Broccoli 1.0. Plugins must now derive from broccoli-plugin. https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md");
+
+    if (isExperimentEnabled('BROCCOLI_2')) {
+      expect(builder.broccoliBuilderFallback).to.be.true;
+      expect(builder.ui.output).to.include('WARNING: Invalid Broccoli2 node detected, falling back to broccoli-builder. Broccoli error:');
+      expect(builder.ui.output).to.include("LegacyPlugin: The .read/.rebuild API is no longer supported as of Broccoli 1.0. Plugins must now derive from broccoli-plugin. https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md");
+    }
   }));
 });


### PR DESCRIPTION
This fixes the current `beta` branch failure (the `EMBER_CLI_BROCCOLI_2=false` build).