### PR TITLE
Do not include `.jshintrc` and `.eslintrc` when generating `lib` or `packages`

### DIFF
--- a/blueprints/lib/files/lib/.eslintrc.js
+++ b/blueprints/lib/files/lib/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  env: {
-    node: true,
-    browser: false
-  }
-};

--- a/blueprints/lib/files/lib/.jshintrc
+++ b/blueprints/lib/files/lib/.jshintrc
@@ -1,4 +1,0 @@
-{
-  "node": true,
-  "browser": false
-}

--- a/blueprints/lib/index.js
+++ b/blueprints/lib/index.js
@@ -8,17 +8,7 @@ module.exports = {
   normalizeEntityName(name) { return name; },
 
   beforeInstall() {
-    // make sure to create `lib` directory even if .jshintrc is not created
+    // make sure to create `lib` directory
     fs.mkdirsSync('lib');
-  },
-
-  files() {
-    return [this.hasJSHint() ? 'lib/.jshintrc' : 'lib/.eslintrc.js'];
-  },
-
-  hasJSHint() {
-    if (this.project) {
-      return 'ember-cli-jshint' in this.project.dependencies();
-    }
   },
 };

--- a/blueprints/packages/files/packages/.eslintrc.js
+++ b/blueprints/packages/files/packages/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  env: {
-    node: true,
-    browser: false
-  }
-};

--- a/blueprints/packages/files/packages/.jshintrc
+++ b/blueprints/packages/files/packages/.jshintrc
@@ -1,4 +1,0 @@
-{
-  "node": true,
-  "browser": false
-}

--- a/blueprints/packages/index.js
+++ b/blueprints/packages/index.js
@@ -8,17 +8,7 @@ module.exports = {
   normalizeEntityName(name) { return name; },
 
   beforeInstall() {
-    // make sure to create `packages` directory even if .jshintrc is not created
+    // make sure to create `packages` directory
     fs.mkdirsSync('packages');
-  },
-
-  files() {
-    return [this.hasJSHint() ? 'packages/.jshintrc' : 'packages/.eslintrc.js'];
-  },
-
-  hasJSHint() {
-    if (this.project) {
-      return 'ember-cli-jshint' in this.project.dependencies();
-    }
   },
 };

--- a/tests/unit/blueprints/lib-test.js
+++ b/tests/unit/blueprints/lib-test.js
@@ -21,6 +21,7 @@ describe('Acceptance: ember generate and destroy lib', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, file => {
         expect(dir('lib')).to.exist;
+        expect(file('lib/.eslintrc.js')).to.not.exist;
         expect(file('lib/.jshintrc')).to.not.exist;
       }));
   });
@@ -34,7 +35,7 @@ describe('Acceptance: ember generate and destroy lib', function() {
       ]))
       .then(() => emberGenerateDestroy(args, file => {
         expect(dir('lib')).to.exist;
-        expect(file('lib/.jshintrc')).to.exist;
+        expect(file('lib/.jshintrc')).to.not.exist;
       }));
   });
 });

--- a/tests/unit/blueprints/packages-test.js
+++ b/tests/unit/blueprints/packages-test.js
@@ -21,6 +21,7 @@ describe('Acceptance: ember generate and destroy packages', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, file => {
         expect(dir('packages')).to.exist;
+        expect(file('lib/.eslintrc.js')).to.not.exist;
         expect(file('packages/.jshintrc')).to.not.exist;
       }));
   });
@@ -34,7 +35,7 @@ describe('Acceptance: ember generate and destroy packages', function() {
       ]))
       .then(() => emberGenerateDestroy(args, file => {
         expect(dir('packages')).to.exist;
-        expect(file('packages/.jshintrc')).to.exist;
+        expect(file('packages/.jshintrc')).to.not.exist;
       }));
   });
 });


### PR DESCRIPTION
Requested by `MU Blueprints` #7530; requirements on this [discussion](https://github.com/ember-cli/ember-cli/pull/7783#discussion_r188061985).