### PR TITLE
Include addon styles for MU apps

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -579,29 +579,14 @@ module.exports = class DefaultPackager {
         minifyCSS: this.minifyCSS.options,
       };
 
-      let stylesAndVendor, preprocessedStyles;
+      let stylesAndVendor = callAddonsPreprocessTreeHook(this.project, 'css', tree);
 
-      if (this._cachedProcessedSrc !== null && this.isModuleUnificationEnabled === true) {
-        stylesAndVendor = mergeTrees([
-          this._cachedProcessedSrc,
-          tree,
-        ], {
-          annotation: 'Module Unification Styles',
-        });
-        preprocessedStyles = new Funnel(this._cachedProcessedSrc, {
-          srcDir: `${this.name}/assets`,
-          destDir: 'assets',
-        });
-      } else {
-        stylesAndVendor = callAddonsPreprocessTreeHook(this.project, 'css', tree);
-
-        preprocessedStyles = preprocessCss(
-          stylesAndVendor,
-          '/app/styles',
-          '/assets',
-          options
-        );
-      }
+      let preprocessedStyles = preprocessCss(
+        stylesAndVendor,
+        this.isModuleUnificationEnabled === true ? 'src/ui/styles' : '/app/styles',
+        '/assets',
+        options
+      );
 
       let vendorStyles = [];
       for (let outputFile in this.styleOutputFiles) {
@@ -682,15 +667,6 @@ module.exports = class DefaultPackager {
 
       let srcAfterPreprocessTreeHook = callAddonsPreprocessTreeHook(this.project, 'src', src);
 
-      let options = {
-        outputPaths: this.distPaths.appCssFile,
-        registry: this.registry,
-      };
-
-      // TODO: This isn't quite correct (but it does function properly in most cases),
-      // and should be re-evaluated before enabling the `MODULE_UNIFICATION` feature
-      let srcAfterStylePreprocessing = preprocessCss(srcAfterPreprocessTreeHook, '/src/ui/styles', '/assets', options);
-
       let srcAfterTemplatePreprocessing = preprocessTemplates(srcAfterPreprocessTreeHook, {
         registry: this.registry,
         annotation: 'Process Templates: src',
@@ -704,7 +680,6 @@ module.exports = class DefaultPackager {
 
       this._cachedProcessedSrc = new Funnel(mergeTrees([
         srcAfterPostprocessTreeHook,
-        srcAfterStylePreprocessing,
       ], { ovewrite: true }), {
         srcDir: '/',
         destDir: this.name,

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -4,6 +4,7 @@ const p = require('ember-cli-preprocess-registry/preprocessors');
 const path = require('path');
 const concat = require('broccoli-concat');
 const Funnel = require('broccoli-funnel');
+const BroccoliDebug = require('broccoli-debug');
 const mergeTrees = require('./merge-trees');
 const ConfigLoader = require('broccoli-config-loader');
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
@@ -120,6 +121,8 @@ module.exports = class DefaultPackager {
     this._cachedProcessedAppAndDependencies = null;
 
     this.options = options || {};
+
+    this._debugTree = BroccoliDebug.buildDebugCallback('default-packager');
 
     this.env = this.options.env;
     this.name = this.options.name;
@@ -580,13 +583,15 @@ module.exports = class DefaultPackager {
       };
 
       let stylesAndVendor = callAddonsPreprocessTreeHook(this.project, 'css', tree);
+      stylesAndVendor = this._debugTree(stylesAndVendor, 'mu-layout:addonsPreprocessTree:css');
 
       let preprocessedStyles = preprocessCss(
         stylesAndVendor,
-        this.isModuleUnificationEnabled === true ? 'src/ui/styles' : '/app/styles',
+        this.isModuleUnificationEnabled ? 'src/ui/styles' : '/app/styles',
         '/assets',
         options
       );
+      preprocessedStyles = this._debugTree(preprocessedStyles, 'mu-layout:preprocess:css');
 
       let vendorStyles = [];
       for (let outputFile in this.styleOutputFiles) {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1105,6 +1105,7 @@ class EmberApp {
       styles = mergeTrees([styles1, styles2], {
         annotation: 'Styles MU',
       });
+      styles = this._debugTree(styles, 'mu-layout:styles');
 
     }
     return styles;

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1084,10 +1084,17 @@ class EmberApp {
     }
     let addons = this.addonTreesFor('styles');
 
-    return mergeTrees(addons.concat(styles), {
+    let mergedtree = mergeTrees(addons.concat(styles), {
       overwrite: true,
       annotation: 'Styles',
     });
+    if (isExperimentEnabled('MODULE_UNIFICATION') && this.trees.src) {
+      mergedtree = new Funnel(mergedtree, {
+        srcDir: '/app/styles',
+        destDir: '/src/ui/styles',
+      });
+    }
+    return mergedtree;
   }
 
   /*

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1089,11 +1089,23 @@ class EmberApp {
       annotation: 'Styles',
     });
     if (isExperimentEnabled('MODULE_UNIFICATION') && this.trees.src) {
-      styles = new Funnel(styles, {
+
+      // move only app/styles to /src/ui/styles
+      let styles1 = new Funnel(styles, {
         allowEmpty: true,
         srcDir: '/app/styles',
         destDir: '/src/ui/styles',
       });
+      let styles2 = new Funnel(styles, {
+        allowEmpty: true,
+        srcDir: '.',
+        exclude: ['app/styles/**'],
+        destDir: '.',
+      });
+      styles = mergeTrees([styles1, styles2], {
+        annotation: 'Styles MU',
+      });
+
     }
     return styles;
   }

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -1084,17 +1084,18 @@ class EmberApp {
     }
     let addons = this.addonTreesFor('styles');
 
-    let mergedtree = mergeTrees(addons.concat(styles), {
+    styles = mergeTrees(addons.concat(styles), {
       overwrite: true,
       annotation: 'Styles',
     });
     if (isExperimentEnabled('MODULE_UNIFICATION') && this.trees.src) {
-      mergedtree = new Funnel(mergedtree, {
+      styles = new Funnel(styles, {
+        allowEmpty: true,
         srcDir: '/app/styles',
         destDir: '/src/ui/styles',
       });
     }
-    return mergedtree;
+    return styles;
   }
 
   /*

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -237,6 +237,36 @@ describe('Acceptance: brocfile-smoke-test', function() {
     });
   }));
 
+  it('specifying custom output paths works properly', co.wrap(function *() {
+    yield copyFixtureFiles('brocfile-tests/custom-output-paths');
+
+    let themeCSSPath;
+    if (isExperimentEnabled('MODULE_UNIFICATION')) {
+      themeCSSPath = path.join(appRoot, 'src', 'ui', 'styles', 'theme.css');
+    } else {
+      themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
+    }
+    fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
+
+    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+    let files = [
+      '/css/app.css',
+      '/css/theme/a.css',
+      '/js/app.js',
+      '/css/vendor.css',
+      '/js/vendor.js',
+      '/css/test-support.css',
+      '/js/test-support.js',
+      '/my-app.html',
+    ];
+
+    let basePath = path.join(appRoot, 'dist');
+    files.forEach(function(f) {
+      expect(file(path.join(basePath, f))).to.exist;
+    });
+  }));
+
   it('specifying outputFile results in an explicitly generated assets', co.wrap(function *() {
     yield copyFixtureFiles('brocfile-tests/app-import-output-file');
     yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -194,31 +194,6 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
   }
 
-  (isExperimentEnabled('MODULE_UNIFICATION') ? it.skip : it)('specifying custom output paths works properly', co.wrap(function *() {
-    yield copyFixtureFiles('brocfile-tests/custom-output-paths');
-
-    let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
-    fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
-
-    yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-    let files = [
-      '/css/app.css',
-      '/css/theme/a.css',
-      '/js/app.js',
-      '/css/vendor.css',
-      '/js/vendor.js',
-      '/css/test-support.css',
-      '/js/test-support.js',
-      '/my-app.html',
-    ];
-
-    let basePath = path.join(appRoot, 'dist');
-    files.forEach(function(f) {
-      expect(file(path.join(basePath, f))).to.exist;
-    });
-  }));
-
   it('multiple css files in styles/ are output when a preprocessor is not used', co.wrap(function *() {
 
     let fixtureFolder = isExperimentEnabled('MODULE_UNIFICATION') ? 'multiple-css-files-mu' : 'multiple-css-files';

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -372,7 +372,7 @@ describe('Acceptance: smoke-test', function() {
   }));
 
   it('ember new foo, build production and verify css files are concatenated', co.wrap(function *() {
-    yield copyFixtureFiles('with-styles');
+    yield copyFixtureFiles(isExperimentEnabled('MODULE_UNIFICATION') ? 'with-styles-mu' : 'with-styles');
 
     yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 
@@ -389,7 +389,7 @@ describe('Acceptance: smoke-test', function() {
   }));
 
   it('ember new foo, build production and verify css files are minified', co.wrap(function *() {
-    yield copyFixtureFiles('with-unminified-styles');
+    yield copyFixtureFiles(isExperimentEnabled('MODULE_UNIFICATION') ? 'with-unminified-styles-mu' : 'with-unminified-styles');
 
     yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 

--- a/tests/fixtures/with-styles-mu/src/ui/styles/app.css
+++ b/tests/fixtures/with-styles-mu/src/ui/styles/app.css
@@ -1,0 +1,2 @@
+@import "some-styles.css";
+@import "some-other-styles.css";

--- a/tests/fixtures/with-styles-mu/src/ui/styles/some-other-styles.css
+++ b/tests/fixtures/with-styles-mu/src/ui/styles/some-other-styles.css
@@ -1,0 +1,1 @@
+.some-even-weirder-selector{cursor: crosshair;}

--- a/tests/fixtures/with-styles-mu/src/ui/styles/some-styles.css
+++ b/tests/fixtures/with-styles-mu/src/ui/styles/some-styles.css
@@ -1,0 +1,1 @@
+.some-weird-selector{cursor: crosshair;}

--- a/tests/fixtures/with-unminified-styles-mu/src/ui/styles/app.css
+++ b/tests/fixtures/with-unminified-styles-mu/src/ui/styles/app.css
@@ -1,0 +1,18 @@
+html {
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+}
+
+h1 {
+  font-size: 2em;
+}
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}

--- a/tests/unit/broccoli/default-packager/javascript-test.js
+++ b/tests/unit/broccoli/default-packager/javascript-test.js
@@ -398,9 +398,6 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
       let outputFiles = outputMU.read();
 
       expect(outputFiles['the-best-app-ever']).to.deep.equal({
-        assets: {
-          'app.css': 'html { height: 100%; }',
-        },
         src: {
           'main.js': '',
           'resolver.js': '',


### PR DESCRIPTION
1) The PR supersedes #8134.


This change fixes the [CSS stylesheets that require importing from addons](https://cli.emberjs.com/release/writing-addons/intro-tutorial/#cssstylesheetsthatrequireimportingfromaddons) feature for MU applications importing styles from classic addons.

2)  This PR also supersedes #8146 to allow MU applications importing SASS modules like the `ember-styleguide`.


MU applications will now execute  `preprocessCss` on `packageStyles` like Classic applications and it removes the existing `preprocessCss` call of the `processSrc` method. 

I am not sure this is the correct implementation but this implementation looks more natural and it enables the `specifying custom output paths works properly` test at https://github.com/ember-cli/ember-cli/pull/8289/commits/6c65235254f446b9dc2d4d78396c05cec97df5d5  (cc @twokul).

A similar issue was reported at https://github.com/ember-cli/ember-cli/pull/8197 where MU applications executed `preprocessTemplates` twice on `processSrc` and `processTemplates`.


Closes #8134, #8133,  #8146


