### PR TITLE
Travis.yml: Remove deprecated `sudo: false` option

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:

--- a/tests/fixtures/app/npm/.travis.yml
+++ b/tests/fixtures/app/npm/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "8"
 
-sudo: false
 dist: trusty
 
 addons:


### PR DESCRIPTION
According to this post: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast. Using `sudo: false` is now deprecated.

Closes: https://github.com/ember-cli/ember-cli/issues/8940