### PR TITLE
Clarify installation error message

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -293,7 +293,9 @@ let Command = CoreObject.extend({
           if (isYarnProject(this.project.root)) {
             installInstuction = '`yarn install`';
           }
-          throw new SilentError(`node_modules appears empty, you may need to run ${installInstuction}`);
+          throw new SilentError(
+            `Required packages are missing, run ${installInstuction} from this directory to install them.`
+          );
         }
       }
 

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -67,7 +67,9 @@ describe('generate command', function() {
       };
 
       return expect(command.validateAndRun(['controller', 'foo'])).to.be.rejected.then(reason => {
-        expect(reason.message).to.eql('node_modules appears empty, you may need to run `npm install`');
+        expect(reason.message).to.eql(
+          'Required packages are missing, run `npm install` from this directory to install them.'
+        );
       });
     });
   });
@@ -78,7 +80,9 @@ describe('generate command', function() {
     };
 
     return expect(command.validateAndRun(['controller', 'foo'])).to.be.rejected.then(reason => {
-      expect(reason.message).to.eql('node_modules appears empty, you may need to run `yarn install`');
+      expect(reason.message).to.eql(
+        'Required packages are missing, run `yarn install` from this directory to install them.'
+      );
     });
   });
 


### PR DESCRIPTION
I noticed this message from a question at https://stackoverflow.com/questions/57668319/ember-serve-node-modules-appears-empty-you-may-need-to-run-npm-install

I'm not sure it would have helped this user, but it seemed a touchup was in order anyway and I don't think this would add any friction for experienced developers.