### PR TITLE
Do not watch `tests` directory when tests are disabled

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -260,7 +260,7 @@ class EmberApp {
     let appTree = buildTreeFor('app', trees.app);
 
     let testsPath = typeof trees.tests === 'string' ? resolvePathFor('tests', trees.tests) : null;
-    let testsTree = buildTreeFor('tests', trees.tests);
+    let testsTree = buildTreeFor('tests', trees.tests, options.tests);
 
     // these are contained within app/ no need to watch again
     // (we should probably have the builder or the watcher dedup though)

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -8,6 +8,7 @@ const Project = require('../../../lib/models/project');
 const expect = require('chai').expect;
 const td = require('testdouble');
 const broccoliTestHelper = require('broccoli-test-helper');
+const { WatchedDir, UnwatchedDir } = require('broccoli-source');
 
 const buildOutput = broccoliTestHelper.buildOutput;
 const createTempDir = broccoliTestHelper.createTempDir;
@@ -1455,6 +1456,31 @@ describe('EmberApp', function() {
     expect(() => {
       app.import('vendor/b/c/foo.js', { type: 'javascript' });
     }).to.throw(/You must pass either `vendor` or `test` for options.type in your call to `app.import` for file: foo.js/);
+  });
+
+  describe('_initOptions', function() {
+    it('sets the tests directory as watched when tests are enabled', function() {
+      let app = new EmberApp({
+        project,
+      });
+
+      app._initOptions({
+        tests: true,
+      });
+
+      expect(app.options.trees.tests).to.be.an.instanceOf(WatchedDir);
+    });
+    it('sets the tests directory as unwatched when tests are disabled', function() {
+      let app = new EmberApp({
+        project,
+      });
+
+      app._initOptions({
+        tests: false,
+      });
+
+      expect(app.options.trees.tests).to.be.an.instanceOf(UnwatchedDir);
+    });
   });
 
   describe('_resolveLocal', function() {


### PR DESCRIPTION
Fixes #8173.

This is useful when e.g. disabling tests in development mode (per recommendation in [this article](https://dev.to/gokatz/how-we-cut-down-our-ember-build-time-ehh)) to prevent the `ember serve` process from triggering a rebuild when test files are changed.

This is a minimal approach to resolving this issue. Another potential option would be to not include the `tests` tree at all when tests are disabled, but I was unsure about the downstream implications of making that change.