### PR TITLE
ecmaVersion 2015 is out of date

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -38,8 +38,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],<% } %>
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -34,8 +34,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -30,8 +30,7 @@ module.exports = {
         'tests/dummy/config/**/*.js'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -36,8 +36,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -30,8 +30,7 @@ module.exports = {
         'server/**/*.js'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -34,8 +34,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/module-unification-addon/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/npm/.eslintrc.js
@@ -34,8 +34,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
@@ -34,8 +34,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/tests/fixtures/module-unification-app/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/.eslintrc.js
@@ -30,8 +30,7 @@ module.exports = {
         'tests/dummy/config/**/*.js'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,


### PR DESCRIPTION
This is preventing using async/await in the non-babel code. We can inherit the 2018 from the parent.