### PR TITLE
variables `test` and `hinting` are expected to be boolean not string.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -185,7 +185,7 @@ class EmberApp {
     @param {Object} options
   */
   _initTestsAndHinting(options) {
-    let testsEnabledDefault = process.env.EMBER_CLI_TEST_COMMAND || !this.isProduction;
+    let testsEnabledDefault = process.env.EMBER_CLI_TEST_COMMAND === 'true' || !this.isProduction;
 
     this.tests = 'tests' in options ? options.tests : testsEnabledDefault;
     this.hinting = 'hinting' in options ? options.hinting : testsEnabledDefault;

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -373,7 +373,7 @@ let addonProto = {
    */
   hintingEnabled() {
     let isProduction = process.env.EMBER_ENV === 'production';
-    let testsEnabledDefault = process.env.EMBER_CLI_TEST_COMMAND || !isProduction;
+    let testsEnabledDefault = process.env.EMBER_CLI_TEST_COMMAND === 'true' || !isProduction;
     let explicitlyDisabled = this.app && this.app.options && this.app.options.hinting === false;
 
     return testsEnabledDefault && !explicitlyDisabled;


### PR DESCRIPTION
variables `test` and `hinting` are read from `env` variable, which is of type `string`. 
This PR will check if those variable exist and then convert it to boolean (using JSON.prase).
We can use Boolean(x) for conversion. Please suggest if you have a better method. 