### PR TITLE
Update NPM version check to avoid double `npm install` when using `npm@5.7.1` or higher.

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -175,7 +175,7 @@ class NpmTask extends Task {
         // this ensures that we run a full `npm install` **after** any `npm
         // install foo` runs to ensure that we have a fully functional
         // node_modules hierarchy
-        if (result.npmVersion && semver.gte(result.npmVersion, '5.0.0')) {
+        if (result.npmVersion && semver.lt(result.npmVersion, '5.7.1')) {
           promise = promise.then(() => this.npm(['install']));
         }
       }


### PR DESCRIPTION
- The issue with deletion of files/folders was resolved in npm 5.7.1. https://github.com/npm/npm/issues/17379#issuecomment-367924115
https://blog.npmjs.org/post/171139955345/v570 

This PR updates the npm version check to reflect this and only runs an additional npm install when below the version with the fix.