### PR TITLE
Treat eslint config as node file

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',<% if (blueprint !== 'app') { %>
         'index.js',<% } %>

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/tests/fixtures/app/npm/.eslintrc.js
+++ b/tests/fixtures/app/npm/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'testem.js',

--- a/tests/fixtures/app/yarn/.eslintrc.js
+++ b/tests/fixtures/app/yarn/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'testem.js',

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/tests/fixtures/module-unification-app/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/npm/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',

--- a/tests/fixtures/module-unification-app/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/yarn/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',


### PR DESCRIPTION
Since #8117 the eslint config will be linted as well. We need to treat it as a node file per default.