### PR TITLE
TravisCI: Remove deprecated `sudo` mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-sudo: false
-dist: trusty
-
-addons:
-  chrome: stable
-
 language: node_js
 node_js:
   - "10"
+
+addons:
+  chrome: stable
 
 branches:
   only:


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration