### PR TITLE
Update ember-resolver to 5.3.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -38,7 +38,7 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-resolver": "^5.2.1",
+    "ember-resolver": "^5.3.0",
     "ember-source": "~3.13.0<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^7.1.0",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-resolver": "^5.2.1",
+    "ember-resolver": "^5.3.0",
     "ember-source": "~3.13.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.2.1",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-resolver": "^5.2.1",
+    "ember-resolver": "^5.3.0",
     "ember-source": "~3.13.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.2.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -38,7 +38,7 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-resolver": "^5.2.1",
+    "ember-resolver": "^5.3.0",
     "ember-source": "~3.13.0",
     "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-node": "^10.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -38,7 +38,7 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-resolver": "^5.2.1",
+    "ember-resolver": "^5.3.0",
     "ember-source": "~3.13.0",
     "ember-welcome-page": "^4.0.0",
     "eslint-plugin-ember": "^7.1.0",


### PR DESCRIPTION
Primarily adds support for component colocation.