### PR TITLE
Revert changes made to enable "octane" as the default for ember new

### DIFF
--- a/blueprints/addon/files/config/optional-features.json
+++ b/blueprints/addon/files/config/optional-features.json
@@ -1,6 +1,3 @@
 {
-  "application-template-wrapper": false,
-  "default-async-observers": true,
-  "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "jquery-integration": false
 }

--- a/blueprints/app/files/.ember-cli
+++ b/blueprints/app/files/.ember-cli
@@ -1,15 +1,9 @@
-'use strict';
-
-const { setEdition } = require('@ember/edition-utils');
-
-setEdition('octane');
-
-module.exports = {
+{
   /**
     Ember CLI sends analytics information by default. The data is completely
     anonymous, but there are times when you might want to disable this behavior.
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  disableAnalytics: false
-};
+  "disableAnalytics": false
+}

--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     // node files
     {
       files: [
-        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',<% if (blueprint !== 'app') { %>

--- a/blueprints/app/files/.template-lintrc.js
+++ b/blueprints/app/files/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane'
+  extends: 'recommended'
 };

--- a/blueprints/app/files/config/optional-features.json
+++ b/blueprints/app/files/config/optional-features.json
@@ -1,6 +1,3 @@
 {
-  "application-template-wrapper": false,
-  "default-async-observers": true,
-  "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "jquery-integration": false
 }

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -18,9 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
-    "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "yam": "^1.0.0"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@octokit/rest": "^16.30.1",
     "broccoli-plugin": "^3.0.0",
     "broccoli-test-helper": "^2.0.0",

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -42,6 +42,23 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   it(
+    'a custom EmberENV in config/environment.js is used for window.EmberENV',
+    co.wrap(function*() {
+      yield copyFixtureFiles('brocfile-tests/custom-ember-env');
+      yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
+        encoding: 'utf8',
+      });
+
+      // Changes in ember-optional-features 0.7.0 cause all defined values in optional-features.json
+      // to end up in EmberENV. jquery-integration is explicitly defined for non MU apps
+      let expected = 'window.EmberENV = {"asdflkmawejf":";jlnu3yr23","_JQUERY_INTEGRATION":false};';
+      expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
+    })
+  );
+
+  it(
     'a custom environment config can be used in Brocfile.js',
     co.wrap(function*() {
       yield copyFixtureFiles('brocfile-tests/custom-environment-config');
@@ -56,23 +73,6 @@ describe('Acceptance: brocfile-smoke-test', function() {
         yield copyFixtureFiles('brocfile-tests/pods-templates');
         yield remove(path.join(process.cwd(), 'app/templates'));
         yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
-      })
-    );
-
-    it(
-      'a custom EmberENV in config/environment.js is used for window.EmberENV',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/custom-ember-env');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
-          encoding: 'utf8',
-        });
-
-        // Changes in config/optional-features.json end up being set in EmberENV
-        let expected =
-          'window.EmberENV = {"asdflkmawejf":";jlnu3yr23","_APPLICATION_TEMPLATE_WRAPPER":false,"_DEFAULT_ASYNC_OBSERVERS":true,"_JQUERY_INTEGRATION":false,"_TEMPLATE_ONLY_GLIMMER_COMPONENTS":true};';
-        expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
       })
     );
   }

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     // node files
     {
       files: [
-        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',

--- a/tests/fixtures/addon/kitchen-sink/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/kitchen-sink/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,2 @@
-<BasicThing>WOOT!!</BasicThing>
-<SecondThing>SECOND!!</SecondThing>
+{{#basic-thing}}WOOT!!{{/basic-thing}}
+{{#second-thing}}SECOND!!{{/second-thing}}

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -25,9 +25,7 @@
     "ember-cli-htmlbars": "^4.0.5"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
-    "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.2",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -25,9 +25,7 @@
     "ember-cli-htmlbars": "^4.0.5"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
-    "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.2",

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     // node files
     {
       files: [
-        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -18,9 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
-    "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.2",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -18,9 +18,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
-    "@glimmer/component": "^0.14.0-alpha.13",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.2",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -47,12 +47,6 @@ function addFiles(mocha, files) {
   files.forEach(mocha.addFile.bind(mocha));
 }
 
-// ensure that the specified edition is unset after each test
-const { clearEdition } = require('@ember/edition-utils');
-mocha.suite.afterEach(function() {
-  clearEdition();
-});
-
 function runMocha() {
   console.time('Mocha Tests Running Time');
   mocha.run(failures => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,11 +175,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember/edition-utils@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.1.1.tgz#d5732c3da593f202e6e1ac6dbee56a758242403f"
-  integrity sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==
-
 "@octokit/endpoint@^5.1.0":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.1.4.tgz#e6bb3ceda8923fdc9703ded78c9acc28eff88c06"


### PR DESCRIPTION
Reverts octane specific changes that landed in ember-cli under the assumption that 3.14 would be "octane" now that we have decided that there is a bit of work yet to do before the octane experience is the new default.

See the blog post for more details:

https://blog.emberjs.com/2019/10/31/octane-release-update.html