### PR TITLE
App and addon blueprint updates to match octane blueprints

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -8,7 +8,7 @@
 # misc
 /.bowerrc
 /.editorconfig
-/.ember-cli
+/.ember-cli.js
 /.env*
 /.eslintignore
 /.eslintrc.js

--- a/blueprints/app/files/.ember-cli.js
+++ b/blueprints/app/files/.ember-cli.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { setEdition } = require('@ember/edition-utils');
 
 setEdition('octane');

--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -3,12 +3,10 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-  Resolver
-});
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
 
 loadInitializers(App, config.modulePrefix);
-
-export default App;

--- a/blueprints/app/files/app/router.js
+++ b/blueprints/app/files/app/router.js
@@ -1,12 +1,10 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = EmberRouter.extend({
-  location: config.locationType,
-  rootURL: config.rootURL
-});
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
 
 Router.map(function() {
 });
-
-export default Router;

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -23,6 +23,7 @@
     "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.2",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.11.1",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -30,6 +30,7 @@
     "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.2",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -30,6 +30,7 @@
     "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.2",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -23,6 +23,7 @@
     "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.2",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.11.1",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -23,6 +23,7 @@
     "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.2",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.11.1",

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/app/app.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/app/app.js
@@ -2,12 +2,10 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 
-const App = Application.extend({
-  modulePrefix: 'some-cool-app',
-  podModulePrefix: 'some-cool-app/pods',
-  Resolver: Resolver
-});
+export default class App extends Application {
+  modulePrefix = 'some-cool-app';
+  podModulePrefix = 'some-cool-app/pods';
+  Resolver = Resolver;
+}
 
 loadInitializers(App, 'some-cool-app');
-
-export default App;

--- a/tests/fixtures/brocfile-tests/query/app/app.js
+++ b/tests/fixtures/brocfile-tests/query/app/app.js
@@ -2,12 +2,10 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 
-const App = Application.extend({
-  modulePrefix: 'query',
-  podModulePrefix: 'app/pods',
-  Resolver: Resolver
-});
+export default class App extends Application {
+  modulePrefix = 'query';
+  podModulePrefix = 'app/pods';
+  Resolver = Resolver;
+}
 
 loadInitializers(App, 'query');
-
-export default App;


### PR DESCRIPTION
I basically diffed the output from app & addon blueprints between ember-cli and [ember-octane-blueprint](https://github.com/ember-cli/ember-octane-blueprint) pulling out the important differences and including them in this PR. (I did the [same thing with the octane blueprints started](https://github.com/ember-cli/ember-octane-blueprint/pull/105).)