### PR TITLE
[ENHANCEMENT] Project#config should use EMBER_ENV as default environment when none is passed in

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -251,10 +251,11 @@ class Project {
     @return {Object}     Merged configuration object
    */
   config(env) {
-    let key = `${this.configPath()}|${env}`;
+    let _env = env === undefined ? process.env.EMBER_ENV : env;
+    let key = `${this.configPath()}|${_env}`;
     let config = this.configCache.get(key);
     if (config === undefined) {
-      config = this.configWithoutCache(env);
+      config = this.configWithoutCache(_env);
       this.configCache.set(key, config);
     }
     return _.cloneDeep(config);
@@ -264,7 +265,7 @@ class Project {
    * @private
    * @method configWithoutCache
    * @param  {String} env Environment name
-   * @return {Object}     Merged confiration object
+   * @return {Object}     Merged configuration object
    */
   configWithoutCache(env) {
     let configPath = this.configPath();

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -87,6 +87,19 @@ describe('models/project.js', function() {
       expect(called).to.equal(true);
     });
 
+    it('config() with no args returns the config corresponding to the current EMBER_ENV', function() {
+      process.env.EMBER_ENV = 'testing';
+
+      project.config();
+      let configCacheKey;
+      for (const key of project.configCache.keys()) {
+        if (key.match('|')) {
+          configCacheKey = key;
+        }
+      }
+      expect(configCacheKey).to.match(/testing/i);
+    });
+
     describe('memoizes', function() {
       it('memoizes', function() {
         project.config('development');


### PR DESCRIPTION
When no `env` is passed to `project#config`, it uses `undefined` which some devs have [found confusing](https://github.com/ember-cli/ember-cli/issues/7779).

I'm proposing using the environment from `EMBER_ENV` as the default if no `env` is supplied.

- [x] Tested in demo app
- [x] Wrote new test
- [x] Both fast and slow ember-cli tests pass

Closes https://github.com/ember-cli/ember-cli/issues/7779