### PR TITLE
Use system temp for ember test

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,6 +7,8 @@ const SilentError = require('silent-error');
 const path = require('path');
 const Win = require('../utilities/windows-admin');
 const fs = require('fs');
+const temp = require('temp');
+temp.track();
 
 require('express').static.mime.define({ 'application/wasm': ['wasm'] });
 
@@ -79,8 +81,6 @@ module.exports = Command.extend({
   init() {
     this._super.apply(this, arguments);
 
-    this.quickTemp = require('quick-temp');
-
     this.Builder = this.Builder || Builder;
     this.Watcher = this.Watcher || Watcher;
 
@@ -90,12 +90,7 @@ module.exports = Command.extend({
   },
 
   tmp() {
-    return this.quickTemp.makeOrRemake(this, '-testsDist');
-  },
-
-  rmTmp() {
-    this.quickTemp.remove(this, '-testsDist');
-    this.quickTemp.remove(this, '-customConfigFile');
+    return temp.mkdirSync('tests-dist-');
   },
 
   _generateCustomConfigs(options) {
@@ -207,13 +202,7 @@ module.exports = Command.extend({
         }).then(() => this.runTask('Test', testOptions));
       }
 
-      return session.finally(this.rmTmp.bind(this));
+      return session;
     });
-  },
-
-  onInterrupt() {
-    this.rmTmp();
-
-    return this._super.onInterrupt.apply(this, arguments);
   },
 });


### PR DESCRIPTION
Since the broccoli 2 upgrade most things don't use a "tmp" dir in the project, but "ember test" still does.

This moves it to system temp. We're relying on `temp.track()` for cleanup, instead of needing `onInterrupt` and `finally`. 

Co-Authored-By: Jen Weber <j@jenweber.me>