### PR TITLE
suppress EOL from insertIntoFile

### DIFF
--- a/lib/utilities/insert-into-file.js
+++ b/lib/utilities/insert-into-file.js
@@ -98,8 +98,12 @@ function insertIntoFile(fullPath, contentsToInsert, providedOptions) {
           let insertIndex = contentMarkerIndex;
           if (insertBehavior === 'after') { insertIndex += contentMarker.length; }
 
+          if (options.appendEOL !== false) {
+            contentsToInsert = contentsToInsert + EOL;
+          }
+
           contentsToWrite = contentsToWrite.slice(0, insertIndex) +
-            contentsToInsert + EOL +
+            contentsToInsert +
             contentsToWrite.slice(insertIndex);
         }
       }

--- a/tests/unit/utilities/insert-into-file-test.js
+++ b/tests/unit/utilities/insert-into-file-test.js
@@ -202,6 +202,26 @@ describe('insertIntoFile()', function() {
       });
   });
 
+  it('will not add an EOL if told not to', function() {
+    let toInsert = 'blahzorz blammo';
+    let line1 = 'line1 is here';
+    let line2 = 'line2 here';
+    let line3 = 'line3';
+    let originalContent = [line1, line2, line3].join(EOL);
+
+    fs.writeFileSync(filePath, originalContent, { encoding: 'utf8' });
+
+    return insertIntoFile(filePath, toInsert + EOL, { after: line2 + EOL, appendEOL: false })
+      .then(function(result) {
+        let contents = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+        expect(contents).to.equal([line1, line2, toInsert, line3].join(EOL),
+          'inserted contents should not have a double EOL');
+        expect(result.originalContents).to.equal(originalContent, 'returned object should contain original contents');
+        expect(result.inserted).to.equal(true, 'inserted should indicate that the file was modified');
+      });
+  });
+
   describe('regex', function() {
     it('options.after supports regex', function() {
       let toInsert = 'blahzorz blammo';


### PR DESCRIPTION
Without this, it is impossible to do this (with our api):

`"test": "ember test",` => `"test": "yarn lint:scss && ember test",`

With this you could do:

```js
    await this.insertIntoFile(
      'package.json',
      `yarn lint:scss && `,
      {
        after: `"test": "`,
        appendEOL: false
      }
    );
```

Alternative solution is:

```js
    let pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
    if (pkg.scripts && pkg.scripts.test) {
      pkg.scripts.test = pkg.scripts.test.replace('ember test', 'yarn lint:scss && ember test');
      fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + require('os').EOL);
    }
```