### PR TITLE
Clarify error message around package/addon name mismatch

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -375,9 +375,9 @@ let addonProto = {
 
           throw new SilentError(
             'Your names in package.json and index.js should match. ' +
-            `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js.` +
-            'For more information about this workaround, see: https://github.com/ember-cli/ember-cli/pull/7950. ' +
-            'Until ember-cli v3.9, this error can be disabled by setting env variable EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH to "true"');
+            `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js. ` +
+            'Until ember-cli v3.9, this error can be disabled by setting env variable EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH to "true". ' +
+            'For more information about this workaround, see: https://github.com/ember-cli/ember-cli/pull/7950.');
         }
 
         return true;


### PR DESCRIPTION
This error message was originally introduced at #7950, but it provided no information (or links to information) about why this new constraint was introduced.

This is particularly important for handling common cases for ember addon packages that provide a different module namespace (i.e, the 'ember-lodash' or 'ember-fetch' cases)