### PR TITLE
[BUGFIX] Don't reload the config for instrumentation

### DIFF
--- a/lib/models/instrumentation.js
+++ b/lib/models/instrumentation.js
@@ -3,6 +3,7 @@
 const fs = require('fs-extra');
 const chalk = require('chalk');
 const heimdallGraph = require('heimdalljs-graph');
+const getConfig = require('../utilities/get-config');
 const utilsInstrumentation = require('../utilities/instrumentation');
 const logger = require('heimdalljs-logger')('ember-cli:instrumentation');
 const hwinfo = require('./hardware-info');
@@ -75,6 +76,8 @@ class Instrumentation {
     };
 
     this._heimdall = null;
+
+    this.config = getConfig();
 
     if (!options.initInstrumentation && this.isEnabled()) {
       this.instrumentations.init = {
@@ -236,7 +239,7 @@ class Instrumentation {
   }
 
   start(name) {
-    if (!instrumentationEnabled()) {
+    if (!instrumentationEnabled(this.config)) {
       return;
     }
 
@@ -255,7 +258,7 @@ class Instrumentation {
   }
 
   stopAndReport(name) {
-    if (!instrumentationEnabled()) {
+    if (!instrumentationEnabled(this.config)) {
       return;
     }
 
@@ -332,7 +335,5 @@ function totalTime(tree) {
 
 // exported for testing
 Instrumentation._enableFSMonitorIfInstrumentationEnabled = _enableFSMonitorIfInstrumentationEnabled;
-Instrumentation._vizEnabled = vizEnabled();
-Instrumentation._instrumentationEnabled = instrumentationEnabled();
 
 module.exports = Instrumentation;


### PR DESCRIPTION
We currently will reload the config to setup instrumentation, which can
happen multiple times while the CLI is running. This sometimes results
in failures when the CLI generates new applications that haven't
installed `node_modules` yet, and in other cases. We really only need to
load the config once, so this PR changes it so that we do.

Fixes https://github.com/ember-cli/ember-cli/issues/8863