### PR TITLE
Add no-implicit-this template lint rule by default.

### DIFF
--- a/blueprints/app/files/.template-lintrc.js
+++ b/blueprints/app/files/.template-lintrc.js
@@ -1,5 +1,9 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'recommended',
+
+  rules: {
+    'no-implicit-this': true
+  }
 };


### PR DESCRIPTION
As part of [emberjs/rfcs#308](https://emberjs.github.io/rfcs/0308-deprecate-property-lookup-fallback.html#transition-path)'s phase 2. The main guides/docs have been updated (will be deployed with 3.7 docs) in https://github.com/ember-learn/guides-source/pull/349.