### PR TITLE
Drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ jobs:
         - yarn test
 
     - stage: additional tests
-      name: Node.js 6
-      node_js: 6
 
     - name: Node.js 8
       node_js: 8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ image: Visual Studio 2017
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
 

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "yuidocjs": "0.10.2"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "trackingCode": "UA-49225444-1",
   "greenkeeper": {


### PR DESCRIPTION
According to https://nodejs.org/en/about/releases/ support for Node.js 6 will end on 2019-04-01. Ember CLI v3.9.0 will be released right after that, but `master` is already targetting v3.10.0 so there should be 6+ weeks between Node.js 6 EOL and the release of this PR.

As stated in https://emberjs.com/blog/2016/09/07/ember-node-lts-support.html this will **not** cause/require a major version bump as our official support policy does not change. We recommend that all sub-dependencies, libraries and addons do bump their major version when dropping support for Node.js 6 though. The main reason for us not doing so is to keep the versions of Ember.js and Ember CLI in sync.