### PR TITLE
Fix ember test --environment=production: excluding testem.js from being fingerprinted

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -368,9 +368,9 @@ class EmberApp {
 
     // Add testem.js to excludes for broccoli-asset-rev.
     // This will allow tests to run against the production builds.
-    if (this.options.fingerprint && this.options.fingerprint.exclude) {
-      this.options.fingerprint.exclude.push('testem');
-    }
+    this.options.fingerprint = this.options.fingerprint || {};
+    this.options.fingerprint.exclude = this.options.fingerprint.exclude || [];
+    this.options.fingerprint.exclude.push('testem');
   }
 
   _emberCLIBabelConfigKey() {

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -153,9 +153,7 @@ describe('Acceptance: smoke-test', function() {
     })
   );
 
-  // TODO: restore, test harness npm appears to incorrectly dedupe broccoli-filter, causing this test to fail.
-  // manually testing that case, it seems to work correctly, will restore soon.
-  it.skip(
+  it(
     'ember test --environment=production',
     co.wrap(function*() {
       yield copyFixtureFiles('smoke-tests/passing-test');
@@ -170,7 +168,7 @@ describe('Acceptance: smoke-test', function() {
       let output = result.output.join(EOL);
 
       expect(exitCode).to.equal(0, 'exit code should be 0 for passing tests');
-      expect(output).to.match(/JSHint/, 'JSHint should be run on production assets');
+      expect(output).to.match(/ESLint/, 'ESLint should be run on production assets');
       expect(output).to.match(/fail\s+0/, 'no failures');
       expect(output).to.match(/pass\s+\d+/, 'many passing');
     })


### PR DESCRIPTION
this helps fix #8154

TLDR: prevent testem.js from being fingerprinted so it can serve the testem.js with code that enables the connection between the browser and testem server & test reporting.