### PR TITLE
Update ember-ajax in blueprints and tests

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -21,7 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^4.0.1",
+    "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.1.2",


### PR DESCRIPTION
Due to an incompatibility with Ember 3.8. See:
https://github.com/ember-cli/ember-ajax/pull/433