### PR TITLE
fix: don't add extra slash in dist paths

### DIFF
--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -84,7 +84,7 @@ module.exports = class AssetPrinterSize {
       return walkSync(outputPath, {
         directories: false,
       }).filter(x => x.endsWith('.css') || x.endsWith('.js'))
-        .map(x => `${outputPath}${x}`);
+        .map(x => path.join(outputPath, x));
     } catch (e) {
       if (e !== null && typeof e === 'object' && e.code === 'ENOENT') {
         throw new Error(`No asset files found in the path provided: ${outputPath}`);

--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -84,7 +84,7 @@ module.exports = class AssetPrinterSize {
       return walkSync(outputPath, {
         directories: false,
       }).filter(x => x.endsWith('.css') || x.endsWith('.js'))
-        .map(x => `${outputPath}/${x}`);
+        .map(x => `${outputPath}${x}`);
     } catch (e) {
       if (e !== null && typeof e === 'object' && e.code === 'ENOENT') {
         throw new Error(`No asset files found in the path provided: ${outputPath}`);


### PR DESCRIPTION
<img width="720" alt="screen shot 2019-02-14 at 5 33 45 pm" src="https://user-images.githubusercontent.com/34726/52822073-b3ad4380-307e-11e9-8513-04db96f6712c.png">

vs

<img width="660" alt="screen shot 2019-02-14 at 5 34 32 pm" src="https://user-images.githubusercontent.com/34726/52822106-cfb0e500-307e-11e9-8691-bd65933e6b97.png">
