### PR TITLE
Update Windows documentation link

### DIFF
--- a/lib/utilities/windows-admin.js
+++ b/lib/utilities/windows-admin.js
@@ -122,7 +122,7 @@ class WindowsSymlinkChecker {
 
         if (!elevated) {
           ui.writeLine(chalk.yellow('\nRunning without permission to symlink will degrade build performance.'));
-          ui.writeLine('See http://ember-cli.com/user-guide/#windows for details.\n');
+          ui.writeLine('See https://cli.emberjs.com/release/appendix/windows/ for details.\n');
         }
 
         resolve({

--- a/tests/unit/utilities/windows-admin-test.js
+++ b/tests/unit/utilities/windows-admin-test.js
@@ -48,7 +48,7 @@ describe('windows-admin', function() {
             expect(result.elevated, 'is not elevated').to.be.eql(false);
             td.verify(exec(td.matchers.contains('NET SESSION'), td.matchers.anything()), { times: 1 });
             expect(ui.output).to.match(/Running without permission to symlink will degrade build performance/);
-            expect(ui.output).to.match(/See http:\/\/ember-cli\.com\/user-guide\/#windows for details./);
+            expect(ui.output).to.match(/See https:\/\/cli.emberjs.com\/release\/appendix\/windows\/ for details./);
           });
         });
 


### PR DESCRIPTION
The current Windows documentation link, provided in the warning about a lack of symlink permissions, is outdated. Updating it to the new one at cli.emberjs.com.