### PR TITLE
BUGFIX [Close #8536] remove chrome flag on Circle CI builds

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -12,9 +12,10 @@ module.exports = {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
+        // --disable-dev-shm-usage shouldn't be used in Circle CI builds
+        process.env.CIRCLECI ? null : '--disable-dev-shm-usage',
         '--headless',
         '--disable-gpu',
-        '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',
         '--remote-debugging-port=0',


### PR DESCRIPTION
checks for the existence of a CircleCI envionment variable `CIRCLECI=true` which is set in all CI runs, and disable the flag similar to how we enable the `--no-sandbox` flag for CI runs.

Different flag, inverse logic.

Fixes https://github.com/ember-cli/ember-cli/issues/8536