### PR TITLE
Enable broccoli memoization by default in Ember-CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ jobs:
     - env: EMBER_CLI_MODULE_UNIFICATION=true
     - env: EMBER_CLI_DELAYED_TRANSPILATION=true
     - env: EMBER_CLI_SYSTEM_TEMP=false
-    - env: EMBER_CLI_BROCCOLI_WATCHER=true
 
     - stage: deploy
       name: Publish API Docs

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -1,15 +1,9 @@
 'use strict';
 
 const chalk = require('chalk');
-const availableExperiments = Object.freeze([
-  'PACKAGER',
-  'MODULE_UNIFICATION',
-  'DELAYED_TRANSPILATION',
-  'SYSTEM_TEMP',
-  'BROCCOLI_WATCHER',
-]);
+const availableExperiments = Object.freeze(['PACKAGER', 'MODULE_UNIFICATION', 'DELAYED_TRANSPILATION', 'SYSTEM_TEMP']);
 
-const deprecatedExperiments = Object.freeze(['MODULE_UNIFICATION']);
+const deprecatedExperiments = Object.freeze(['MODULE_UNIFICATION', 'BROCCOLI_WATCHER']);
 const enabledExperiments = Object.freeze(['SYSTEM_TEMP']);
 const deprecatedExperimentsDeprecationsIssued = [];
 

--- a/lib/models/server-watcher.js
+++ b/lib/models/server-watcher.js
@@ -10,11 +10,6 @@ module.exports = class ServerWatcher extends Watcher {
     this.watcher.on('delete', this.didDelete.bind(this));
   }
 
-  // This branch can be removed once BROCCOLI_WATCHER is enabled by default
-  constructWatcher(options) {
-    return this.constructBroccoliWatcher(options);
-  }
-
   constructBroccoliWatcher(options) {
     return new (require('sane'))(this.watchedDir, options);
   }

--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -4,7 +4,6 @@ const chalk = require('chalk');
 const logger = require('heimdalljs-logger')('ember-cli:watcher');
 const CoreObject = require('core-object');
 const serveURL = require('../utilities/get-serve-url');
-const { isExperimentEnabled } = require('../experiments');
 const printSlowTrees = require('broccoli-slow-trees');
 const promiseFinally = require('promise.prototype.finally');
 
@@ -26,24 +25,14 @@ module.exports = class Watcher extends CoreObject {
 
     this.serving = _options.serving;
 
-    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
-      this.watcher = this.watcher || this.constructBroccoliWatcher(options);
+    this.watcher = this.watcher || this.constructBroccoliWatcher(options);
 
-      this.setupBroccoliChangeEvent();
-      this.watcher.on('buildStart', this._setupBroccoliWatcherBuild.bind(this));
-      this.watcher.on('buildSuccess', this.didChange.bind(this));
-    } else {
-      // This branch can be removed once BROCCOLI_WATCHER is enabled by default
-      this.watcher = this.watcher || this.constructWatcher(options);
-      this.watcher.on('change', this.didChange.bind(this));
-    }
+    this.setupBroccoliChangeEvent();
+    this.watcher.on('buildStart', this._setupBroccoliWatcherBuild.bind(this));
+    this.watcher.on('buildSuccess', this.didChange.bind(this));
 
     this.watcher.on('error', this.didError.bind(this));
     this.serveURL = serveURL;
