### PR TITLE
Refactor template build pipeline to enable co-located templates.

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -237,24 +237,33 @@ module.exports = class DefaultPackager {
     if (this._cachedProcessedAppAndDependencies === null) {
       let config = this.packageConfig();
       let internal = this.packageEmberCliInternalFiles();
-      let templates = this.processTemplates(allTrees);
+      let appContentsWithCompiledTemplates = this._debugTree(
+        this.processTemplates(allTrees),
+        'app-and-deps:post-templates'
+      );
 
-      let trees = [allTrees, templates, this.processJavascriptSrc(allTrees)].filter(Boolean);
+      let trees = [allTrees, appContentsWithCompiledTemplates, this.processJavascriptSrc(allTrees)].filter(Boolean);
 
-      let mergedTree = mergeTrees(trees, {
-        annotation: 'TreeMerger (preprocessedApp & templates)',
-        overwrite: true,
-      });
+      let mergedTree = this._debugTree(
+        mergeTrees(trees, {
+          annotation: 'TreeMerger (preprocessedApp & templates)',
+          overwrite: true,
+        }),
+        'app-and-deps:merged'
+      );
 
       let external = this.applyCustomTransforms(allTrees);
       let postprocessedApp = this.processJavascript(mergedTree);
 
       let sourceTrees = [external, postprocessedApp, config, internal];
 
-      this._cachedProcessedAppAndDependencies = mergeTrees(sourceTrees, {
-        overwrite: true,
-        annotation: 'Processed Application and Dependencies',
-      });
+      this._cachedProcessedAppAndDependencies = this._debugTree(
+        mergeTrees(sourceTrees, {
+          overwrite: true,
+          annotation: 'Processed Application and Dependencies',
+        }),
+        'app-and-deps:final'
+      );
     }
 
     return this._cachedProcessedAppAndDependencies;
@@ -430,20 +439,20 @@ module.exports = class DefaultPackager {
    * @param {BroccoliTree} tree
    * @return {BroccoliTree}
    */
-  processTemplates(templates) {
+  processTemplates(inputTree) {
     if (this._cachedProcessedTemplates === null) {
-      let include = this.registry.extensionsForType('template').map(extension => `**/*/template.${extension}`);
-
-      let classic = new Funnel(templates, {
-        srcDir: `${this.name}/templates`,
-        destDir: `${this.name}/templates`,
-        annotation: 'Classic Templates',
+      let appFiles = new Funnel(inputTree, {
+        srcDir: `${this.name}/`,
+        destDir: `${this.name}/`,
+        annotation: 'processTemplates: app files',
       });
 
-      let mergedTemplates = [classic];
+      let mergedTemplates = [appFiles];
 
       if (this.isModuleUnificationEnabled) {
-        let mu = new Funnel(templates, {
+        let include = this.registry.extensionsForType('template').map(extension => `**/*/template.${extension}`);
+
+        let mu = new Funnel(inputTree, {
           srcDir: 'src',
           destDir: `${this.name}/src`,
           include,
@@ -452,13 +461,6 @@ module.exports = class DefaultPackager {
         });
         mu = this._debugTree(mu, 'mu-layout:tree:template');
         mergedTemplates.push(mu);
-      } else {
-        let pods = new Funnel(templates, {
-          include,
-          exclude: ['templates/**/*'],
-          annotation: 'Pod Templates',
-        });
-        mergedTemplates.push(pods);
       }
 
       mergedTemplates = mergeTrees(mergedTemplates, {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1216,7 +1216,7 @@ let addonProto = {
         );
       }
 
-      let preprocessedTemplateTree = this._addonPreprocessTree('template', this._addonTemplateFiles(addonTree));
+      let preprocessedTemplateTree = this._addonPreprocessTree('template', addonTree);
 
       let processedTemplateTree;
       if (!isExperimentEnabled('DELAYED_TRANSPILATION') || registryHasPreprocessor(this.registry, 'template')) {
@@ -1230,7 +1230,9 @@ let addonProto = {
 
       let postprocessedTemplateTree = this._addonPostprocessTree('template', processedTemplateTree);
 
-      return processModulesOnly(postprocessedTemplateTree, 'Babel: Modules for Templates');
+      return postprocessedTemplateTree;
+    } else {
+      return addonTree;
     }
   },
 
@@ -1279,15 +1281,10 @@ let addonProto = {
       this.options[emberCLIBabelConfigKey] = this.__originalOptions[emberCLIBabelConfigKey];
     }
 
-    let addonJs = this.processedAddonJsFiles(tree);
-    let templatesTree = this.compileTemplates(tree);
+    let treeWithCompiledTemplates = this.compileTemplates(tree);
+    let final = this.processedAddonJsFiles(treeWithCompiledTemplates);
 
-    let trees = [addonJs, templatesTree].filter(Boolean);
-
-    return mergeTrees(trees, {
-      overwrite: true,
-      annotation: `Addon#compileAddon(${this.name})`,
-    });
+    return final;
   },
 
   /**
@@ -1303,6 +1300,7 @@ let addonProto = {
     let addonPath = this._treePathFor('addon');
     if (fs.existsSync(addonPath)) {
       let addonJs = new Funnel(this.addonJsFiles(addonPath), {
+        exclude: ['templates/**/*'],
         srcDir: this.moduleName(),
         destDir: 'addon',
         allowEmpty: true,
@@ -1364,10 +1362,7 @@ let addonProto = {
     @return {Tree} The filtered addon js files
   */
   addonJsFiles(tree) {
-    let includePatterns = this.registry.extensionsForType('js').map(extension => new RegExp(`${extension}$`));
-
     return new Funnel(tree, {
-      include: includePatterns,
       destDir: this.moduleName(),
       annotation: 'Funnel: Addon JS',
     });

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   },
   "devDependencies": {
     "@octokit/rest": "^16.25.6",
+    "broccoli-plugin": "^2.1.0",
     "broccoli-test-helper": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -116,9 +116,7 @@ describe('Addon - linting', function() {
 
       output = yield buildOutput(lintTrees[0]);
 
-      expect(output.read()).to.deep.equal({
-        addon: {},
-      });
+      expect(output.read()).to.deep.equal({});
 
       yield output.dispose();
 

--- a/tests/unit/broccoli/template-precompilation-test.js
+++ b/tests/unit/broccoli/template-precompilation-test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+const BroccoliPlugin = require('broccoli-plugin');
+const walkSync = require('walk-sync');
+
+const MockCLI = require('../../helpers/mock-cli');
+const Project = require('../../../lib/models/project');
+const Addon = require('../../../lib/models/addon');
+const EmberApp = require('../../../lib/broccoli/ember-app');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('template preprocessors', function() {
+  let input, output, addon;
+
+  class FakeTemplateColocator extends BroccoliPlugin {
+    constructor(trees, options = { root: '' }) {
+      super(...arguments);
+      this.options = options;
+    }
+
+    build() {
+      let [inputPath] = this.inputPaths;
+      let root = fs.existsSync(path.join(inputPath, this.options.root)) ? this.options.root : '';
+
+      let files = walkSync(path.join(inputPath, root), { directories: false });
+
+      files.forEach(file => {
+        let fullInputPath = path.join(inputPath, root, file);
+        let fullOutputPath = path.join(this.outputPath, root, file);
+
+        if (file.startsWith(`components/`)) {
+          let pathParts = path.parse(file);
+          let templatePath = path.join(inputPath, root, 'templates', pathParts.dir, `${pathParts.name}.hbs`);
+          let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+          let componentContents = fs.readFileSync(fullInputPath, { encoding: 'utf8' });
+
+          let contents = `${componentContents}\nexport const template = hbs\`${templateContents}\``;
+          fs.ensureDirSync(path.dirname(fullOutputPath));
+          fs.writeFileSync(fullOutputPath, contents, { encoding: 'utf8' });
+        } else if (file.startsWith(`templates/components/`)) {
+          // do nothing
+        } else {
+          fs.copySync(fullInputPath, fullOutputPath);
+        }
+      });
+    }
+  }
+
+  describe('Addon', function() {
+    beforeEach(async function() {
+      input = await createTempDir();
+      let MockAddon = Addon.extend({
+        root: input.path(),
+        name: 'fake-addon',
+      });
+      let cli = new MockCLI();
+      let pkg = { name: 'ember-app-test' };
+      let project = new Project(input.path(), pkg, cli.ui, cli);
+
+      addon = new MockAddon(project, project);
+
+      addon.registry.add('js', {
+        name: 'fake-js-compiler',
+        ext: 'js',
+        toTree(tree) {
+          return tree;
+        },
+      });
+    });
+
+    afterEach(async function() {
+      await input.dispose();
+      await output.dispose();
+    });
+
+    it('the template preprocessor receives access to all files', async function() {
+      addon.registry.add('template', {
+        name: 'fake-template-compiler',
+        ext: 'hbs',
+        toTree(tree) {
+          return new FakeTemplateColocator([tree]);
+        },
+      });
+
+      input.write({
+        addon: {
+          components: {
+            'awesome-button.js': 'export default class {}',
+          },
+          templates: {
+            components: {
+              'awesome-button.hbs': '<!-- flerpy -->',
+            },
+          },
+        },
+      });
+
+      output = await buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
+
+      expect(output.read()).to.deep.equal({
+        'fake-addon': {
+          components: {
+            'awesome-button.js': `export default class {}\nexport const template = hbs\`<!-- flerpy -->\``,
+          },
+        },
+      });
+    });
+  });
+
+  describe('EmberApp', function() {
+    let project;
+
+    beforeEach(async function() {
+      input = await createTempDir();
+      let cli = new MockCLI();
+      let pkg = { name: 'fake-app-test', devDependencies: { 'ember-cli': '*' } };
+      project = new Project(input.path(), pkg, cli.ui, cli);
+    });
+
+    afterEach(async function() {
+      await input.dispose();
+      await output.dispose();
+    });
+
+    it('the template preprocessor receives access to all files', async function() {
+      input.write({
+        app: {
+          components: {
+            'awesome-button.js': 'export default class {}',
+          },
+          styles: {
+            'app.css': '/* styles */',
+          },
+          templates: {
+            components: {
+              'awesome-button.hbs': '<!-- flerpy -->',
+            },
+          },
+          'index.html': '<body></body>',
+        },
+        config: {
+          'environment.js': 'module.exports = function() { return { modulePrefix: "fake-app-test" } };',
+        },
+      });
+
+      let app = new EmberApp(
+        {
+          project,
+          name: project.pkg.name,
+          _ignoreMissingLoader: true,
+          sourcemaps: { enabled: false },
+        },
+        {}
+      );
+
+      app.registry.add('js', {
+        name: 'fake-js-compiler',
+        ext: 'js',
+        toTree(tree) {
+          return tree;
+        },
+      });
+
+      app.registry.add('template', {
+        name: 'fake-template-compiler',
+        ext: 'hbs',
+        toTree(tree) {
+          return new FakeTemplateColocator([tree], { root: 'fake-app-test/' });
+        },
+      });
+
+      output = await buildOutput(app.toTree());
+
+      let expectedContent = `export default class {}\nexport const template = hbs\`<!-- flerpy -->\``;
+      let actualContent = output.read().assets['fake-app-test.js'];
+
+      expect(actualContent).to.include(expectedContent);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,6 +949,16 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
+broccoli-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
+  integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
+  dependencies:
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^2.3.4"
+    symlink-or-copy "^1.1.8"
+
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz#9bf2a9e2f8eb3ed3a3f2abdde988da437ccdc9b4"
@@ -5442,13 +5452,6 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.7.1, resolve@^1.8.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
-  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==


### PR DESCRIPTION
This refactors the processing of templates so that instead of filtering out templates from JavaScript we process them in a pipeline (first the templates, and the result of that is passed in to be compiled as JavaScript).

On its own, this change does not enable co-located templates, but this work is required so that ember-cli-htmlbars can implement the feature.