### PR TITLE
Fix MU addon styles

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -700,6 +700,7 @@ class EmberApp {
         let tree = addon.treeFor(type);
         if (tree && !mergeTrees.isEmptyTree(tree)) {
           sum.push({
+            addon,
             name: addon.name,
             tree,
             root: addon.root,
@@ -1078,7 +1079,24 @@ class EmberApp {
     if (this.trees.styles) {
       styles.push(this.trees.styles);
     }
-    let addons = this.addonTreesFor('styles');
+    let addons = this._addonTreesFor('styles').map(a => {
+      const name = a.addon.moduleName();
+
+      const addonStyles = new Funnel(a.tree, {
+        allowEmpty: true,
+        srcDir: a.addon.treePaths.styles,
+        destDir: '.',
+      });
+
+      const customStyles = new Funnel(a.tree, {
+        exclude: [a.addon.treePaths.styles],
+        destDir: '.',
+      });
+
+      return mergeTrees([addonStyles, customStyles], {
+        annotation: `Addon#treeForStyles (${name})`,
+      });
+    });
     styles = styles.concat(addons);
     let mergedAddonStyles = mergeTrees(styles, {
       overwrite: true,

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1074,19 +1074,20 @@ class EmberApp {
    * @return {BroccoliTree}
   */
   getStyles() {
-    let styles;
+    let styles = [];
     if (this.trees.styles) {
-      styles = new Funnel(this.trees.styles, {
-        srcDir: '/',
-        destDir: '/app/styles',
-        annotation: 'Funnel (styles)',
-      });
+      styles.push(this.trees.styles);
     }
     let addons = this.addonTreesFor('styles');
-
-    return mergeTrees(addons.concat(styles), {
+    styles = styles.concat(addons);
+    let mergedAddonStyles = mergeTrees(styles, {
       overwrite: true,
-      annotation: 'Styles',
+      annotation: 'Addon Styles',
+    });
+
+    return new Funnel(mergedAddonStyles, {
+      allowEmpty: true,
+      destDir: isExperimentEnabled('MODULE_UNIFICATION') ? 'src/ui/styles' : `app/styles`,
     });
   }
 

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -943,26 +943,7 @@ let addonProto = {
     @return {Tree} The return tree has the same contents as the input tree, but is moved so that the `app/styles/` path is preserved.
   */
   treeForStyles(tree) {
-    if (!tree) {
-      return tree;
-    }
-
-    const name = this.moduleName();
-
-    const addonStyles = new Funnel(tree, {
-      allowEmpty: true,
-      srcDir: this.treePaths.styles,
-      destDir: '.',
-    });
-
-    const customStyles = new Funnel(tree, {
-      exclude: [this.treePaths.styles],
-      destDir: '.',
-    });
-
-    return mergeTrees([addonStyles, customStyles], {
-      annotation: `Addon#treeForStyles (${name})`,
-    });
+    return tree;
   },
 
   /**

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -298,6 +298,10 @@ let addonProto = {
       public: 'public',
     };
 
+    if (this.isModuleUnification()) {
+      this.treePaths.styles = 'src/ui/styles';
+    }
+
     this.treeForMethods = defaultsDeep({}, DEFAULT_TREE_FOR_METHODS);
 
     if (this.parent) {
@@ -943,9 +947,21 @@ let addonProto = {
       return tree;
     }
 
-    return new Funnel(tree, {
-      destDir: 'app/styles',
-      annotation: `Addon#treeForStyles (${this.name})`,
+    const name = this.moduleName();
+
+    const addonStyles = new Funnel(tree, {
+      allowEmpty: true,
+      srcDir: this.treePaths.styles,
+      destDir: '.',
+    });
+
+    const customStyles = new Funnel(tree, {
+      exclude: [this.treePaths.styles],
+      destDir: '.',
+    });
+
+    return mergeTrees([addonStyles, customStyles], {
+      annotation: `Addon#treeForStyles (${name})`,
     });
   },
 

--- a/tests/fixtures/addon/with-mu-styles/package.json
+++ b/tests/fixtures/addon/with-mu-styles/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+    "something-else": "latest"
+  },
+  "ember-addon": {
+    "paths": ["./lib/ember-super-button"]
+  },
+    "devDependencies": {
+    "ember-resolver": "^5.0.1",
+    "ember-cli": "latest",
+    "ember-random-addon": "latest",
+    "ember-non-root-addon": "latest",
+    "ember-generated-with-export-addon": "latest",
+    "non-ember-thingy": "latest",
+    "ember-before-blueprint-addon": "latest",
+    "ember-after-blueprint-addon": "latest",
+    "ember-devDeps-addon": "latest",
+    "ember-addon-with-dependencies": "latest"
+  }
+}

--- a/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
+++ b/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
@@ -1,0 +1,1 @@
+/* app/styles/foo-bar.css contents */

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -17,6 +17,28 @@ const mergeTrees = require('../../../lib/broccoli/merge-trees');
 const BroccoliMergeTrees = require('broccoli-merge-trees');
 
 let EmberApp = require('../../../lib/broccoli/ember-app');
+const Addon = require('../../../lib/models/addon');
+
+
+function createAddon({ name, app, project, styles, isMu }) {
+  const AddonFoo = Addon.extend({
+    root: name,
+    name,
+    isModuleUnification() {
+      return isMu;
+    },
+    _treeFor(name) {
+      let treeForMethod = this.treeForMethods[name];
+      let tree = styles.path();
+      if (this[treeForMethod]) {
+        tree = this[treeForMethod](tree);
+      }
+      return tree;
+    },
+  });
+  return new AddonFoo(app, project);
+}
+
 
 function mockTemplateRegistry(app) {
   let oldLoad = app.registry.load;
@@ -34,6 +56,7 @@ function mockTemplateRegistry(app) {
 
 describe('EmberApp', function() {
   let project, projectPath, app, addon;
+  this.timeout(200000);
 
   function setupProject(rootPath) {
     const packageContents = require(path.join(rootPath, 'package.json'));
@@ -165,7 +188,7 @@ describe('EmberApp', function() {
 
         let outputFiles = output.read();
 
-        expect(outputFiles).to.deep.equal({
+        const result = {
           'addon-tree-output': {},
           fake: {
             dist: {
@@ -190,7 +213,18 @@ describe('EmberApp', function() {
           vendor: {
             '.gitkeep': '',
           },
-        });
+        };
+        if (isExperimentEnabled('MODULE_UNIFICATION')) {
+          result.src = {
+            ui: {
+              styles: {
+                'app.css': '// css styles',
+              },
+            },
+          };
+          delete result.app;
+        }
+        expect(outputFiles).to.deep.equal(result);
       }));
 
       it('prints a warning if `package` is not a function and falls back to default packaging', co.wrap(function *() {
@@ -265,9 +299,6 @@ describe('EmberApp', function() {
   describe('getStyles()', function() {
     it('can handle empty styles folders', co.wrap(function *() {
       let appStyles = yield createTempDir();
-      appStyles.write({
-        'app.css': '// css styles',
-      });
 
       let app = new EmberApp({
         project,
@@ -276,27 +307,30 @@ describe('EmberApp', function() {
         },
       });
 
-      app.addonTreesFor = () => [];
-
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        app: {
-          styles: {
-            'app.css': '// css styles',
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {},
           },
-        },
-      });
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {},
+          },
+        });
+      }
 
       yield output.dispose();
     }));
 
-    it('returns add-ons styles files', co.wrap(function *() {
+    it('flattens `app/styles` folder from add-ons', co.wrap(function *() {
       let addonFooStyles = yield createTempDir();
-      let addonBarStyles = yield createTempDir();
 
-      // `ember-basic-dropdown`
+      // `ember-cli-tailwind`
       addonFooStyles.write({
         app: {
           styles: {
@@ -304,6 +338,62 @@ describe('EmberApp', function() {
           },
         },
       });
+
+      let app = new EmberApp({
+        project,
+      });
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      app.project.addons.push(addonFoo);
+
+      let output = yield buildOutput(app.getStyles());
+      let outputFiles = output.read();
+
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        });
+      }
+
+      yield output.dispose();
+    }));
+
+    it('returns add-ons styles files', co.wrap(function *() {
+      let addonFooStyles = yield createTempDir();
+      let addonBarStyles = yield createTempDir();
+      let addonMUStyles = yield createTempDir();
+
+      // `ember-basic-dropdown`
+      addonFooStyles.write({
+        'bar.css': 'bar',
+        app: {
+          styles: {
+            'foo.css': 'foo',
+          },
+        },
+      });
+
+      addonMUStyles.write({
+        src: {
+          ui: {
+            styles: {
+              'foo.css': 'foo',
+            },
+          },
+        },
+      });
+
       // `ember-bootstrap`
       addonBarStyles.write({
         baztrap: {
@@ -314,42 +404,74 @@ describe('EmberApp', function() {
       let app = new EmberApp({
         project,
       });
-      app.addonTreesFor = function() {
-        return [
-          addonFooStyles.path(),
-          addonBarStyles.path(),
-        ];
+
+      const oldMuFn = project.isModuleUnification;
+      project.isModuleUnification = function() {
+        return true;
       };
+
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      let addonBar = createAddon({ name: 'bar', app, project, styles: addonBarStyles });
+      let addonMu = createAddon({ name: 'mu', app, project, styles: addonMUStyles, isMu: true });
+      app.project.addons.push(addonFoo, addonBar, addonMu);
 
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        app: {
-          styles: {
-            'foo.css': 'foo',
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: {
+            styles: {
+              'foo.css': 'foo',
+              'bar.css': 'bar',
+              "baztrap": {
+                "baztrap.css": "// baztrap.css",
+              },
+            },
           },
-        },
-        baztrap: {
-          'baztrap.css': '// baztrap.css',
-        },
-      });
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {
+              'foo.css': 'foo',
+              'bar.css': 'bar',
+              "baztrap": {
+                "baztrap.css": "// baztrap.css",
+              },
+            },
+          },
+        });
+      }
 
       yield addonFooStyles.dispose();
       yield addonBarStyles.dispose();
       yield output.dispose();
+      project.isModuleUnification = oldMuFn;
     }));
 
     it('does not fail if add-ons do not export styles', co.wrap(function *() {
       let app = new EmberApp({
         project,
       });
-      app.addonTreesFor = () => [];
+      let addonFooStyles = yield createTempDir();
+      let addonFoo = createAddon({ name: 'foo', app, project, styles: addonFooStyles });
+      app.project.addons.push(addonFoo);
 
       let output = yield buildOutput(app.getStyles());
       let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({});
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        expect(outputFiles['src']).to.deep.equal({
+          ui: { styles: { } },
+        });
+      } else {
+        expect(outputFiles).to.deep.equal({
+          app: {
+            styles: {},
+          },
+        });
+      }
 
       yield output.dispose();
     }));


### PR DESCRIPTION
Before , addon stlyes where taken from /app/styles and merged into <appname>/app/styles, instead of src/ui/styles in case of module unification.
Changed Funnel to change destination to src/ui/styles for MU.

Closes #8133 