### PR TITLE
Bump testem from 2.14.0 to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "sort-package-json": "^1.22.1",
     "symlink-or-copy": "^1.2.0",
     "temp": "0.9.0",
-    "testem": "^2.14.0",
+    "testem": "^2.15.0",
     "tiny-lr": "^1.1.1",
     "tree-sync": "^1.4.0",
     "uuid": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6028,10 +6028,10 @@ testdouble@^3.11.0, testdouble@^3.2.6:
     stringify-object-es5 "^2.5.0"
     theredoc "^1.0.0"
 
-testem@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-2.14.0.tgz#418a9a15843f68381659c6a486abb4ea48d06c29"
-  integrity sha512-tldpNPCzXfibmxOoTMGOfr8ztUiHf9292zSXCu7SitBx9dCK83k7vEoa77qJBS9t3RGCQCRF+GNMUuiFw//Mbw==
+testem@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-2.15.0.tgz#60b56411d4ca8c39dcfabacf876ba7f9c427699e"
+  integrity sha512-J49mCb12awwEUgOYcirRVUsntfajex/3NMyTgaSXWuvlvSg1a+XfOXFxpoULsodXYGOH9fHM/joS54TCd3LDvw==
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"


### PR DESCRIPTION
Bump testem from 2.14.0 to 2.15.0

This pulls in 2 improvements:
- [Improve browser console log & add console.group as additional method to interrupt](https://github.com/testem/testem/pull/1331)
- [[XUnit] Show info about failed assertion](https://github.com/testem/testem/pull/1324)
