### PR TITLE
Remove `app/resolver.js` in favor of importing in `app/app.js`

### DIFF
--- a/blueprints/app/files/app/app.js
+++ b/blueprints/app/files/app/app.js
@@ -1,5 +1,5 @@
 import Application from '@ember/application';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 

--- a/blueprints/app/files/app/resolver.js
+++ b/blueprints/app/files/app/resolver.js
@@ -1,3 +1,0 @@
-import Resolver from 'ember-resolver';
-
-export default Resolver;


### PR DESCRIPTION
The implementation of `app/resolver.js` was a simple re-export from `ember-resolver`, and we do not expect (or really want) folks to be modifying it. Why was it a separate module in the app then?!?

This remvoes `app/resolver.js` in favor of importing from `ember-resolver` directly in `app/app.js`.