### PR TITLE
[docs] Fix links in Addon API docs header

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -142,7 +142,7 @@ function warn(message) {
   - {{#crossLink "Addon/config:method"}}{{/crossLink}}
   - {{#crossLink "Addon/blueprintsPath:method"}}{{/crossLink}}
   - {{#crossLink "Addon/includedCommands:method"}}{{/crossLink}}
-  - {{#crossLink "Addon/importTransforms:method"}}
+  - {{#crossLink "Addon/importTransforms:method"}}{{/crossLink}}
   - {{#crossLink "Addon/serverMiddleware:method"}}{{/crossLink}}
   - {{#crossLink "Addon/testemMiddleware:method"}}{{/crossLink}}
   - {{#crossLink "Addon/postBuild:method"}}{{/crossLink}}


### PR DESCRIPTION
The crosslinks for addon hooks in the header on https://ember-cli.com/api/classes/Addon.html are currently broken because of a missing closing mustache.