### PR TITLE
Expose build annotation information to the Addon's preBuild method.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1602,9 +1602,16 @@ let addonProto = {
 /**
   This hook is called before a build takes place.
 
+  It is passed information about what triggered the build.
+  For the initial build, the list of changed files is empty.
+
   @public
   @method preBuild
-  @param {Object} result Build object
+  @param {Object} annotation Build annotation
+    type: 'rebuild' | 'initial'
+    reason: 'watcher' | 'build'
+    primaryFile: string
+    changedFiles: Array<string>
 */
 
 /**

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -166,7 +166,7 @@ class Builder extends CoreObject {
    * @method build
    * @return {Promise}
    */
-  async build(addWatchDirCallback, resultAnnotation) {
+  async build(addWatchDirCallback, annotation) {
     let buildResults, uiProgressIntervalID;
 
     try {
@@ -184,7 +184,7 @@ class Builder extends CoreObject {
         this.ui.spinner.text = progress.format(progress());
       }, this.ui.spinner.interval);
 
-      await this.processAddonBuildSteps('preBuild');
+      await this.processAddonBuildSteps('preBuild', annotation);
 
       if (this.broccoliBuilderFallback) {
         try {
@@ -222,7 +222,7 @@ class Builder extends CoreObject {
     } finally {
       clearInterval(uiProgressIntervalID);
       this.ui.stopProgress();
-      this.project._instrumentation.stopAndReport('build', buildResults, resultAnnotation);
+      this.project._instrumentation.stopAndReport('build', buildResults, annotation);
       this.project.configCache.clear();
     }
   }


### PR DESCRIPTION
This lets the preBuild method prepare the addon for the next build iteration.

For instance, when a `rebuild` occurs, the `changedFiles` can be inspected. Based on the file paths or extensions, a persistent addon might be able to set a flag to make the next build a no-op because it can easily determine that the files changed aren't related to the addon's purpose.

I would like to use this in ember-cli-eyeglass to avoid doing any work during a rebuild unless one of the files that's changed is a Sass file. Similarly, I can imagine that if the only file that changed is a Sass file, there's probably no reason to run babel addons.