### PR TITLE
Changes dummy app's detection and `project.isModuleUnification()`

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -224,7 +224,7 @@ class Project {
   }
 
   isDummyApp() {
-    return this.has('dummy');
+    return this.root.includes('/dummy');
   }
 
   /**

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -223,6 +223,10 @@ class Project {
     }
   }
 
+  isDummyApp() {
+    return this.has('dummy');
+  }
+
   /**
     Returns the path to the configuration.
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -557,24 +557,105 @@ describe('models/project.js', function() {
 
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     describe('isModuleUnification', function() {
+      describe('is app/addon', function() {
+        beforeEach(function() {
+          projectPath = `${process.cwd()}/tmp/test-app`;
+
+          makeProject();
+        });
+
+        it('returns false when `./src` does not exist', function() {
+          expect(project.isModuleUnification()).to.equal(false);
+        });
+
+        it('returns true when `./src` exists', function() {
+          let srcPath = path.join(projectPath, 'src');
+          fs.ensureDirSync(srcPath);
+
+          expect(project.isModuleUnification()).to.equal(true);
+        });
+      });
+
+      describe('is dummy app', function() {
+        let dummyPath;
+
+        beforeEach(function() {
+          dummyPath = `${process.cwd()}/tmp/test-app/tests/dummy`;
+        });
+
+        describe('is a module unification dummy app', function() {
+          beforeEach(function() {
+            projectPath = `${dummyPath}/mu-app`;
+
+            makeProject();
+            let srcPath = path.join(projectPath, 'src');
+            fs.ensureDirSync(srcPath);
+          });
+
+          it('is a Module Unification app', function() {
+            expect(project.isModuleUnification()).to.equal(true);
+          });
+        });
+
+        describe('is a classic dummy app', function() {
+          beforeEach(function() {
+            projectPath = `${dummyPath}/classic-app`;
+
+            makeProject();
+          });
+
+          it('is not a Module Unification app', function() {
+            expect(project.isModuleUnification()).to.equal(false);
+          });
+        });
+      });
+    });
+  }
+
+  describe('isDummyApp', function() {
+    let appPath, dummyPath;
+
+    beforeEach(function() {
+      appPath = `${process.cwd()}/tmp/test-app`;
+      dummyPath = `${appPath}/tests/dummy`;
+    });
+
+    describe('a real app', function() {
       beforeEach(function() {
-        projectPath = `${process.cwd()}/tmp/test-app`;
+        projectPath = `${appPath}`;
 
         makeProject();
       });
 
-      it('returns false when `./src` does not exist', function() {
-        expect(project.isModuleUnification()).to.equal(false);
-      });
-
-      it('returns true when `./src` exists', function() {
-        let srcPath = path.join(projectPath, 'src');
-        fs.ensureDirSync(srcPath);
-
-        expect(project.isModuleUnification()).to.equal(true);
+      it('is not a dummy app', function() {
+        expect(project.isDummyApp()).to.equal(true);
       });
     });
-  }
+
+    describe('a dummy app', function() {
+      beforeEach(function() {
+        projectPath = `${dummyPath}`;
+
+        makeProject();
+      });
+
+      it('is a dummy app', function() {
+        expect(project.isDummyApp()).to.equal(true);
+      });
+    });
+
+    describe('a nested dummy app', function() {
+      beforeEach(function() {
+        projectPath = `${dummyPath}/dummy-app-scenario-one`;
+
+        makeProject();
+      });
+
+      it('is a dummy app', function() {
+        expect(project.isDummyApp()).to.equal(true);
+      });
+    });
+  });
 
   describe('findAddonByName', function() {
     beforeEach(function() {

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -564,48 +564,140 @@ describe('models/project.js', function() {
           makeProject();
         });
 
-        it('returns false when `./src` does not exist', function() {
-          expect(project.isModuleUnification()).to.equal(false);
-        });
-
-        it('returns true when `./src` exists', function() {
-          let srcPath = path.join(projectPath, 'src');
-          fs.ensureDirSync(srcPath);
-
-          expect(project.isModuleUnification()).to.equal(true);
-        });
-      });
-
-      describe('is dummy app', function() {
-        let dummyPath;
-
-        beforeEach(function() {
-          dummyPath = `${process.cwd()}/tmp/test-app/tests/dummy`;
-        });
-
-        describe('is a module unification dummy app', function() {
+        describe('is a module unification app/addon', function() {
           beforeEach(function() {
-            projectPath = `${dummyPath}/mu-app`;
-
-            makeProject();
             let srcPath = path.join(projectPath, 'src');
             fs.ensureDirSync(srcPath);
           });
 
-          it('is a Module Unification app', function() {
+          it('returns true', function() {
             expect(project.isModuleUnification()).to.equal(true);
+          });
+
+          describe('dummy apps', function() {
+            let dummyPath;
+
+            beforeEach(function() {
+              dummyPath = `${process.cwd()}/tmp/test-app/tests/dummy`;
+            });
+
+            describe('a classic dummy app', function() {
+              beforeEach(function() {
+                projectPath = dummyPath;
+
+                makeProject();
+              });
+
+              it('returns false', function() {
+                expect(project.isModuleUnification()).to.equal(false);
+              });
+            });
+
+            describe('a module unification dummy app', function() {
+              beforeEach(function() {
+                projectPath = dummyPath;
+
+                makeProject();
+                let srcPath = path.join(projectPath, 'src');
+                fs.ensureDirSync(srcPath);
+              });
+
+              it('returns true', function() {
+                expect(project.isModuleUnification()).to.equal(true);
+              });
+            });
+
+            describe('a nested classic dummy app', function() {
+              beforeEach(function() {
+                projectPath = `${dummyPath}/classic-app`;
+
+                makeProject();
+              });
+
+              it('returns false', function() {
+                expect(project.isModuleUnification()).to.equal(false);
+              });
+            });
+
+            describe('a nested module unification dummy app', function() {
+              beforeEach(function() {
+                projectPath = `${dummyPath}/mu-app`;
+
+                makeProject();
+                let srcPath = path.join(projectPath, 'src');
+                fs.ensureDirSync(srcPath);
+              });
+
+              it('returns true', function() {
+                expect(project.isModuleUnification()).to.equal(true);
+              });
+            });
           });
         });
 
-        describe('is a classic dummy app', function() {
-          beforeEach(function() {
-            projectPath = `${dummyPath}/classic-app`;
-
-            makeProject();
+        describe('is a classic app/addon', function() {
+          it('returns false', function() {
+            expect(project.isModuleUnification()).to.equal(false);
           });
 
-          it('is not a Module Unification app', function() {
-            expect(project.isModuleUnification()).to.equal(false);
+          describe('dummy apps', function() {
+            let dummyPath;
+
+            beforeEach(function() {
+              dummyPath = `${process.cwd()}/tmp/test-app/tests/dummy`;
+            });
+
+            describe('a classic dummy app', function() {
+              beforeEach(function() {
+                projectPath = dummyPath;
+
+                makeProject();
+              });
+
+              it('returns false', function() {
+                expect(project.isModuleUnification()).to.equal(false);
+              });
+            });
+
+            describe('a module unification dummy app', function() {
+              beforeEach(function() {
+                projectPath = dummyPath;
+
+                makeProject();
+                let srcPath = path.join(projectPath, 'src');
+                fs.ensureDirSync(srcPath);
+              });
+
+              it('returns true', function() {
+                expect(project.isModuleUnification()).to.equal(true);
+              });
+            });
+
+            describe('a nested classic dummy app', function() {
+              beforeEach(function() {
+                projectPath = `${dummyPath}/classic-app`;
+
+                makeProject();
+              });
+
+              it('returns false', function() {
+                expect(project.isModuleUnification()).to.equal(false);
+              });
+            });
+
+            describe('a nested module unification dummy app', function() {
+              beforeEach(function() {
+                projectPath = `${dummyPath}/mu-app`;
+
+                makeProject();
+                let srcPath = path.join(projectPath, 'src');
+                fs.ensureDirSync(srcPath);
+              });
+
+              it('returns true', function() {
+                expect(project.isModuleUnification()).to.equal(true);
+              });
+            });
           });
         });
       });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -628,7 +628,7 @@ describe('models/project.js', function() {
       });
 
       it('is not a dummy app', function() {
-        expect(project.isDummyApp()).to.equal(true);
+        expect(project.isDummyApp()).to.equal(false);
       });
     });
 


### PR DESCRIPTION
from the quest issue: https://github.com/emberjs/ember.js/issues/16373

specifically, this partially covers:
 -  Fix lib/models/project.js's isModuleUnification method to not only rely on presence of top level src as "the project is module unification format". Specifically, an addon may be in module unification format, but have its dummy app be in classic format.
 - Ember CLI uses the presence of src/ to configure the return value of isModuleUnification(). This works well for apps and addons. The detection fails for a classic dummy app in a module unification addon, however. Although a dummy app may be in tests/dummy/app/ with no tests/dummy/src/ directory, the addon's root level src/ confuses our logic and the dummy app is incorrectly treated as a module unification app.

proposed scheme for multiple dummy apps:

 - \<root\>/
   - tests/
     - dummy/
        - {app-name1}
           - a classic app
        - {app-name2}
           - a mu app