### PR TITLE
Move all package related path resolution to resolve-package-path.

### DIFF
--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -12,91 +12,10 @@ const Errors = require('./errors');
 const PackageInfo = require('./package-info');
 const NodeModulesList = require('./node-modules-list');
 const logger = require('heimdalljs-logger')('ember-cli:package-info-cache');
+const resolvePackagePath = require('resolve-package-path');
 
-let realFilePathCache;
-let realDirectoryPathCache;
-
-/**
- * Resolve the real path for a file, return null if does not
- * exist or is not a file or FIFO, return the real path otherwise.
- *
- * @private
- * @method getRealFilePath
- * @param  {String} filePath the path to the file of interest
- * @return {String} real path or null
- */
-function getRealFilePath(filePath) {
-  let realPath;
-
-  try {
-    realPath = realFilePathCache[filePath];
-
-    if (realPath) {
-      return realPath;
-    }
-
-    let stat = fs.statSync(filePath);
-
-    if (stat.isFile() || stat.isFIFO()) {
-      realPath = fs.realpathSync(filePath);
-    }
-  } catch (e) {
-    if (
-      e !== null &&
-      typeof e === 'object' &&
-      (e.code === 'ENOENT' || e.code === 'ENOTDIR')
-    ) {
-      realPath = null;
-    } else {
-      throw e;
-    }
-  }
-
-  realFilePathCache[filePath] = realPath;
-
-  return realPath;
-}
-
-/**
- * Resolve the real path for a directory, return null if does not
- * exist or is not a directory, return the real path otherwise.
- *
- * @private
- * @method getRealDirectoryPath
- * @param  {String} directoryPath the path to the directory of interest
- * @return {String} real path or null
- */
-function getRealDirectoryPath(directoryPath) {
-  let realPath;
-
-  try {
-    realPath = realDirectoryPathCache[directoryPath];
-
-    if (realPath) {
-      return realPath;
-    }
-
-    let stat = fs.statSync(directoryPath);
-
-    if (stat.isDirectory()) {
-      realPath = fs.realpathSync(directoryPath);
-    }
-  } catch (e) {
-    if (
-      e !== null &&
-      typeof e === 'object' &&
-      (e.code === 'ENOENT' || e.code === 'ENOTDIR')
-    ) {
-      realPath = null;
-    } else {
-      throw e;
-    }
-  }
-
-  realDirectoryPathCache[directoryPath] = realPath;
-
-  return realPath;
-}
+const getRealFilePath = resolvePackagePath.getRealFilePath;
+const getRealDirectoryPath = resolvePackagePath.getRealDirectoryPath;
 
 const PACKAGE_JSON = 'package.json';
 
@@ -122,8 +41,6 @@ class PackageInfoCache {
   _clear() {
     this.entries = Object.create(null);
     this.projects = [];
-    realFilePathCache = Object.create(null);
-    realDirectoryPathCache = Object.create(null);
   }
 
   /**
@@ -774,7 +691,3 @@ class PackageInfoCache {
 }
 
 module.exports = PackageInfoCache;
-
-// export the getRealXXXPath functions to enable testing
-module.exports.getRealFilePath = getRealFilePath;
-module.exports.getRealDirectoryPath = getRealDirectoryPath;

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "promise-map-series": "^0.2.3",
     "quick-temp": "^0.1.8",
     "resolve": "^1.10.0",
+    "resolve-package-path": "^1.1.1",
     "rsvp": "^4.8.4",
     "sane": "^4.0.2",
     "semver": "^5.6.0",

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const expect = require('chai').expect;
-const PackageInfoCache = require('../../../../lib/models/package-info-cache');
 const PackageInfo = require('../../../../lib/models/package-info-cache/package-info');
 const Project = require('../../../../lib/models/project');
 const addonFixturePath = path.resolve(__dirname, '../../../fixtures/addon');
@@ -530,50 +529,6 @@ describe('models/package-info-cache/package-info-cache-test.js', function() {
 
       resolvedFile = projectPackageInfo.addonMainPath;
       expect(resolvedFile).to.equal(path.join(projectPath, 'index.js'));
-    });
-  });
-
-  describe('getRealFilePath tests', function() {
-    let fakePackageJsonPath;
-
-    beforeEach(function() {
-      projectPath = path.resolve(addonFixturePath, 'external-dependency');
-      packageJsonPath = path.join(projectPath, 'package.json');
-      fakePackageJsonPath = path.join(projectPath, 'foozleberry.js');
-    });
-
-    it('getRealFilePath(real package.json file) exists', function() {
-      expect(PackageInfoCache.getRealFilePath(packageJsonPath)).to.exist;
-    });
-
-    it('getRealFilePath(fake file path) does not exist', function() {
-      expect(PackageInfoCache.getRealFilePath(fakePackageJsonPath)).not.to.exist;
-    });
-
-    it('getRealFilePath(dir path) does not exist', function() {
-      expect(PackageInfoCache.getRealFilePath(projectPath)).not.to.exist;
-    });
-  });
-
-  describe('getRealDirectoryPath tests', function() {
-    let fakePackageJsonPath;
-
-    beforeEach(function() {
-      projectPath = path.resolve(addonFixturePath, 'external-dependency');
-      packageJsonPath = path.join(projectPath, 'package.json');
-      fakePackageJsonPath = path.join(projectPath, 'foozleberry.js');
-    });
-
-    it('getRealDirectoryPath(real package directory) exists', function() {
-      expect(PackageInfoCache.getRealDirectoryPath(projectPath)).to.exist;
-    });
-
-    it('getRealDirectoryPath(fake path) does not exist', function() {
-      expect(PackageInfoCache.getRealDirectoryPath(fakePackageJsonPath)).not.to.exist;
-    });
-
-    it('getRealDirectoryPath(real file path) does not exist', function() {
-      expect(PackageInfoCache.getRealDirectoryPath(packageJsonPath)).not.to.exist;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5376,6 +5376,14 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-package-path@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.1.1.tgz#39db6201f7db8800207d8f82cc8005ee30c9200e"
+  integrity sha512-6vg7LnxKY3NhmlH/K/CfudgPDx7ah4RPgHjhMCcP3L1LPsoxOXeClUBFpF5c2FRlQScVQ4VL8GTbB5FjHQ3ISQ==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"


### PR DESCRIPTION
This ensures hash-for-dep, ember-cli-verison-checker, and ember-cli all have the same behavior and potentially the same cache.

This also should in theory make the resolution aspects yarn PNP aware.
https://github.com/stefanpenner/resolve-package-path/blob/e995d8c74bb94c21aa06d1e3fbb131ee4aa9557f/tests/index-tests.js#L69