### PR TITLE
Track the time taken to collect hardware metrics

### DIFF
--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -22,6 +22,17 @@ function _enableFSMonitorIfInstrumentationEnabled(config) {
 
 _enableFSMonitorIfInstrumentationEnabled();
 
+function _getHardwareInfo(platform) {
+  const startTime = process.hrtime();
+
+  Object.getOwnPropertyNames(hwinfo).forEach(metric => (platform[metric] = hwinfo[metric]()));
+
+  const collectionTime = process.hrtime(startTime);
+
+  // Convert from integer [seconds, nanoseconds] to floating-point milliseconds.
+  platform.collectionTime = collectionTime[0] * 10e3 + collectionTime[1] / 10e6;
+}
+
 class Instrumentation {
   /**
      An instance of this class is used for invoking the instrumentation
@@ -126,7 +137,7 @@ class Instrumentation {
       buildSteps,
     };
 
-    Object.getOwnPropertyNames(hwinfo).forEach(metric => (summary.platform[metric] = hwinfo[metric]()));
+    _getHardwareInfo(summary.platform);
 
     if (result) {
       summary.build.outputChangedFiles = result.outputChanges;
@@ -150,7 +161,7 @@ class Instrumentation {
       },
     };
 
-    Object.getOwnPropertyNames(hwinfo).forEach(metric => (summary.platform[metric] = hwinfo[metric]()));
+    _getHardwareInfo(summary.platform);
 
     return summary;
   }
@@ -165,7 +176,7 @@ class Instrumentation {
       },
     };
 
-    Object.getOwnPropertyNames(hwinfo).forEach(metric => (summary.platform[metric] = hwinfo[metric]()));
+    _getHardwareInfo(summary.platform);
 
     return summary;
   }
@@ -178,7 +189,7 @@ class Instrumentation {
       },
     };
 
-    Object.getOwnPropertyNames(hwinfo).forEach(metric => (summary.platform[metric] = hwinfo[metric]()));
+    _getHardwareInfo(summary.platform);
 
     return summary;
   }

--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -803,7 +803,7 @@ describe('models/instrumentation.js', function() {
         expect(summary.buildSteps).to.eql(2); // 2 uncached broccli nodes
         expect(summary.totalTime).to.be.within(0, 2000000); //2ms (in nanoseconds)
         expect(summary).to.have.nested.property('platform.name', process.platform);
-        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo)]);
+        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo), 'collectionTime']);
       });
 
       it('computes rebuild summaries', function() {
@@ -839,7 +839,7 @@ describe('models/instrumentation.js', function() {
         expect(summary.buildSteps).to.eql(2); // 2 uncached broccli nodes
         expect(summary.totalTime).to.be.within(0, 2000000); //2ms (in nanoseconds)
         expect(summary).to.have.nested.property('platform.name', process.platform);
-        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo)]);
+        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo), 'collectionTime']);
       });
     });
 
@@ -851,7 +851,7 @@ describe('models/instrumentation.js', function() {
 
         expect(summary.totalTime).to.be.within(0, 2000000); //2ms (in nanoseconds)
         expect(summary).to.have.nested.property('platform.name', process.platform);
-        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo)]);
+        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo), 'collectionTime']);
       });
     });
 
@@ -865,7 +865,7 @@ describe('models/instrumentation.js', function() {
         expect(summary.args).to.eql(['--like', '--whatever']);
         expect(summary.totalTime).to.be.within(0, 2000000); //2ms (in nanoseconds)
         expect(summary).to.have.nested.property('platform.name', process.platform);
-        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo)]);
+        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo), 'collectionTime']);
       });
     });
 
@@ -877,7 +877,7 @@ describe('models/instrumentation.js', function() {
 
         expect(summary.totalTime).to.be.within(0, 2000000); //2ms (in nanoseconds)
         expect(summary).to.have.nested.property('platform.name', process.platform);
-        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo)]);
+        expect(Object.keys(summary.platform)).to.eql(['name', ...Object.keys(hwinfo), 'collectionTime']);
       });
     });
   });


### PR DESCRIPTION
Adds a property to the `.summary.platform` object containing the number of milliseconds taken to collect the hardware info also included in that object.