### PR TITLE
Add support for running different dummy apps

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -141,6 +141,7 @@ module.exports = class DefaultPackager {
     this.vendorTestStaticStyles = this.options.vendorTestStaticStyles;
     this.legacyTestFilesToAppend = this.options.legacyTestFilesToAppend;
     this.isModuleUnificationEnabled = this.options.isModuleUnificationEnabled;
+    this.isDummyApp = this.options.isDummyApp;
   }
 
   /*
@@ -835,8 +836,7 @@ module.exports = class DefaultPackager {
             testSrcTree,
             srcDir;
 
-        // ember-addon
-        if (this.name === 'dummy') {
+        if (this.isDummyApp) {
           testSrcTree = 'src';
           destDir = `${this.project.name()}/src`;
         } else {

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -28,39 +28,54 @@ class EmberAddon extends EmberApp {
       defaultsDeep(options, defaults);
     }
 
+    // Let's use first an ENV variable until there is a feature agreement
+    let name = process.env.EMBER_CLI_DUMMY = process.env.EMBER_CLI_DUMMY || 'dummy';
     process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';
+
+    let testsExclude = [new RegExp(`^${name}`)];
+
     let overrides = {
-      name: 'dummy',
-      configPath: './tests/dummy/config/environment',
+      name,
+      configPath: `./tests/${name}/config/environment`,
       trees: {
-        app: 'tests/dummy/app',
-        public: 'tests/dummy/public',
+        app: `tests/${name}/app`,
+        public: `tests/${name}/public`,
         src: null,
-        styles: 'tests/dummy/app/styles',
-        templates: 'tests/dummy/app/templates',
+        styles: `tests/${name}/app/styles`,
+        templates: `tests/${name}/app/templates`,
         tests: new Funnel('tests', {
-          exclude: [/^dummy/],
+          exclude: testsExclude,
         }),
         vendor: null,
       },
       jshintrc: {
         tests: './tests',
-        app: './tests/dummy',
+        app: `./tests/${name}`,
+      },
+      // outputPaths can be changed  to use `name` when tests/index.html support dynamic assets
+      outputPaths: {
+        app: {
+          css: {
+            app: `/assets/dummy.css`,
+          },
+          js: `/assets/dummy.js`,
+        },
       },
     };
 
-    if (!fs.existsSync('tests/dummy/app')) {
+
+    if (!fs.existsSync(`tests/${name}/app`)) {
       overrides.trees.app = null;
       overrides.trees.styles = null;
       overrides.trees.templates = null;
     }
-    if (fs.existsSync('tests/dummy/src')) {
-      overrides.trees.src = 'tests/dummy/src';
-      overrides.trees.styles = 'tests/dummy/src/ui/styles';
+    if (fs.existsSync(`tests/${name}/src`)) {
+      overrides.trees.src = `tests/${name}/src`;
+      overrides.trees.styles = `tests/${name}/src/ui/styles`;
     }
 
-    if (fs.existsSync('tests/dummy/vendor')) {
-      overrides.trees.vendor = 'tests/dummy/vendor';
+    if (fs.existsSync(`tests/${name}/vendor`)) {
+      overrides.trees.vendor = `tests/${name}/vendor`;
     }
 
     super(defaultsDeep(options, overrides));

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -36,6 +36,7 @@ class EmberAddon extends EmberApp {
 
     let overrides = {
       name,
+      isDummyApp: true,
       configPath: `./tests/${name}/config/environment`,
       trees: {
         app: `tests/${name}/app`,

--- a/lib/broccoli/ember-addon.js
+++ b/lib/broccoli/ember-addon.js
@@ -32,6 +32,9 @@ class EmberAddon extends EmberApp {
     let name = process.env.EMBER_CLI_DUMMY = process.env.EMBER_CLI_DUMMY || 'dummy';
     process.env.EMBER_ADDON_ENV = process.env.EMBER_ADDON_ENV || 'development';
 
+    // `testExclude` only excludes the "running" dummy app (provided by the `name` value),
+    // but additional `dummy` apps may be included on the `testTree`.
+    // It does not look to trigger functional errors, but the linter may run on the additional `dummy` apps.
     let testsExclude = [new RegExp(`^${name}`)];
 
     let overrides = {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -168,6 +168,7 @@ class EmberApp {
       vendorTestStaticStyles: this.vendorTestStaticStyles,
       legacyTestFilesToAppend: this.legacyTestFilesToAppend,
       isModuleUnificationEnabled: isExperimentEnabled('MODULE_UNIFICATION') && !!this.trees.src,
+      isDummyApp: this.options.isDummyApp,
       distPaths: {
         appJsFile: this.options.outputPaths.app.js,
         appCssFile: this.options.outputPaths.app.css,

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/addon-test-support/helper.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/addon-test-support/helper.js
@@ -1,0 +1,3 @@
+export default function truthyHelper() {
+  return true;
+}

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/components/basic-thing.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/components/basic-thing.js
@@ -1,0 +1,6 @@
+import template from '../templates/components/basic-thing';
+import Component from '@ember/component';
+
+export default Component.extend({
+  layout: template
+});

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/index.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/index.js
@@ -1,0 +1,2 @@
+import BasicThing from "./components/basic-thing";
+export default BasicThing;

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/styles/app.css
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/styles/app.css
@@ -1,0 +1,1 @@
+/* addon/styles/app.css is present */

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/templates/components/basic-thing.hbs
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/addon/templates/components/basic-thing.hbs
@@ -1,0 +1,3 @@
+<div class="basic-thing">
+  {{yield}}
+</div>

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/app/components/basic-thing.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/app/components/basic-thing.js
@@ -1,0 +1,2 @@
+import BasicThing from 'some-cool-addon/components/basic-thing';
+export default BasicThing;

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/index.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: require('./package').name,
+
+  contentFor(type, config) {
+    if (type === 'head') {
+      return '"SOME AWESOME STUFF"';
+    }
+  }
+};

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/acceptance/main-test.js
@@ -1,0 +1,23 @@
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import truthyHelper from 'some-cool-addon/test-support/helper';
+import { module, test } from 'qunit';
+
+module('Acceptance', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('renders properly', async function(assert) {
+    await visit('/');
+
+    var element = this.element.querySelector('.basic-thing');
+    assert.equal(element.textContent.trim(), 'WOOT!!');
+    assert.ok(truthyHelper(), 'addon-test-support helper');
+  });
+
+  test('renders imported component', async function(assert) {
+    await visit('/');
+
+    var element = this.element.querySelector('.second-thing');
+    assert.equal(element.textContent.trim(), 'SECOND!!');
+  });
+});

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/app.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/app.js
@@ -1,0 +1,14 @@
+import Application from '@ember/application';
+import Resolver from './resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
+
+const App = Application.extend({
+  modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
+  Resolver
+});
+
+loadInitializers(App, config.modulePrefix);
+
+export default App;

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/components/second-thing.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/components/second-thing.js
@@ -1,0 +1,5 @@
+import BasicThing from 'some-cool-addon/components/basic-thing';
+
+export default BasicThing.extend({
+  classNames: ['second-thing']
+});

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/index.html
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Dummy</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+
+    {{content-for "head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+
+    {{content-for "body-footer"}}
+  </body>
+</html>

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/resolver.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/router.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/router.js
@@ -1,0 +1,12 @@
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+const Router = EmberRouter.extend({
+  location: config.locationType,
+  rootURL: config.rootURL
+});
+
+Router.map(function() {
+});
+
+export default Router;

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/templates/application.hbs
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{#basic-thing}}WOOT!!{{/basic-thing}}
+{{#second-thing}}SECOND!!{{/second-thing}}

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/config/environment.js
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/config/environment.js
@@ -1,0 +1,51 @@
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'dummy2',
+    environment,
+    rootURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
+  }
+
+  if (environment === 'production') {
+    // here you can enable a production-specific feature
+  }
+
+  return ENV;
+};

--- a/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/public/robots.txt
+++ b/tests/fixtures/addon/kitchen-sink-with-dummy2/tests/dummy2/public/robots.txt
@@ -1,0 +1,1 @@
+# tests/dummy2/public/robots.txt is present


### PR DESCRIPTION
```
EMBER_CLI_DUMMY=dummy2 ember serve
EMBER_CLI_DUMMY=dummy2 ember test
```

* The dummy app must be located at `tests/${dummyAppName}`
* The default value of the option is `dummy`

A non default dummy app must change the default `modulePrefix`:

```
//config/environment.js
    modulePrefix: 'dummy2'
```

A needed additional change is that the `DefaultPackager` needs to be informed that it is building a Dummy app https://github.com/ember-cli/ember-cli/pull/8416/commits/a7848d694e751a36f45341ae90dbab5064cc17b0



Related

https://github.com/mansona/ember-cli-multiple-dummy-apps
https://github.com/mansona/testing-mu
#8322
#8158

- Should the blueprint option (`ember g component foo-bar --dummy`) be considered?
