### PR TITLE
ENHANCEMENT Ensure Node 11 does not issue warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ jobs:
 
     - env: NAME=NODE_10
       node_js: 10
+
+    - env: NAME=NODE_11
+      node_js: 11
       script:
         - yarn test:cover
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,13 @@ jobs:
 
     - env: NAME=NODE_10
       node_js: 10
-
-    - env: NAME=NODE_11
-      node_js: 11
       script:
         - yarn test:cover
       after_success:
         - .travis/codecoverage.sh
+
+    - env: NAME=NODE_11
+      node_js: 11
 
     - env: EMBER_CLI_ENABLE_ALL_EXPERIMENTS=true
     - env: EMBER_CLI_PACKAGER=true


### PR DESCRIPTION
This will get rid of the _"WARNING: Node v11.3.0 is not tested against Ember CLI on your platform."_ message when using Node 11.