### PR TITLE
Fix the module path for MU non-acceptance tests

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -844,27 +844,30 @@ module.exports = class DefaultPackager {
         exclude: ['addon-test-support/**/*'],
       });
 
-      if (this.isModuleUnificationEnabled) {
-
-        let testSrcTree = new Funnel(tree, {
-          srcDir: 'src',
-          include: ['**/*-test.{js,ts}'],
-          annotation: 'Module Unification Tests',
-        });
-        testTree = mergeTrees([testTree, testSrcTree], {
-          annotation: 'Merge MU Tests',
-        });
-
-      }
-
       let treeToCompile = new Funnel(testTree, {
         destDir: `${this.name}/tests`,
         annotation: 'Tests To Process',
       });
 
+      if (this.isModuleUnificationEnabled) {
+        let testSrcTree = new Funnel(tree, {
+          srcDir: 'src',
+          include: ['**/*-test.{js,ts}'],
+          annotation: 'Module Unification Tests',
+        });
+        testSrcTree = new Funnel(testSrcTree, {
+          destDir: `${this.name}/src`,
+        });
+
+        treeToCompile = mergeTrees([treeToCompile, testSrcTree], {
+          annotation: 'Merge MU Tests',
+        });
+      }
+
       treeToCompile = callAddonsPreprocessTreeHook(this.project, 'test', treeToCompile);
 
-      let preprocessedTests = preprocessJs(treeToCompile, '/tests', this.name, {
+      const inputPath = this.isModuleUnificationEnabled ? '/' : '/tests';
+      let preprocessedTests = preprocessJs(treeToCompile, inputPath, this.name, {
         registry: this.registry,
       });
 
@@ -1076,7 +1079,7 @@ module.exports = class DefaultPackager {
     });
 
     return concat(appTestTrees, {
-      inputFiles: [`${this.name}/tests/**/*.js`],
+      inputFiles: [`${this.name}/{tests,src}/**/*.js`],
       headerFiles: ['vendor/ember-cli/tests-prefix.js'],
       footerFiles: ['vendor/ember-cli/app-config.js', 'vendor/ember-cli/tests-suffix.js'],
       outputFile: this.distPaths.testJsFile,

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -425,4 +425,23 @@ describe('Acceptance: brocfile-smoke-test', function() {
       expect(file(path.join(basePath, f))).to.exist;
     });
   }));
+
+  if (isExperimentEnabled('MODULE_UNIFICATION')) {
+
+    it('can run a MU unit test with a relative import', co.wrap(function *() {
+      yield copyFixtureFiles('brocfile-tests/mu-unit-test-with-relative-import');
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'tests.js'), {
+        encoding: 'utf8',
+      });
+
+      expect(appFileContents).to.include('Unit | Utility | string');
+
+      let result = yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+      expect(result.code).to.eql(0);
+
+    }));
+
+  }
 });

--- a/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string-test.js
+++ b/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+import stringFn from './string';
+
+module('Unit | Utility | string', function() {
+
+  test('returns hola', function(assert) {
+    assert.equal(stringFn(), 'hola');
+  });
+
+});

--- a/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string.js
+++ b/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 'hola';
+}


### PR DESCRIPTION
Closes #8363

It set correctly the module path of the MU tests; given the following test file `/src/utils/unit-test`:

Before -> `$packageName/tests/utils/unit-test` 
Now ->  `$packageName/src/utils/unit-test`

The fix solves relative imports within the test file. The PR includes an unit test:

```
import { module, test } from 'qunit';
import stringFn from './string';

 module('Unit | Utility | string', function() {
  ...
 });
```

