### PR TITLE
bin/ember: Add support for Yarn PnP

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -25,6 +25,35 @@ try {
 
 logger.info('Resolved "ember-cli" to %j', projectLocalCli);
 
+if (!projectLocalCli && !process.versions.pnp) {
+  // If we haven't found `ember-cli` locally it might be installed though
+  // yarn plug'n'play. Let's check if an `.pnp.js` file exists and if so,
+  // use it to find `ember-cli` in the yarn cache and setup yarn PnP support
+  // for the following `require()` calls.
+  var findUp = require('find-up');
+
+  logger.info('Checking for ".pnp.js" file from %j...', basedir);
+  var pnpFile = findUp.sync('.pnp.js', { cwd: basedir });
+  logger.info('-> pnpFile: %j', pnpFile);
+  if (pnpFile) {
+    logger.info('Loading Yarn PnP API...');
+    var pnp = require(pnpFile);
+
+    logger.info('Setting up Yarn PnP compatibility layer...');
+    pnp.setupCompatibilityLayer();
+
+    logger.info('Setting up Yarn PnP Node.js hooks...');
+    pnp.setup();
+
+    logger.info('Resolving "ember-cli" through Yarn PnP...');
+    try {
+      projectLocalCli = pnp.resolveToUnqualified('ember-cli', basedir, { considerBuiltins: false });
+    } catch(ignored) {}
+
+    logger.info('Resolved "ember-cli" to %j', projectLocalCli);
+  }
+}
+
 // Load `ember-cli` either from the project-local path, or if it could not
 // be resolved use the global version
 logger.info('Loading "ember-cli"...');

--- a/bin/ember
+++ b/bin/ember
@@ -45,6 +45,8 @@ if (!projectLocalCli && !process.versions.pnp) {
     logger.info('Setting up Yarn PnP Node.js hooks...');
     pnp.setup();
 
+    // We add `--require ${pnpFile}` to the NODE_OPTIONS environment variable
+    // here to ensure that any `child_process` calls will use Yarn PnP mode too
     logger.info('Adding ' + pnpFile + ' to NODE_OPTIONS...');
     process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' --require ' + pnpFile;
 

--- a/bin/ember
+++ b/bin/ember
@@ -45,6 +45,9 @@ if (!projectLocalCli && !process.versions.pnp) {
     logger.info('Setting up Yarn PnP Node.js hooks...');
     pnp.setup();
 
+    logger.info('Adding ' + pnpFile + ' to NODE_OPTIONS...');
+    process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' --require ' + pnpFile;
+
     logger.info('Resolving "ember-cli" through Yarn PnP...');
     try {
       projectLocalCli = pnp.resolveToUnqualified('ember-cli', basedir, { considerBuiltins: false });


### PR DESCRIPTION
This PR adds support for Yarn Plug'n'Play to our CLI entry point.

The code will first resolve the `ember-cli` dependency locally as usual. If it does not exist it will traverse the file system upwards and look for a `.pnp.js` file and if it finds one it will `require()` it and run the necessary functions to enable PnP mode. Afterward it will use the `resolveToUnqualified()` API to look up the `ember-cli` dependency. If it can still not be resolved (e.g. no `ember-cli` dependency in the `package.json`) we fall back to the global Ember CLI.

If `ember` is being run through `yarn run` then PnP mode will already be activated for us. In that case, the project-local `resolve.sync()` call will work as usual and resolve to the correct `ember-cli`. If that resolve call should fail (e.g. 'ember-cli` dependency missing) then we detect the PnP mode, skip the PnP file search, and fall back to the global CLI directly.

~One potential caveat: We call `setupCompatibilityLayer()` and `setup()` to enable PnP mode, but those functions are not yet confirmed to be public API.~
**UPDATE:** @arcanis confirmed that these methods are public API.

Also please keep in mind that this only adds support for the entry point, there is more work to be done in other parts of EmberCLI, specifically the `PackageInfoCache` needs some changes.

related to https://github.com/ember-cli/ember-cli/issues/8164

/cc @arcanis