### PR TITLE
Ensure npm version is available during ember new / ember install foo.

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -73,6 +73,7 @@ class NpmTask extends Task {
           'verified to work with the current Ember CLI release.');
       }
 
+      return { npmVersion: version };
     }).catch(error => {
       logger.error('npm --version failed: %s', error);
 
@@ -137,7 +138,7 @@ class NpmTask extends Task {
   run(options) {
     this.useYarn = options.useYarn;
 
-    return this.findPackageManager().then(() => {
+    return this.findPackageManager().then(result => {
       let ui = this.ui;
       let startMessage = this.formatStartMessage(options.packages);
       let completeMessage = this.formatCompleteMessage(options.packages);
@@ -162,7 +163,7 @@ class NpmTask extends Task {
         // this ensures that we run a full `npm install` **after** any `npm
         // install foo` runs to ensure that we have a fully functional
         // node_modules heirarchy
-        if (semver.gte(this.npmVersion, '5.0.0')) {
+        if (result.npmVersion && semver.gte(result.npmVersion, '5.0.0')) {
           promise = promise.then(() => this.npm(['install']));
         }
       }


### PR DESCRIPTION
Tested locally via:

```
cd ember-cli
npm link
cd ~/sandbox
ember new test-npm-version-failure
```

^ failed before these changes (with an `Invalid Version` error), and passes after

Fixes #8458