### PR TITLE
Add CI testing for Node 12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
       after_success:
         - .travis/codecoverage.sh
 
+    - name: Node.js 12
+      node_js: 12
+
     - env: EMBER_CLI_ENABLE_ALL_EXPERIMENTS=true
     - env: EMBER_CLI_PACKAGER=true
     - env: EMBER_CLI_MODULE_UNIFICATION=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Prevents warnings when running under Node 12.

Note: this targets lts-3-8 (for a 3.8.3), and will be merged into `release` (for 3.9.1 release), we well as beta (for 3.10) + master.