### PR TITLE
Fix how MU blueprints fetches `ember-source`

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -37,7 +37,7 @@ module.exports = {
   updatePackageJson(content) {
     let contents = JSON.parse(content);
 
-    contents.name = this.locals(this.options).addonName;
+    contents.name = stringUtil.dasherize(this.options.entity.name);
     contents.description = this.description;
     delete contents.private;
     contents.scripts = contents.scripts || {};

--- a/blueprints/module-unification-addon/index.js
+++ b/blueprints/module-unification-addon/index.js
@@ -2,7 +2,6 @@
 const addonBlueprint = require('../addon');
 const getURLFor = require('ember-source-channel-url');
 
-let emberCanaryVersion;
 module.exports = Object.assign({}, addonBlueprint, {
   description: 'Generates an Ember addon with a module unification layout.',
   appBlueprintName: 'module-unification-app',
@@ -12,15 +11,12 @@ module.exports = Object.assign({}, addonBlueprint, {
     '^addon-src/.gitkeep': 'src/.gitkeep',
   }),
 
-  beforeInstall() {
-    return getURLFor('canary').then(url => {
-      emberCanaryVersion = url;
-    });
-  },
 
   locals(options) {
-    let result = addonBlueprint.locals(options);
-    result.emberCanaryVersion = emberCanaryVersion;
-    return result;
+    return getURLFor('canary').then(url => {
+      let result = addonBlueprint.locals(options);
+      result.emberCanaryVersion = url;
+      return result;
+    });
   },
 });

--- a/blueprints/module-unification-app/index.js
+++ b/blueprints/module-unification-app/index.js
@@ -3,8 +3,6 @@
 const stringUtil = require('ember-cli-string-utils');
 const getURLFor = require('ember-source-channel-url');
 
-let emberCanaryVersion;
-
 module.exports = {
   description: 'Generates an Ember application with a module unification layout.',
 
@@ -16,21 +14,16 @@ module.exports = {
     let name = stringUtil.dasherize(rawName);
     let namespace = stringUtil.classify(rawName);
 
-    return {
+    return getURLFor('canary').then(url => ({
       name,
       modulePrefix: name,
       namespace,
       emberCLIVersion: require('../../package').version,
-      emberCanaryVersion,
+      emberCanaryVersion: url,
       yarn: options.yarn,
       welcome: options.welcome,
-    };
-  },
+    }));
 
-  beforeInstall() {
-    return getURLFor('canary').then(url => {
-      emberCanaryVersion = url;
-    });
   },
 
   fileMapTokens(options) {

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -71,6 +71,8 @@ describe('Acceptance: addon-smoke-test', function() {
     let packageJsonPath = path.join(addonRoot, 'package.json');
     let packageJson = fs.readJsonSync(packageJsonPath);
 
+    expect(packageJson.devDependencies['ember-source']).to.not.be.empty;
+
     packageJson.dependencies = packageJson.dependencies || {};
     // add HTMLBars for templates (generators do this automatically when components/templates are added)
     packageJson.dependencies['ember-cli-htmlbars'] = 'latest';


### PR DESCRIPTION
Fix the initial implementation of https://github.com/ember-cli/ember-cli/pull/8323.

In some cases, the `ember-source` version was assigned empty because the promise was not fulfilled yet.

I think the test suite did not fail because it may have been using a local `ember-source` version.

Making `locals` to return a Promise looks correct based on the [`locals` documentation](https://ember-cli.com/extending/#locals).

> This hook must return an object or a Promise which resolves to an object. The resolved object will be merged with the aforementioned default locals.

I added an assertion that failed previously.

Initially, I realized about this error when adding the feature to the `octane-blueprint`(the octane blueprints follow this structure), and this error has also been reported at https://github.com/ember-cli/ember-cli/pull/8424/files#r256792430 and https://github.com/ember-cli/ember-cli/pull/8431


