### PR TITLE
lint dummy node files slightly differently

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -48,6 +48,17 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })<% } %>
-    }
+    }<% if (blueprint !== 'app') { %>,
+
+    // dummy node files
+    {
+      files: [
+        'ember-cli-build.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      rules: {
+        'node/no-unpublished-require': 'off'
+      }
+    }<% } %>
   ]
 };

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -44,6 +44,17 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // dummy node files
+    {
+      files: [
+        'ember-cli-build.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      rules: {
+        'node/no-unpublished-require': 'off'
+      }
     }
   ]
 };

--- a/tests/fixtures/addon/npm/.eslintrc.js
+++ b/tests/fixtures/addon/npm/.eslintrc.js
@@ -47,6 +47,17 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // dummy node files
+    {
+      files: [
+        'ember-cli-build.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      rules: {
+        'node/no-unpublished-require': 'off'
+      }
     }
   ]
 };

--- a/tests/fixtures/addon/yarn/.eslintrc.js
+++ b/tests/fixtures/addon/yarn/.eslintrc.js
@@ -47,6 +47,17 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // dummy node files
+    {
+      files: [
+        'ember-cli-build.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      rules: {
+        'node/no-unpublished-require': 'off'
+      }
     }
   ]
 };

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -45,6 +45,17 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    // dummy node files
+    {
+      files: [
+        'ember-cli-build.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      rules: {
+        'node/no-unpublished-require': 'off'
+      }
     }
   ]
 };


### PR DESCRIPTION
A single override for node files seems like not enough. We really have two groups of node files, those that are published on npm, and those that are not. For those that are not, it is OK to require modules that are only dev dependencies. This creates a second override which turns that rule off.