### PR TITLE
Ensure addon tree is scoped to addon name before compiling templates.

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -83,7 +83,6 @@ let DEFAULT_TREE_FOR_METHOD_METHODS = {
     '_addonTemplateFiles',
     'compileStyles',
     'preprocessJs',
-    'addonJsFiles',
   ],
   'addon-styles': ['treeForAddonStyles'],
   'addon-templates': ['treeForAddonTemplates'],
@@ -1281,7 +1280,12 @@ let addonProto = {
       this.options[emberCLIBabelConfigKey] = this.__originalOptions[emberCLIBabelConfigKey];
     }
 
-    let treeWithCompiledTemplates = this.compileTemplates(tree);
+    let scopedInput = new Funnel(tree, {
+      destDir: this.moduleName(),
+      annotation: `Funnel: ${this.name}/addon`,
+    });
+
+    let treeWithCompiledTemplates = this.compileTemplates(scopedInput);
     let final = this.processedAddonJsFiles(treeWithCompiledTemplates);
 
     return final;
@@ -1299,9 +1303,8 @@ let addonProto = {
 
     let addonPath = this._treePathFor('addon');
     if (fs.existsSync(addonPath)) {
-      let addonJs = new Funnel(this.addonJsFiles(addonPath), {
+      let addonJs = new Funnel(addonPath, {
         exclude: ['templates/**/*'],
-        srcDir: this.moduleName(),
         destDir: 'addon',
         allowEmpty: true,
       });
@@ -1358,10 +1361,13 @@ let addonProto = {
     Returns a tree containing the addon's js files
 
     @private
+    @deprecated
     @method addonJsFiles
     @return {Tree} The filtered addon js files
   */
   addonJsFiles(tree) {
+    this._warn(`Addon.prototype.addonJsFiles is deprecated`);
+
     return new Funnel(tree, {
       destDir: this.moduleName(),
       annotation: 'Funnel: Addon JS',
@@ -1387,8 +1393,8 @@ let addonProto = {
     @param {Tree} the tree to preprocess
     @return {Tree} Processed javascript file tree
   */
-  processedAddonJsFiles(addonTree) {
-    let preprocessedAddonJS = this._addonPreprocessTree('js', this.addonJsFiles(addonTree));
+  processedAddonJsFiles(inputTree) {
+    let preprocessedAddonJS = this._addonPreprocessTree('js', inputTree);
 
     let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
       annotation: `processedAddonJsFiles(${this.name})`,

--- a/tests/unit/broccoli/template-precompilation-test.js
+++ b/tests/unit/broccoli/template-precompilation-test.js
@@ -19,15 +19,18 @@ describe('template preprocessors', function() {
   let input, output, addon;
 
   class FakeTemplateColocator extends BroccoliPlugin {
-    constructor(trees, options = { root: '' }) {
-      super(...arguments);
-      this.options = options;
-    }
-
     build() {
       let [inputPath] = this.inputPaths;
-      let root = fs.existsSync(path.join(inputPath, this.options.root)) ? this.options.root : '';
+      let entries = fs.readdirSync(inputPath);
+      if (entries.length > 1) {
+        throw new Error('all input files should be scoped to the addon or project name');
+      }
 
+      if (entries.length === 0) {
+        // nothing to do, no files in input tree
+        return;
+      }
+      let root = entries[0];
       let files = walkSync(path.join(inputPath, root), { directories: false });
 
       files.forEach(file => {
@@ -171,7 +174,7 @@ describe('template preprocessors', function() {
         name: 'fake-template-compiler',
         ext: 'hbs',
         toTree(tree) {
-          return new FakeTemplateColocator([tree], { root: 'fake-app-test/' });
+          return new FakeTemplateColocator([tree]);
         },
       });
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -20,7 +20,6 @@ let root = process.cwd();
 let tmproot = path.join(root, 'tmp');
 
 let fixturePath = path.resolve(__dirname, '../../fixtures/addon');
-const ensurePosixPath = require('ensure-posix-path');
 
 describe('models/addon.js', function() {
   let addon, project, projectPath;
@@ -100,20 +99,6 @@ describe('models/addon.js', function() {
         };
 
         addon.jshintTrees = function() {};
-      });
-
-      it('uses the fullPath', function() {
-        let addonPath;
-        addon.addonJsFiles = function(_path) {
-          addonPath = _path;
-          return _path;
-        };
-
-        let root = path.join(fixturePath, 'with-styles');
-        addon.root = root;
-
-        addon.jshintAddonTree();
-        expect(addonPath).to.eql(ensurePosixPath(path.join(root, 'addon')));
       });
 
       it('lints the files before preprocessing', function() {


### PR DESCRIPTION
Without this, addon templates are compiled with an incorrect module name (they would be seen as `templates/components/foo-bar` instead of `addon-name/templates/components/foo-bar`).

The scoping was happening just before JS compilation (which is why that wasn't also incorrect), but not before template compilation. This fixes issues by doing the scoping first, and passing the scoped tree through the pipeline.