### PR TITLE
MU blueprints: enable `EMBER_MODULE_UNIFICATION` feature flag

### DIFF
--- a/blueprints/module-unification-app/files/config/environment.js
+++ b/blueprints/module-unification-app/files/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
-        'ember-module-unification': true
+        EMBER_MODULE_UNIFICATION: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.

--- a/tests/fixtures/module-unification-addon/npm/tests/dummy/config/environment.js
+++ b/tests/fixtures/module-unification-addon/npm/tests/dummy/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
-        'ember-module-unification': true
+        EMBER_MODULE_UNIFICATION: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.

--- a/tests/fixtures/module-unification-addon/yarn/tests/dummy/config/environment.js
+++ b/tests/fixtures/module-unification-addon/yarn/tests/dummy/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
-        'ember-module-unification': true
+        EMBER_MODULE_UNIFICATION: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.


### PR DESCRIPTION
Thanks to @patricklx for finding and providing the fix of this issue at https://github.com/ember-cli/ember-cli/pull/8424#discussion_r256795007

The MU blueprints were not enabling the `EMBER_MODULE_UNIFICATION` Ember Feature Flag. This PR enables it (I will also add it to the octane blueprints).

Relates #8431 and #8424 

---------------------------------


I have reviewed the Ember code and it looks that there is an issue regarding how Ember Feature Flags works: the [Feature Flags doc](https://github.com/emberjs/ember.js/blob/master/FEATURES.md) and [guide](https://guides.emberjs.com/release/configuring-ember/feature-flags/) looks to indicate that the feature key should be in dash and lowercase format, but I could not find in the Ember code that a key transformation from lowercase to uppercase format. 

Should it be enabled in lowercase and fix the issue or should the documentation be updated? 


 