### PR TITLE
[ENHANCEMENT] Added `--pods` alias to generator's pod option

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -16,7 +16,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'pod', type: Boolean, default: false, aliases: ['p'] },
+    { name: 'pod', type: Boolean, default: false, aliases: ['p', 'pods'] },
     { name: 'classic', type: Boolean, default: false, aliases: ['c'] },
     { name: 'dummy', type: Boolean, default: false, aliases: ['dum', 'id'] },
     { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir'] },

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -19,7 +19,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
-    { name: 'pod', type: Boolean, default: false, aliases: ['p'] },
+    { name: 'pod', type: Boolean, default: false, aliases: ['p', 'pods'] },
     { name: 'classic', type: Boolean, default: false, aliases: ['c'] },
     { name: 'dummy', type: Boolean, default: false, aliases: ['dum', 'id'] },
     { name: 'in-repo-addon', type: String, default: null, aliases: ['in-repo', 'ir'] },

--- a/tests/fixtures/help/generate-blueprint.txt
+++ b/tests/fixtures/help/generate-blueprint.txt
@@ -8,7 +8,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m

--- a/tests/fixtures/help/generate-with-addon.txt
+++ b/tests/fixtures/help/generate-with-addon.txt
@@ -8,7 +8,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -46,7 +46,7 @@ ember destroy \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
@@ -63,7 +63,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -166,7 +166,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },
@@ -224,7 +224,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -46,7 +46,7 @@ ember destroy \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
@@ -63,7 +63,7 @@ ember generate \u001b[33m<blueprint>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--verbose\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -v\u001b[39m
   \u001b[36m--pod\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
-    \u001b[90maliases: -p\u001b[39m
+    \u001b[90maliases: -p, -pods\u001b[39m
   \u001b[36m--classic\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m
     \u001b[90maliases: -c\u001b[39m
   \u001b[36m--dummy\u001b[39m \u001b[36m(Boolean)\u001b[39m \u001b[36m(Default: false)\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -166,7 +166,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },
@@ -224,7 +224,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -166,7 +166,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },
@@ -224,7 +224,7 @@ module.exports = {
         {
           name: 'pod',
           default: false,
-          aliases: ['p'],
+          aliases: ['p', 'pods'],
           key: 'pod',
           required: false
         },


### PR DESCRIPTION
When we talk about pods it seems most common to use or hear the word "pods". Rarely do I hear mention of a singular pod though clearly it exists conceptually and in reality. 

When using ember-cli's generator (and destroyer) in a project with pods file layout I often find myself trying to invoke a non-existent `--pods` command option.

This PR adds an alias to the `--pod` generator option.

_Notes_
- I did not add any tests because I couldn't find any precedent for testing option aliases.
- ~I did not generate a new help `help.txt` fixture because I wasn't sure how.~