### PR TITLE
tasks/server: Remove obsolete `exists-sync` dependency declaration

### DIFF
--- a/lib/tasks/server/middleware/tests-server/package.json
+++ b/lib/tasks/server/middleware/tests-server/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "clean-base-url": "*",
-    "exists-sync": "*",
     "heimdalljs-logger": "*"
   }
 }


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/pull/7711 removed the usage of the dependency, but did not remove the declaration from the nested `package.json` file