### PR TITLE
Ignore node modules for eslint

### DIFF
--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -8,6 +8,7 @@
 
 # dependencies
 /bower_components/
+/node_modules/
 
 # misc
 /coverage/

--- a/blueprints/module-unification-app/files/.eslintignore
+++ b/blueprints/module-unification-app/files/.eslintignore
@@ -8,6 +8,7 @@
 
 # dependencies
 /bower_components/
+/node_modules/
 
 # misc
 /coverage/


### PR DESCRIPTION
Since https://github.com/ember-cli/ember-cli/pull/8117 I had an issue where files in `/node_modules/.bin/` were linted - which is obviously incorrect. ESlint (https://eslint.org/docs/user-guide/configuring#eslintignore) states that node and bower modules are excluded by default (which would make the `bower_components` obsolete as well), however I think that this new ignore rule (`!.*`) overwrites that.