### PR TITLE
Travis.yml: use fast_finish instead of undocumented fail_fast

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -29,7 +29,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -26,7 +26,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -25,7 +25,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 


### PR DESCRIPTION
`fail_fast` used in `.travis.yml` config for addons is undocumented and I'm not sure if it even works. Travis config online validator complains about it. The closest option to what we would like to achieve is [`fast_finish`](https://docs.travis-ci.com/user/customizing-the-build#fast-finishing).

Closes: https://github.com/ember-cli/ember-cli/issues/8912