### PR TITLE
Use cwd from testem if configured else use default value

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -41,16 +41,7 @@ class TestTask extends Task {
   }
 
   defaultOptions(options) {
-    let defaultOptions = this.transformOptions(options);
-    defaultOptions.cwd = options.outputPath;
-    /* eslint-disable camelcase */
-    defaultOptions.config_dir = process.cwd();
-    /* eslint-enable camelcase */
-    return defaultOptions;
-  }
-
-  transformOptions(options) {
-    let transformed = {
+    return {
       host: options.host,
       port: options.port,
       debug: options.testemDebug,
@@ -62,7 +53,18 @@ class TestTask extends Task {
       test_page: options.testPage,
       query_params: options.queryString,
       /* eslint-enable camelcase */
+      cwd: options.outputPath,
+      /* eslint-disable camelcase */
+      config_dir: process.cwd(),
+      /* eslint-enable camelcase */
     };
+  }
+
+  transformOptions(options) {
+    let transformed = this.defaultOptions(options);
+    if (options.cwd) {
+      transformed.cwd = options.cwd;
+    }
 
     if (options.ssl) {
       transformed.key = options.sslKey;

--- a/tests/unit/tasks/test-server-test.js
+++ b/tests/unit/tasks/test-server-test.js
@@ -30,8 +30,8 @@ describe('test server', function() {
           expect(options.reporter).to.equal('xunit');
           expect(options.middleware).to.deep.equal(['middleware1', 'middleware2']);
           expect(options.test_page).to.equal('http://my/test/page');
-          expect(options.cwd).to.be.undefined;
-          expect(options.config_dir).to.be.undefined;
+          expect(options.cwd).to.equal('cwd-from-testem');
+          expect(options.config_dir).to.be.an('string');
           expect(this.defaultOptions.cwd).to.equal('blerpy-derpy');
           expect(this.defaultOptions.config_dir).to.be.an('string');
           finalizer(0);
@@ -40,6 +40,7 @@ describe('test server', function() {
     });
 
     let runResult = subject.run({
+      cwd: 'cwd-from-testem',
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -7,7 +7,7 @@ const MockProject = require('../../helpers/mock-project');
 describe('test task test', function() {
   let subject;
 
-  it('transforms options for testem configuration', function() {
+  it('transforms options for testem configuration, uses default cwd when not configured in testem.js file', function() {
     subject = new TestTask({
       project: new MockProject(),
       addonMiddlewares() {
@@ -16,20 +16,19 @@ describe('test task test', function() {
 
       invokeTestem(options) {
         expect(options.ssl).to.equal(false);
-
-        // cwd and config_dir are not passed to testem progOptions
+        // cwd is not passed to testem progOptions so takes default value
         let testemOptions = this.transformOptions(options);
         expect(testemOptions.host).to.equal('greatwebsite.com');
         expect(testemOptions.port).to.equal(123324);
-        expect(testemOptions.cwd).to.be.undefined;
+        expect(testemOptions.cwd).to.equal('blerpy-derpy');
         expect(testemOptions.reporter).to.equal('xunit');
         expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
         expect(testemOptions.test_page).to.equal('http://my/test/page');
-        expect(testemOptions.config_dir).to.be.undefined;
+        expect(testemOptions.config_dir).to.be.an('string');
         expect(testemOptions.key).to.be.undefined;
         expect(testemOptions.cert).to.be.undefined;
 
-        // cwd and config_dir are present as part of default options.
+        // default cwd is present as part of default options.
         let defaultOptions = this.defaultOptions(options);
         expect(defaultOptions.host).to.equal('greatwebsite.com');
         expect(defaultOptions.port).to.equal(123324);
@@ -42,6 +41,54 @@ describe('test task test', function() {
     });
 
     subject.run({
+      host: 'greatwebsite.com',
+      port: 123324,
+      reporter: 'xunit',
+      outputPath: 'blerpy-derpy',
+      testemDebug: 'testem.log',
+      testPage: 'http://my/test/page',
+      configFile: 'custom-testem-config.json',
+      ssl: false,
+      sslKey: 'ssl/server.key',
+      sslCert: 'ssl/server.cert',
+    });
+  });
+
+  it('transforms options for testem configuration, uses cwd from testem.js file when configured', function() {
+    subject = new TestTask({
+      project: new MockProject(),
+      addonMiddlewares() {
+        return ['middleware1', 'middleware2'];
+      },
+
+      invokeTestem(options) {
+        expect(options.ssl).to.equal(false);
+        // cwd is passed to testem progOptions so uses it
+        let testemOptions = this.transformOptions(options);
+        expect(testemOptions.host).to.equal('greatwebsite.com');
+        expect(testemOptions.port).to.equal(123324);
+        expect(testemOptions.cwd).to.equal('cwd-from-testem');
+        expect(testemOptions.reporter).to.equal('xunit');
+        expect(testemOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
+        expect(testemOptions.test_page).to.equal('http://my/test/page');
+        expect(testemOptions.config_dir).to.be.an('string');
+        expect(testemOptions.key).to.be.undefined;
+        expect(testemOptions.cert).to.be.undefined;
+
+        let defaultOptions = this.defaultOptions(options);
+        expect(defaultOptions.host).to.equal('greatwebsite.com');
+        expect(defaultOptions.port).to.equal(123324);
+        // default cwd is set in defaultOptions
+        expect(defaultOptions.cwd).to.equal('blerpy-derpy');
+        expect(defaultOptions.reporter).to.equal('xunit');
+        expect(defaultOptions.middleware).to.deep.equal(['middleware1', 'middleware2']);
+        expect(defaultOptions.test_page).to.equal('http://my/test/page');
+        expect(defaultOptions.config_dir).to.be.an('string');
+      },
+    });
+
+    subject.run({
+      cwd: 'cwd-from-testem',
       host: 'greatwebsite.com',
       port: 123324,
       reporter: 'xunit',


### PR DESCRIPTION
If cwd is configured in testem.js file it should use it, else outputPath should be used as cwd.