### PR TITLE
run eslint-plugin-node on apps

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -69,9 +69,6 @@ module.exports = {
     // add `ember-disable-prototype-extensions` to addons by default
     contents.devDependencies['ember-disable-prototype-extensions'] = '^1.1.3';
 
-    // add `eslint-plugin-node` to addons by default
-    contents.devDependencies['eslint-plugin-node'] = '^8.0.1';
-
     // add ember-try
     contents.devDependencies['ember-try'] = '^1.0.0';
 

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -44,11 +44,15 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }<% if (blueprint !== 'app') { %>,
+      },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      })<% } %>
+        // add your custom rules and overrides for node files here<% if (blueprint === 'app') { %>
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'<% } %>
+      })
     }
   ]
 };

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -42,6 +42,7 @@
     "ember-source": "~3.10.0-beta.1<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -44,6 +44,10 @@ module.exports = {
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
       })
     }
   ]

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -36,7 +36,15 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
+      })
     }
   ]
 };

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -42,6 +42,7 @@
     "ember-source": "<%= emberCanaryVersion %><% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -36,7 +36,15 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
+      })
     }
   ]
 };

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -41,6 +41,7 @@
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.10.0-beta.1",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -42,6 +42,7 @@
     "ember-source": "~3.10.0-beta.1",
     "ember-welcome-page": "^4.0.0",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -44,6 +44,10 @@ module.exports = {
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
       })
     }
   ]

--- a/tests/fixtures/module-unification-app/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/.eslintrc.js
@@ -36,7 +36,15 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
+      })
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -41,6 +41,7 @@
     "ember-resolver": "^5.0.1",
     "ember-source": "<%= emberCanaryVersion %>",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -42,6 +42,7 @@
     "ember-source": "<%= emberCanaryVersion %>",
     "ember-welcome-page": "^4.0.0",
     "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.4"
   },

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -82,8 +82,7 @@ describe('blueprint - addon', function() {
   "devDependencies": {\n\
     "ember-disable-prototype-extensions": "^1.1.3",\n\
     "ember-source-channel-url": "^1.1.0",\n\
-    "ember-try": "^1.0.0",\n\
-    "eslint-plugin-node": "^8.0.1"\n\
+    "ember-try": "^1.0.0"\n\
   },\n\
   "ember-addon": {\n\
     "configPath": "tests/dummy/config"\n\


### PR DESCRIPTION
I'm finding that it is pretty useful to run eslint-plugin-node on apps, even though the code is unpublished. You get the nice rules that prevent running newer node code and relying on transient deps. Especially if your code is ember-cli-deploy code that doesn't always run with your test suite.