### PR TITLE
DefaultPackager: Fix addon preprocessing

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -838,12 +838,12 @@ module.exports = class DefaultPackager {
         exclude: ['addon-test-support/**/*'],
       });
 
-      testTree = callAddonsPreprocessTreeHook(this.project, 'test', testTree);
-
       let treeToCompile = new Funnel(testTree, {
         destDir: `${this.name}/tests`,
         annotation: 'Tests To Process',
       });
+
+      treeToCompile = callAddonsPreprocessTreeHook(this.project, 'test', treeToCompile);
 
       let preprocessedTests = preprocessJs(treeToCompile, '/tests', this.name, {
         registry: this.registry,


### PR DESCRIPTION
`preprocessTree('test', ...)` assumes that the input tree has the tests in an `<app-name>/tests` folder, but the default packager implementation regressed and passed the tests in a non-nested `tests` folder. This commit fixes the packager to correctly pass the tests in `<app-name>/tests` again, by moving the `callAddonsPreprocessTreeHook()` call below the `Funnel` that does the `<app-name>` prefixing.

Resolves https://github.com/ember-cli/ember-cli/issues/8056

/cc @twokul @rwjblue 