### PR TITLE
[BUGFIX beta] Merge with existing `EmberENV`

### DIFF
--- a/lib/broccoli/vendor-prefix.js
+++ b/lib/broccoli/vendor-prefix.js
@@ -1,4 +1,11 @@
-window.EmberENV = {{EMBER_ENV}};
+window.EmberENV = (function(EmberENV, extra) {
+  for (var key in extra) {
+    EmberENV[key] = extra[key];
+  }
+
+  return EmberENV;
+})(window.EmberENV || {}, {{EMBER_ENV}});
+
 var runningTests = false;
 
 {{content-for 'vendor-prefix'}}

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -53,7 +53,7 @@ describe('Acceptance: brocfile-smoke-test', function() {
 
       // Changes in ember-optional-features 0.7.0 cause all defined values in optional-features.json
       // to end up in EmberENV. jquery-integration is explicitly defined for non MU apps
-      let expected = 'window.EmberENV = {"asdflkmawejf":";jlnu3yr23","_JQUERY_INTEGRATION":false};';
+      let expected = '(window.EmberENV || {}, {"asdflkmawejf":";jlnu3yr23","_JQUERY_INTEGRATION":false});';
       expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
     })
   );

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -156,7 +156,9 @@ describe('Default Packager: Ember CLI Internal', function() {
         'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
       );
 
-      expect(vendorPrefixFileContent).to.contain('window.EmberENV = {};\nvar runningTests = false;');
+      expect(vendorPrefixFileContent).to.contain(
+        'window.EmberENV = (function(EmberENV, extra) {\n  for (var key in extra) {\n    EmberENV[key] = extra[key];\n  }\n\n  return EmberENV;\n})(window.EmberENV || {}, {});\n\nvar runningTests = false;'
+      );
       expect(vendorSuffixFileContent).to.equal('');
     })
   );


### PR DESCRIPTION
This allows Ember Inspector or other code in `index.html` before the vendor script tag to set values in `EmberENV`.