### PR TITLE
[BUGFIX] Use moduleName() for templates

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1150,7 +1150,7 @@ let addonProto = {
     if (addonTemplates) {
       standardTemplates = new Funnel(addonTemplates, {
         srcDir: '/',
-        destDir: `${this.name}/templates`,
+        destDir: `${this.moduleName()}/templates`,
         annotation: `Addon#_addonTemplateFiles (${this.name})`,
       });
 
@@ -1163,7 +1163,7 @@ let addonProto = {
 
       let podTemplates = new Funnel(addonTree, {
         include: includePatterns,
-        destDir: `${this.name}/`,
+        destDir: `${this.moduleName()}/`,
         annotation: 'Funnel: Addon Pod Templates',
       });
 

--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -11,7 +11,7 @@ const Addon = require('../../../../lib/models/addon');
 const buildOutput = broccoliTestHelper.buildOutput;
 const createTempDir = broccoliTestHelper.createTempDir;
 
-describe('Addon', function() {
+describe('Addon - linting', function() {
   let input, output, addon, lintTrees;
 
   beforeEach(co.wrap(function *() {

--- a/tests/unit/broccoli/addon/module-name-test.js
+++ b/tests/unit/broccoli/addon/module-name-test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const co = require('co');
+const path = require('path');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+
+const MockCLI = require('../../../helpers/mock-cli');
+const Project = require('../../../../lib/models/project');
+const Addon = require('../../../../lib/models/addon');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('Addon - moduleName', function() {
+  let input, output, addon;
+
+  beforeEach(co.wrap(function *() {
+    input = yield createTempDir();
+    let MockAddon = Addon.extend({
+      root: input.path(),
+      name: 'fake-addon',
+      moduleName() {
+        return 'totes-not-fake-addon';
+      },
+    });
+    let cli = new MockCLI();
+    let pkg = { name: 'ember-app-test' };
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+
+    addon = new MockAddon(project, project);
+
+    // override the registry so it just returns the input for everything
+    // and doesn't whine about not finding template preprocessors
+    addon.registry.load = () => [{
+      toTree(t) {
+        return t;
+      },
+    }];
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield input.dispose();
+    yield output.dispose();
+  }));
+
+  it('uses the module name function', co.wrap(function *() {
+    input.write({
+      'addon': {
+        'herp.js': '// slerpy',
+        'templates': {
+          'derp.hbs': '<!-- flerpy -->',
+        },
+      },
+    });
+
+    output = yield buildOutput(
+      addon.treeForAddon(path.join(addon.root, '/addon'))
+    );
+
+    expect(output.read()).to.deep.equal({
+      'totes-not-fake-addon': {
+        'herp.js': '// slerpy',
+        'templates': {
+          'derp.hbs': '<!-- flerpy -->',
+        },
+      },
+    });
+  }));
+});
+


### PR DESCRIPTION
We were working on an internal addon and trying to upgrade `ember-cli`, and were attempting to use `moduleName()` to squash the whole "name must match package name" errors temporarily, but some of the modules weren't respecting `moduleName`. It turned out that templates do not currently use it, and this PR fixes that.

There weren't any tests for `moduleName()` that I could find, happy to add some but would need some guidance on where the best place would be for that, and how to do it