### PR TITLE
Remove redundant _requireBuildPackages and format comments

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -250,20 +250,20 @@ let addonProto = {
   */
 
   /**
-  Initializes the addon.  If you override this method make sure and call `this._super.init && this._super.init.apply(this, arguments);` or your addon will not work.
+    Initializes the addon.  If you override this method make sure and call `this._super.init && this._super.init.apply(this, arguments);` or your addon will not work.
 
-  @public
-  @method init
-  @param {Project|Addon} parent The project or addon that directly depends on this addon
-  @param {Project} project The current project (deprecated)
+    @public
+    @method init
+    @param {Project|Addon} parent The project or addon that directly depends on this addon
+    @param {Project} project The current project (deprecated)
 
-  @example
-  ```js
-  init(parent, project) {
-    this._super.init && this._super.init.apply(this, arguments);
-    this._someCustomSetup();
-  }
-  ```
+    @example
+    ```js
+    init(parent, project) {
+      this._super.init && this._super.init.apply(this, arguments);
+      this._someCustomSetup();
+    }
+    ```
   */
   init(parent, project) {
     this._super();
@@ -273,7 +273,6 @@ let addonProto = {
     this.addonPackages = Object.create(null);
     this.addons = [];
     this.registry = p.defaultRegistry(this);
-    this._didRequiredBuildPackages = false;
 
     if (!this.root) {
       throw new Error('Addon classes must be instantiated with the `root` property');
@@ -364,7 +363,7 @@ let addonProto = {
     return false;
   },
 
-  /*
+  /**
    * Find an addon of the current addon.
    *
    * Example: ember-data depends on ember-cli-babel and wishes to have
@@ -388,7 +387,7 @@ let addonProto = {
     return this.addons.find(addon => addon.name === name);
   },
 
-  /*
+  /**
    * Check if the current addon intends to be hinted. Typically this is for
    * hinting/linting libraries such as eslint or jshint
    *
@@ -401,21 +400,6 @@ let addonProto = {
     let explicitlyDisabled = this.app && this.app.options && this.app.options.hinting === false;
 
     return testsEnabledDefault && !explicitlyDisabled;
-  },
-
-  /**
-    Loads all required modules for a build
-
-    @private
-    @method _requireBuildPackages
-   */
-
-  _requireBuildPackages() {
-    if (this._didRequiredBuildPackages === true) {
-      return;
-    } else {
-      this._didRequiredBuildPackages = true;
-    }
   },
 
   /**
@@ -603,7 +587,8 @@ let addonProto = {
     return ensurePosixPath(normalizedAbsoluteTreePath);
   },
 
-  /* @private
+  /**
+   * @private
    * @method _warn
    */
   _warn: warn,
@@ -640,8 +625,6 @@ let addonProto = {
     @return {Tree}
   */
   treeFor(treeType) {
-    this._requireBuildPackages();
-
     let node = heimdall.start({
       name: `treeFor(${this.name} - ${treeType})`,
       addonName: this.name,
@@ -935,8 +918,6 @@ let addonProto = {
     ```
    */
   treeForAddon(tree) {
-    this._requireBuildPackages();
-
     if (!tree) {
       return tree;
     }
@@ -958,8 +939,6 @@ let addonProto = {
     @return {Tree} The return tree has the same contents as the input tree, but is moved so that the `app/styles/` path is preserved.
   */
   treeForStyles(tree) {
-    this._requireBuildPackages();
-
     if (!tree) {
       return tree;
     }
@@ -1003,8 +982,6 @@ let addonProto = {
     @return {Tree} Public file tree
   */
   treeForPublic(tree) {
-    this._requireBuildPackages();
-
     if (!tree) {
       return tree;
     }
@@ -1058,8 +1035,6 @@ let addonProto = {
     @return {Tree} Compiled styles tree
   */
   compileStyles(addonStylesTree) {
-    this._requireBuildPackages();
-
     if (addonStylesTree) {
       let preprocessedStylesTree = this._addonPreprocessTree('css', addonStylesTree);
 
@@ -1164,8 +1139,6 @@ let addonProto = {
   },
 
   _addonTemplateFiles(addonTree) {
-    this._requireBuildPackages();
-
     if (this._cachedAddonTemplateFiles) {
       return this._cachedAddonTemplateFiles;
     }
@@ -1213,8 +1186,6 @@ let addonProto = {
     @return {Tree} Compiled templates tree
   */
   compileTemplates(addonTree) {
-    this._requireBuildPackages();
-
     if (this.shouldCompileTemplates()) {
       if (!isExperimentEnabled('DELAYED_TRANSPILATION') && !registryHasPreprocessor(this.registry, 'template')) {
         throw new SilentError(`Addon templates were detected, but there are no template compilers registered for \`${this.name}\`. ` +
@@ -1249,8 +1220,6 @@ let addonProto = {
     @return {Tree} Compiled addon tree
   */
   compileAddon(tree) {
-    this._requireBuildPackages();
-
     if (!this.options) {
       this._warn(
         `Ember CLI addons manage their own module transpilation during the \`treeForAddon\` processing. ` +
@@ -1304,8 +1273,6 @@ let addonProto = {
     @return {Tree} Tree with JShint output (tests)
   */
   jshintAddonTree() {
-    this._requireBuildPackages();
-
     let trees = [];
 
     let addonPath = this._treePathFor('addon');
@@ -1369,8 +1336,6 @@ let addonProto = {
     @return {Tree} The filtered addon js files
   */
   addonJsFiles(tree) {
-    this._requireBuildPackages();
-
     let includePatterns = this.registry.extensionsForType('js')
       .map(extension => new RegExp(`${extension}$`));
 


### PR DESCRIPTION
`_requireBuildPackages ` is a no-op since https://github.com/ember-cli/ember-cli/pull/7525