### PR TITLE
Fix non-acceptance tests for MU addons

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -850,13 +850,28 @@ module.exports = class DefaultPackager {
       });
 
       if (this.isModuleUnificationEnabled) {
-        let testSrcTree = new Funnel(tree, {
-          srcDir: 'src',
+
+        let destDir,
+            testSrcTree,
+            srcDir;
+
+        // ember-addon
+        if (this.name === 'dummy') {
+          testSrcTree = 'src';
+          destDir = `${this.project.name()}/src`;
+        } else {
+          testSrcTree = tree;
+          destDir = `${this.name}/src`;
+          srcDir = 'src';
+        }
+        testSrcTree = new Funnel(testSrcTree, {
+          srcDir,
           include: ['**/*-test.{js,ts}'],
           annotation: 'Module Unification Tests',
         });
+
         testSrcTree = new Funnel(testSrcTree, {
-          destDir: `${this.name}/src`,
+          destDir,
         });
 
         treeToCompile = mergeTrees([treeToCompile, testSrcTree], {
@@ -1079,7 +1094,7 @@ module.exports = class DefaultPackager {
     });
 
     return concat(appTestTrees, {
-      inputFiles: [`${this.name}/{tests,src}/**/*.js`],
+      inputFiles: ['**/{tests,src}/**/*.js'],
       headerFiles: ['vendor/ember-cli/tests-prefix.js'],
       footerFiles: ['vendor/ember-cli/app-config.js', 'vendor/ember-cli/tests-suffix.js'],
       outputFile: this.distPaths.testJsFile,

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -140,6 +140,36 @@ describe('Acceptance: addon-smoke-test', function() {
     expect(outputFiles).to.not.contain(unnecessaryFiles);
     expect(outputFiles).to.not.contain(unnecessaryFolders);
   }));
+
+  if (isExperimentEnabled('MODULE_UNIFICATION')) {
+
+    it('can run a MU unit test with a relative import', co.wrap(function *() {
+      yield copyFixtureFiles('brocfile-tests/mu-unit-test-with-relative-import');
+
+      let packageJsonPath = path.join(addonRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+
+      packageJson.dependencies = packageJson.dependencies || {};
+      // add HTMLBars for templates (generators do this automatically when components/templates are added)
+      packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
+
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      let result = yield runCommand('node_modules/ember-cli/bin/ember', 'build');
+      expect(result.code).to.eql(0);
+
+      let appFileContents = fs.readFileSync(path.join(addonRoot, 'dist', 'assets', 'tests.js'), {
+        encoding: 'utf8',
+      });
+
+      expect(appFileContents).to.include('Unit | Utility | string');
+
+      result = yield runCommand('node_modules/ember-cli/bin/ember', 'test');
+      expect(result.code).to.eql(0);
+
+    }));
+
+  }
 });
 
 function npmPack() {


### PR DESCRIPTION
The PR fixes non-acceptance tests in MU addons. Now tests in MU addons works like MU apps.

Given:

```
/src/utils/string-test.js
/src/utils/string.js
```

`string-test.js` is bundled in  the`tests.js` file with the namespace `${addonName}/src/utils/string-test.js`

`string.js` is bundled in  the`vendors.js` file with the namespace `${addonName}/src/utils/string.js`


Relates to #8379