### PR TITLE
Remove --disable-gpu flag when starting headless chrome

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/blueprints/module-unification-app/files/testem.js
+++ b/blueprints/module-unification-app/files/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/module-unification-addon/npm/testem.js
+++ b/tests/fixtures/module-unification-addon/npm/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/module-unification-addon/yarn/testem.js
+++ b/tests/fixtures/module-unification-addon/yarn/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -15,7 +15,6 @@ module.exports = {
       // --no-sandbox is needed when running Chrome inside a container
       process.env.TRAVIS ? '--no-sandbox' : null,
 
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"

--- a/tests/fixtures/tasks/testem-config/testem-with-query-string.json
+++ b/tests/fixtures/tasks/testem-config/testem-with-query-string.json
@@ -11,7 +11,6 @@
   "browser_args": {
     "Chrome": [
       "--no-sandbox",
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"

--- a/tests/fixtures/tasks/testem-config/testem.json
+++ b/tests/fixtures/tasks/testem-config/testem.json
@@ -10,7 +10,6 @@
   "browser_args": {
     "Chrome": [
       "--no-sandbox",
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"


### PR DESCRIPTION
* https://bugs.chromium.org/p/chromium/issues/detail?id=982977 is is causing issues
* https://bugs.chromium.org/p/chromium/issues/detail?id=737678 it appears to now no longer be needed

i think this should fix:

```
 message: >
                Error: Browser failed to connect within 30s. testem.js not loaded?
                Stderr:

                DevTools listening on ws://127.0.0.1:59131/devtools/browser/ba633bc8-25cf-49a3-8f32-d14cf24fb5d8
                [0801/105531.351003:WARNING:system_snapshot_mac.cc(42)] sysctlbyname kern.nx: No such file or directory (2)
                [0801/105531.498065:WARNING:gpu_process_host.cc(1188)] The GPU process has crashed 1 time(s)
                [0801/105532.794732:WARNING:gpu_process_host.cc(962)] Reinitialized the GPU process after a crash. The reported initialization time was 0 ms
                [0801/105533.131335:WARNING:system_snapshot_mac.cc(42)] sysctlbyname kern.nx: No such file or directory (2)
                [0801/105533.155083:WARNING:gpu_process_host.cc(1188)] The GPU process has crashed 2 time(s)
                [0801/105534.318595:WARNING:gpu_process_host.cc(962)] Reinitialized the GPU process after a crash. The reported initialization time was 0 ms
                [0801/105534.559282:WARNING:system_snapshot_mac.cc(42)] sysctlbyname kern.nx: No such file or directory (2)
                [0801/105534.656891:WARNING:gpu_process_host.cc(1188)] The GPU process has crashed 3 time(s)
                [0801/105534.656929:FATAL:gpu_data_manager_impl_private.cc(894)] The display compositor is frequently crashing. Goodbye.
                [0801/105535.025242:WARNING:system_snapshot_mac.cc(42)] sysctlbyname kern.nx: No such file or directory (2)

```