### PR TITLE
Add documentation for various properties on `Addon`

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -175,7 +175,7 @@ let addonProto = {
   */
 
   /**
-    The root directory where this addon is located.
+    The absolute path of the root directory where this addon is located.
 
     @public
     @final
@@ -187,8 +187,8 @@ let addonProto = {
     The host app instance.
 
     **Note**: this property will only be present on addons that are a direct dependency
-    of the application itself, not of other addons. It is also only available after the
-    base `included()` hook has been run.
+    of the application itself, not of other addons. It is also not available in `init()`,
+    but will be set before `setupPreprocessorRegistry()` and `included()` are invoked.
 
     @public
     @final
@@ -220,6 +220,9 @@ let addonProto = {
 
   /**
     The set of addons that this addon itself depends on.
+
+    This array is populated from the addon's listed `dependencies` and any items in
+    `ember-addon.paths` in its `package.json`.
 
     @public
     @final

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -165,6 +165,86 @@ function warn(message) {
   @param {Project} project The current project (deprecated)
 */
 let addonProto = {
+  /**
+    The name of this addon.
+
+    @public
+    @final
+    @type String
+    @property name
+  */
+
+  /**
+    The root directory where this addon is located.
+
+    @public
+    @final
+    @type String
+    @property root
+  */
+
+  /**
+    The host app instance.
+
+    **Note**: this property will only be present on addons that are a direct dependency
+    of the application itself, not of other addons. It is also only available after the
+    base `included()` hook has been run.
+
+    @public
+    @final
+    @type EmberApp
+    @property app
+  */
+
+  /**
+    The root {{#crossLink "Project"}}project{{/crossLink}} to which this addon belongs.
+
+    @public
+    @final
+    @type Project
+    @property project
+  */
+
+  /**
+    This addon's parent.
+
+    If the addon is a direct dependency of an application, then `parent` will be the
+    corresponding {{#crossLink "Project"}}project{{/crossLink}} instance. If it's a
+    dependency of another addon, then `parent` will be a reference to that addon.
+
+    @public
+    @final
+    @type Project|Addon
+    @property parent
+  */
+
+  /**
+    The set of addons that this addon itself depends on.
+
+    @public
+    @final
+    @type Addon[]
+    @property addons
+  */
+
+  /**
+    A [`console-ui`](https://github.com/ember-cli/console-ui) object that can be used
+    to log messages for the user and indicate progress on long-running operations.
+
+    @public
+    @final
+    @type UI
+    @property ui
+  */
+
+  /**
+    The contents of the addon's `package.json`.
+
+    @public
+    @final
+    @type Object
+    @property pkg
+  */
 
   /**
   Initializes the addon.  If you override this method make sure and call `this._super.init && this._super.init.apply(this, arguments);` or your addon will not work.


### PR DESCRIPTION
This PR adds YUIDoc comments for a handful of properties on the `Addon` class. I've aimed to stick with the style of existing doc comments, though I don't know if there's a preference for having these be free-floating or trying to position them in the code near where the properties are assigned.

For each property below, I've included a note about why I added it and a link to a rough code search for usage of that property on EmberObserver. If it turns out there's disagreement over whether some of these things should be public, or over the contents of the documentation, I'm happy to make changes.

I have a few other additions lined up on other classes, but wanted to get a start here before filing the rest all at once.

- `name`: seems noncontroversial ([code-search](https://emberobserver.com/code-search?codeQuery=addon.name&sort=score&sortAscending=false))
- `root`: frequently accessed by addons locating themselves or other addons on disk, and also a nice parallel with `Project#root` when dealing with `this.parent` on an addon ([code-search](https://emberobserver.com/code-search?codeQuery=(this%7Caddon)%5C.root%5Cb&regex=true&sort=score&sortAscending=false))
- `app`: kind of a foot gun since it isn't always present, but very widely used ([code-search](https://emberobserver.com/code-search?codeQuery=this%5C.app%5Cb&regex=true&sort=score&sortAscending=false))
- `project`: generally useful, widely used ([code-search](https://emberobserver.com/code-search?codeQuery=this.project&sort=score&sortAscending=false))
- `parent`: frequently misunderstood (since it's not necessarily the same as the object passed to `included()`), but very widely (ab)used ([code-search](https://emberobserver.com/code-search?codeQuery=this.parent&sort=score&sortAscending=false), though a bit tricky to avoid false positives)
- `addons`: useful for dependency traversal, and actually part of [ember-cli-babel's README](https://github.com/babel/ember-cli-babel#transpiletree-usage) ([code-search](https://emberobserver.com/code-search?codeQuery=(this%7Caddon)%5C.addons&regex=true&sort=score&sortAscending=false))
- `ui`: seems noncontroversial ([code-search](https://emberobserver.com/code-search?codeQuery=this.ui&sort=score&sortAscending=false))
- `pkg`: frequently used by addons with their own plugin ecosystems to check package keywords without having to read and parse addons' `package.json` themselves ([code-search](https://emberobserver.com/code-search?codeQuery=(this%7Caddon)%5C.pkg&regex=true&sort=score&sortAscending=false))