### PR TITLE
project.findAddonByName was intended to be public

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -626,7 +626,7 @@ class Project {
   /**
     Find an addon by its name
 
-    @private
+    @public
     @method findAddonByName
     @param  {String} name Addon name as specified in package.json
     @return {Addon}       Addon instance


### PR DESCRIPTION
I noticed `project.findAddonByName` was labeled as `private` but I believe this was in-error, it was added to avoid addons having to dig deep into the object model.