### PR TITLE
In MU apps, exclude test files from the app JS file

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -676,6 +676,7 @@ module.exports = class DefaultPackager {
       let src = new Funnel(tree, {
         srcDir: 'src',
         destDir: 'src',
+        exclude: ['**/*-test.js'],
         annotation: 'Module Unification Src',
       });
 
@@ -842,6 +843,19 @@ module.exports = class DefaultPackager {
         srcDir: 'tests',
         exclude: ['addon-test-support/**/*'],
       });
+
+      if (this.isModuleUnificationEnabled) {
+
+        let testSrcTree = new Funnel(tree, {
+          srcDir: 'src',
+          include: ['**/*-test.js'],
+          annotation: 'Module Unification Tests',
+        });
+        testTree = mergeTrees([testTree, testSrcTree], {
+          annotation: 'Merge MU Tests',
+        });
+
+      }
 
       let treeToCompile = new Funnel(testTree, {
         destDir: `${this.name}/tests`,

--- a/tests/unit/broccoli/default-packager/javascript-test.js
+++ b/tests/unit/broccoli/default-packager/javascript-test.js
@@ -320,6 +320,7 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
         ui: {
           components: {
             'login-form': {
+              'component-test.js': ' // login-form-component-test',
               'component.js': '',
               'template.hbs': '',
             },

--- a/tests/unit/broccoli/default-packager/tests-test.js
+++ b/tests/unit/broccoli/default-packager/tests-test.js
@@ -558,23 +558,7 @@ describe('Default Packager: Tests', function() {
             'login-test.lint.js': ' // login-test.lint.js',
             'logout-test.lint.js': '',
           },
-          helpers: {
-            'resolver.js': '',
-            'start-app.js': '',
-          },
           'index.html': 'index',
-          integration: {
-            components: {
-              'login-form-test.js': '',
-              'user-menu-test.js': '',
-            },
-          },
-          'test-helper.js': '// test-helper.js',
-          unit: {
-            services: {
-              'session-test.js': '',
-            },
-          },
         },
         src: {
           'main.js': '',
@@ -583,6 +567,7 @@ describe('Default Packager: Tests', function() {
           ui: {
             components: {
               'login-form': {
+                'component-test.js': ' // login-form-component-test',
                 'component.js': '',
                 'template.hbs': '',
               },
@@ -632,7 +617,7 @@ describe('Default Packager: Tests', function() {
 
           customTransformsMap: new Map(),
 
-          isModuleUnification: true,
+          isModuleUnificationEnabled: true,
 
           vendorTestStaticStyles: [],
           legacyTestFilesToAppend: [],
@@ -661,6 +646,7 @@ describe('Default Packager: Tests', function() {
           'tests',
         ]);
 
+        expect(outputFiles.assets['tests.js']).to.include('login-form-component-test');
         expect(outputFiles.assets['tests.js']).to.include('login-test.js');
         expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
         expect(outputFiles.assets['tests.js']).to.include('test-helper');


### PR DESCRIPTION
The PR fixes that test files in the `src` folder are added to the `testJsFile` instead of the `appJsFile`.

The current implementation recognize tests with the pattern `**/*-test.js`, but this will fail if a non-test class is named like `xxx-test.js`. 

```
services/app-test.js         // the service
services/app-test-test.js // test of the `app-test` service
```

This case will fail because both files will be added into the `testJsFile`.


It should fix some of the issues reported at emberjs/ember.js#17224
