### PR TITLE
Fix: generated assets get out of sync with index.html when app name (package.json#name) changes

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/{{appName}}.css">
 
     {{content-for "head-footer"}}
   </head>
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/<%= name %>.js"></script>
+    <script src="{{rootURL}}assets/{{appName}}.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/{{appName}}.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}{{outputPaths.vendor.css}}">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}{{outputPaths.app.css.app}}">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/{{appName}}.js"></script>
+    <script src="{{rootURL}}{{outputPaths.vendor.js}}"></script>
+    <script src="{{rootURL}}{{outputPaths.app.js}}"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -11,7 +11,7 @@
     {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/{{appName}}.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
@@ -24,7 +24,7 @@
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
-    <script src="{{rootURL}}assets/<%= name %>.js"></script>
+    <script src="{{rootURL}}assets/{{appName}}>.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/{{appName}}.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}{{outputPaths.vendor.css}}">
+    <link rel="stylesheet" href="{{rootURL}}{{outputPaths.app.css.app}}">
+    <link rel="stylesheet" href="{{rootURL}}{{outputPaths.testSupport.css}}">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -22,10 +22,10 @@
     {{content-for "test-body"}}
 
     <script src="/testem.js" integrity=""></script>
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
-    <script src="{{rootURL}}assets/{{appName}}>.js"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="{{rootURL}}{{outputPaths.vendor.js}}"></script>
+    <script src="{{rootURL}}{{outputPaths.testSupport.js.testSupport}}"></script>
+    <script src="{{rootURL}}{{outputPaths.app.js}}"></script>
+    <script src="{{rootURL}}{{outputPaths.tests.js}}"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -9,7 +9,7 @@ const mergeTrees = require('./merge-trees');
 const ConfigLoader = require('broccoli-config-loader');
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 const ConfigReplace = require('broccoli-config-replace');
-const emberAppUtils = require('../utilities/ember-app-utils');
+const { configReplacePatterns } = require('../utilities/ember-app-utils');
 const funnelReducer = require('broccoli-funnel-reducer');
 const addonProcessTree = require('../utilities/addon-process-tree');
 
@@ -33,8 +33,6 @@ const EMBER_CLI_FILES = [
   'vendor-prefix.js',
   'vendor-suffix.js',
 ];
-
-const configReplacePatterns = emberAppUtils.configReplacePatterns;
 
 function callAddonsPreprocessTreeHook(project, type, tree) {
   return addonProcessTree(project, 'preprocessTree', type, tree);
@@ -131,6 +129,7 @@ module.exports = class DefaultPackager {
     this.sourcemaps = this.options.sourcemaps;
     this.minifyCSS = this.options.minifyCSS;
     this.distPaths = this.options.distPaths;
+    this.outputPaths = this.options.outputPaths;
     this.areTestsEnabled = this.options.areTestsEnabled;
     this.styleOutputFiles = this.options.styleOutputFiles;
     this.scriptOutputFiles = this.options.scriptOutputFiles;
@@ -183,6 +182,7 @@ module.exports = class DefaultPackager {
         addons: this.project.addons,
         autoRun: this.autoRun,
         storeConfigInMeta: this.storeConfigInMeta,
+        outputPaths: this.outputPaths,
       });
 
       this._cachedProcessedIndex = new ConfigReplace(index, this.packageConfig(), {
@@ -371,6 +371,7 @@ module.exports = class DefaultPackager {
         addons: this.project.addons,
         autoRun: this.autoRun,
         storeConfigInMeta: this.storeConfigInMeta,
+        outputPaths: this.outputPaths,
       });
 
       let configTree = this.packageConfig();
@@ -837,6 +838,7 @@ module.exports = class DefaultPackager {
       addons: this.project.addons,
       autoRun: this.autoRun,
       storeConfigInMeta: this.storeConfigInMeta,
+      outputPaths: this.outputPaths,
     });
 
     let configPath = path.join(this.name, 'config', 'environments', 'test.json');
@@ -883,6 +885,7 @@ module.exports = class DefaultPackager {
       addons: this.project.addons,
       autoRun: this.autoRun,
       storeConfigInMeta: this.storeConfigInMeta,
+      outputPaths: this.outputPaths,
     });
 
     let configPath = path.join(this.name, 'config', 'environments', `test.json`);

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -46,17 +46,17 @@ let DEFAULT_CONFIG = {
       html: 'index.html',
     },
     tests: {
-      js: '/assets/tests.js',
+      js: 'assets/tests.js',
     },
     vendor: {
-      css: '/assets/vendor.css',
-      js: '/assets/vendor.js',
+      css: 'assets/vendor.css',
+      js: 'assets/vendor.js',
     },
     testSupport: {
-      css: '/assets/test-support.css',
+      css: 'assets/test-support.css',
       js: {
-        testSupport: '/assets/test-support.js',
-        testLoader: '/assets/test-loader.js',
+        testSupport: 'assets/test-support.js',
+        testLoader: 'assets/test-loader.js',
       },
     },
   },
