### PR TITLE
restrict app Travis to master and PRs

### DIFF
--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -20,6 +20,10 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
+
+branches:
+  only:
+    - master
 <% if (yarn) { %>
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/tests/fixtures/app/npm/.travis.yml
+++ b/tests/fixtures/app/npm/.travis.yml
@@ -18,6 +18,10 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+branches:
+  only:
+    - master
+
 script:
   - npm run lint:hbs
   - npm run lint:js

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -17,6 +17,10 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+branches:
+  only:
+    - master
+
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH


### PR DESCRIPTION
We did this to addons, where they are restricted to master, PRs, and npm tags. I think it makes sense to do the same with apps, minus the npm tags?