### PR TITLE
Remove --disable-gpu flag from testem config blueprints

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/blueprints/module-unification-app/files/testem.js
+++ b/blueprints/module-unification-app/files/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/module-unification-addon/npm/testem.js
+++ b/tests/fixtures/module-unification-addon/npm/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/module-unification-addon/yarn/testem.js
+++ b/tests/fixtures/module-unification-addon/yarn/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
 
-        '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/fixtures/smoke-tests/js-testem-config/testem.js
+++ b/tests/fixtures/smoke-tests/js-testem-config/testem.js
@@ -15,7 +15,6 @@ module.exports = {
       // --no-sandbox is needed when running Chrome inside a container
       process.env.TRAVIS ? '--no-sandbox' : null,
 
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"

--- a/tests/fixtures/tasks/testem-config/testem-with-query-string.json
+++ b/tests/fixtures/tasks/testem-config/testem-with-query-string.json
@@ -11,7 +11,6 @@
   "browser_args": {
     "Chrome": [
       "--no-sandbox",
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"

--- a/tests/fixtures/tasks/testem-config/testem.json
+++ b/tests/fixtures/tasks/testem-config/testem.json
@@ -10,7 +10,6 @@
   "browser_args": {
     "Chrome": [
       "--no-sandbox",
-      "--disable-gpu",
       "--headless",
       "--remote-debugging-port=0",
       "--window-size=1440,900"


### PR DESCRIPTION
Unfortunately, Chrome v76 contains a regression [where passing the `--disable-gpu` flag on the Mac cause the process to crash](https://bugs.chromium.org/p/chromium/issues/detail?id=982977). This PR removes this flag from the testem config in several different blueprints, because it is no longer necessary.

This flag was originally required by headless Chrome when running on Windows. However, now that https://bugs.chromium.org/p/chromium/issues/detail?id=729961 has landed, this flag is no longer needed.