### PR TITLE
[BUGFIX] reset resolve-package-path caches in PackageInfoCache._clear()

### DIFF
--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -16,6 +16,7 @@ const resolvePackagePath = require('resolve-package-path');
 
 const getRealFilePath = resolvePackagePath.getRealFilePath;
 const getRealDirectoryPath = resolvePackagePath.getRealDirectoryPath;
+const _resetCache = resolvePackagePath._resetCache;
 
 const PACKAGE_JSON = 'package.json';
 
@@ -41,6 +42,7 @@ class PackageInfoCache {
   _clear() {
     this.entries = Object.create(null);
     this.projects = [];
+    _resetCache();
   }
 
   /**


### PR DESCRIPTION
#8469 moved package related path resolution to the `resolve-package-path` package, which also removed the [resetting of the related caches in `PackageInfoCache._clear()`](https://github.com/ember-cli/ember-cli/pull/8469/files#diff-efb0efc58f8837467992f746c5228672L125). At least one addon ([`ember-cli-typescript`](https://github.com/typed-ember/ember-cli-typescript)) [depends on this behavior for tests]( https://github.com/typed-ember/ember-cli-typescript/issues/670). This PR restores the resetting in `PackageInfoCache._clear()` of the caches used by `getRealFilePath` and `getRealDirectoryPath`.