### PR TITLE
By default make ember test to pick ports automatically

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -187,7 +187,7 @@ module.exports = Command.extend({
         ui: this.ui,
         outputPath,
         project: this.project,
-        port: await this._generateTestPortNumber(commandOptions),
+        port: await this._generateTestPortNumber(commandOptions, this.ui),
       },
       this._generateCustomConfigs(commandOptions)
     );

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -8,6 +8,10 @@ const path = require('path');
 const Win = require('../utilities/windows-admin');
 const fs = require('fs');
 const temp = require('temp');
+const util = require('util');
+const PortFinder = require('portfinder');
+let getPort = util.promisify(PortFinder.getPort);
+
 temp.track();
 
 let defaultPort = 7357;
@@ -118,14 +122,26 @@ module.exports = Command.extend({
     return config;
   },
 
-  _generateTestPortNumber(options) {
-    if ((options.port && options.testPort !== defaultPort) || (!isNaN(parseInt(options.testPort)) && !options.port)) {
-      return options.testPort;
+  async _generateTestPortNumber(options, ui) {
+    let port = parseInt(options.testPort, 10);
+    if (options.testPort === defaultPort && !options.port) {
+      let foundPort = await getPort({ port: options.testPort });
+
+      if (options.testPort !== foundPort) {
+        ui.writeInfoLine(`Default port ${options.testPort} is already in use. Using alternate port ${foundPort}`);
+      }
+      options.port = foundPort;
+      return options;
     }
 
-    if (options.port) {
-      return parseInt(options.port, 10) + 1;
+    if ((options.port && options.testPort !== defaultPort) || (!isNaN(parseInt(options.testPort)) && !options.port)) {
+      port = parseInt(options.testPort, 10);
+    } else if (options.port) {
+      port = parseInt(options.port, 10) + 1;
     }
+    options.port = port;
+
+    return options;
   },
 
   buildTestPageQueryString(options) {
@@ -171,7 +187,7 @@ module.exports = Command.extend({
         ui: this.ui,
         outputPath,
         project: this.project,
-        port: this._generateTestPortNumber(commandOptions),
+        port: await this._generateTestPortNumber(commandOptions),
       },
       this._generateCustomConfigs(commandOptions)
     );

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -130,8 +130,8 @@ module.exports = Command.extend({
       if (options.testPort !== foundPort) {
         ui.writeInfoLine(`Default port ${options.testPort} is already in use. Using alternate port ${foundPort}`);
       }
-      options.port = foundPort;
-      return options;
+
+      return foundPort;
     }
 
     if ((options.port && options.testPort !== defaultPort) || (!isNaN(parseInt(options.testPort)) && !options.port)) {
@@ -139,9 +139,8 @@ module.exports = Command.extend({
     } else if (options.port) {
       port = parseInt(options.port, 10) + 1;
     }
-    options.port = port;
 
-    return options;
+    return port;
   },
 
   buildTestPageQueryString(options) {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -123,7 +123,6 @@ module.exports = Command.extend({
   },
 
   async _generateTestPortNumber(options, ui) {
-    let port = parseInt(options.testPort, 10);
     if (options.testPort === defaultPort && !options.port) {
       let foundPort = await getPort({ port: options.testPort });
 
@@ -134,6 +133,7 @@ module.exports = Command.extend({
       return foundPort;
     }
 
+    let port = parseInt(options.testPort, 10);
     if ((options.port && options.testPort !== defaultPort) || (!isNaN(parseInt(options.testPort)) && !options.port)) {
       port = parseInt(options.testPort, 10);
     } else if (options.port) {

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -8,6 +8,7 @@ const commandOptions = require('../../factories/command-options');
 const Task = require('../../../lib/models/task');
 const TestCommand = require('../../../lib/commands/test');
 const td = require('testdouble');
+const http = require('http');
 
 describe('test command', function () {
   this.timeout(30000);
@@ -87,6 +88,18 @@ describe('test command', function () {
 
         td.verify(tasks.Test.prototype.run(captor.capture()));
         expect(captor.value.port).to.equal(7357);
+      });
+    });
+
+    it('default port in use', function () {
+      let server = http.createServer();
+      server.listen(7357);
+      return command.validateAndRun([]).then(function () {
+        let captor = td.matchers.captor();
+
+        td.verify(tasks.Test.prototype.run(captor.capture()));
+        expect(captor.value.port).to.not.equal(7357);
+        server.close();
       });
     });
 


### PR DESCRIPTION
1) This will avoid port collission when two instances of tests running.
2) Changes made to failing tests