### PR TITLE
WIP [FEATURE] Run 'eslint --fix' when generating a blueprint

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -309,6 +309,12 @@ let Blueprint = CoreObject.extend({
     }
   },
 
+    /**
+    @private
+    @method _renderFile
+    @param {Object} info
+    @return {Promise}
+  */
   _renderFile(info) {
     if (info.outputPath.indexOf('.js') > 0) {
       const projectEslint = require.resolve('eslint', {paths: this.project.root});

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -303,8 +303,29 @@ let Blueprint = CoreObject.extend({
   */
   _writeFile(info) {
     if (!this.dryRun) {
-      return writeFile(info.outputPath, info.render());
+      const fileOutput = this._renderFile(info);
+
+      return writeFile(info.outputPath, fileOutput);
     }
+  },
+
+  _renderFile(info) {
+    if (info.outputPath.indexOf('.js') > 0) {
+      const projectEslint = require.resolve('eslint', {paths: this.project.root});
+      const CLIEngine = require(projectEslint).CLIEngine;
+      const eslintCli = new CLIEngine({
+        fix: true,
+        useEslintrc: true
+      });
+
+      return info.render().then((data) => {
+        var report = eslintCli.executeOnText(data);
+
+        return report.results[0].output;
+      });
+    }
+
+    return info.render();
   },
 
   /**

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -317,18 +317,22 @@ let Blueprint = CoreObject.extend({
   */
   _renderFile(info) {
     if (info.outputPath.indexOf('.js') > 0) {
-      const projectEslint = require.resolve('eslint', {paths: this.project.root});
-      const CLIEngine = require(projectEslint).CLIEngine;
-      const eslintCli = new CLIEngine({
-        fix: true,
-        useEslintrc: true
-      });
+      try {
+        const projectEslint = require.resolve('eslint', {paths: this.project.root});
+        const CLIEngine = require(projectEslint).CLIEngine;
+        const eslintCli = new CLIEngine({
+          fix: true,
+          useEslintrc: true
+        });
 
-      return info.render().then((data) => {
-        var report = eslintCli.executeOnText(data);
+        return info.render().then((data) => {
+          var report = eslintCli.executeOnText(data);
 
-        return report.results[0].output;
-      });
+          return report.results[0].output;
+        });
+      } catch (exception) {
+        // should not finding eslint throw?
+      }
     }
 
     return info.render();


### PR DESCRIPTION
This have some additional benefits over https://github.com/ember-cli/ember-cli/issues/3664
It'll fix everthing that eslint can fix with the blueprint and there are many things that are autofixable: https://eslint.org/docs/rules/

This means that generated blueprint will pass eslint test in a project OOTB.

This implementation might not be in a best place and needs some defensiveness (e.g. what if eslint is not insalled in project.root)

Submitting this PR for discussion and guideance how this should be done to adhere to ember-cli standards.

One thing that eslint --fix won't fix are spaces inside template stiring (and for good reasons!) 
so if project is setup to use tabs:
 ```
		// Template block usage:
		await render(hbs`
      {{#my-test-41}}
        template block text
      {{/my-test-41}}
    `);
``` 
you'll end up with properly indented code but you'll still have spaces in the hbs`` string