### PR TITLE
[ENHANCEMENT] Adding --output-path to test command

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -18,24 +18,25 @@ module.exports = Command.extend({
   aliases: ['t'],
 
   availableOptions: [
-    { name: 'environment', type: String,  default: 'test',          aliases: ['e'],  description: 'Possible values are "development", "production", and "test".' },
-    { name: 'config-file', type: String,                            aliases: ['c', 'cf'] },
-    { name: 'server',      type: Boolean, default: false,           aliases: ['s'] },
-    { name: 'host',        type: String,                            aliases: ['H'] },
-    { name: 'test-port',   type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running tests. Pass 0 to automatically pick an available port' },
-    { name: 'filter',      type: String,                            aliases: ['f'],  description: 'A string to filter tests to run' },
-    { name: 'module',      type: String,                            aliases: ['m'],  description: 'The name of a test module to run' },
-    { name: 'watcher',     type: String,  default: 'events',        aliases: ['w'] },
-    { name: 'launch',      type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
-    { name: 'reporter',    type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit] (default: tap)' },
-    { name: 'silent',      type: Boolean, default: false,                            description: 'Suppress any output except for the test report' },
-    { name: 'ssl',         type: Boolean, default: false,                            description: 'Set to true to configure testem to run the test suite using SSL.' },
-    { name: 'ssl-key',     type: String,  default: 'ssl/server.key',                 description: 'Specify the private key to use for SSL.' },
-    { name: 'ssl-cert',    type: String,  default: 'ssl/server.crt',                 description: 'Specify the certificate to use for SSL.' },
-    { name: 'testem-debug', type: String,                                            description: 'File to write a debug log from testem' },
-    { name: 'test-page',   type: String,                                             description: 'Test page to invoke' },
-    { name: 'path',        type: 'Path',                                             description: 'Reuse an existing build at given path.' },
-    { name: 'query',       type: String,                                             description: 'A query string to append to the test page URL.' },
+    { name: 'environment',  type: String,  default: 'test',          aliases: ['e'],  description: 'Possible values are "development", "production", and "test".' },
+    { name: 'config-file',  type: String,                            aliases: ['c', 'cf'] },
+    { name: 'server',       type: Boolean, default: false,           aliases: ['s'] },
+    { name: 'host',         type: String,                            aliases: ['H'] },
+    { name: 'test-port',    type: Number,  default: defaultPort,     aliases: ['tp'], description: 'The test port to use when running tests. Pass 0 to automatically pick an available port' },
+    { name: 'filter',       type: String,                            aliases: ['f'],  description: 'A string to filter tests to run' },
+    { name: 'module',       type: String,                            aliases: ['m'],  description: 'The name of a test module to run' },
+    { name: 'watcher',      type: String,  default: 'events',        aliases: ['w'] },
+    { name: 'launch',       type: String,  default: false,                            description: 'A comma separated list of browsers to launch for tests.' },
+    { name: 'reporter',     type: String,                            aliases: ['r'],  description: 'Test reporter to use [tap|dot|xunit] (default: tap)' },
+    { name: 'silent',       type: Boolean, default: false,                            description: 'Suppress any output except for the test report' },
+    { name: 'ssl',          type: Boolean, default: false,                            description: 'Set to true to configure testem to run the test suite using SSL.' },
+    { name: 'ssl-key',      type: String,  default: 'ssl/server.key',                 description: 'Specify the private key to use for SSL.' },
+    { name: 'ssl-cert',     type: String,  default: 'ssl/server.crt',                 description: 'Specify the certificate to use for SSL.' },
+    { name: 'testem-debug', type: String,                                             description: 'File to write a debug log from testem' },
+    { name: 'test-page',    type: String,                                             description: 'Test page to invoke' },
+    { name: 'path',         type: 'Path',                                             description: 'Reuse an existing build at given path.' },
+    { name: 'query',        type: String,                                             description: 'A query string to append to the test page URL.' },
+    { name: 'output-path',  type: 'Path',                            aliases: ['o'] },
   ],
 
   init() {
@@ -121,7 +122,7 @@ module.exports = Command.extend({
         throw new SilentError(`The path ${commandOptions.path} does not exist. Please specify a valid build directory to test.`);
       }
     } else {
-      outputPath = this.tmp();
+      outputPath = commandOptions.outputPath || this.tmp();
     }
 
     process.env['EMBER_CLI_TEST_OUTPUT'] = outputPath;

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -194,6 +194,8 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.
+  \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m
+    \u001b[90maliases: -o <value>\u001b[39m
 
 ember version \u001b[36m<options...>\u001b[39m
   outputs ember-cli version

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -826,6 +826,13 @@ module.exports = {
           description: 'A query string to append to the test page URL.',
           key: 'query',
           required: false
+        },
+        {
+          name: 'output-path',
+          aliases: ['o'],
+          key: 'outputPath',
+          required: false,
+          type: 'Path'
         }
       ],
       anonymousOptions: []

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -194,6 +194,8 @@ ember test \u001b[36m<options...>\u001b[39m
   \u001b[36m--test-page\u001b[39m \u001b[36m(String)\u001b[39m Test page to invoke
   \u001b[36m--path\u001b[39m \u001b[36m(Path)\u001b[39m Reuse an existing build at given path.
   \u001b[36m--query\u001b[39m \u001b[36m(String)\u001b[39m A query string to append to the test page URL.
+  \u001b[36m--output-path\u001b[39m \u001b[36m(Path)\u001b[39m
+    \u001b[90maliases: -o <value>\u001b[39m
 
 ember version \u001b[36m<options...>\u001b[39m
   outputs ember-cli version

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -858,6 +858,13 @@ module.exports = {
           description: 'A query string to append to the test page URL.',
           key: 'query',
           required: false
+        },
+        {
+          name: 'output-path',
+          aliases: ['o'],
+          key: 'outputPath',
+          required: false,
+          type: 'Path'
         }
       ],
       anonymousOptions: []

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -826,6 +826,13 @@ module.exports = {
           description: 'A query string to append to the test page URL.',
           key: 'query',
           required: false
+        },
+        {
+          name: 'output-path',
+          aliases: ['o'],
+          key: 'outputPath',
+          required: false,
+          type: 'Path'
         }
       ],
       anonymousOptions: []

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -135,6 +135,15 @@ describe('test command', function() {
       });
     });
 
+    it('passes through output path option', function() {
+      return command.validateAndRun(['--output-path=some/path']).then(function() {
+        let captor = td.matchers.captor();
+
+        td.verify(tasks.Test.prototype.run(captor.capture()));
+        expect(captor.value.outputPath).to.equal(path.resolve('some/path'));
+      });
+    });
+
     it('passes through custom reporter option', function() {
       return command.validateAndRun(['--reporter=xunit']).then(function() {
         let captor = td.matchers.captor();


### PR DESCRIPTION
Adding --output-path to `test` command to be on parity with `build` and `serve`

One difference is there will be no default for `test` command's `output-path` option.