### PR TITLE
`preprocessTemplates` is called only once in MU layout

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -245,7 +245,7 @@ module.exports = class DefaultPackager {
       let trees = [
         allTrees,
         templates,
-        this.processSrc(allTrees),
+        this.processJavascriptSrc(allTrees),
       ].filter(Boolean);
 
       let mergedTree = mergeTrees(trees, {
@@ -444,19 +444,36 @@ module.exports = class DefaultPackager {
       let include = this.registry.extensionsForType('template')
         .map(extension => `**/*/template.${extension}`);
 
-      let pods = new Funnel(templates, {
-        include,
-        exclude: ['templates/**/*'],
-        annotation: 'Pod Templates',
-      });
       let classic = new Funnel(templates, {
         srcDir: `${this.name}/templates`,
         destDir: `${this.name}/templates`,
         annotation: 'Classic Templates',
       });
-      let mergedTemplates = mergeTrees([pods, classic], {
+
+      let mergedTemplates = [classic];
+
+      if (this.isModuleUnificationEnabled) {
+        let mu = new Funnel(templates, {
+          srcDir: 'src',
+          destDir: `${this.name}/src`,
+          include,
+          exclude: ['templates/**/*'],
+          annotation: 'MU Templates',
+        });
+        mu = this._debugTree(mu, 'mu-layout:tree:template');
+        mergedTemplates.push(mu);
+      } else {
+        let pods = new Funnel(templates, {
+          include,
+          exclude: ['templates/**/*'],
+          annotation: 'Pod Templates',
+        });
+        mergedTemplates.push(pods);
+      }
+
+      mergedTemplates = mergeTrees(mergedTemplates, {
         overwrite: true,
-        annotation: 'Pod & Classic Templates',
+        annotation: 'Templates',
       });
       let preprocessedTemplatesFromAddons = callAddonsPreprocessTreeHook(
         this.project,
@@ -631,8 +648,8 @@ module.exports = class DefaultPackager {
   }
 
   /*
-   * Runs pre/post-processors hooks on the application files (javascript,
-   * styles, templates) and returns a single tree with the processed ones.
+   * Runs pre/post-processors hooks on the application javascript files
+   * and returns a single tree with the processed ones.
    *
    * Used only when `MODULE_UNIFICATION` experiment is enabled.
    *
@@ -654,34 +671,32 @@ module.exports = class DefaultPackager {
    *             └── app.css
    * ```
    *
-   * Returns the tree with the same structure, but with processed files.
+   * Returns the tree with only the JS/TS files, but with processed files.
    *
    * @private
-   * @method processSrc
+   * @method processJavascriptSrc
    * @param {BroccoliTree} tree
    * @return {BroccoliTree}
   */
-  processSrc(tree) {
+  processJavascriptSrc(tree) {
     if (this._cachedProcessedSrc === null && this.isModuleUnificationEnabled) {
       let src = new Funnel(tree, {
         srcDir: 'src',
         destDir: 'src',
+        include: ['**/*.{js,ts}'],
         exclude: ['**/*-test.{js,ts}'],
         annotation: 'Module Unification Src',
       });
 
       let srcAfterPreprocessTreeHook = callAddonsPreprocessTreeHook(this.project, 'src', src);
-
-      let srcAfterTemplatePreprocessing = preprocessTemplates(srcAfterPreprocessTreeHook, {
-        registry: this.registry,
-        annotation: 'Process Templates: src',
-      });
+      srcAfterPreprocessTreeHook = this._debugTree(srcAfterPreprocessTreeHook, 'mu-layout:addonsPreprocessTree:js');
 
       let srcAfterPostprocessTreeHook = callAddonsPostprocessTreeHook(
         this.project,
         'src',
-        srcAfterTemplatePreprocessing
+        srcAfterPreprocessTreeHook
       );
+      srcAfterPostprocessTreeHook = this._debugTree(srcAfterPostprocessTreeHook, 'mu-layout:addonsPostprocessTree:js');
 
       this._cachedProcessedSrc = new Funnel(mergeTrees([
         srcAfterPostprocessTreeHook,

--- a/tests/unit/broccoli/default-packager/javascript-test.js
+++ b/tests/unit/broccoli/default-packager/javascript-test.js
@@ -363,11 +363,6 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
 
         registry: setupRegistry({
           js: tree => tree,
-          template: tree => new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/hbs$/g, 'js');
-            },
-          }),
         }),
 
         isModuleUnificationEnabled: true,
@@ -378,13 +373,11 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
         project: {
           addons: [{
             preprocessTree(type, tree) {
-              addonPreprocessTreeHookCalled = true;
-
+              expect(type).to.equal('src');
               return tree;
             },
             postprocessTree(type, tree) {
-              addonPostprocessTreeHookCalled = true;
-
+              expect(type).to.equal('src');
               return tree;
             },
           }],
@@ -393,7 +386,7 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
 
       expect(defaultPackager._cachedProcessedSrc).to.equal(null);
 
-      outputMU = yield buildOutput(defaultPackager.processSrc(inputMU.path()));
+      outputMU = yield buildOutput(defaultPackager.processJavascriptSrc(inputMU.path()));
 
       let outputFiles = outputMU.read();
 
@@ -406,17 +399,7 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
             components: {
               'login-form': {
                 'component.js': '',
-                'template.js': '',
               },
-            },
-            'index.html': '',
-            routes: {
-              application: {
-                'template.js': '',
-              },
-            },
-            styles: {
-              'app.css': 'html { height: 100%; }',
             },
           },
         },
@@ -424,6 +407,10 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
     }));
 
     it('runs pre/post-process add-on hooks', co.wrap(function *() {
+
+      addonPreprocessTreeHookCalled = false;
+      addonPostprocessTreeHookCalled = false;
+
       let defaultPackager = new DefaultPackager({
         name: 'the-best-app-ever',
 
@@ -435,11 +422,6 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
 
         registry: setupRegistry({
           js: tree => tree,
-          template: tree => new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/hbs$/g, 'js');
-            },
-          }),
         }),
 
         isModuleUnificationEnabled: true,
@@ -450,11 +432,13 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
         project: {
           addons: [{
             preprocessTree(type, tree) {
+              expect(type).to.equal('src');
               addonPreprocessTreeHookCalled = true;
 
               return tree;
             },
             postprocessTree(type, tree) {
+              expect(type).to.equal('src');
               addonPostprocessTreeHookCalled = true;
 
               return tree;
@@ -463,7 +447,7 @@ if (isExperimentEnabled('MODULE_UNIFICATION')) {
         },
       });
 
-      outputMU = yield buildOutput(defaultPackager.processSrc(inputMU.path()));
+      outputMU = yield buildOutput(defaultPackager.processJavascriptSrc(inputMU.path()));
 
       expect(addonPreprocessTreeHookCalled).to.equal(true);
       expect(addonPostprocessTreeHookCalled).to.equal(true);

--- a/tests/unit/broccoli/default-packager/templates-test.js
+++ b/tests/unit/broccoli/default-packager/templates-test.js
@@ -117,11 +117,14 @@ describe('Default Packager: Templates', function() {
       project: {
         addons: [{
           preprocessTree(type, tree) {
+            expect(type).to.equal('template');
             addonPreprocessTreeHookCalled = true;
 
             return tree;
           },
           postprocessTree(type, tree) {
+
+            expect(type).to.equal('template');
             addonPostprocessTreeHookCalled = true;
 
             return tree;


### PR DESCRIPTION
Fixes #8196 and supersedes #8197. The PR avoid `preprocessTemplates` being called twice on the same templates.

The implementation follows the same type of changes that were done at #8289 where `defaultPackager.packageStyles` became the function to process styles (Classic and MU layout).

This PR changes `defaultPackager.processTemplates` to be the only function to process templates (Classic and MU layout).

`defaultPackager.processSrc` becomes `defaultPackager.processJavascriptSrc` and will only process JS/TS files for MU apps.



