### PR TITLE
CI: Remove deprecated exp. from ALL_EXPERIMENTS

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -18,6 +18,10 @@ function isExperimentEnabled(experimentName) {
     return false;
   }
 
+  if (process.env.EMBER_CLI_ENABLE_ALL_EXPERIMENTS && deprecatedExperiments.includes(experimentName)) {
+    return false;
+  }
+
   if (process.env.EMBER_CLI_ENABLE_ALL_EXPERIMENTS) {
     return true;
   }


### PR DESCRIPTION
Disable `MODULE_UNIFICATION` experiment for `EMBER_CLI_ALL_EXPERIMENTS` CI job.

With https://github.com/ember-cli/ember-cli/pull/8827 I've set some acceptance tests behind the following conditional:
```
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
    it(
      'addons with standard preprocessors compile correctly',
      co.wrap(function*() {
        ...
      })
    );
  }
```

That PR would disable some acceptance tests for `EMBER_CLI_ALL_EXPERIMENTS` test scenario. This PR aims at fixing that.