### PR TITLE
[WIP] Replace watcher with Broccoli watcher

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const availableExperiments = Object.freeze(['PACKAGER', 'MODULE_UNIFICATION', 'DELAYED_TRANSPILATION', 'SYSTEM_TEMP']);
+const availableExperiments = Object.freeze([
+  'PACKAGER',
+  'MODULE_UNIFICATION',
+  'DELAYED_TRANSPILATION',
+  'SYSTEM_TEMP',
+  'BROCCOLI_WATCHER',
+]);
 
 const enabledExperiments = Object.freeze(['SYSTEM_TEMP']);
 

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -7,7 +7,7 @@ const serveURL = require('../utilities/get-serve-url');
 const { isExperimentEnabled } = require('../experiments');
 const printSlowTrees = require('broccoli-slow-trees');
 
-class Watcher extends CoreObject {
+module.exports = class Watcher extends CoreObject {
   constructor(_options) {
     super(_options);
 
@@ -24,11 +24,12 @@ class Watcher extends CoreObject {
       this.watcher.on('change', this.didChange.bind(this));
       this.watcher.on('buildSuccess', this.didBuild.bind(this));
       this.watcher.start();
-      this._setupBuild(this.watcher.currentBuild);
+      this.build = this.watcher.currentBuild;
+      this._setupBuild(this.build);
     } else {
       this.watcher = this.watcher || this._constructWatcher(options);
       this.watcher.on('change', this.didBuild.bind(this));
-      this.build = this.watche;
+      this.build = this.watcher;
     }
 
     this.watcher.on('error', this.didError.bind(this));
@@ -36,9 +37,7 @@ class Watcher extends CoreObject {
   }
 
   _constructWatcher(options) {
-    const watcher = new (require('ember-cli-broccoli-sane-watcher'))(this.builder, options);
-    this.build = watcher;
-    return watcher;
+    return new (require('ember-cli-broccoli-sane-watcher'))(this.builder, options);
   }
 
   _constructBroccoliWatcher(options) {
@@ -50,19 +49,7 @@ class Watcher extends CoreObject {
   }
 
   _setupBuild(build) {
-    this.build = build;
-
     let heimdallNode;
-    function cleanup(run) {
-      // guard against `build` rejecting
-      if (heimdallNode) {
-        // remove the heimdall subtree for this build so we don't leak.  If
-        // BROCCOLI_VIZ=1 then we have already output the json in `verboseOutput`.
-        heimdallNode.remove();
-      }
-
-      return run;
-    }
 
     build
       .then(hash => {
@@ -70,7 +57,13 @@ class Watcher extends CoreObject {
         return hash;
       })
       .finally(() => {
-        cleanup();
+        // guard against `build` rejecting
+        if (heimdallNode) {
+          // remove the heimdall subtree for this build so we don't leak.  If
+          // BROCCOLI_VIZ=1 then we have already output the json in `verboseOutput`.
+          heimdallNode.remove();
+        }
+
         // Setup the next build then handlers
         this._setupBuild(this.watcher.currentBuild);
       });
@@ -196,6 +189,4 @@ class Watcher extends CoreObject {
   off() {
     this.watcher.off.apply(this.watcher, arguments);
   }
-}
-
-module.exports = Watcher;
+};

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -41,9 +41,7 @@ module.exports = class Watcher extends CoreObject {
   }
 
   _constructBroccoliWatcher(options) {
-    this.builder.watchedPaths = this.builder.builder.watchedPaths;
-
-    return new (require('broccoli')).Watcher(this.builder, {
+    return new (require('broccoli')).Watcher(this.builder, this.builder.builder.watchedSourceNodeWrappers, {
       saneOptions: options,
     });
   }

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -127,7 +127,7 @@ class Watcher extends CoreObject {
         break;
     }
 
-    console.log(`file ${action} ${filePath}`);
+    this.ui.writeLine(`file ${action} ${filePath}`);
   }
 
   didBuild(results) {

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -13,7 +13,7 @@ class Watcher extends CoreObject {
 
     this.verbose = true;
 
-    let options = this._buildOptions();
+    let options = this.buildOptions();
 
     logger.info('initialize %o', options);
 
@@ -21,17 +21,17 @@ class Watcher extends CoreObject {
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
       this.watcher = this.watcher || this._constructBroccoliWatcher(options);
-      this.watcher.on('change', this._didChange.bind(this));
-      this.watcher.on('buildSuccess', this._didBuild.bind(this));
+      this.watcher.on('change', this.didChange.bind(this));
+      this.watcher.on('buildSuccess', this.didBuild.bind(this));
       this.watcher.start();
       this._setupBuild(this.watcher.currentBuild);
     } else {
       this.watcher = this.watcher || this._constructWatcher(options);
-      this.watcher.on('change', this._didBuild.bind(this));
+      this.watcher.on('change', this.didBuild.bind(this));
       this.build = this.watche;
     }
 
-    this.watcher.on('error', this._didError.bind(this));
+    this.watcher.on('error', this.didError.bind(this));
     this.serveURL = serveURL;
   }
 
@@ -102,7 +102,7 @@ class Watcher extends CoreObject {
     throw error;
   }
 
-  _didError(error) {
+  didError(error) {
     logger.info('didError %o', error);
     this.ui.writeError(error);
     this.analytics.trackError({
@@ -110,7 +110,7 @@ class Watcher extends CoreObject {
     });
   }
 
-  _didChange(event, filePath) {
+  didChange(event, filePath) {
     let action;
     switch (event) {
       case 'add':
@@ -130,7 +130,7 @@ class Watcher extends CoreObject {
     console.log(`file ${action} ${filePath}`);
   }
 
-  _didBuild(results) {
+  didBuild(results) {
     logger.info('didChange %o', results);
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
@@ -170,7 +170,7 @@ class Watcher extends CoreObject {
     }
   }
 
-  _buildOptions() {
+  buildOptions() {
     let watcher = this.options && this.options.watcher;
 
     if (watcher && ['polling', 'watchman', 'node', 'events'].indexOf(watcher) === -1) {

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -28,7 +28,7 @@ class Watcher extends CoreObject {
     } else {
       this.watcher = this.watcher || this._constructWatcher(options);
       this.watcher.on('change', this._didBuild.bind(this));
-      this.build = watcher;
+      this.build = this.watche;
     }
 
     this.watcher.on('error', this._didError.bind(this));
@@ -78,8 +78,8 @@ class Watcher extends CoreObject {
 
   _totalTime(hash) {
     const sumNodes = (node, cb) => {
-      var total = 0;
-      node.visitPreOrder(function(node) {
+      let total = 0;
+      node.visitPreOrder(node => {
         total += cb(node);
       });
       return total;

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -4,6 +4,8 @@ const chalk = require('chalk');
 const logger = require('heimdalljs-logger')('ember-cli:watcher');
 const CoreObject = require('core-object');
 const serveURL = require('../utilities/get-serve-url');
+const { isExperimentEnabled } = require('../experiments');
+const printSlowTrees = require('broccoli-slow-trees');
 
 class Watcher extends CoreObject {
   constructor(_options) {
@@ -11,23 +13,96 @@ class Watcher extends CoreObject {
 
     this.verbose = true;
 
-    let options = this.buildOptions();
+    let options = this._buildOptions();
 
     logger.info('initialize %o', options);
 
     this.serving = _options.serving;
-    this.watcher = this.watcher || this.constructWatcher(options);
 
-    this.watcher.on('error', this.didError.bind(this));
-    this.watcher.on('change', this.didChange.bind(this));
+    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
+      this.watcher = this.watcher || this._constructBroccoliWatcher(options);
+      this.watcher.on('change', this._didChange.bind(this));
+      this.watcher.on('buildSuccess', this._didBuild.bind(this));
+      this.watcher.start();
+      this._setupBuild(this.watcher.currentBuild);
+    } else {
+      this.watcher = this.watcher || this._constructWatcher(options);
+      this.watcher.on('change', this._didBuild.bind(this));
+      this.build = watcher;
+    }
+
+    this.watcher.on('error', this._didError.bind(this));
     this.serveURL = serveURL;
   }
 
-  constructWatcher(options) {
-    return new (require('ember-cli-broccoli-sane-watcher'))(this.builder, options);
+  _constructWatcher(options) {
+    const watcher = new (require('ember-cli-broccoli-sane-watcher'))(this.builder, options);
+    this.build = watcher;
+    return watcher;
   }
 
-  didError(error) {
+  _constructBroccoliWatcher(options) {
+    this.builder.watchedPaths = this.builder.builder.watchedPaths;
+
+    return new (require('broccoli')).Watcher(this.builder, {
+      saneOptions: options,
+    });
+  }
+
+  _setupBuild(build) {
+    this.build = build;
+
+    let heimdallNode;
+    function cleanup(run) {
+      // guard against `build` rejecting
+      if (heimdallNode) {
+        // remove the heimdall subtree for this build so we don't leak.  If
+        // BROCCOLI_VIZ=1 then we have already output the json in `verboseOutput`.
+        heimdallNode.remove();
+      }
+
+      return run;
+    }
+
+    build
+      .then(hash => {
+        heimdallNode = hash.graph.__heimdall__;
+        return hash;
+      })
+      .finally(() => {
+        cleanup();
+        // Setup the next build then handlers
+        this._setupBuild(this.watcher.currentBuild);
+      });
+  }
+
+  _totalTime(hash) {
+    const sumNodes = (node, cb) => {
+      var total = 0;
+      node.visitPreOrder(function(node) {
+        total += cb(node);
+      });
+      return total;
+    };
+
+    return sumNodes(hash.graph.__heimdall__, function(node) {
+      return node.stats.time.self;
+    });
+  }
+
+  _triggerBuild(hash) {
+    logger.info('triggerBuildSuccess');
+    this.watcher.emit('buildSuccess', hash);
+    return hash;
+  }
+
+  _triggerError(error) {
+    logger.info('triggerError %o', error);
+    this.watcher.emit('error', error);
+    throw error;
+  }
+
+  _didError(error) {
     logger.info('didError %o', error);
     this.ui.writeError(error);
     this.analytics.trackError({
@@ -35,13 +110,32 @@ class Watcher extends CoreObject {
     });
   }
 
-  then() {
-    return this.watcher.then.apply(this.watcher, arguments);
+  _didChange(event, filePath) {
+    let action;
+    switch (event) {
+      case 'add':
+        action = 'added';
+        break;
+      case 'change':
+        action = 'changed';
+        break;
+      case 'delete':
+        action = 'deleted';
+        break;
+      default:
+        action = event;
+        break;
+    }
+
+    console.log(`file ${action} ${filePath}`);
   }
 
-  didChange(results) {
+  _didBuild(results) {
     logger.info('didChange %o', results);
 
+    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
+      results.totalTime = this._totalTime(results);
+    }
     let totalTime = results.totalTime / 1e6;
     let message = chalk.green(`Build successful (${Math.round(totalTime)}ms)`);
 
@@ -70,17 +164,13 @@ class Watcher extends CoreObject {
       label: 'broccoli rebuild time',
       value: Number(totalTime),
     });
+
+    if (isExperimentEnabled('BROCCOLI_WATCHER') && this.verbose) {
+      printSlowTrees(results.graph.__heimdall__);
+    }
   }
 
-  on() {
-    this.watcher.on.apply(this.watcher, arguments);
-  }
-
-  off() {
-    this.watcher.off.apply(this.watcher, arguments);
-  }
-
-  buildOptions() {
+  _buildOptions() {
     let watcher = this.options && this.options.watcher;
 
     if (watcher && ['polling', 'watchman', 'node', 'events'].indexOf(watcher) === -1) {
@@ -93,6 +183,18 @@ class Watcher extends CoreObject {
       watchman: watcher === 'watchman' || watcher === 'events',
       node: watcher === 'node',
     };
+  }
+
+  then() {
+    return this.build.then.apply(this.build, arguments);
+  }
+
+  on() {
+    this.watcher.on.apply(this.watcher, arguments);
+  }
+
+  off() {
+    this.watcher.off.apply(this.watcher, arguments);
   }
 }
 

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -7,6 +7,12 @@ const serveURL = require('../utilities/get-serve-url');
 const { isExperimentEnabled } = require('../experiments');
 const printSlowTrees = require('broccoli-slow-trees');
 
+const EVENT_ACTIONS = {
+  add: 'added',
+  change: 'changed',
+  delete: 'deleted',
+};
+
 module.exports = class Watcher extends CoreObject {
   constructor(_options) {
     super(_options);
@@ -21,18 +27,16 @@ module.exports = class Watcher extends CoreObject {
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
       this.watcher = this.watcher || this._constructBroccoliWatcher(options);
-      this.watcher.on('change', this.didChange.bind(this));
-      this.watcher.on('buildSuccess', this.didBuild.bind(this));
+      this.watcher.on('change', this._didChange.bind(this));
+      this.watcher.on('buildStart', this._setupBroccoliWatcherBuild.bind(this));
+      this.watcher.on('buildSuccess', this._didBuild.bind(this));
       this.watcher.start();
-      this.build = this.watcher.currentBuild;
-      this._setupBuild(this.build);
     } else {
       this.watcher = this.watcher || this._constructWatcher(options);
-      this.watcher.on('change', this.didBuild.bind(this));
-      this.build = this.watcher;
+      this.watcher.on('change', this._didBuild.bind(this));
     }
 
-    this.watcher.on('error', this.didError.bind(this));
+    this.watcher.on('error', this._didError.bind(this));
     this.serveURL = serveURL;
   }
 
@@ -46,10 +50,10 @@ module.exports = class Watcher extends CoreObject {
     });
   }
 
-  _setupBuild(build) {
+  _setupBroccoliWatcherBuild() {
     let heimdallNode;
 
-    build
+    this.watcher.currentBuild
       .then(hash => {
         heimdallNode = hash.graph.__heimdall__;
         return hash;
@@ -61,9 +65,6 @@ module.exports = class Watcher extends CoreObject {
           // BROCCOLI_VIZ=1 then we have already output the json in `verboseOutput`.
           heimdallNode.remove();
         }
-
-        // Setup the next build then handlers
-        this._setupBuild(this.watcher.currentBuild);
       });
   }
 
@@ -93,7 +94,7 @@ module.exports = class Watcher extends CoreObject {
     throw error;
   }
 
-  didError(error) {
+  _didError(error) {
     logger.info('didError %o', error);
     this.ui.writeError(error);
     this.analytics.trackError({
@@ -101,27 +102,12 @@ module.exports = class Watcher extends CoreObject {
     });
   }
 
-  didChange(event, filePath) {
-    let action;
-    switch (event) {
-      case 'add':
-        action = 'added';
-        break;
-      case 'change':
-        action = 'changed';
-        break;
-      case 'delete':
-        action = 'deleted';
-        break;
-      default:
-        action = event;
-        break;
-    }
-
+  _didChange(event, filePath) {
+    const action = EVENT_ACTIONS[event] || event;
     this.ui.writeLine(`file ${action} ${filePath}`);
   }
 
-  didBuild(results) {
+  _didBuild(results) {
     logger.info('didChange %o', results);
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
@@ -177,7 +163,11 @@ module.exports = class Watcher extends CoreObject {
   }
 
   then() {
-    return this.build.then.apply(this.build, arguments);
+    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
+      return this.watcher.currentBuild.apply(this.watcher.currentBuild, arguments);
+    }
+
+    return this.watcher.then.apply(this.build, arguments);
   }
 
   on() {

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -27,16 +27,16 @@ module.exports = class Watcher extends CoreObject {
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
       this.watcher = this.watcher || this._constructBroccoliWatcher(options);
-      this.watcher.on('change', this._didChange.bind(this));
+      this.watcher.on('change', this.didChange.bind(this));
       this.watcher.on('buildStart', this._setupBroccoliWatcherBuild.bind(this));
-      this.watcher.on('buildSuccess', this._didBuild.bind(this));
+      this.watcher.on('buildSuccess', this.didBuild.bind(this));
       this.watcher.start();
     } else {
       this.watcher = this.watcher || this._constructWatcher(options);
-      this.watcher.on('change', this._didBuild.bind(this));
+      this.watcher.on('change', this.didBuild.bind(this));
     }
 
-    this.watcher.on('error', this._didError.bind(this));
+    this.watcher.on('error', this.didError.bind(this));
     this.serveURL = serveURL;
   }
 
@@ -82,19 +82,7 @@ module.exports = class Watcher extends CoreObject {
     });
   }
 
-  _triggerBuild(hash) {
-    logger.info('triggerBuildSuccess');
-    this.watcher.emit('buildSuccess', hash);
-    return hash;
-  }
-
-  _triggerError(error) {
-    logger.info('triggerError %o', error);
-    this.watcher.emit('error', error);
-    throw error;
-  }
-
-  _didError(error) {
+  didError(error) {
     logger.info('didError %o', error);
     this.ui.writeError(error);
     this.analytics.trackError({
@@ -102,12 +90,12 @@ module.exports = class Watcher extends CoreObject {
     });
   }
 
-  _didChange(event, filePath) {
+  didChange(event, filePath) {
     const action = EVENT_ACTIONS[event] || event;
     this.ui.writeLine(`file ${action} ${filePath}`);
   }
 
-  _didBuild(results) {
+  didBuild(results) {
     logger.info('didChange %o', results);
 
     if (isExperimentEnabled('BROCCOLI_WATCHER')) {
@@ -171,10 +159,18 @@ module.exports = class Watcher extends CoreObject {
   }
 
   on() {
-    this.watcher.on.apply(this.watcher, arguments);
+    const args = arguments;
+    if (isExperimentEnabled('BROCCOLI_WATCHER') && args[0] === 'change') {
+      args[0] = 'buildSuccess';
+    }
+    this.watcher.on.apply(this.watcher, args);
   }
 
   off() {
-    this.watcher.off.apply(this.watcher, arguments);
+    const args = arguments;
+    if (isExperimentEnabled('BROCCOLI_WATCHER') && args[0] === 'change') {
+      args[0] = 'buildSuccess';
+    }
+    this.watcher.off.apply(this.watcher, args);
   }
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "broccoli-middleware": "^2.0.1",
     "broccoli-module-normalizer": "^1.3.0",
     "broccoli-module-unification-reexporter": "^1.0.0",
+    "broccoli-slow-trees": "^3.0.1",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^2.1.0",
     "calculate-cache-key-for-tree": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-module-resolver": "^3.2.0",
     "bower-config": "^1.4.1",
     "bower-endpoint-parser": "0.2.2",
-    "broccoli": "^2.3.0",
+    "broccoli": "^3.0.0",
     "broccoli-amd-funnel": "^2.0.1",
     "broccoli-babel-transpiler": "^7.2.0",
     "broccoli-builder": "^0.18.14",

--- a/tests/helpers/mock-broccoli-watcher.js
+++ b/tests/helpers/mock-broccoli-watcher.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const RSVP = require('rsvp');
+const EventEmitter = require('events').EventEmitter;
+const path = require('path');
+
+class MockBroccoliWatcher extends EventEmitter {
+  start() {
+
+  }
+  then() {
+    let promise = RSVP.resolve({
+      directory: path.resolve(__dirname, '../fixtures/express-server'),
+    });
+    return promise.then.apply(promise, arguments);
+  }
+}
+
+module.exports = MockBroccoliWatcher;

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -134,7 +134,7 @@ describe('Watcher', function() {
         },
       });
 
-      subject.didChange({
+      subject.didBuild({
         totalTime: 12344000000,
       });
 
@@ -163,7 +163,7 @@ describe('Watcher', function() {
         },
       });
 
-      subject.didChange({
+      subject.didBuild({
         totalTime: 12344000000,
       });
 
@@ -195,7 +195,7 @@ describe('Watcher', function() {
         },
       });
 
-      subject.didChange({
+      subject.didBuild({
         totalTime: 12344000000,
       });
 
@@ -229,7 +229,7 @@ describe('Watcher', function() {
         },
       });
 
-      subject.didChange({
+      subject.didBuild({
         totalTime: 12344000000,
       });
 
@@ -262,7 +262,7 @@ describe('Watcher', function() {
       subject.serveURL = function() {
         return `http://customurl.com/`;
       };
-      subject.didChange({
+      subject.didBuild({
         totalTime: 12344000000,
       });
 

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -11,6 +11,7 @@ const EOL = require('os').EOL;
 const chalk = require('chalk');
 const BuildError = require('../../helpers/build-error');
 const { isExperimentEnabled } = require('../../../lib/experiments');
+const buildEvent = isExperimentEnabled('BROCCOLI_WATCHER') ? 'buildSuccess' : 'change';
 
 describe('Watcher', function() {
   let ui;
@@ -38,8 +39,6 @@ describe('Watcher', function() {
       },
     }
   };
-
-  let buildEvent = isExperimentEnabled('BROCCOLI_WATCHER') ? 'buildSuccess' : 'change';
 
   beforeEach(function() {
     ui = new MockUI();

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,6 +891,11 @@ broccoli-node-info@1.1.0, broccoli-node-info@^1.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz#3aa2e31e07e5bdb516dd25214f7c45ba1c459412"
   integrity sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=
 
+broccoli-node-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.0.0.tgz#652a7940ede40630b84ad009c6236f4bc548b556"
+  integrity sha512-xfnzPYdf8Uu3mfhEPkh3CX1suGHNNW4k3f730llzr4Dl7UXvI5T8RUb7X04BSvJfvqYTekM/JTmYrjB01WAsCg==
+
 broccoli-persistent-filter@^1.1.6:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz#80762d19000880a77da33c34373299c0f6a3e615"
@@ -983,12 +988,37 @@ broccoli-test-helper@^2.0.0:
     tmp "^0.0.33"
     walk-sync "^0.3.3"
 
-broccoli@^2.0.0, broccoli@^2.3.0:
+broccoli@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.3.0.tgz#b3f71b2c3d02fc042988e208827a09c75dd7b350"
   integrity sha512-TeYMYlCGFK8EGk4Wce1G1uU3i52+YxRqP3WPOVDojC1zUk+Gi40wHBzUT2fncQZDl26dmCQMNugtHKjvUpcGQg==
   dependencies:
     broccoli-node-info "1.1.0"
+    broccoli-slow-trees "^3.0.1"
+    broccoli-source "^1.1.0"
+    commander "^2.15.1"
+    connect "^3.6.6"
+    esm "^3.2.4"
+    findup-sync "^2.0.0"
+    handlebars "^4.0.11"
+    heimdalljs "^0.2.6"
+    heimdalljs-logger "^0.1.9"
+    mime-types "^2.1.19"
+    promise.prototype.finally "^3.1.0"
+    resolve-path "^1.4.0"
+    rimraf "^2.6.2"
+    sane "^4.0.0"
+    tmp "0.0.33"
+    tree-sync "^1.2.2"
+    underscore.string "^3.2.2"
+    watch-detector "^0.1.0"
+
+broccoli@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-3.0.0.tgz#9b239bad111cf7c1d33a620c03e19f7a2d94a816"
+  integrity sha512-RcKIjIdFfRiwFR/KBcI0f1O6xtf/jBtISSQtMXYRH4Qn1Au6biGBXTf8btCgPnQJ1ABT7uZQNOzOZPoh5WFrRw==
+  dependencies:
+    broccoli-node-info "^2.0.0"
     broccoli-slow-trees "^3.0.1"
     broccoli-source "^1.1.0"
     commander "^2.15.1"
@@ -5432,13 +5462,6 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.7.1, resolve@^1.8.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
-  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==


### PR DESCRIPTION
This PR is an attempt to replace the Ember CLI file watcher with the Broccoli one.
At this point I'm only replacing the watcher, not the server etc to keep the changes contained, but in the future I see these also moving to Broccoli.

There are quite a few differences in the API and functionality of the Ember-CLI watcher and the Broccoli one.
The Ember version https://github.com/ember-cli/broccoli-sane-watcher/blob/ember-cli/index.js#L116 sets up a bunch of handlers on the build that do the following:

```js
  return this.builder
    .build(addWatchDir, annotation) // 1
    .then(saveNode) // 2
    .then(totalTime) // 3
    .then(appendFilePath) // 4
    .then(triggerChange, triggerError) // 5
    .then(verboseOutput.bind(this)) // 6
    .finally(cleanup); // 2
```

1. Notify the watcher of watched directories - this isn't necessary as Broccoli watcher does it a different way https://github.com/broccolijs/broccoli/blob/master/lib/watcher.js#L39
2. Some heimdall cleanup
3. Total time calculations (weirdly this total time is different from the output nodes totalTime stat...)
4. `appendFilePath` which appears to do nothing as `filePath` is null https://github.com/ember-cli/broccoli-sane-watcher/blob/ember-cli/index.js#L58
5. Triggers a change in the Ember watcher model
6. Print slow nodes

All of the above (except 4) have been ported into the Ember watcher model.
These changes are needed in broccoli https://github.com/broccolijs/broccoli/pull/398 so will land that first.