### PR TITLE
Update heimdalljs-fs-monitor to 0.2.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "git-repo-info": "^2.1.0",
     "glob": "^7.1.4",
     "heimdalljs": "^0.2.6",
-    "heimdalljs-fs-monitor": "^0.2.2",
+    "heimdalljs-fs-monitor": "^0.2.3",
     "heimdalljs-graph": "^0.3.5",
     "heimdalljs-logger": "^0.1.10",
     "http-proxy": "^1.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,10 +3054,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-heimdalljs-fs-monitor@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/heimdalljs-fs-monitor/-/heimdalljs-fs-monitor-0.2.2.tgz#a76d98f52dbf3aa1b7c20cebb0132e2f5eeb9204"
-  integrity sha512-R/VhkWs8tm4x+ekLIp+oieR8b3xYK0oFDumEraGnwNMixpiKwO3+Ms5MJzDP5W5Ui1+H/57nGW5L3lHbxi20GA==
+heimdalljs-fs-monitor@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/heimdalljs-fs-monitor/-/heimdalljs-fs-monitor-0.2.3.tgz#1aedd4b1c61d86c51f6141fb75c5a3350dc41b15"
+  integrity sha512-fYAvqSP0CxeOjLrt61B4wux/jqZzdZnS2xfb2oc14NP6BTZ8gtgtR2op6gKFakOR8lm8GN9Xhz1K4A1ZvJ4RQw==
   dependencies:
     heimdalljs "^0.2.3"
     heimdalljs-logger "^0.1.7"


### PR DESCRIPTION
This fixes a number of failures on our CI. heimdalljs-fs-monitor was mutating `fs.Stats` such that when `esm` was accessing `fs.Stats.prototype.isFile` the method was not found.

That issue was fixed in heimdalljs-fs-monitor@0.2.3.

Fixes https://github.com/ember-cli/ember-cli/issues/8796