### PR TITLE
Support npm blueprints with versions

### DIFF
--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -10,7 +10,7 @@ const path = require('path');
 const merge = require('ember-cli-lodash-subset').merge;
 const execa = require('../utilities/execa');
 const SilentError = require('silent-error');
-const validateNpmPackageName = require('validate-npm-package-name');
+const npa = require('npm-package-arg');
 
 const logger = require('heimdalljs-logger')('ember-cli:tasks:install-blueprint');
 
@@ -77,20 +77,27 @@ class InstallBlueprintTask extends Task {
   _handleLookupFailure(name, error) {
     logger.info(`Blueprint lookup for "${name}" failed`);
 
-    if (!validateNpmPackageName(name).validForNewPackages) {
+    let parsed;
+    try {
+      parsed = npa(name);
+    } catch (err) {
       logger.info(`"${name} is not a valid npm package name -> rethrowing original error`);
       throw error;
     }
 
     logger.info(`"${name} is a valid npm package name -> trying npm`);
-    return this._tryNpmBlueprint(name);
+    return this._tryNpmBlueprint(parsed.name, parsed.fetchSpec);
   }
 
-  _tryNpmBlueprint(name) {
+  _tryNpmBlueprint(nameWithoutVersion, version) {
     return this._createTempFolder()
-      .then(pathName => this._npmInstallModule(name, pathName).catch(error => this._handleNpmInstallModuleError(error)))
+      .then(pathName =>
+        this._npmInstallModule(nameWithoutVersion, version, pathName).catch(error =>
+          this._handleNpmInstallModuleError(error)
+        )
+      )
       .then(modulePath => {
-        this._validateNpmModule(modulePath, name);
+        this._validateNpmModule(modulePath, nameWithoutVersion);
         return this._loadBlueprintFromPath(modulePath);
       });
   }
@@ -111,11 +118,12 @@ class InstallBlueprintTask extends Task {
     return execa('npm', ['install'], { cwd });
   }
 
-  _npmInstallModule(module, cwd) {
+  _npmInstallModule(nameWithoutVersion, version, cwd) {
+    let module = `${nameWithoutVersion}@${version}`;
     logger.info(`Running "npm install ${module}" in "${cwd}" ...`);
 
     this._copyNpmrc(cwd);
-    return execa('npm', ['install', module], { cwd }).then(() => path.join(cwd, 'node_modules', module));
+    return execa('npm', ['install', module], { cwd }).then(() => path.join(cwd, 'node_modules', nameWithoutVersion));
   }
 
   _handleNpmInstallModuleError(error) {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "tiny-lr": "^1.1.1",
     "tree-sync": "^1.4.0",
     "uuid": "^3.3.2",
-    "validate-npm-package-name": "^3.0.0",
     "walk-sync": "^1.1.3",
     "watch-detector": "^0.1.0",
     "yam": "^1.0.0"

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -114,6 +114,15 @@ describe('Acceptance: ember new', function() {
   );
 
   it(
+    'ember new npm blueprint with old version',
+    co.wrap(function*() {
+      yield ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm', '--skip-bower']);
+
+      expect(dir('src')).to.exist;
+    })
+  );
+
+  it(
     'ember new foo, where foo does not yet exist, works',
     co.wrap(function*() {
       yield ember(['new', 'foo', '--skip-npm', '--skip-bower']);


### PR DESCRIPTION
There are various reasons you may want to generate an older blueprint (`ember new -b @ember/octane-app-blueprint@0.17.2`).

The main use I have planned is using this in ember-cli-update https://github.com/ember-cli/ember-cli-update/issues/546.