### PR TITLE
Avoid using configstore when analytics is disabled

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -103,7 +103,7 @@ module.exports = function(options) {
   let defaultLeekOptions = {
     trackingCode,
     globalName: name,
-    name: clientId(),
+    name: disableAnalytics ? 'disabled' : clientId(),
     version,
     silent: disableAnalytics,
   };


### PR DESCRIPTION
configstore crashes if the user's $HOME directory is not writable.

Usually a user's $HOME directory is writeable, but the [Nix][nix]
build system purposefully points $HOME at a non-existent directory
to ensure an isolated, repeatable build environment.

This creates a workaround so that disabling analytics will not
trigger the crash.

<details>
<summary>(the error I get without this workaround)</summary>

    🚀 nomicon$ nix-build
    these derivations will be built:
      /nix/store/xr426vfl94fjmg1vh3ia1sdz2y2mb941-nomicon-frontend.drv
    building '/nix/store/xr426vfl94fjmg1vh3ia1sdz2y2mb941-nomicon-frontend.drv'...
    
    > nomicon@0.0.0 build-prod /private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0
    > ember build --prod
    
    /private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/node_modules/configstore/index.js:65
                            throw error;
                            ^
    
    Error: EACCES: permission denied, mkdir '/homeless-shelter'
    You don't have access to this file.
    
        at Object.mkdirSync (fs.js:764:3)
        at make (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/make-dir/index.js:61:12)
        at make (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/make-dir/index.js:68:5)
        at make (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/make-dir/index.js:68:5)
        at Function.module.exports.sync (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/make-dir/index.js:84:9)
        at Configstore.set all [as all] (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/node_modules/configstore/index.js:56:12)
        at Configstore.set (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/node_modules/configstore/index.js:88:12)
        at clientId (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/lib/cli/index.js:55:17)
        at module.exports (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/lib/cli/index.js:103:11)
        at Object.<anonymous> (/private/var/folders/wq/80s2kwss4qj_rk353wfyl4nc0000gn/T/nix-build-nomicon-frontend.drv-0/node_modules/ember-cli/bin/ember:34:1) {
      errno: -13,
      syscall: 'mkdir',
      code: 'EACCES',
      path: '/homeless-shelter'
    }
    npm ERR! code ELIFECYCLE
    npm ERR! errno 1
    npm ERR! nomicon@0.0.0 build-prod: `ember build --prod`
    npm ERR! Exit status 1
    npm ERR!
    npm ERR! Failed at the nomicon@0.0.0 build-prod script.
    npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
    builder for '/nix/store/xr426vfl94fjmg1vh3ia1sdz2y2mb941-nomicon-frontend.drv' failed with exit code 1
    error: build of '/nix/store/xr426vfl94fjmg1vh3ia1sdz2y2mb941-nomicon-frontend.drv' failed

<summary>


[nix]: https://nixos.org/nix/