### PR TITLE
Update blueprint reference for ember-source to 3.13.0-beta.2.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -39,7 +39,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.12.0<% if (welcome) { %>",
+    "ember-source": "~3.13.0-beta.2<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^6.2.0",
     "eslint-plugin-node": "^9.0.1",


### PR DESCRIPTION
This was changed when we merged release up into the beta branch, but the tests in beta branch were still expecting the 3.13 beta series.

Should fix beta and master (once merged upwards) CI once #8797 is also landed.