### PR TITLE
 DefaultPackager: Move `addon-test-support` out of the `tests` folder

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -833,6 +833,11 @@ module.exports = class DefaultPackager {
   */
   processTests(tree) {
     if (this._cachedTests === null) {
+      let addonTestSupportTree = new Funnel(tree, {
+        srcDir: 'tests/addon-test-support',
+        destDir: `${this.name}/tests`,
+      });
+
       let testTree = new Funnel(tree, {
         srcDir: 'tests',
         exclude: ['addon-test-support/**/*'],
@@ -849,10 +854,7 @@ module.exports = class DefaultPackager {
         registry: this.registry,
       });
 
-      let mergedTestTrees = mergeTrees([new Funnel(tree, {
-        srcDir: 'tests/addon-test-support',
-        destDir: `${this.name}/tests`,
-      }), preprocessedTests], {
+      let mergedTestTrees = mergeTrees([addonTestSupportTree, preprocessedTests], {
         overwrite: true,
         annotation: 'Packaged Tests',
       });

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -835,7 +835,7 @@ module.exports = class DefaultPackager {
     if (this._cachedTests === null) {
       let addonTestSupportTree = new Funnel(tree, {
         srcDir: 'tests/addon-test-support',
-        destDir: `${this.name}/tests`,
+        destDir: 'addon-test-support',
       });
 
       let testTree = new Funnel(tree, {
@@ -1114,7 +1114,7 @@ module.exports = class DefaultPackager {
       this.legacyTestFilesToAppend
     );
 
-    let inputFiles = ['tests/addon-test-support/**/*.js'];
+    let inputFiles = ['addon-test-support/**/*.js'];
 
     let footerFiles = ['vendor/ember-cli/test-support-suffix.js'];
 

--- a/tests/unit/broccoli/default-packager/tests-test.js
+++ b/tests/unit/broccoli/default-packager/tests-test.js
@@ -246,16 +246,18 @@ describe('Default Packager: Tests', function() {
     let outputFiles = output.read();
 
     expect(outputFiles).to.deep.equal({
+      'addon-test-support': {
+        '@ember': {
+          'test-helpers': {
+            'global.js': 'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
+          },
+        },
+      },
       [name]: {
         tests: {
           acceptance: {
             'login-test.js-test': ' // login-test.js',
             'logout-test.js-test': '',
-          },
-          '@ember': {
-            'test-helpers': {
-              'global.js': 'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
-            },
           },
           lint: {
             'login-test.lint.js-test': ' // login-test.lint.js',
@@ -318,16 +320,18 @@ describe('Default Packager: Tests', function() {
     let outputFiles = output.read();
 
     expect(outputFiles).to.deep.equal({
+      'addon-test-support': {
+        '@ember': {
+          'test-helpers': {
+            'global.js': 'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
+          },
+        },
+      },
       [name]: {
         tests: {
           acceptance: {
             'login-test.js-test': ' // login-test.js',
             'logout-test.js-test': '',
-          },
-          '@ember': {
-            'test-helpers': {
-              'global.js': 'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
-            },
           },
           lint: {
             'login-test.lint.js-test': ' // login-test.lint.js',


### PR DESCRIPTION
`packageApplicationTests()` packages *all* files in the `tests` folder, which caused the `addon-test-support` files to be packaged in the `tests.js` *and* the `test-support.js` files. By moving `addon-test-support` out of the `tests` folder for the downstream trees, we can make sure that `packageApplicationTests()` only packages actual test files and `packageTestFiles()` correctly picks up the `addon-test-support` files.

Resolves https://github.com/ember-cli/ember-cli/issues/8053

/cc @twokul @rwjblue 