### PR TITLE
fix: clean up readme noise

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -4,21 +4,19 @@
 [Short description of the addon.]
 
 Installation
-------------------------------------------------------------------------------
+------------
 
-```
+```sh
 ember install <%= addonName %>
 ```
 
-
 Usage
-------------------------------------------------------------------------------
+-----
 
 [Longer description of how to use the addon in apps.]
 
-
 Contributing
-------------------------------------------------------------------------------
+------------
 
 ### Installation
 
@@ -46,6 +44,6 @@ Contributing
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
 
 License
-------------------------------------------------------------------------------
+-------
 
 This project is licensed under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Basically a new README is very noisy and distracting. I left the addon name line long since it could be a varied length, and programmatically making that line is more effort for sure.

Also added syntax highlighting to the install command