### PR TITLE
Adjust message for when a new app is created

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -116,7 +116,8 @@ module.exports = Command.extend({
         this.ui.writeLine('');
         const command = `cd ${projectName}`;
         this.ui.writeLine(`  ${chalk.gray('$')} ${chalk.cyan(command)}`);
-        this.ui.writeLine(`  ${chalk.gray('$')} ${chalk.cyan('yarn start')}`);
+        const packageManager = commandOptions.yarn ? 'yarn' : 'npm';
+        this.ui.writeLine(`  ${chalk.gray('$')} ${chalk.cyan(`${packageManager} start`)}`);
         this.ui.writeLine('');
         this.ui.writeLine('Happy coding!');
       });


### PR DESCRIPTION
Before, the terminal output of `npx ember-cli new super-rental` would
end with:
```
$ cd super-rentals
$ yarn start
```

After, it will end with:
```
$ cd super-rentals
$ npm start
```

`npx ember-cli new super-rental --yarn`'s terminaloutput keep ending
with:
```
$ cd super-rentals
$ yarn start
```