### PR TITLE
Issue deprecation when enabling MODULE_UNIFICATION flag.

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const chalk = require('chalk');
 const availableExperiments = Object.freeze([
   'PACKAGER',
   'MODULE_UNIFICATION',
@@ -8,7 +9,9 @@ const availableExperiments = Object.freeze([
   'BROCCOLI_WATCHER',
 ]);
 
+const deprecatedExperiments = Object.freeze(['MODULE_UNIFICATION']);
 const enabledExperiments = Object.freeze(['SYSTEM_TEMP']);
+const deprecatedExperimentsDeprecationsIssued = [];
 
 function isExperimentEnabled(experimentName) {
   if (!availableExperiments.includes(experimentName)) {
@@ -21,6 +24,19 @@ function isExperimentEnabled(experimentName) {
 
   let experimentEnvironmentVariable = `EMBER_CLI_${experimentName}`;
   let experimentValue = process.env[experimentEnvironmentVariable];
+
+  if (deprecatedExperiments.includes(experimentName)) {
+    let deprecationPreviouslyIssued = deprecatedExperimentsDeprecationsIssued.includes(experimentName);
+    let isSpecifiedByUser = experimentValue !== undefined;
+
+    if (!deprecationPreviouslyIssued && isSpecifiedByUser) {
+      console.warn(
+        chalk.yellow(`The ${experimentName} experiment in ember-cli has been deprecated and will be removed.`)
+      );
+      deprecatedExperimentsDeprecationsIssued.push(experimentName);
+    }
+  }
+
   if (enabledExperiments.includes(experimentName)) {
     return experimentValue !== 'false';
   } else {
@@ -28,4 +44,9 @@ function isExperimentEnabled(experimentName) {
   }
 }
 
-module.exports = { isExperimentEnabled };
+module.exports = {
+  isExperimentEnabled,
+
+  // exported for testing purposes
+  _deprecatedExperimentsDeprecationsIssued: deprecatedExperimentsDeprecationsIssued,
+};

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
+const chalk = require('chalk');
 const expect = require('chai').expect;
-const { isExperimentEnabled } = require('../../lib/experiments');
+const { isExperimentEnabled, _deprecatedExperimentsDeprecationsIssued } = require('../../lib/experiments');
 
 function resetProcessEnv(originalProcessEnv) {
   for (let key in process.env) {
@@ -19,9 +20,11 @@ function resetProcessEnv(originalProcessEnv) {
   }
 }
 
+const ORIGINAL_CONSOLE = Object.assign({}, console);
+
 describe('experiments', function() {
   describe('isExperimentEnabled', function() {
-    let originalProcessEnv;
+    let originalProcessEnv, warnings;
 
     beforeEach(function() {
       originalProcessEnv = Object.assign({}, process.env);
@@ -33,10 +36,15 @@ describe('experiments', function() {
       delete process.env.EMBER_CLI_PACKAGER;
       delete process.env.EMBER_CLI_DELAYED_TRANSPILATION;
       delete process.env.EMBER_CLI_SYSTEM_TEMP;
+
+      warnings = [];
+      console.warn = warning => warnings.push(warning);
     });
 
     afterEach(function() {
       resetProcessEnv(originalProcessEnv);
+      Object.assign(console, ORIGINAL_CONSOLE);
+      _deprecatedExperimentsDeprecationsIssued.length = 0;
     });
 
     it('should return true for all experiments when `EMBER_CLI_ENABLE_ALL_EXPERIMENTS` is set', function() {
@@ -45,25 +53,51 @@ describe('experiments', function() {
       expect(isExperimentEnabled('PACKAGER')).to.be.true;
       expect(isExperimentEnabled('SYSTEM_TEMP')).to.be.true;
       expect(isExperimentEnabled('DELAYED_TRANSPILATION')).to.be.true;
+
+      expect(warnings).to.deep.equal([]);
     });
 
     it('should have SYSTEM_TEMP disabled when environment flag is present', function() {
       process.env.EMBER_CLI_SYSTEM_TEMP = 'false';
       expect(isExperimentEnabled('SYSTEM_TEMP')).to.be.false;
+
+      expect(warnings).to.deep.equal([]);
     });
 
     it('setting an already disabled feature to false does not enable it', function() {
       process.env.EMBER_CLI_PACKAGER = 'false';
       expect(isExperimentEnabled('PACKAGER')).to.be.false;
+
+      expect(warnings).to.deep.equal([]);
     });
 
     it('should have MODULE_UNIFICATION disabled by default', function() {
       expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.false;
+
+      expect(warnings).to.deep.equal([]);
     });
 
     it('should have MODULE_UNIFICATION enabled when environment variable is set', function() {
       process.env.EMBER_CLI_MODULE_UNIFICATION = 'true';
       expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.true;
+
+      expect(warnings).to.deep.equal([
+        chalk.yellow(`The MODULE_UNIFICATION experiment in ember-cli has been deprecated and will be removed.`),
+      ]);
+    });
+
+    it('only emits deprecation warnings once', function() {
+      process.env.EMBER_CLI_MODULE_UNIFICATION = 'true';
+      expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.true;
+
+      expect(warnings).to.deep.equal([
+        chalk.yellow(`The MODULE_UNIFICATION experiment in ember-cli has been deprecated and will be removed.`),
+      ]);
+
+      warnings = [];
+      expect(isExperimentEnabled('MODULE_UNIFICATION')).to.be.true;
+
+      expect(warnings).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
MODULE_UNIFICATION has always required using canary versions of Ember and ember-cli. `ember-source` has disabled the feature completely so that apps can no longer enable the feature at all.

This implements a basic system for ember-cli to tell folks that were leveraging that experiment that we will be removing support from ember-cli. This will _likely_ be removed in ember-cli@3.17 (after the next LTS release).

Begins addressing https://github.com/ember-cli/ember-cli/issues/8790.