### PR TITLE
fix npm floating deps addon travis bug

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -36,7 +36,6 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
       script:
@@ -44,7 +43,8 @@ jobs:
         - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> lint:js
         - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test
 
-    - name: "Floating Dependencies"
+    - stage: "Additional Tests"
+      name: "Floating Dependencies"
       install:<% if (yarn) { %>
         - yarn install --no-lockfile --non-interactive<% } else { %>
         - npm install --no-package-lock<% } %>
@@ -53,8 +53,7 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -40,16 +40,16 @@ jobs:
     - stage: "Tests"
       name: "Tests"
       script:
-        - <% if (yarn) { %>yarn lint:hbs<% } else { %>npm run lint:hbs<% } %>
-        - <% if (yarn) { %>yarn lint:js<% } else { %>npm run lint:js<% } %>
-        - <% if (yarn) { %>yarn test<% } else { %>npm test<% } %>
+        - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> lint:hbs
+        - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> lint:js
+        - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test
 
     - name: "Floating Dependencies"
       install:<% if (yarn) { %>
         - yarn install --no-lockfile --non-interactive<% } else { %>
         - npm install --no-package-lock<% } %>
       script:
-        - <% if (yarn) { %>yarn test<% } else { %>npm test<% } %>
+        - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -46,10 +46,10 @@ jobs:
 
     - name: "Floating Dependencies"
       install:<% if (yarn) { %>
-        - yarn install --no-lockfile --non-interactive
-      script:
-        - yarn test<% } else { %>
+        - yarn install --no-lockfile --non-interactive<% } else { %>
         - npm install --no-package-lock<% } %>
+      script:
+        - <% if (yarn) { %>yarn test<% } else { %>npm test<% } %>
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -33,7 +33,6 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
       script:
@@ -41,7 +40,8 @@ jobs:
         - npm run lint:js
         - npm test
 
-    - name: "Floating Dependencies"
+    - stage: "Additional Tests"
+      name: "Floating Dependencies"
       install:
         - npm install --no-package-lock
       script:
@@ -49,8 +49,7 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -44,6 +44,8 @@ jobs:
     - name: "Floating Dependencies"
       install:
         - npm install --no-package-lock
+      script:
+        - npm test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -32,7 +32,6 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
       script:
@@ -40,7 +39,8 @@ jobs:
         - yarn lint:js
         - yarn test
 
-    - name: "Floating Dependencies"
+    - stage: "Additional Tests"
+      name: "Floating Dependencies"
       install:
         - yarn install --no-lockfile --non-interactive
       script:
@@ -48,8 +48,7 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta


### PR DESCRIPTION
I noticed I made a mistake when looking at https://travis-ci.org/ember-cli/ember-addon-output/builds/612417903. The `npm test` `script:` was not inheriting like I thought. This fixes it like yarn, and also moves floating deps to the later stage to get faster feedback.