@@ -159,6 +159,7 @@ class EmberApp {
       additionalAssetPaths: this.otherAssetPaths,
       vendorTestStaticStyles: this.vendorTestStaticStyles,
       legacyTestFilesToAppend: this.legacyTestFilesToAppend,
+      outputPaths: this.options.outputPaths,
       distPaths: {
         appJsFile: this.options.outputPaths.app.js,
         appCssFile: this.options.outputPaths.app.css,
@@ -309,9 +310,9 @@ class EmberApp {
       outputPaths: {
         app: {
           css: {
-            app: `/assets/${this.name}.css`,
+            app: `assets/${this.name}.css`,
           },
-          js: `/assets/${this.name}.js`,
+          js: `assets/${this.name}.js`,
         },
       },
       sourcemaps: {

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -186,6 +186,13 @@ function configReplacePatterns(options) {
         return config.modulePrefix;
       },
     },
+    {
+      match: /{{\s?appName\s?}}/g,
+      replacement(config) {
+        // addons don't have an APP object, so default to dummy
+        return config.APP.name || 'dummy';
+      },
+    },
   ];
 }
 

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -158,6 +158,7 @@ function contentFor(config, match, type, options) {
                     application or not
  * @param {Boolean} options.storeConfigInMeta Controls whether to include the
                     contents of config
+ * @param {Object} options.outputPaths The filenames referenced in app/index.html + tests/index.html
    @return {Array} An array of patterns to match against and replace
 */
 function configReplacePatterns(options) {
@@ -187,10 +188,15 @@ function configReplacePatterns(options) {
       },
     },
     {
-      match: /{{\s?appName\s?}}/g,
-      replacement(config) {
-        // addons don't have an APP object, so default to dummy
-        return config.APP.name || 'dummy';
+      match: /{{\s?outputPaths\.([^.]+)\.([^.]+)\s?}}/g,
+      replacement(_config, _match, category, fileType) {
+        return options.outputPaths[category][fileType];
+      },
+    },
+    {
+      match: /{{\s?outputPaths\.([^.]+)\.([^.]+)\.([^.]+)\s?}}/g,
+      replacement(_config, _match, category, fileType, subType) {
+        return options.outputPaths[category][fileType][subType];
       },
     },
   ];

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1294,7 +1294,7 @@ describe('EmberApp', function () {
 
     it('appends dependencies to vendor by default', function () {
       app.import('vendor/moment.js');
-      let outputFile = app._scriptOutputFiles['/assets/vendor.js'];
+      let outputFile = app._scriptOutputFiles['assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
@@ -1302,7 +1302,7 @@ describe('EmberApp', function () {
     it('appends dependencies', function () {
       app.import('vendor/moment.js', { type: 'vendor' });
 
-      let outputFile = app._scriptOutputFiles['/assets/vendor.js'];
+      let outputFile = app._scriptOutputFiles['assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/moment.js')).to.equal(outputFile.length - 1);
@@ -1311,7 +1311,7 @@ describe('EmberApp', function () {
     it('prepends dependencies', function () {
       app.import('vendor/es5-shim.js', { type: 'vendor', prepend: true });
 
-      let outputFile = app._scriptOutputFiles['/assets/vendor.js'];
+      let outputFile = app._scriptOutputFiles['assets/vendor.js'];
 
       expect(outputFile).to.be.instanceof(Array);
       expect(outputFile.indexOf('vendor/es5-shim.js')).to.equal(0);
@@ -1341,7 +1341,7 @@ describe('EmberApp', function () {
         development: 'vendor/jquery.js',
       });
 
-      let outputFile = app._scriptOutputFiles['/assets/vendor.js'];
+      let outputFile = app._scriptOutputFiles['assets/vendor.js'];
       expect(outputFile.indexOf('vendor/jquery.js')).to.equal(outputFile.length - 1);
     });
 
@@ -1358,15 +1358,15 @@ describe('EmberApp', function () {
         production: null,
       });
 
-      expect(app._scriptOutputFiles['/assets/vendor.js']).to.not.contain('vendor/jquery.js');
+      expect(app._scriptOutputFiles['assets/vendor.js']).to.not.contain('vendor/jquery.js');
     });
 
     it('normalizes asset path correctly', function () {
       app.import('vendor\\path\\to\\lib.js', { type: 'vendor' });
       app.import('vendor/path/to/lib2.js', { type: 'vendor' });
 
-      expect(app._scriptOutputFiles['/assets/vendor.js']).to.contain('vendor/path/to/lib.js');
-      expect(app._scriptOutputFiles['/assets/vendor.js']).to.contain('vendor/path/to/lib2.js');
+      expect(app._scriptOutputFiles['assets/vendor.js']).to.contain('vendor/path/to/lib.js');
+      expect(app._scriptOutputFiles['assets/vendor.js']).to.contain('vendor/path/to/lib2.js');
     });
 
     it('option.using throws exception given invalid inputs', function () {
@@ -1597,7 +1597,7 @@ describe('EmberApp', function () {
         app.import('files/a.css', { prepend: true });
         app.import('files/d.css');
 
-        expect(app._styleOutputFiles['/assets/vendor.css']).to.deep.equal([
+        expect(app._styleOutputFiles['assets/vendor.css']).to.deep.equal([
           'files/a.css',
           'files/b.css',
           'files/c.css',

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -32,6 +32,25 @@ describe('ember-app-utils', function () {
     });
   });
 
+  describe(`appName`, function () {
+    it('`appName` regex accepts space-padded padded variation', function () {
+      const regex = configReplacePatterns().find((entry) => `${entry.match}`.includes('appName')).match;
+      const variations = ['{{appName}}', '{{ appName }}', 'foo'];
+      const results = [];
+
+      variations.forEach((variation) => {
+        const match = variation.match(regex);
+
+        if (match !== null) {
+          results.push(match[0]);
+        }
+      });
+
+      variations.pop();
+      expect(results).to.deep.equal(variations);
+    });
+  });
+
   describe(`EMBER_ENV`, function () {
     it('`EMBER_ENV` regex accepts space-padded padded variation', function () {
       const regex = configReplacePatterns()[1].match;


### PR DESCRIPTION
Related: https://github.com/ember-cli/ember-octane-blueprint/pull/183

The workflow I'm trying to resolve:

```
ember new my-app
# build project, notice dist/assets has:
# - my-app.css, my-app.js

change package.json#name to "my-app-updated"
# build project, notice dist/assets has:
# - my-app-updated.css, my-app-updated.js
```
but the output index.html still expects my-app instead of my-app-updated

--------------------------------

I would have expected that the index.html still refers to the correct asset paths.

I don't know what all package.json#name is tied to -- is it tied to other things?
Is there a reason the index.html css/js names were static after app generation, even though the generated asset names are dynamic?


I guess there could maybe be somewhat undefined behavior here?

This PR locks the generated assets into the value of package.json which happens to be APP.name.
Another approach may be to generate assets based of MODULE_PREFIX instead of APP.name