### PR TITLE
Cleanup repo README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,58 @@ There are many ways to contribute to the project, you can fix issues,
 improve documentation or work on any of the features on the
 [wish list](https://github.com/ember-cli/ember-cli/wiki/Wish-List).
 
+
+# Development
+
+Start by cloning the Git project to your local hard drive:
+
+```
+git clone https://github.com/ember-cli/ember-cli.git
+```
+
+## Link `ember` to your development version
+
+
+Running the following command will link the global `ember` utility to your
+local development version:
+
+```
+npm link
+```
+
+Note that the global `ember` CLI utility will automatically relay to any
+project-local ember-cli installation. If you want to use your development
+version there instead run the following command from your Ember.js
+project folder:
+
+```
+npm link ember-cli
+```
+
+Read the official [npm-link documentation](https://www.npmjs.org/doc/cli/npm-link.html)
+for more information.
+
+
+## Run the test suite
+
+```
+npm test
+```
+
+will run ESLint and the "fast" subset of the test suite. Run
+`npm run test-all` for the full test suite which will currently take quite a
+few minutes due to heavy IO and network usage.
+
+ember-cli is using [Mocha](https://mochajs.org/) for its internal tests. If
+you want to run a specific subset of tests have a look at their
+[documentation](https://mochajs.org/#exclusive-tests).
+
+
+## Build the documentation
+
+Use `npm run docs` to build HTML and JSON documentation with YUIDoc and place
+it in `docs/build/`. Please help by improving this documentation.
+
 # Questions
 
 This is the issue tracker for `ember-cli`. The community uses this site
@@ -207,7 +259,7 @@ We can always use help improving our [Code Climate](https://codeclimate.com/gith
 
 Have you got enough knowledge in a specific feature and want to help with docs?
 Ember-cli documentation lives at the repository
-[ember-cli.github.io](https://github.com/ember-cli/ember-cli.github.io).
+[ember-learn/cli-guides](https://github.com/ember-learn/cli-guides).
 
 Feel free to contribute and help us to keep an updated, clear and complete
 documentation.

--- a/README.md
+++ b/README.md
@@ -50,145 +50,22 @@ After installation the `ember` CLI tool will be available to you. It is the
 entrypoint for all the functionality mentioned above.
 
 You can call `ember <command> --help` to find out more about all of the
-following commands or visit <https://ember-cli.com/user-guide/> to read
+following commands or visit <https://cli.emberjs.com/release/> to read
 the in-depth documentation.
 
 
-### Create a new project
-
-```
-ember new my-new-app
-```
-
-This will create a new folder `my-new-app`, initialize a Git project in it,
-add the basic Ember.js project structure and install any necessary npm and
-Bower dependencies.
-
-
-### Create a new addon project
-
-```
-ember addon my-new-addon
-```
-
-This is essentially similar to `ember new` but will generate the structure
-for an ember-cli addon instead.
-
-
-### Build the project
-
-```
-ember build
-```
-
-This will create a `dist` folder and run the build pipeline to generate all
-the output files in it. You can specify `--environment=production` to build
-in production mode, which includes code minification and other optimizations.
-
-
-### Run the development server
-
-```
-ember serve
-```
-
-This will launch a development server that will automatically rebuild your
-project on file changes and serves the built app at <http://localhost:4200/>.
-
-
-### Run the test suite
-
-```
-ember test
-```
-
-This command will start the Testem runner, which will run all your tests from
-the `tests` folder. This command also supports a `--server` option which will
-automatically run tests on file changes.
-
-
-### Generate files
-
-```
-ember generate route foo
-```
-
-This will generate a `route` named `foo`. `route` is an example here and can
-be replaced by any other available blueprint. Blueprints are provided by
-ember-cli itself and any of your installed addons. Run `ember generate --help`
-to see a list of available blueprints in your project and their options.
-
-
-### Install an ember-cli addon
-
-```
-ember install some-other-addon
-```
-
-This will search npm for a package named `some-other-addon`, install it and
-run any additional install steps defined in the addon.
+Documentation
+------------------------------------------------------------------------------
+Please refer to the [CLI guides](https://cli.emberjs.com/release/) for help using Ember CLI.
 
 
 Community
 ------------------------------------------------------------------------------
 
-- Slack: [Get your invite](https://ember-community-slackin.herokuapp.com/)
-- IRC: #ember-cli on [freenode](https://webchat.freenode.net/?channels=%23ember-cli)
+- Discord: [Get your invite](https://discordapp.com/invite/zT3asNS)
 - Issues: [ember-cli/issues](https://github.com/ember-cli/ember-cli/issues)
-- Website: [ember-cli.com](https://ember-cli.com)
+- Documentation: [ember-cli.com](https://cli.emberjs.com/release/)
 
-
-Development
-------------------------------------------------------------------------------
-
-Start by cloning the Git project to your local hard drive:
-
-```
-git clone https://github.com/ember-cli/ember-cli.git
-```
-
-### Link `ember` to your development version
-
-
-Running the following command will link the global `ember` utility to your
-local development version:
-
-```
-npm link
-```
-
-Note that the global `ember` CLI utility will automatically relay to any
-project-local ember-cli installation. If you want to use your development
-version there instead run the following command from your Ember.js
-project folder:
-
-```
-npm link ember-cli
-```
-
-Read the official [npm-link documentation](https://www.npmjs.org/doc/cli/npm-link.html)
-for more information.
-
-
-### Run the test suite
-
-```
-npm test
-```
-
-will run ESLint and the "fast" subset of the test suite. Run
-`npm run test-all` for the full test suite which will currently take quite a
-few minutes due to heavy IO and network usage.
-
-ember-cli is using [Mocha](https://mochajs.org/) for its internal tests. If
-you want to run a specific subset of tests have a look at their
-[documentation](https://mochajs.org/#exclusive-tests).
-
-
-## Build the documentation
-
-Use `npm run docs` to build HTML and JSON documentation with YUIDoc and place
-it in `docs/build/`. Please help by improving this documentation.
 
 
 License


### PR DESCRIPTION
This PR contains three things:
* Update links to CLI docs to the new CLI guides
* Moves contribution info to CONTRIBUTING.md instead of README.md
* Removes help documentation since it already lives in the guides (no need to maintain it in two places)