### PR TITLE
Remove extra Node 10 Travis CI job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ jobs:
         - yarn test
 
     - stage: additional tests
-
-    - name: Node.js 8
+      name: Node.js 8
       node_js: 8
 
     - name: Node.js 10


### PR DESCRIPTION
Each entry in the `jobs.include` list (indicated by a `-` prefix at that indentation level) will result in a CI job.

This means that with the prior config:

```yaml
jobs:
  include:
    - stage: basic test
      name: Basic Tests
      script:
        - yarn lint
        - yarn test

    - stage: additional tests

    - name: Node.js 8
      node_js: 8
```

We were actually instructing Travis to run **three** jobs:

* One for "basic tests" that runs `yarn lint` and `yarn test`
* One with all default settings (Node 10, yarn test, etc) for the `- stage: additional tests`
* One for "Node.js 8" using Node 8 and all defaults for `install` and `script`

This change removes the extra `-` in front of `name: 'Node.js 8'` so that we only have two jobs (as desired).