### PR TITLE
#8511 Mondernize build-watch.js build-watch-test.js

### DIFF
--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const Task = require('../models/task');
 const Watcher = require('../models/watcher');
 const Builder = require('../models/builder');
-const RSVP = require('rsvp');
+const pDefer = require('p-defer');
 
 class BuildWatchTask extends Task {
   constructor(options) {
@@ -14,12 +14,12 @@ class BuildWatchTask extends Task {
     this._runDeferred = null;
   }
 
-  run(options) {
+  async run(options) {
     let { ui } = this;
 
     ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
-    this._runDeferred = RSVP.defer();
+    this._runDeferred = pDefer();
 
     let builder = (this._builder =
       options._builder ||
@@ -41,7 +41,9 @@ class BuildWatchTask extends Task {
         options,
       });
 
-    return watcher.then(() => this._runDeferred.promise /* Run until failure or signal to exit */);
+    await watcher;
+    // Run until failure or signal to exit
+    return this._runDeferred.promise;
   }
 
   /**
@@ -50,8 +52,9 @@ class BuildWatchTask extends Task {
    * @private
    * @method onInterrupt
    */
-  onInterrupt() {
-    return this._builder.cleanup().then(() => this._runDeferred.resolve());
+  async onInterrupt() {
+    await this._builder.cleanup();
+    this._runDeferred.resolve();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "morgan": "^1.9.1",
     "nopt": "^3.0.6",
     "npm-package-arg": "^6.1.0",
+    "p-defer": "^2.1.0",
     "portfinder": "^1.0.20",
     "promise-map-series": "^0.2.3",
     "quick-temp": "^0.1.8",

--- a/tests/unit/tasks/build-watch-test.js
+++ b/tests/unit/tasks/build-watch-test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const RSVP = require('rsvp');
 const BuildWatchTask = require('../../../lib/tasks/build-watch');
 const Builder = require('../../../lib/models/builder');
 const MockProject = require('../../helpers/mock-project');
 const expect = require('chai').expect;
-
-const Promise = RSVP.Promise;
 
 describe('build-watch task', function() {
   let task, ui;
@@ -62,15 +59,14 @@ describe('build-watch task', function() {
   }
 
   describe('onInterrupt', function() {
-    it('fulfills the run promise and cleans up the builder', function() {
+    it('fulfills the run promise and cleans up the builder', async function() {
       let runPromise = runBuildWatchTask();
 
-      RSVP.resolve().then(() => task.onInterrupt());
+      Promise.resolve().then(() => task.onInterrupt());
 
-      return runPromise.then(() => {
-        expect(ui.output).to.include('cleaning up...');
-        expect(ui.output).to.include('Environment: test');
-      });
+      await runPromise;
+      expect(ui.output).to.include('cleaning up...');
+      expect(ui.output).to.include('Environment: test');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4810,6 +4810,11 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
+p-defer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-2.1.0.tgz#d9c97b40f8fb5c256a70b4aabec3c1c8c42f1fae"
+  integrity sha512-xMwL9id1bHn/UfNGFEMFwlULOprQUEOg6vhqSfr6oKxPFB0oSh0zhGq/9/tPSE+cyij2+RW6H8+0Ke4xsPdZ7Q==
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"


### PR DESCRIPTION
`defer` is used by lib/tasks/build-watch.js and lib/tasks/server.js

@Turbo87 how do you feel about introducing a new dependency here?