### PR TITLE
[Bugfix release] Addon name mismatch should be a warning

### DIFF
--- a/ADDON-NAME-MIGRATION.md
+++ b/ADDON-NAME-MIGRATION.md
@@ -1,0 +1,11 @@
+# Addon Name Migration
+
+Prior to 3.5.1 of ember-cli we would allow the name of the addon; specified in the index.js, and the name in the package.json to differ. We would like to canonicalize the name so they are the same. While we feel that this divergence is uncommon, addons that did not have a canonicalized name would produce code that did not align to the package name. This will make efforts like tree-shaking much easier to do as there doesn't need to be multiple resolution rules for `import`s in application code. This also will make debugging code much easier because the runtime module name will reflect the NPM package name.
+
+### For Addon Authors
+
+To help migrate this category of addons we have created a utility for providing a migration path for your consumers. [ember-cli/canonicalize-addon-name](https://github.com/ember-cli/canonicalize-addon-name) provides functionality to add runtime deprecations. It also provides a codemod that you can provide to your consumers to help them migrate.
+
+### For Addon Consumers
+
+If you have encountered this warning please open an issue up against the offending addon, so they can provide you with a migration path.

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -372,10 +372,10 @@ let addonProto = {
       if (this.root === this.parent.root) {
         if (parentName !== this.name && !process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH) {
           let pathToDisplay = process.cwd() === this.root ? process.cwd() : path.relative(process.cwd(), this.root);
-
-          throw new SilentError(
-            'Your names in package.json and index.js should match. ' +
-            `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js.`);
+          this._warn('Your names in package.json and index.js should match. ' +
+          `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js. ` +
+          'Until ember-cli v3.9, this warning can be disabled by setting env variable EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH to "true". ' +
+          'For more information see: https://github.com/ember-cli/ember-cli/blob/master/ADDON-NAME-MIGRATION.md.');
         }
 
         return true;

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -330,12 +330,19 @@ describe('models/addon.js', function() {
         expect(addon.isDevelopingAddon(), 'addon is being developed').to.eql(true);
       });
 
-      it('throws when the addon name is prefixed in package.json and not in index.js', function() {
+      it('warns when the addon name is prefixed in package.json and not in index.js', function() {
         process.env.EMBER_ADDON_ENV = 'development';
         project.root = 'foo';
         project.name = () => ('@foo/my-addon');
         addon.name = 'my-addon';
-        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
+        let warn = addon._warn;
+
+        addon._warn = message => {
+          expect(message).to.match(/Your names in package.json and index.js should match*/);
+        };
+
+        addon.isDevelopingAddon();
+        addon._warn = warn;
       });
 
       it('does not throw for a mismatched addon name when process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH is set', function() {
@@ -347,12 +354,19 @@ describe('models/addon.js', function() {
         expect(addon.isDevelopingAddon()).to.eql(true);
       });
 
-      it('throws an error if addon name is different in package.json and index.js ', function() {
+      it('warns if addon name is different in package.json and index.js ', function() {
         process.env.EMBER_ADDON_ENV = 'development';
         project.root = 'foo';
         project.name = () => ('foo-my-addon');
         addon.name = 'my-addon';
-        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
+        let warn = addon._warn;
+
+        addon._warn = message => {
+          expect(message).to.match(/Your names in package.json and index.js should match*/);
+        };
+
+        addon.isDevelopingAddon();
+        addon._warn = warn;
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function() {


### PR DESCRIPTION
This PR changes the way we handle a mismatch in an addon name and the name field in the package.json. To help addon authors provide a deprecation path for their users I created [ember-cli/canonicalize-addon-name](https://github.com/ember-cli/canonicalize-addon-name).

### canonicalize-addon-name
This utility library provides functionality to addon authors to emit runtime deprecations for the mismatched import paths. It also provides the an ember-cli command that addon authors can offer to applications to codemod their application away from the old imports.