### PR TITLE
fix: reset resolve-package-path caches in PackageInfoCache._clear()

### DIFF
--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -16,6 +16,7 @@ const resolvePackagePath = require('resolve-package-path');
 
 const getRealFilePath = resolvePackagePath.getRealFilePath;
 const getRealDirectoryPath = resolvePackagePath.getRealDirectoryPath;
+const _resetCache = resolvePackagePath._resetCache;
 
 const PACKAGE_JSON = 'package.json';
 
@@ -41,6 +42,7 @@ class PackageInfoCache {
   _clear() {
     this.entries = Object.create(null);
     this.projects = [];
+    _resetCache();
   }
 
   /**


### PR DESCRIPTION
Backport changes from https://github.com/ember-cli/ember-cli/pull/8650 to `release` branch (for 3.10.x release).