### PR TITLE
Adds babel-eslint as the default ESlint parser

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/blueprints/module-unification-app/files/package.json
+++ b/blueprints/module-unification-app/files/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~<%= emberCLIVersion %>",

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/module-unification-addon/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/npm/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/module-unification-addon/npm/package.json
+++ b/tests/fixtures/module-unification-addon/npm/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/module-unification-addon/yarn/package.json
+++ b/tests/fixtures/module-unification-addon/yarn/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/fixtures/module-unification-app/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/fixtures/module-unification-app/npm/package.json
+++ b/tests/fixtures/module-unification-app/npm/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/tests/fixtures/module-unification-app/yarn/package.json
+++ b/tests/fixtures/module-unification-app/yarn/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "github:ember-cli/ember-cli",


### PR DESCRIPTION
`ember-cli-babel` now supports class fields and decorators out of the
box, and we're currently on track to ship decorators as on by default in
Ember 3.10. However, users will get ESLint errors if they attempt to use
decorators, since it's default parser does not yet support them.

This PR adds the `babel-eslint` parser, which will allow things to work
as expected and has been what we've been recommending to early adopters
for some time.

It's worth noting that the next major version of `babel-eslint` seems to
be breaking, and will apparently _require_ a `.babelrc`. I'm not sure
whether or not we'll be able to support that, given `ember-cli-babel`
handles that type of configuration for us. We can probably continue
using `babel-eslint@10` until that gets sorted out.