### PR TITLE
ignore .env* files

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -9,6 +9,7 @@
 /.bowerrc
 /.editorconfig
 /.ember-cli
+/.env*
 /.eslintignore
 /.eslintrc.js
 /.gitignore

--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -9,6 +9,7 @@
 /node_modules/
 
 # misc
+/.env*
 /.sass-cache
 /connect.lock
 /coverage/

--- a/blueprints/module-unification-addon/files/npmignore
+++ b/blueprints/module-unification-addon/files/npmignore
@@ -9,6 +9,7 @@
 /.bowerrc
 /.editorconfig
 /.ember-cli
+/.env*
 /.eslintignore
 /.eslintrc.js
 /.gitignore

--- a/blueprints/module-unification-app/files/gitignore
+++ b/blueprints/module-unification-app/files/gitignore
@@ -9,6 +9,7 @@
 /node_modules/
 
 # misc
+/.env*
 /.sass-cache
 /connect.lock
 /coverage/


### PR DESCRIPTION
Because lots of people have these, and since npm doesn't merge .npmignore files from system unlike .gitignore, we can be nice to people and prevent the mistake.