### PR TITLE
Move contribution info away from README to CONTRIBUTING

### DIFF
--- a/blueprints/addon/files/CONTRIBUTING.md
+++ b/blueprints/addon/files/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd <%= addonName %>`
+* `<% if (yarn) { %>yarn<% } else { %>npm<% } %> install`
+
+## Linting
+
+* `<% if (yarn) { %>yarn lint:hbs<% } else { %>npm run lint:hbs<% } %>`
+* `<% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>`
+* `<% if (yarn) { %>yarn lint:js --fix<% } else { %>npm run lint:js -- --fix<% } %>`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -17,34 +17,6 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd <%= addonName %>`
-* `<% if (yarn) { %>yarn<% } else { %>npm<% } %> install`
-
-### Linting
-
-* `<% if (yarn) { %>yarn lint:hbs<% } else { %>npm run lint:hbs<% } %>`
-* `<% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>`
-* `<% if (yarn) { %>yarn lint:js --fix<% } else { %>npm run lint:js -- --fix<% } %>`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-
 License
 ------------------------------------------------------------------------------
 

--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -17,6 +17,7 @@
 /.watchmanconfig
 /bower.json
 /config/ember-try.js
+/CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
 /tests/

--- a/blueprints/module-unification-addon/files/CONTRIBUTING.md
+++ b/blueprints/module-unification-addon/files/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd <%= addonName %>`
+* `<% if (yarn) { %>yarn<% } else { %>npm<% } %> install`
+
+## Linting
+
+* `<% if (yarn) { %>yarn lint:hbs<% } else { %>npm run lint:hbs<% } %>`
+* `<% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>`
+* `<% if (yarn) { %>yarn lint:js --fix<% } else { %>npm run lint:js -- --fix<% } %>`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/blueprints/module-unification-addon/files/README.md
+++ b/blueprints/module-unification-addon/files/README.md
@@ -17,34 +17,6 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd <%= addonName %>`
-* `<% if (yarn) { %>yarn<% } else { %>npm<% } %> install`
-
-### Linting
-
-* `<% if (yarn) { %>yarn lint:hbs<% } else { %>npm run lint:hbs<% } %>`
-* `<% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>`
-* `<% if (yarn) { %>yarn lint:js --fix<% } else { %>npm run lint:js -- --fix<% } %>`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-
 License
 ------------------------------------------------------------------------------
 

--- a/blueprints/module-unification-addon/files/npmignore
+++ b/blueprints/module-unification-addon/files/npmignore
@@ -16,6 +16,7 @@
 /.travis.yml
 /bower.json
 /config/ember-try.js
+/CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
 /tests/

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -543,6 +543,7 @@ describe('Acceptance: ember new', function() {
           'tests/dummy/app/templates/application.hbs',
           '.travis.yml',
           'README.md',
+          'CONTRIBUTING.md',
           '.eslintrc.js',
         ].forEach(filePath => {
           expect(file(filePath))
@@ -569,6 +570,7 @@ describe('Acceptance: ember new', function() {
           'tests/dummy/app/templates/application.hbs',
           '.travis.yml',
           'README.md',
+          'CONTRIBUTING.md',
           '.eslintrc.js',
         ].forEach(filePath => {
           expect(file(filePath))

--- a/tests/fixtures/addon/npm/CONTRIBUTING.md
+++ b/tests/fixtures/addon/npm/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd foo`
+* `npm install`
+
+## Linting
+
+* `npm run lint:hbs`
+* `npm run lint:js`
+* `npm run lint:js -- --fix`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/tests/fixtures/addon/npm/README.md
+++ b/tests/fixtures/addon/npm/README.md
@@ -17,34 +17,6 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd foo`
-* `npm install`
-
-### Linting
-
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-
 License
 ------------------------------------------------------------------------------
 

--- a/tests/fixtures/addon/yarn/CONTRIBUTING.md
+++ b/tests/fixtures/addon/yarn/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd foo`
+* `yarn install`
+
+## Linting
+
+* `yarn lint:hbs`
+* `yarn lint:js`
+* `yarn lint:js --fix`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/tests/fixtures/addon/yarn/README.md
+++ b/tests/fixtures/addon/yarn/README.md
@@ -17,34 +17,6 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd foo`
-* `yarn install`
-
-### Linting
-
-* `yarn lint:hbs`
-* `yarn lint:js`
-* `yarn lint:js --fix`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-
 License
 ------------------------------------------------------------------------------
 

--- a/tests/fixtures/module-unification-addon/CONTRIBUTING.md
+++ b/tests/fixtures/module-unification-addon/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd foo`
+* `npm install`
+
+## Linting
+
+* `npm run lint:hbs`
+* `npm run lint:js`
+* `npm run lint:js -- --fix`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/tests/fixtures/module-unification-addon/README.md
+++ b/tests/fixtures/module-unification-addon/README.md
@@ -17,34 +17,6 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd foo`
-* `npm install`
-
-### Linting
-
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-
 License
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR moves information about how to contribute to an addon away from README.md to a new CONTRIBUTING.md. 

The README is a bit cluttered by default when generating a new addon and I think we would benefit a lot by encouraging addon developers to use a CONTRIBUTING.md by default. 

Let me know what you think.