### PR TITLE
Add .git directory to npmignore

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -12,6 +12,7 @@
 /.env*
 /.eslintignore
 /.eslintrc.js
+/.git/
 /.gitignore
 /.template-lintrc.js
 /.travis.yml


### PR DESCRIPTION
I am not sure why this suddenly became an issue, but it appears that `.git` is being published to npm now, at least for ember-shepherd. It might be related to me recently updating node/npm and perhaps it used to be ignored by default, but we probably do not want to publish the `.git` directory, so this should ignore it. Related issue is here https://github.com/shipshapecode/ember-shepherd/issues/319