### PR TITLE
Reset blueprint's ignoredFiles

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -30,6 +30,10 @@ const Promise = RSVP.Promise;
 const stat = RSVP.denodeify(fs.stat);
 const writeFile = RSVP.denodeify(fs.outputFile);
 
+const initialIgnoredFiles = [
+  '.DS_Store',
+];
+
 /**
   A blueprint is a bundle of template files with optional install
   logic.
@@ -693,13 +697,15 @@ let Blueprint = CoreObject.extend({
   },
 
   /**
-    Add update files to ignored files
+    Add update files to ignored files or reset them
     @private
     @method _ignoreUpdateFiles
   */
   _ignoreUpdateFiles() {
     if (this.isUpdate()) {
       Blueprint.ignoredFiles = Blueprint.ignoredFiles.concat(Blueprint.ignoredUpdateFiles);
+    } else {
+      Blueprint.ignoredFiles = initialIgnoredFiles;
     }
   },
 
@@ -1381,9 +1387,7 @@ Blueprint.renamedFiles = {
   @static
   @property ignoredFiles
 */
-Blueprint.ignoredFiles = [
-  '.DS_Store',
-];
+Blueprint.ignoredFiles = initialIgnoredFiles;
 
 /**
   @static

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -77,20 +77,6 @@ describe('Acceptance: ember generate in-addon', function() {
     }
   }));
 
-  it('runs the `addon-import` blueprint from a classic addon', co.wrap(function *() {
-    yield initAddon('my-addon');
-
-    yield outputFile(
-      'blueprints/service/files/__root__/__path__/__name__.js',
-      "import Service from '@ember/service';\n" +
-      'export default Service.extend({ });\n'
-    );
-
-    yield ember(['generate', 'service', 'session']);
-
-    expect(file('app/services/session.js')).to.exist;
-  }));
-
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     it('does not run the `addon-import` blueprint from a module unification addon', co.wrap(function *() {
       yield initAddon('my-addon');
@@ -106,26 +92,21 @@ describe('Acceptance: ember generate in-addon', function() {
 
       expect(file('app/services/session.js')).to.not.exist;
     }));
+  } else {
+    it('runs the `addon-import` blueprint from a classic addon', co.wrap(function *() {
+      yield initAddon('my-addon');
+
+      yield outputFile(
+        'blueprints/service/files/__root__/__path__/__name__.js',
+        "import Service from '@ember/service';\n" +
+        'export default Service.extend({ });\n'
+      );
+
+      yield ember(['generate', 'service', 'session']);
+
+      expect(file('app/services/session.js')).to.exist;
+    }));
   }
-
-  it('runs a custom "*-addon" blueprint from a classic addon', co.wrap(function *() {
-    yield initAddon('my-addon');
-
-    yield outputFile(
-      'blueprints/service/files/__root__/__path__/__name__.js',
-      "import Service from '@ember/service';\n" +
-      'export default Service.extend({ });\n'
-    );
-
-    yield outputFile(
-      'blueprints/service-addon/files/app/services/session.js',
-      "export { default } from 'somewhere';\n"
-    );
-
-    yield ember(['generate', 'service', 'session']);
-
-    expect(file('app/services/session.js')).to.exist;
-  }));
 
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     it('skips a custom "*-addon" blueprint from a module unification addon', co.wrap(function *() {
@@ -146,6 +127,25 @@ describe('Acceptance: ember generate in-addon', function() {
       yield ember(['generate', 'service', 'session']);
 
       expect(file('app/services/session.js')).to.not.exist;
+    }));
+  } else {
+    it('runs a custom "*-addon" blueprint from a classic addon', co.wrap(function *() {
+      yield initAddon('my-addon');
+
+      yield outputFile(
+        'blueprints/service/files/__root__/__path__/__name__.js',
+        "import Service from '@ember/service';\n" +
+        'export default Service.extend({ });\n'
+      );
+
+      yield outputFile(
+        'blueprints/service-addon/files/app/services/session.js',
+        "export { default } from 'somewhere';\n"
+      );
+
+      yield ember(['generate', 'service', 'session']);
+
+      expect(file('app/services/session.js')).to.exist;
     }));
   }
 

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -87,8 +87,6 @@ let fixtureBlueprints = path.resolve(__dirname, '..', '..', 'fixtures', 'bluepri
 let basicBlueprint = path.join(fixtureBlueprints, 'basic');
 let basicNewBlueprint = path.join(fixtureBlueprints, 'basic_2');
 
-let defaultIgnoredFiles = Blueprint.ignoredFiles;
-
 let basicBlueprintFiles = [
   '.ember-cli',
   '.gitignore',
@@ -117,8 +115,6 @@ describe('Blueprint', function() {
   let InstrumentedBasicBlueprint = BasicBlueprintClass.extend(instrumented);
 
   beforeEach(function() {
-    Blueprint.ignoredFiles = defaultIgnoredFiles;
-
     resetCalled();
   });
 
@@ -464,6 +460,54 @@ describe('Blueprint', function() {
             expect(output.shift()).to.match(/^installing/);
             expect(output.shift()).to.match(/identical.* \.ember-cli/);
             expect(output.shift()).to.match(/identical.* \.gitignore/);
+            expect(output.shift()).to.match(/skip.* test.txt/);
+            expect(output.length).to.equal(0);
+
+            expect(actualFiles).to.deep.equal(basicBlueprintFiles);
+          });
+      });
+    });
+
+    describe('called on a new project', function() {
+      beforeEach(function() {
+        Blueprint.ignoredUpdateFiles.push('foo.txt');
+      });
+
+      it('does not ignores files in ignoredUpdateFiles', function() {
+        td.when(ui.prompt(), { ignoreExtraArgs: true }).thenReturn(Promise.resolve({ answer: 'skip' }));
+
+        return blueprint
+          .install(options)
+          .then(function() {
+            let output = ui.output.trim().split(EOL);
+            ui.output = '';
+
+            expect(output.shift()).to.match(/^installing/);
+            expect(output.shift()).to.match(/create.* .ember-cli/);
+            expect(output.shift()).to.match(/create.* .gitignore/);
+            expect(output.shift()).to.match(/create.* app[/\\]basics[/\\]mock-project.txt/);
+            expect(output.shift()).to.match(/create.* bar/);
+            expect(output.shift()).to.match(/create.* file-to-remove.txt/);
+            expect(output.shift()).to.match(/create.* foo.txt/);
+            expect(output.shift()).to.match(/create.* test.txt/);
+            expect(output.length).to.equal(0);
+
+            let blueprintNew = new Blueprint(basicNewBlueprint);
+
+            options.project.isEmberCLIProject = function() { return false; };
+
+            return blueprintNew.install(options);
+          })
+          .then(function() {
+
+            let actualFiles = walkSync(tmpdir).sort();
+            // Prompts contain \n EOL
+            // Split output on \n since it will have the same affect as spliting on OS specific EOL
+            let output = ui.output.trim().split('\n');
+            expect(output.shift()).to.match(/^installing/);
+            expect(output.shift()).to.match(/identical.* \.ember-cli/);
+            expect(output.shift()).to.match(/identical.* \.gitignore/);
+            expect(output.shift()).to.match(/skip.* foo.txt/);
             expect(output.shift()).to.match(/skip.* test.txt/);
             expect(output.length).to.equal(0);
 


### PR DESCRIPTION
When running `ember new` or `ember addon` in sequence, on the same node
process, `ignoredFiles` gets properly incremented. But it was never reset.

The change this PR introduce is especially usefull in tests.

This PR aims at reseting the key so that the following test setup
works properly:
```javascript
beforeEach(() => {
  emberNew({ isModuleUnification: true, target: 'addon' })
})
```

Indeed, a bug occured while testing the `addon` blueprint for the Module
Unification Quest. Because in the tests, we want to make sure the `src`
directory exists. Previously, `addon` directory was disapearing but
the issue remained silent as we were not asserting its existence.

I set the release branch as a target. Because this would unblock `ember-cli` upgrade in emberjs package (https://github.com/emberjs/ember.js/pull/17212). Not sure if it's appropriate though.

/cc @ppcano 