### PR TITLE
fix: allow use of prettier on index.html

### DIFF
--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -167,13 +167,13 @@ function contentFor(config, match, type, options) {
 function configReplacePatterns(options) {
   return [
     {
-      match: /{{rootURL}}/g,
+      match: /{{\s?rootURL\s?}}/g,
       replacement(config) {
         return normalizeUrl(config.rootURL);
       },
     },
     {
-      match: /{{EMBER_ENV}}/g,
+      match: /{{\s?EMBER_ENV\s?}}/g,
       replacement(config) {
         return convertObjectToString(config.EmberENV);
       },
@@ -185,7 +185,7 @@ function configReplacePatterns(options) {
       },
     },
     {
-      match: /{{MODULE_PREFIX}}/g,
+      match: /{{\s?MODULE_PREFIX\s?}}/g,
       replacement(config) {
         return config.modulePrefix;
       },

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -13,6 +13,63 @@ const calculateBaseTag = emberAppUtils.calculateBaseTag;
 const convertObjectToString = emberAppUtils.convertObjectToString;
 
 describe('ember-app-utils', function() {
+  describe(`rootURL`, function() {
+    it('`rootURL` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[0].match;
+      const variations = ['{{rootURL}}', '{{ rootURL }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
+  describe(`EMBER_ENV`, function() {
+    it('`EMBER_ENV` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[1].match;
+      const variations = ['{{EMBER_ENV}}', '{{ EMBER_ENV }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
+  describe(`MODULE_PREFIX`, function() {
+    it('`MODULE_PREFIX` regex accepts space-padded padded variation', function() {
+      const regex = configReplacePatterns()[3].match;
+      const variations = ['{{MODULE_PREFIX}}', '{{ MODULE_PREFIX }}', 'foo'];
+      const results = [];
+
+      variations.forEach(variation => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
   describe(`contentFor`, function() {
     let config = {
       modulePrefix: 'cool-foo',


### PR DESCRIPTION
Replaces #8682 

### Problem

When using Prettier to auto-format HTML files on save, if the `index.html` file is saved, Prettier will perform the following conversion where space padding is applied to `{{rootURL}}`:

from:
`<script src="{{rootURL}}assets/vendor.js"></script>`

to:
`<script src="{{ rootURL }}assets/vendor.js"></script>`

Because `ember-cli` expects exactly `{{rootURL}}` - the output of Prettier causes the app to fail to boot because `ember-cli` has not performed the usual replacements on `{{ rootURL }}`.

### Solution

Add optional spaces to the regex used to identify these `{{rootURL}}` tags in index.html.

This PR also allows space padding for the following tags: `{{EMBER_ENV}}` `{{MODULE_PREFIX}}`.

**Note:**
The fix was not added for `{{content-for ...}}` because Prettier only applies this padding when a tag is part of a string literal (`<script src="{{ rootURL }}...">`) and `{{content-for ...}}` seems to not be used in string literals.

This can easily be added for safety if required.