### PR TITLE
[INTERNAL] Improve jQuery deprecation message

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -489,7 +489,11 @@ class EmberApp {
       if (optionFeatures && !optionFeatures.isFeatureEnabled('jquery-integration')) {
         return;
       }
-      this.project.ui.writeDeprecateLine('Ember will stop including jQuery by default in an upcoming version. If you wish keep using jQuery in your application explicitly add `@ember/jquery` to your package.json');
+      this.project.ui.writeDeprecateLine(
+        'The integration of jQuery into Ember has been deprecated and will be removed with Ember 4.0. You can either' +
+        ' opt-out of using jQuery, or install the `@ember/jquery` addon to provide the jQuery integration. Please' +
+        ' consult the deprecation guide for further details: https://emberjs.com/deprecations/v3.x#toc_jquery-apis'
+      );
       jqueryPath = ember.paths.jquery;
     } else {
       jqueryPath = `${this.bowerDirectory}/jquery/dist/jquery.js`;


### PR DESCRIPTION
* As discussed with @rwjblue, this makes the existing deprecation message more specific, stating explicitly that  the jQuery integration per se is deprecated and will be removed from Ember itself
* added tests