### PR TITLE
[INTERNAL] Fix install warnings for @babel/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:debug": "node debug tests/runner"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/plugin-transform-modules-amd": "^7.2.0",
     "amd-name-resolver": "^1.3.1",
     "babel-plugin-module-resolver": "^3.1.1",


### PR DESCRIPTION
Since `@babel/plugin-transform-modules-amd` requires `@babel/core` a `peerDependency`
adding it here will remove the warning from applications which require
ember-cli.

```
warning "ember-cli > @babel/plugin-transform-modules-amd@7.2.0" has unmet peer dependency "@babel/core@^7.0.0-0".
```

This is the recommended solution from https://github.com/babel/babel/pull/9483#issuecomment-462996137.

I know this is just a warning, but warnings like this bother new developers on my team who think it implies a problem with their setup which makes it difficult to onboard contributors. I think that justifies and extra line in `package.json` that doesn't actually change the dependency graph since `broccoli-babel-transpiler` (and probably others) require it anyway.