### PR TITLE
Improve styles tests

### DIFF
--- a/tests/fixtures/addon/with-mu-styles/package.json
+++ b/tests/fixtures/addon/with-mu-styles/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-project",
+  "private": true,
+  "dependencies": {
+    "something-else": "latest"
+  },
+  "ember-addon": {
+    "paths": ["./lib/ember-super-button"]
+  },
+    "devDependencies": {
+    "ember-resolver": "^5.0.1",
+    "ember-cli": "latest",
+    "ember-random-addon": "latest",
+    "ember-non-root-addon": "latest",
+    "ember-generated-with-export-addon": "latest",
+    "non-ember-thingy": "latest",
+    "ember-before-blueprint-addon": "latest",
+    "ember-after-blueprint-addon": "latest",
+    "ember-devDeps-addon": "latest",
+    "ember-addon-with-dependencies": "latest"
+  }
+}

--- a/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
+++ b/tests/fixtures/addon/with-mu-styles/src/ui/styles/foo-bar.css
@@ -1,0 +1,1 @@
+/* app/styles/foo-bar.css contents */

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -52,7 +52,6 @@ function mockTemplateRegistry(app) {
 
 describe('EmberApp', function() {
   let project, projectPath, app, addon;
-  this.timeout(435436);
 
   function setupProject(rootPath) {
     const packageContents = require(path.join(rootPath, 'package.json'));

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -52,6 +52,7 @@ function mockTemplateRegistry(app) {
 
 describe('EmberApp', function() {
   let project, projectPath, app, addon;
+  this.timeout(435436);
 
   function setupProject(rootPath) {
     const packageContents = require(path.join(rootPath, 'package.json'));
@@ -430,7 +431,7 @@ describe('EmberApp', function() {
         src: {
           ui: {
             styles: {
-              'foo.css': 'foo',
+              'mu.css': 'mu',
             },
           },
         },
@@ -470,6 +471,7 @@ describe('EmberApp', function() {
               styles: {
                 'foo.css': 'foo',
                 'bar.css': 'bar',
+                'mu.css': 'mu',
                 "baztrap": {
                   "baztrap.css": "// baztrap.css",
                 },
@@ -483,6 +485,7 @@ describe('EmberApp', function() {
             styles: {
               'foo.css': 'foo',
               'bar.css': 'bar',
+              'mu.css': 'mu',
               "baztrap": {
                 "baztrap.css": "// baztrap.css",
               },

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -734,6 +734,7 @@ describe('models/addon.js', function() {
   });
 
   describe('treeForStyles', function() {
+    this.timeout(50000);
     let builder, addon;
     const { isExperimentEnabled } = require('../../../lib/experiments');
 
@@ -773,6 +774,7 @@ describe('models/addon.js', function() {
     });
 
     it('should move files in the root of the addons app/styles tree into the app/styles path', function() {
+      this.timeout(50000);
       builder = new broccoli.Builder(addon.treeFor('styles'));
 
       return builder.build()

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -734,7 +734,6 @@ describe('models/addon.js', function() {
   });
 
   describe('treeForStyles', function() {
-    this.timeout(50000);
     let builder, addon;
     const { isExperimentEnabled } = require('../../../lib/experiments');
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -735,17 +735,32 @@ describe('models/addon.js', function() {
 
   describe('treeForStyles', function() {
     let builder, addon;
+    const { isExperimentEnabled } = require('../../../lib/experiments');
 
     beforeEach(function() {
-      projectPath = path.resolve(fixturePath, 'with-app-styles');
+      if (isExperimentEnabled('MODULE_UNIFICATION')) {
+        projectPath = path.resolve(fixturePath, 'with-mu-styles');
+      } else {
+        projectPath = path.resolve(fixturePath, 'with-app-styles');
+      }
       const packageContents = require(path.join(projectPath, 'package.json'));
       let cli = new MockCLI();
 
       project = new Project(projectPath, packageContents, cli.ui, cli);
+      project.isModuleUnification = function() {
+        if (isExperimentEnabled('MODULE_UNIFICATION')) {
+          return true;
+        }
+      };
 
       let BaseAddon = Addon.extend({
         name: 'test-project',
         root: projectPath,
+        isModuleUnification() {
+          if (isExperimentEnabled('MODULE_UNIFICATION')) {
+            return true;
+          }
+        },
       });
 
       addon = new BaseAddon(project, project);


### PR DESCRIPTION
@rwjblue trying the get at least some of my work from https://github.com/ember-cli/ember-cli/pull/8146 for contribution :)

This improves the tests to use real addon instances, so they are closer to real use. Previous test did not catch the issues.
Also the test `can handle empty styles folders`, does actually not test on an empty folder.