### PR TITLE
Prepare for first Octane beta.

### DIFF
--- a/blueprints/addon/files/config/optional-features.json
+++ b/blueprints/addon/files/config/optional-features.json
@@ -1,3 +1,6 @@
 {
-  "jquery-integration": false
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }

--- a/blueprints/app/files/.ember-cli.js
+++ b/blueprints/app/files/.ember-cli.js
@@ -1,9 +1,13 @@
-{
+const { setEdition } = require('@ember/edition-utils');
+
+setEdition('octane');
+
+module.exports = {
   /**
     Ember CLI sends analytics information by default. The data is completely
     anonymous, but there are times when you might want to disable this behavior.
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
-}
+  disableAnalytics: false
+};

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',<% if (blueprint !== 'app') { %>

--- a/blueprints/app/files/config/optional-features.json
+++ b/blueprints/app/files/config/optional-features.json
@@ -1,3 +1,6 @@
 {
-  "jquery-integration": false
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -33,7 +33,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
-    "ember-data": "~3.13.0",
+    "ember-data": "~3.14.0-beta.0",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.7.0",
     "ember-load-initializers": "^2.1.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -39,7 +39,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
-    "ember-source": "~3.13.0<% if (welcome) { %>",
+    "ember-source": "~3.14.0-beta.1<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-node": "^10.0.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -18,6 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-babel": "^7.11.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^4.0.0",
+    "ember-cli-htmlbars": "^4.0.1",
     "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "yam": "^1.0.0"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@octokit/rest": "^16.30.1",
     "broccoli-plugin": "^3.0.0",
     "broccoli-test-helper": "^2.0.0",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -42,23 +42,6 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   it(
-    'a custom EmberENV in config/environment.js is used for window.EmberENV',
-    co.wrap(function*() {
-      yield copyFixtureFiles('brocfile-tests/custom-ember-env');
-      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-      let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
-        encoding: 'utf8',
-      });
-
-      // Changes in ember-optional-features 0.7.0 cause all defined values in optional-features.json
-      // to end up in EmberENV. jquery-integration is explicitly defined for non MU apps
-      let expected = 'window.EmberENV = {"asdflkmawejf":";jlnu3yr23","_JQUERY_INTEGRATION":false};';
-      expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
-    })
-  );
-
-  it(
     'a custom environment config can be used in Brocfile.js',
     co.wrap(function*() {
       yield copyFixtureFiles('brocfile-tests/custom-environment-config');
@@ -73,6 +56,23 @@ describe('Acceptance: brocfile-smoke-test', function() {
         yield copyFixtureFiles('brocfile-tests/pods-templates');
         yield remove(path.join(process.cwd(), 'app/templates'));
         yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+      })
+    );
+
+    it(
+      'a custom EmberENV in config/environment.js is used for window.EmberENV',
+      co.wrap(function*() {
+        yield copyFixtureFiles('brocfile-tests/custom-ember-env');
+        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+        let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
+          encoding: 'utf8',
+        });
+
+        // Changes in config/optional-features.json end up being set in EmberENV
+        let expected =
+          'window.EmberENV = {"asdflkmawejf":";jlnu3yr23","_APPLICATION_TEMPLATE_WRAPPER":false,"_DEFAULT_ASYNC_OBSERVERS":true,"_JQUERY_INTEGRATION":false,"_TEMPLATE_ONLY_GLIMMER_COMPONENTS":true};';
+        expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
       })
     );
   }

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.11.1",
-    "ember-cli-htmlbars": "^4.0.0"
+    "ember-cli-htmlbars": "^4.0.1"
   },
   "devDependencies": {
     "@ember/edition-utils": "^1.1.1",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -25,6 +25,7 @@
     "ember-cli-htmlbars": "^4.0.0"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
-    "ember-source": "~3.13.0",
+    "ember-source": "~3.14.0-beta.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.2.1",
     "eslint-plugin-ember": "^7.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
-    "ember-source": "~3.13.0",
+    "ember-source": "~3.14.0-beta.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.2.1",
     "ember-welcome-page": "^4.0.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.11.1",
-    "ember-cli-htmlbars": "^4.0.0"
+    "ember-cli-htmlbars": "^4.0.1"
   },
   "devDependencies": {
     "@ember/edition-utils": "^1.1.1",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -25,6 +25,7 @@
     "ember-cli-htmlbars": "^4.0.0"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -33,7 +33,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
-    "ember-data": "~3.13.0",
+    "ember-data": "~3.14.0-beta.0",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.7.0",
     "ember-load-initializers": "^2.1.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -18,6 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -27,7 +27,7 @@
     "ember-cli-babel": "^7.11.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^4.0.0",
+    "ember-cli-htmlbars": "^4.0.1",
     "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -39,7 +39,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
-    "ember-source": "~3.13.0",
+    "ember-source": "~3.14.0-beta.1",
     "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -33,7 +33,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
-    "ember-data": "~3.13.0",
+    "ember-data": "~3.14.0-beta.0",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.7.0",
     "ember-load-initializers": "^2.1.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -18,6 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -27,7 +27,7 @@
     "ember-cli-babel": "^7.11.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^4.0.0",
+    "ember-cli-htmlbars": "^4.0.1",
     "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -39,7 +39,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
-    "ember-source": "~3.13.0",
+    "ember-source": "~3.14.0-beta.1",
     "ember-welcome-page": "^4.0.0",
     "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-node": "^10.0.0",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -47,6 +47,12 @@ function addFiles(mocha, files) {
   files.forEach(mocha.addFile.bind(mocha));
 }
 
+// ensure that the specified edition is unset after each test
+const { clearEdition } = require('@ember/edition-utils');
+mocha.suite.afterEach(function() {
+  clearEdition();
+});
+
 function runMocha() {
   console.time('Mocha Tests Running Time');
   mocha.run(failures => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,6 +175,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember/edition-utils@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.1.1.tgz#d5732c3da593f202e6e1ac6dbee56a758242403f"
+  integrity sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==
+
 "@octokit/endpoint@^5.1.0":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.1.4.tgz#e6bb3ceda8923fdc9703ded78c9acc28eff88c06"


### PR DESCRIPTION
* Update ember-source to 3.14.0-beta.1
* Add `@ember/edition-utils` to new apps
* Move `.ember-cli` to `.ember-cli.js`
* Add octane defaulted optional features to
  `config/optional-features.json`
* `setEdition('octane')` for new apps / addons