### PR TITLE
fix: allow use of prettier on index.html

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -237,24 +237,33 @@ module.exports = class DefaultPackager {
     if (this._cachedProcessedAppAndDependencies === null) {
       let config = this.packageConfig();
       let internal = this.packageEmberCliInternalFiles();
-      let templates = this.processTemplates(allTrees);
+      let appContentsWithCompiledTemplates = this._debugTree(
+        this.processTemplates(allTrees),
+        'app-and-deps:post-templates'
+      );
 
-      let trees = [allTrees, templates, this.processJavascriptSrc(allTrees)].filter(Boolean);
+      let trees = [allTrees, appContentsWithCompiledTemplates, this.processJavascriptSrc(allTrees)].filter(Boolean);
 
-      let mergedTree = mergeTrees(trees, {
-        annotation: 'TreeMerger (preprocessedApp & templates)',
-        overwrite: true,
-      });
+      let mergedTree = this._debugTree(
+        mergeTrees(trees, {
+          annotation: 'TreeMerger (preprocessedApp & templates)',
+          overwrite: true,
+        }),
+        'app-and-deps:merged'
+      );
 
       let external = this.applyCustomTransforms(allTrees);
       let postprocessedApp = this.processJavascript(mergedTree);
 
       let sourceTrees = [external, postprocessedApp, config, internal];
 
-      this._cachedProcessedAppAndDependencies = mergeTrees(sourceTrees, {
-        overwrite: true,
-        annotation: 'Processed Application and Dependencies',
-      });
+      this._cachedProcessedAppAndDependencies = this._debugTree(
+        mergeTrees(sourceTrees, {
+          overwrite: true,
+          annotation: 'Processed Application and Dependencies',
+        }),
+        'app-and-deps:final'
+      );
     }
 
     return this._cachedProcessedAppAndDependencies;
@@ -430,20 +439,20 @@ module.exports = class DefaultPackager {
    * @param {BroccoliTree} tree
    * @return {BroccoliTree}
    */
-  processTemplates(templates) {
+  processTemplates(inputTree) {
     if (this._cachedProcessedTemplates === null) {
-      let include = this.registry.extensionsForType('template').map(extension => `**/*/template.${extension}`);
-
-      let classic = new Funnel(templates, {
-        srcDir: `${this.name}/templates`,
-        destDir: `${this.name}/templates`,
-        annotation: 'Classic Templates',
+      let appFiles = new Funnel(inputTree, {
+        srcDir: `${this.name}/`,
+        destDir: `${this.name}/`,
+        annotation: 'processTemplates: app files',
       });
 
-      let mergedTemplates = [classic];
+      let mergedTemplates = [appFiles];
 
       if (this.isModuleUnificationEnabled) {
-        let mu = new Funnel(templates, {
+        let include = this.registry.extensionsForType('template').map(extension => `**/*/template.${extension}`);
+
+        let mu = new Funnel(inputTree, {
           srcDir: 'src',
           destDir: `${this.name}/src`,
           include,
@@ -452,13 +461,6 @@ module.exports = class DefaultPackager {
         });
         mu = this._debugTree(mu, 'mu-layout:tree:template');
         mergedTemplates.push(mu);
-      } else {
-        let pods = new Funnel(templates, {
-          include,
-          exclude: ['templates/**/*'],
-          annotation: 'Pod Templates',
-        });
-        mergedTemplates.push(pods);
       }
 
       mergedTemplates = mergeTrees(mergedTemplates, {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -7,6 +7,8 @@ const SilentError = require('silent-error');
 const path = require('path');
 const Win = require('../utilities/windows-admin');
 const fs = require('fs');
+const temp = require('temp');
+temp.track();
 
 require('express').static.mime.define({ 'application/wasm': ['wasm'] });
 
@@ -79,8 +81,6 @@ module.exports = Command.extend({
   init() {
     this._super.apply(this, arguments);
 
-    this.quickTemp = require('quick-temp');
-
     this.Builder = this.Builder || Builder;
     this.Watcher = this.Watcher || Watcher;
 
@@ -90,12 +90,7 @@ module.exports = Command.extend({
   },
 
   tmp() {
-    return this.quickTemp.makeOrRemake(this, '-testsDist');
-  },
-
-  rmTmp() {
-    this.quickTemp.remove(this, '-testsDist');
-    this.quickTemp.remove(this, '-customConfigFile');
+    return temp.mkdirSync('tests-dist-');
   },
 
   _generateCustomConfigs(options) {
@@ -207,13 +202,7 @@ module.exports = Command.extend({
         }).then(() => this.runTask('Test', testOptions));
       }
 
-      return session.finally(this.rmTmp.bind(this));
+      return session;
     });
-  },
-
-  onInterrupt() {
-    this.rmTmp();
-
-    return this._super.onInterrupt.apply(this, arguments);
   },
 });

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1216,7 +1216,7 @@ let addonProto = {
         );
       }
 
-      let preprocessedTemplateTree = this._addonPreprocessTree('template', this._addonTemplateFiles(addonTree));
+      let preprocessedTemplateTree = this._addonPreprocessTree('template', addonTree);
 
       let processedTemplateTree;
       if (!isExperimentEnabled('DELAYED_TRANSPILATION') || registryHasPreprocessor(this.registry, 'template')) {
@@ -1230,7 +1230,9 @@ let addonProto = {
 
       let postprocessedTemplateTree = this._addonPostprocessTree('template', processedTemplateTree);
 
-      return processModulesOnly(postprocessedTemplateTree, 'Babel: Modules for Templates');
+      return postprocessedTemplateTree;
+    } else {
+      return addonTree;
     }
   },
 
@@ -1279,15 +1281,10 @@ let addonProto = {
       this.options[emberCLIBabelConfigKey] = this.__originalOptions[emberCLIBabelConfigKey];
     }
 
-    let addonJs = this.processedAddonJsFiles(tree);
-    let templatesTree = this.compileTemplates(tree);
+    let treeWithCompiledTemplates = this.compileTemplates(tree);
+    let final = this.processedAddonJsFiles(treeWithCompiledTemplates);
 
-    let trees = [addonJs, templatesTree].filter(Boolean);
-
-    return mergeTrees(trees, {
-      overwrite: true,
-      annotation: `Addon#compileAddon(${this.name})`,
-    });
+    return final;
   },
 
   /**
@@ -1303,6 +1300,7 @@ let addonProto = {
     let addonPath = this._treePathFor('addon');
     if (fs.existsSync(addonPath)) {
       let addonJs = new Funnel(this.addonJsFiles(addonPath), {
+        exclude: ['templates/**/*'],
         srcDir: this.moduleName(),
         destDir: 'addon',
         allowEmpty: true,
@@ -1364,10 +1362,7 @@ let addonProto = {
     @return {Tree} The filtered addon js files
   */
   addonJsFiles(tree) {
-    let includePatterns = this.registry.extensionsForType('js').map(extension => new RegExp(`${extension}$`));
-
     return new Funnel(tree, {
-      include: includePatterns,
       destDir: this.moduleName(),
       annotation: 'Funnel: Addon JS',
     });

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -167,13 +167,13 @@ function contentFor(config, match, type, options) {
 function configReplacePatterns(options) {
   return [
     {
-      match: /{{rootURL}}/g,
+      match: /{{\s?rootURL\s?}}/g,
       replacement(config) {
         return normalizeUrl(config.rootURL);
       },
     },
     {
-      match: /{{EMBER_ENV}}/g,
+      match: /{{\s?EMBER_ENV\s?}}/g,
       replacement(config) {
         return convertObjectToString(config.EmberENV);
       },
@@ -185,7 +185,7 @@ function configReplacePatterns(options) {
       },
     },
     {
-      match: /{{MODULE_PREFIX}}/g,
+      match: /{{\s?MODULE_PREFIX\s?}}/g,
       replacement(config) {
         return config.modulePrefix;
       },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "promise-map-series": "^0.2.3",
     "promise.prototype.finally": "^3.1.0",
     "quick-temp": "^0.1.8",
-    "resolve": "^1.10.1",
+    "resolve": "^1.11.0",
     "resolve-package-path": "^1.2.7",
     "rsvp": "^4.8.4",
     "sane": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "yam": "^1.0.0"
   },
   "devDependencies": {
-    "@octokit/rest": "^16.25.3",
+    "@octokit/rest": "^16.25.6",
     "broccoli-test-helper": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:debug": "node debug tests/runner"
   },
   "dependencies": {
-    "@babel/core": "^7.4.5",
+    "@babel/core": "^7.4.3",
     "@babel/plugin-transform-modules-amd": "^7.2.0",
     "amd-name-resolver": "^1.3.1",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -56,12 +56,8 @@
     "broccoli-middleware": "^2.0.1",
     "broccoli-module-normalizer": "^1.3.0",
     "broccoli-module-unification-reexporter": "^1.0.0",
-<<<<<<< HEAD
     "broccoli-slow-trees": "^3.0.1",
     "broccoli-source": "^1.1.0",
-=======
-    "broccoli-source": "^2.1.2",
->>>>>>> Bump broccoli-source from 1.1.0 to 2.1.2
     "broccoli-stew": "^2.1.0",
     "calculate-cache-key-for-tree": "^2.0.0",
     "capture-exit": "^2.0.0",
@@ -120,7 +116,7 @@
     "resolve-package-path": "^1.2.7",
     "rsvp": "^4.8.4",
     "sane": "^4.1.0",
-    "semver": "^6.1.1",
+    "semver": "^6.0.0",
     "silent-error": "^1.1.1",
     "sort-package-json": "^1.22.1",
     "symlink-or-copy": "^1.2.0",
@@ -144,7 +140,7 @@
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-internal-test-helpers": "^0.9.1",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.3.0",
+    "eslint-config-prettier": "^4.2.0",
     "eslint-plugin-chai-expect": "^2.0.1",
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-node": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-internal-test-helpers": "^0.9.1",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.2.0",
+    "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-chai-expect": "^2.0.1",
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-node": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "resolve-package-path": "^1.2.7",
     "rsvp": "^4.8.4",
     "sane": "^4.1.0",
-    "semver": "^6.0.0",
+    "semver": "^6.1.1",
     "silent-error": "^1.1.1",
     "sort-package-json": "^1.22.1",
     "symlink-or-copy": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:debug": "node debug tests/runner"
   },
   "dependencies": {
-    "@babel/core": "^7.4.3",
+    "@babel/core": "^7.4.5",
     "@babel/plugin-transform-modules-amd": "^7.2.0",
     "amd-name-resolver": "^1.3.1",
     "babel-plugin-module-resolver": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,12 @@
     "broccoli-middleware": "^2.0.1",
     "broccoli-module-normalizer": "^1.3.0",
     "broccoli-module-unification-reexporter": "^1.0.0",
+<<<<<<< HEAD
     "broccoli-slow-trees": "^3.0.1",
     "broccoli-source": "^1.1.0",
+=======
+    "broccoli-source": "^2.1.2",
+>>>>>>> Bump broccoli-source from 1.1.0 to 2.1.2
     "broccoli-stew": "^2.1.0",
     "calculate-cache-key-for-tree": "^2.0.0",
     "capture-exit": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   },
   "devDependencies": {
     "@octokit/rest": "^16.25.6",
+    "broccoli-plugin": "^2.1.0",
     "broccoli-test-helper": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -116,9 +116,7 @@ describe('Addon - linting', function() {
 
       output = yield buildOutput(lintTrees[0]);
 
-      expect(output.read()).to.deep.equal({
-        addon: {},
-      });
+      expect(output.read()).to.deep.equal({});
 
       yield output.dispose();
 

--- a/tests/unit/broccoli/template-precompilation-test.js
+++ b/tests/unit/broccoli/template-precompilation-test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const broccoliTestHelper = require('broccoli-test-helper');
+const expect = require('chai').expect;
+const BroccoliPlugin = require('broccoli-plugin');
+const walkSync = require('walk-sync');
+
+const MockCLI = require('../../helpers/mock-cli');
+const Project = require('../../../lib/models/project');
+const Addon = require('../../../lib/models/addon');
+const EmberApp = require('../../../lib/broccoli/ember-app');
+
+const buildOutput = broccoliTestHelper.buildOutput;
+const createTempDir = broccoliTestHelper.createTempDir;
+
+describe('template preprocessors', function() {
+  let input, output, addon;
+
+  class FakeTemplateColocator extends BroccoliPlugin {
+    constructor(trees, options = { root: '' }) {
+      super(...arguments);
+      this.options = options;
+    }
+
+    build() {
+      let [inputPath] = this.inputPaths;
+      let root = fs.existsSync(path.join(inputPath, this.options.root)) ? this.options.root : '';
+
+      let files = walkSync(path.join(inputPath, root), { directories: false });
+
+      files.forEach(file => {
+        let fullInputPath = path.join(inputPath, root, file);
+        let fullOutputPath = path.join(this.outputPath, root, file);
+
+        if (file.startsWith(`components/`)) {
+          let pathParts = path.parse(file);
+          let templatePath = path.join(inputPath, root, 'templates', pathParts.dir, `${pathParts.name}.hbs`);
+          let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+          let componentContents = fs.readFileSync(fullInputPath, { encoding: 'utf8' });
+
+          let contents = `${componentContents}\nexport const template = hbs\`${templateContents}\``;
+          fs.ensureDirSync(path.dirname(fullOutputPath));
+          fs.writeFileSync(fullOutputPath, contents, { encoding: 'utf8' });
+        } else if (file.startsWith(`templates/components/`)) {
+          // do nothing
+        } else {
+          fs.copySync(fullInputPath, fullOutputPath);
+        }
+      });
+    }
+  }
+
+  describe('Addon', function() {
+    beforeEach(async function() {
+      input = await createTempDir();
+      let MockAddon = Addon.extend({
+        root: input.path(),
+        name: 'fake-addon',
+      });
+      let cli = new MockCLI();
+      let pkg = { name: 'ember-app-test' };
+      let project = new Project(input.path(), pkg, cli.ui, cli);
+
+      addon = new MockAddon(project, project);
+
+      addon.registry.add('js', {
+        name: 'fake-js-compiler',
+        ext: 'js',
+        toTree(tree) {
+          return tree;
+        },
+      });
+    });
+
+    afterEach(async function() {
+      await input.dispose();
+      await output.dispose();
+    });
+
+    it('the template preprocessor receives access to all files', async function() {
+      addon.registry.add('template', {
+        name: 'fake-template-compiler',
+        ext: 'hbs',
+        toTree(tree) {
+          return new FakeTemplateColocator([tree]);
+        },
+      });
+
+      input.write({
+        addon: {
+          components: {
+            'awesome-button.js': 'export default class {}',
+          },
+          templates: {
+            components: {
+              'awesome-button.hbs': '<!-- flerpy -->',
+            },
+          },
+        },
+      });
+
+      output = await buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
+
+      expect(output.read()).to.deep.equal({
+        'fake-addon': {
+          components: {
+            'awesome-button.js': `export default class {}\nexport const template = hbs\`<!-- flerpy -->\``,
+          },
+        },
+      });
+    });
+  });
+
+  describe('EmberApp', function() {
+    let project;
+
+    beforeEach(async function() {
+      input = await createTempDir();
+      let cli = new MockCLI();
+      let pkg = { name: 'fake-app-test', devDependencies: { 'ember-cli': '*' } };
+      project = new Project(input.path(), pkg, cli.ui, cli);
+    });
+
+    afterEach(async function() {
+      await input.dispose();
+      await output.dispose();
+    });
+
+    it('the template preprocessor receives access to all files', async function() {
+      input.write({
+        app: {
+          components: {
+            'awesome-button.js': 'export default class {}',
+          },
+          styles: {
+            'app.css': '/* styles */',
+          },
+          templates: {
+            components: {
+              'awesome-button.hbs': '<!-- flerpy -->',
+            },
+          },
+          'index.html': '<body></body>',
+        },
+        config: {
+          'environment.js': 'module.exports = function() { return { modulePrefix: "fake-app-test" } };',
+        },
+      });
+
+      let app = new EmberApp(
+        {
+          project,
+          name: project.pkg.name,
+          _ignoreMissingLoader: true,
+          sourcemaps: { enabled: false },
+        },
+        {}
+      );
+
+      app.registry.add('js', {
+        name: 'fake-js-compiler',
+        ext: 'js',
+        toTree(tree) {
+          return tree;
+        },
+      });
+
+      app.registry.add('template', {
+        name: 'fake-template-compiler',
+        ext: 'hbs',
+        toTree(tree) {
+          return new FakeTemplateColocator([tree], { root: 'fake-app-test/' });
+        },
+      });
+
+      output = await buildOutput(app.toTree());
+
+      let expectedContent = `export default class {}\nexport const template = hbs\`<!-- flerpy -->\``;
+      let actualContent = output.read().assets['fake-app-test.js'];
+
+      expect(actualContent).to.include(expectedContent);
+    });
+  });
+});

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -13,6 +13,63 @@ const calculateBaseTag = emberAppUtils.calculateBaseTag;
 const convertObjectToString = emberAppUtils.convertObjectToString;
 
 describe('ember-app-utils', function() {
+  describe(`rootURL`, function() {
+    it('`rootURL` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[0].match;
+      const variations = ['{{rootURL}}', '{{ rootURL }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
+  describe(`EMBER_ENV`, function() {
+    it('`EMBER_ENV` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[1].match;
+      const variations = ['{{EMBER_ENV}}', '{{ EMBER_ENV }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
+  describe(`MODULE_PREFIX`, function() {
+    it('`MODULE_PREFIX` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[3].match;
+      const variations = ['{{MODULE_PREFIX}}', '{{ MODULE_PREFIX }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
   describe(`contentFor`, function() {
     let config = {
       modulePrefix: 'cool-foo',

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,16 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
+broccoli-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
+  integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
+  dependencies:
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^2.3.4"
+    symlink-or-copy "^1.1.8"
+
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz#9bf2a9e2f8eb3ed3a3f2abdde988da437ccdc9b4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,10 +5591,10 @@ sane@^4.0.0, sane@^4.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
-semver@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
-  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+semver@^6.0.0, semver@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
+  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
 send@0.16.2:
   version "0.16.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.2.0.tgz#70b946b629cd0e3e98233fd9ecde4cb9778de96c"
-  integrity sha512-y0uWc/FRfrHhpPZCYflWC8aE0KRJRY04rdZVfl8cL3sEZmOYyaBdhdlQPjKZBnuRMyLVK+JUZr7HaZFClQiH4w==
+eslint-config-prettier@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
+  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
   dependencies:
     get-stdin "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,6 +976,11 @@ broccoli-source@^1.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-1.1.0.tgz#54f0e82c8b73f46580cbbc4f578f0b32fca8f809"
   integrity sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=
 
+broccoli-source@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-2.1.2.tgz#e9ae834f143b607e9ec114ade66731500c38b90b"
+  integrity sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==
+
 broccoli-stew@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.1.0.tgz#ba73add17fda3b9b01d8cfb343a8b613b7136a0a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,28 +192,38 @@
     universal-user-agent "^2.0.1"
     url-template "^2.0.8"
 
-"@octokit/request@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-3.0.2.tgz#dd2424691f486d7ea332ec06e3de55b1ea13c5dc"
-  integrity sha512-lBH2hf2Yuh9XlmP3MSpn3jL9DyCGG+cuPXDRQiJMK42BwW6xFhwWmG1k6xWykcLM4GwZG/5fuwcqnQXYG0ZTSg==
+"@octokit/request-error@^1.0.1", "@octokit/request-error@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.0.2.tgz#e6dbc5be13be1041ef8eca9225520982add574cf"
+  integrity sha512-T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==
+  dependencies:
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^4.0.1":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-4.1.0.tgz#e85dc377113baf2fe24433af8feb20e8a32e21b0"
+  integrity sha512-RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==
   dependencies:
     "@octokit/endpoint" "^5.1.0"
-    deprecation "^1.0.1"
+    "@octokit/request-error" "^1.0.1"
+    deprecation "^2.0.0"
     is-plain-object "^3.0.0"
     node-fetch "^2.3.0"
     once "^1.4.0"
-    universal-user-agent "^2.0.1"
+    universal-user-agent "^2.1.0"
 
-"@octokit/rest@^16.25.3":
-  version "16.25.3"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.3.tgz#ce9e7a6230d20d58574ec929f622f2778ead7eb4"
-  integrity sha512-/6/Isn9pNoKUQwuWUaskxMC6kFxtXTHhzsgYbyirEQ3UvcLciHvPgtRTbuV3bbVf0x4+4WEfKaI9UzxmPQ3W3A==
+"@octokit/rest@^16.25.6":
+  version "16.25.6"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.6.tgz#6bc3a7da834d0c6f6076c384a89158b892dbeb2d"
+  integrity sha512-pUM6n8OKo2lyr8zxdgkeWrqRZvnKhor420KrbcrhD7L2tJJ9VEjE/yVGySfswbMjOKJMcIGWDHfA7b3JuuueEw==
   dependencies:
-    "@octokit/request" "3.0.2"
+    "@octokit/request" "^4.0.1"
+    "@octokit/request-error" "^1.0.2"
     atob-lite "^2.0.0"
     before-after-hook "^1.4.0"
     btoa-lite "^1.0.0"
-    deprecation "^1.0.1"
+    deprecation "^2.0.0"
     lodash.get "^4.4.2"
     lodash.set "^4.3.2"
     lodash.uniq "^4.5.0"
@@ -1750,10 +1760,10 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-deprecation@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
-  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
+deprecation@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.0.0.tgz#dd0427cd920c78bc575ec39dab2f22e7c304fb9d"
+  integrity sha512-lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -6381,10 +6391,10 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
-  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
+universal-user-agent@^2.0.0, universal-user-agent@^2.0.1, universal-user-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.1.0.tgz#5abfbcc036a1ba490cb941f8fd68c46d3669e8e4"
+  integrity sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==
   dependencies:
     os-name "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,18 +9,18 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.3.3", "@babel/core@^7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
-  integrity sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==
+"@babel/core@^7.3.3", "@babel/core@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
+  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.0"
-    "@babel/helpers" "^7.4.3"
-    "@babel/parser" "^7.4.3"
-    "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.3"
-    "@babel/types" "^7.4.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.5"
+    "@babel/types" "^7.4.4"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -29,12 +29,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.0.tgz#c230e79589ae7a729fd4631b9ded4dc220418196"
-  integrity sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==
+"@babel/generator@^7.4.0", "@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
   dependencies:
-    "@babel/types" "^7.4.0"
+    "@babel/types" "^7.4.4"
     jsesc "^2.5.1"
     lodash "^4.17.11"
     source-map "^0.5.0"
@@ -95,21 +95,21 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-split-export-declaration@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz#571bfd52701f492920d63b7f735030e9a3e10b55"
-  integrity sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
   dependencies:
-    "@babel/types" "^7.4.0"
+    "@babel/types" "^7.4.4"
 
-"@babel/helpers@^7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.3.tgz#7b1d354363494b31cb9a2417ae86af32b7853a3b"
-  integrity sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==
+"@babel/helpers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
+  integrity sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==
   dependencies:
-    "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.3"
-    "@babel/types" "^7.4.0"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
@@ -120,10 +120,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.0", "@babel/parser@^7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
-  integrity sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==
+"@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
+  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
 "@babel/plugin-transform-modules-amd@^7.2.0":
   version "7.2.0"
@@ -141,34 +141,34 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
-"@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
-  integrity sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==
+"@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.4.0"
-    "@babel/types" "^7.4.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.3.tgz#1a01f078fc575d589ff30c0f71bf3c3d9ccbad84"
-  integrity sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==
+"@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
+  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.0"
+    "@babel/generator" "^7.4.4"
     "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.0"
-    "@babel/parser" "^7.4.3"
-    "@babel/types" "^7.4.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/types" "^7.4.4"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.11"
 
-"@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
-  integrity sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==
+"@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5481,10 +5481,10 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.7.1, resolve@^1.8.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
-  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.7.1, resolve@^1.8.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
### Problem

When using Prettier to auto-format HTML files on save, if the `index.html` file is saved, Prettier will perform the following conversion where space padding is applied to `{{rootURL}}`:

from:
`<script src="{{rootURL}}assets/vendor.js"></script>`

to:
`<script src="{{ rootURL }}assets/vendor.js"></script>`

Because `ember-cli` expects exactly `{{rootURL}}` - the output of Prettier causes the app to fail to boot because `ember-cli` has not performed the usual replacements on `{{ rootURL }}`.

### Solution

Add optional spaces to the regex used to identify these `{{rootURL}}` tags in index.html.

This PR also allows space padding for the following tags: `{{EMBER_ENV}}` `{{MODULE_PREFIX}}`.

**Note:**
The fix was not added for `{{content-for ...}}` because Prettier only applies this padding when a tag is part of a string literal (`<script src="{{ rootURL }}...">`) and `{{content-for ...}}` seems to not be used in string literals.

This can easily be added for safety if required.