### PR TITLE
Revert #8165

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -59,6 +59,10 @@ module.exports = function() {
             }
           }
         },
+        // The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
+        // not via `ember try`. It's still included here so that running
+        // `ember try:each` manually or from a customized CI config will run it
+        // along with all the other scenarios.
         {
           name: 'ember-default',
           npm: {

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -60,6 +60,12 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
+        },
+        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -58,6 +58,10 @@ module.exports = function() {
             }
           }
         },
+        // The default `.travis.yml` runs this scenario via `npm test`,
+        // not via `ember try`. It's still included here so that running
+        // `ember try:each` manually or from a customized CI config will run it
+        // along with all the other scenarios.
         {
           name: 'ember-default',
           npm: {

--- a/tests/fixtures/addon/npm/config/ember-try.js
+++ b/tests/fixtures/addon/npm/config/ember-try.js
@@ -59,6 +59,12 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
+        },
+        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -59,6 +59,10 @@ module.exports = function() {
             }
           }
         },
+        // The default `.travis.yml` runs this scenario via `yarn test`,
+        // not via `ember try`. It's still included here so that running
+        // `ember try:each` manually or from a customized CI config will run it
+        // along with all the other scenarios.
         {
           name: 'ember-default',
           npm: {

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -60,6 +60,12 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
+        },
+        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({


### PR DESCRIPTION
Removing the default scenario from `ember-try.js` omits it from tests runs initiated via `yarn test:all` or `ember try:each`, and potentially creates holes in test coverage for users that use CI services other than travis.

Reverts #8165