### PR TITLE
lint vendor files for bare-bones IE11

### DIFF
--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -1,6 +1,5 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -52,6 +56,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'<% } %>
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/blueprints/module-unification-addon/files/.eslintrc.js
+++ b/blueprints/module-unification-addon/files/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -48,6 +52,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/blueprints/module-unification-app/files/.eslintignore
+++ b/blueprints/module-unification-app/files/.eslintignore
@@ -1,6 +1,5 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/

--- a/blueprints/module-unification-app/files/.eslintrc.js
+++ b/blueprints/module-unification-app/files/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -44,6 +48,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -46,6 +50,28 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -44,6 +48,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/module-unification-addon/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -48,6 +52,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/module-unification-addon/npm/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/npm/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -44,6 +48,28 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
+++ b/tests/fixtures/module-unification-addon/yarn/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -44,6 +48,28 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };

--- a/tests/fixtures/module-unification-app/.eslintrc.js
+++ b/tests/fixtures/module-unification-app/.eslintrc.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const path = require('path');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -44,6 +48,28 @@ module.exports = {
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
       })
+    },
+
+    {
+      files: ['vendor/**/*.js'],
+      parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script'
+      },
+      env: {
+        amd: true
+      },
+      globals: {
+        Ember: 'readonly'
+      },
+      rules: Object.keys(Object.assign({},
+        // eslint-disable-next-line node/no-extraneous-require
+        require(path.resolve(path.dirname(require.resolve('eslint')), '../conf/eslint-recommended')).rules,
+        require('eslint-plugin-ember').configs.recommended.rules
+      )).reduce((rules, rule) => {
+        rules[rule] = 'off';
+        return rules;
+      }, {})
     }
   ]
 };


### PR DESCRIPTION
This come up before, but it has recently bit me again. I accidentally used newer features in a vendor file and regressed IE11. https://github.com/kellyselden/ember-macro-helpers/pull/273/files. This could have been easily been prevented with an older eslint parser, which I added with success. I'm offerring it here again for more debate, because I think it is a good idea and will help prevent errors.

I'm waiting for an answer [here](https://stackoverflow.com/questions/57107800/eslint-disable-extends-in-override) to see if I can clean up that override any.