### PR TITLE
BUGFIX: Clear project.configCache before starting the build

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -216,6 +216,8 @@ class Builder extends CoreObject {
       this.ui.spinner.text = progress.format(progress());
     }, this.ui.spinner.interval);
 
+    this.project.configCache.clear();
+
     return this.processAddonBuildSteps('preBuild')
       .then(() => this.builder.build(this.broccoliBuilderFallback ? addWatchDirCallback : null))
       .then(this.compatNode.bind(this), this.compatBroccoliPayload.bind(this))


### PR DESCRIPTION
Fixes https://github.com/ember-cli/ember-cli/issues/8478
The problem I noticed was that `get-serve-url` would access `project.config` after `finalizeBuild` and hence the config would get cached and would be used in the next build. Hence each build was using the previous build's config.
This PR simply clears the `project.configCache` before the build is started.