### PR TITLE
blueprints/init: Simplify "Get started" message

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -112,7 +112,7 @@ module.exports = Command.extend({
 
         this.ui.writeLine('');
         this.ui.writeLine(prependEmoji('🎉', `Successfully created project ${chalk.yellow(projectName)}.`));
-        this.ui.writeLine(prependEmoji('👉 ', 'We suggest you that you get started by typing:'));
+        this.ui.writeLine(prependEmoji('👉 ', 'Get started by typing:'));
         this.ui.writeLine('');
         const command = `cd ${projectName}`;
         this.ui.writeLine(`  ${chalk.gray('$')} ${chalk.cyan(command)}`);


### PR DESCRIPTION
This fixes a typo in the message.

Closes https://github.com/ember-learn/guides-source/issues/1133.