### PR TITLE
Skip flaky `serve-wasm` test on Node 6

### DIFF
--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const crypto = require('crypto');
 const walkSync = require('walk-sync');
+const semver = require('semver');
 const EOL = require('os').EOL;
 
 const { isExperimentEnabled } = require('../../lib/experiments');
@@ -22,6 +23,8 @@ const chai = require('../chai');
 let expect = chai.expect;
 let file = chai.file;
 let dir = chai.dir;
+
+const isNode6 = semver.satisfies(process.version, '^6');
 
 let appName = 'some-cool-app';
 let appRoot;
@@ -179,7 +182,7 @@ describe('Acceptance: smoke-test', function() {
     expect(output).to.match(/pass\s+\d+/, 'many passing');
   }));
 
-  it('ember test wasm', co.wrap(function *() {
+  (isNode6 ? it.skip : it)('ember test wasm', co.wrap(function *() {
     let originalWrite = process.stdout.write;
     let output = [];
 


### PR DESCRIPTION
CI is currently quite unreliable due to this test. It is unclear why it is sometimes failing, but since Node 6 will soon be EOL, I don't think it would be wise to invest much more time into figuring this out.