-  }
-
-  constructWatcher(options) {
-    return new (require('ember-cli-broccoli-sane-watcher'))(this.builder, options);
   }
 
   constructBroccoliWatcher(options) {
@@ -109,9 +98,7 @@ module.exports = class Watcher extends CoreObject {
   didChange(results) {
     logger.info('didChange %o', results);
 
-    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
-      results.totalTime = this._totalTime(results);
-    }
+    results.totalTime = this._totalTime(results);
     let totalTime = results.totalTime / 1e6;
     let message = chalk.green(`Build successful (${Math.round(totalTime)}ms)`);
 
@@ -141,7 +128,7 @@ module.exports = class Watcher extends CoreObject {
       value: Number(totalTime),
     });
 
-    if (isExperimentEnabled('BROCCOLI_WATCHER') && this.verbose) {
+    if (this.verbose) {
       printSlowTrees(results.graph.__heimdall__);
     }
   }
@@ -162,16 +149,12 @@ module.exports = class Watcher extends CoreObject {
   }
 
   then() {
-    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
-      return this.watcher.currentBuild.then.apply(this.watcher.currentBuild, arguments);
-    }
-
-    return this.watcher.then.apply(this.watcher, arguments);
+    return this.watcher.currentBuild.then.apply(this.watcher.currentBuild, arguments);
   }
 
   on() {
     const args = arguments;
-    if (isExperimentEnabled('BROCCOLI_WATCHER') && args[0] === 'change' && !this.watchedDir) {
+    if (args[0] === 'change' && !this.watchedDir) {
       args[0] = 'buildSuccess';
     }
     this.watcher.on.apply(this.watcher, args);
@@ -179,7 +162,7 @@ module.exports = class Watcher extends CoreObject {
 
   off() {
     const args = arguments;
-    if (isExperimentEnabled('BROCCOLI_WATCHER') && args[0] === 'change' && !this.watchedDir) {
+    if (args[0] === 'change' && !this.watchedDir) {
       args[0] = 'buildSuccess';
     }
     this.watcher.off.apply(this.watcher, args);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "core-object": "^3.1.5",
     "dag-map": "^2.0.2",
     "diff": "^4.0.1",
-    "ember-cli-broccoli-sane-watcher": "^3.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-lodash-subset": "^2.0.1",
     "ember-cli-normalize-entity-name": "^1.0.0",

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -4,14 +4,11 @@ const expect = require('chai').expect;
 
 const MockUI = require('console-ui/mock');
 const MockAnalytics = require('../../helpers/mock-analytics');
-const MockWatcher = require('../../helpers/mock-watcher');
 const MockBroccoliWatcher = require('../../helpers/mock-broccoli-watcher');
 const Watcher = require('../../../lib/models/watcher');
 const EOL = require('os').EOL;
 const chalk = require('chalk');
 const BuildError = require('../../helpers/build-error');
-const { isExperimentEnabled } = require('../../../lib/experiments');
-const buildEvent = isExperimentEnabled('BROCCOLI_WATCHER') ? 'buildSuccess' : 'change';
 
 describe('Watcher', function() {
   let ui;
@@ -42,11 +39,7 @@ describe('Watcher', function() {
     ui = new MockUI();
     analytics = new MockAnalytics();
 
-    if (isExperimentEnabled('BROCCOLI_WATCHER')) {
-      watcher = new MockBroccoliWatcher();
-    } else {
-      watcher = new MockWatcher();
-    }
+    watcher = new MockBroccoliWatcher();
 
     subject = new Watcher({
       ui,
@@ -95,26 +88,24 @@ describe('Watcher', function() {
     });
   });
 
-  if (isExperimentEnabled('BROCCOLI_WATCHER')) {
-    describe('underlining watcher properly logs change events', function() {
-      it('logs that the file was added', function() {
-        watcher.emit('change', 'add', 'foo.txt');
-        expect(ui.output).to.equal(`file added foo.txt${EOL}`);
-      });
-      it('logs that the file was changed', function() {
-        watcher.emit('change', 'change', 'foo.txt');
-        expect(ui.output).to.equal(`file changed foo.txt${EOL}`);
-      });
-      it('logs that the file was deleted', function() {
-        watcher.emit('change', 'delete', 'foo.txt');
-        expect(ui.output).to.equal(`file deleted foo.txt${EOL}`);
-      });
+  describe('underlining watcher properly logs change events', function() {
+    it('logs that the file was added', function() {
+      watcher.emit('change', 'add', 'foo.txt');
+      expect(ui.output).to.equal(`file added foo.txt${EOL}`);
     });
-  }
+    it('logs that the file was changed', function() {
+      watcher.emit('change', 'change', 'foo.txt');
+      expect(ui.output).to.equal(`file changed foo.txt${EOL}`);
+    });
+    it('logs that the file was deleted', function() {
+      watcher.emit('change', 'delete', 'foo.txt');
+      expect(ui.output).to.equal(`file deleted foo.txt${EOL}`);
+    });
+  });
 
-  describe(`watcher:${buildEvent}`, function() {
+  describe(`watcher:buildSuccess`, function() {
     beforeEach(function() {
-      watcher.emit(buildEvent, mockResult);
+      watcher.emit(`buildSuccess`, mockResult);
     });
 
     it('tracks events', function() {
@@ -386,7 +377,7 @@ describe('Watcher', function() {
         stack: new Error().stack,
       });
 
-      watcher.emit(buildEvent, mockResult);
+      watcher.emit(`buildSuccess`, mockResult);
     });
 
     it('log that the build was green', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,17 +1878,6 @@ ember-cli-blueprint-test-helpers@^0.19.2:
     testdouble "^3.2.6"
     tmp-sync "^1.0.0"
 
-ember-cli-broccoli-sane-watcher@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-3.0.0.tgz#dc1812c047e1ceec4413d3c41b51a9ffc61b4cfe"
-  integrity sha512-sLn+wy6FJpGMHtSwAGUjQK3nJFvw2b6H8bR2EgMIXxkUI3DYFLi6Xnyxm02XlMTcfTxF10yHFhHJe0O+PcJM7A==
-  dependencies:
-    broccoli-slow-trees "^3.0.1"
-    heimdalljs "^0.2.1"
-    heimdalljs-logger "^0.1.7"
-    rsvp "^3.0.18"
-    sane "^4.0.0"
-
 ember-cli-internal-test-helpers@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/ember-cli-internal-test-helpers/-/ember-cli-internal-test-helpers-0.9.1.tgz#d54a9124bb6408ceba83f049ba8479f4b96cdd19"


### PR DESCRIPTION
`EMBER_CLI_BROCCOLI_WATCHER` flag is being tested for long enough time and we have seen a good response as well. Now we can make this behavior a default and remove the flag from the code. 
https://github.com/ember-cli/ember-cli/issues/8681