### PR TITLE
In MU apps, exclude TS test files from the app JS file

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -676,7 +676,7 @@ module.exports = class DefaultPackager {
       let src = new Funnel(tree, {
         srcDir: 'src',
         destDir: 'src',
-        exclude: ['**/*-test.js'],
+        exclude: ['**/*-test.{js,ts}'],
         annotation: 'Module Unification Src',
       });
 
@@ -848,7 +848,7 @@ module.exports = class DefaultPackager {
 
         let testSrcTree = new Funnel(tree, {
           srcDir: 'src',
-          include: ['**/*-test.js'],
+          include: ['**/*-test.{js,ts}'],
           annotation: 'Module Unification Tests',
         });
         testTree = mergeTrees([testTree, testSrcTree], {


### PR DESCRIPTION
It continues #8314 and fixes the issue reported at https://github.com/emberjs/ember.js/issues/17224#issuecomment-452294926