### PR TITLE
Close #8589 addon templates were detected, but no template compilers …

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -51,6 +51,12 @@ module.exports = {
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];
     delete contents.devDependencies['ember-cli-babel'];
 
+    // Move ember-cli-htmlbars into the dependencies of the addon blueprint by default
+    // to prevent error:
+    // `Addon templates were detected but there are no template compilers registered for (addon-name)`
+    contents.dependencies['ember-cli-htmlbars'] = contents.devDependencies['ember-cli-htmlbars'];
+    delete contents.devDependencies['ember-cli-htmlbars'];
+
     // 99% of addons don't need ember-data, make it opt-in instead
     delete contents.devDependencies['ember-data'];
 

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -21,7 +21,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.7.3"
+    "ember-cli-babel": "^7.7.3",
+    "ember-cli-htmlbars": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -29,7 +30,6 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -21,7 +21,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.7.3"
+    "ember-cli-babel": "^7.7.3",
+    "ember-cli-htmlbars": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -29,7 +30,6 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/module-unification-addon/npm/package.json
+++ b/tests/fixtures/module-unification-addon/npm/package.json
@@ -21,7 +21,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.7.3"
+    "ember-cli-babel": "^7.7.3",
+    "ember-cli-htmlbars": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -29,7 +30,6 @@
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/module-unification-addon/yarn/package.json
+++ b/tests/fixtures/module-unification-addon/yarn/package.json
@@ -21,7 +21,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.7.3"
+    "ember-cli-babel": "^7.7.3",
+    "ember-cli-htmlbars": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -29,7 +30,6 @@
     "ember-cli": "<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -125,6 +125,22 @@ describe('blueprint - addon', function() {
         expect(json.devDependencies).to.not.have.property('ember-cli-babel');
       });
 
+      it('moves `ember-cli-htmlbars` from devDependencies to dependencies', function() {
+        let output = blueprint.updatePackageJson(
+          JSON.stringify({
+            devDependencies: {
+              'ember-cli-htmlbars': '1.0.0',
+            },
+          })
+        );
+
+        let json = JSON.parse(output);
+        expect(json.dependencies).to.deep.equal({
+          'ember-cli-htmlbars': '1.0.0',
+        });
+        expect(json.devDependencies).to.not.have.property('ember-cli-htmlbars');
+      });
+
       it('does not push multiple `ember-addon` keywords', function() {
         let output = blueprint.updatePackageJson(
           JSON.stringify({


### PR DESCRIPTION
For #8589. 

As mentioned by @rwjblue, moved `ember-cli-htmlbars` into the dependencies of the addon blueprint by default, since we will only see this error in ember addons.
