### PR TITLE
Use absolute link to Contribution.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please refer to the [CLI guides](https://cli.emberjs.com/release/) for help usin
 
 Contributing
 ------------------------------------------------------------------------------
-Please see the [contributing guidelines](./CONTRIBUTING.md)
+Please see the [contributing guidelines](https://github.com/ember-cli/ember-cli/blob/master/CONTRIBUTING.md)
 
 
 Community


### PR DESCRIPTION
Because `README.md` is also built in YUIDoc that does not link to `Contribution.md` relatively, I've changed the link to absolute. Fixes #8640.

Welcome for improvements as I can't find a conversion option in the YUIDoc [site](https://yui.github.io/yuidoc/args/index.html). =)