### PR TITLE
WIP: add hook for addons to add to the resolver config

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -639,6 +639,14 @@ class EmberApp {
       if (addon.included) {
         addon.included(this);
       }
+
+      // addons may provide their own types and collections
+      // within the resolver
+      if (addon.addToResolver) {
+        let addonResolverConfig = addon.addToResolver(this.project.resolver);
+
+        merge(addonResolverConfig, this.project.resolver);
+      }
     });
   }
 


### PR DESCRIPTION
some info here: https://github.com/emberjs/ember.js/issues/17234#issuecomment-461810595 (comment on the octane tracking issue).

This is important so addon authors can add to the resolver config at build time, and that the "install steps" for addons with custom types and collections are kept as they are today (small).


I got stuck, cause I couldn't find where src/resolver.js was being loaded.

The closest I got was actually in ember-resolver, where the default config path from ember-resolver is added to the build tree: 
https://github.com/ember-cli/ember-resolver/blob/master/index.js#L64-L67
and that lead me to here: https://github.com/ember-cli/ember-cli-preprocess-registry/blob/master/preprocessors.js#L141
and now I don't know how or why anything is relevant :(