### PR TITLE
livereload-server: Fix logger output

### DIFF
--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -213,7 +213,7 @@ module.exports = class LiveReloadServer {
       files = ['LiveReload files'];
     }
 
-    logger.info('files %a', files);
+    logger.info('files %o', files);
 
     if (this.shouldTriggerReload(results)) {
       this.liveReloadServer.changed({


### PR DESCRIPTION
`%a` is not a valid format specifier