### PR TITLE
feat(blueprint): allow cloning git repo with ref

### DIFF
--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -109,7 +109,7 @@ class InstallBlueprintTask extends Task {
   _gitClone(source, destination) {
     logger.info(`Cloning from git (${source}) into "${destination}" ...`);
 
-    let [, repo, ref] = /^(.+?)(?:\#([-\d\w._]+))?$/.exec(source);
+    let [, repo, ref] = /^(.+?)(?:#([-\d\w._]+))?$/.exec(source);
 
     let args = [
       'clone',
@@ -121,7 +121,9 @@ class InstallBlueprintTask extends Task {
     ];
 
     // Checkout the given ref. Can be branch, tag or commit sha.
-    if (ref) args.push('--branch', ref);
+    if (ref) {
+      args.push('--branch', ref);
+    }
 
     args.push(repo, destination);
 

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -108,7 +108,24 @@ class InstallBlueprintTask extends Task {
 
   _gitClone(source, destination) {
     logger.info(`Cloning from git (${source}) into "${destination}" ...`);
-    return execa('git', ['clone', source, destination]);
+
+    let [, repo, ref] = /^(.+?)(?:\#([-\d\w._]+))?$/.exec(source);
+
+    let args = [
+      'clone',
+      // We only care about the selected branch. (default: master)
+      '--single-branch',
+      // We're not interested in the full history.
+      '--depth',
+      '1',
+    ];
+
+    // Checkout the given ref. Can be branch, tag or commit sha.
+    if (ref) args.push('--branch', ref);
+
+    args.push(repo, destination);
+
+    return execa('git', args);
   }
 
   _npmInstall(cwd) {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -235,6 +235,24 @@ describe('Acceptance: ember new', function() {
   );
 
   it(
+    'ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it',
+    co.wrap(function*() {
+      this.timeout(20000); // relies on GH network stuff
+
+      yield ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-bower',
+        '--skip-git',
+        '--blueprint=https://github.com/buschtoens/app-blueprint-test.git#named-ref',
+      ]);
+
+      expect(file('.named-ref')).to.exist;
+    })
+  );
+
+  it(
     'ember new passes blueprint options through to blueprint',
     co.wrap(function*() {
       fs.mkdirsSync('my_blueprint/files');

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -245,7 +245,7 @@ describe('Acceptance: ember new', function() {
         '--skip-npm',
         '--skip-bower',
         '--skip-git',
-        '--blueprint=https://github.com/buschtoens/app-blueprint-test.git#named-ref',
+        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
       ]);
 
       expect(file('.named-ref')).to.exist;

--- a/tests/unit/utilities/git-repo-test.js
+++ b/tests/unit/utilities/git-repo-test.js
@@ -5,9 +5,16 @@ const expect = require('chai').expect;
 
 describe('is-git-url', function() {
   it('recognizes git-style urls in various formats', function() {
+    // without ref
     expect(isGitRepo('https://github.com/trek/app-blueprint-test.git')).to.be.ok;
     expect(isGitRepo('git@github.com:trek/app-blueprint-test.git')).to.be.ok;
     expect(isGitRepo('git+ssh://user@server/project.git')).to.be.ok;
     expect(isGitRepo('git+https://user@server/project.git')).to.be.ok;
+
+    // with ref
+    expect(isGitRepo('https://github.com/trek/app-blueprint-test.git#named-ref')).to.be.ok;
+    expect(isGitRepo('git@github.com:trek/app-blueprint-test.git#named-ref')).to.be.ok;
+    expect(isGitRepo('git+ssh://user@server/project.git#named-ref')).to.be.ok;
+    expect(isGitRepo('git+https://user@server/project.git#named-ref')).to.be.ok;
   });
 });


### PR DESCRIPTION
This PR adds the ability to checkout a specific ref (branch, tag, commit sha) when using a git repo as the blueprint source, similar to how you can specify named refs as npm dependencies.

```bash
ember new -b https://github.com/ember-cli/app-blueprint-test.git#named-ref
```

It also adds [`--single-branch`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---no-single-branch) and [`--depth 1`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) to the `git clone` command to speed up the checkout in general.