### PR TITLE
remove unused "ember-default" scenario

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -60,12 +60,6 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-default',
-          npm: {
-            devDependencies: {}
-          }
-        },
-        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -59,12 +59,6 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-default',
-          npm: {
-            devDependencies: {}
-          }
-        },
-        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -60,12 +60,6 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-default',
-          npm: {
-            devDependencies: {}
-          }
-        },
-        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({


### PR DESCRIPTION
This scenario was replaced with just `npm test` once we adopted Travis stages. It no longer shows up in the .travis.yml.