### PR TITLE
Add npmignore to Blueprint.renamedFiles{}

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -172,8 +172,6 @@ module.exports = {
 
     '^addon-config/environment.js': 'config/environment.js',
     '^addon-config/ember-try.js': 'config/ember-try.js',
-
-    '^npmignore': '.npmignore',
   },
 
   fileMapper(path) {

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1381,7 +1381,7 @@ Blueprint._readdirSync = function(path) {
 */
 Blueprint.renamedFiles = {
   gitignore: '.gitignore',
-  npmignore: '.npmignore'
+  npmignore: '.npmignore',
 };
 
 /**

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1381,6 +1381,7 @@ Blueprint._readdirSync = function(path) {
 */
 Blueprint.renamedFiles = {
   gitignore: '.gitignore',
+  npmignore: '.npmignore'
 };
 
 /**


### PR DESCRIPTION
The addons blueprint should also included a `npmignore` file that is renamed to `.npmignore`. This would allow the octane addon blueprint to include the npmignore file. The current, 3.10 addon blueprint does this via some hooks in `index.js`, which IMO would be unneeded if npmignore is added here.