### PR TITLE
Update ember-resolver to v7.0.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -39,7 +39,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
-    "ember-resolver": "^6.0.0",
+    "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint-plugin-ember": "^7.7.1",

--- a/tests/fixtures/addon/npm/package.json
+++ b/tests/fixtures/addon/npm/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
-    "ember-resolver": "^6.0.0",
+    "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -8,7 +8,7 @@
     "paths": ["./lib/ember-super-button"]
   },
   "devDependencies": {
-    "ember-resolver": "^5.0.1",
+    "ember-resolver": "^7.0.0",
     "ember-cli": "latest",
     "ember-random-addon": "latest",
     "ember-non-root-addon": "latest",

--- a/tests/fixtures/addon/with-app-styles/package.json
+++ b/tests/fixtures/addon/with-app-styles/package.json
@@ -8,7 +8,7 @@
     "paths": ["./lib/ember-super-button"]
   },
     "devDependencies": {
-    "ember-resolver": "^5.0.1",
+    "ember-resolver": "^7.0.0",
     "ember-cli": "latest",
     "ember-random-addon": "latest",
     "ember-non-root-addon": "latest",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
-    "ember-resolver": "^6.0.0",
+    "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -39,7 +39,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
-    "ember-resolver": "^6.0.0",
+    "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0",
     "eslint-plugin-ember": "^7.7.1",
     "eslint-plugin-node": "^10.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -39,7 +39,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
-    "ember-resolver": "^6.0.0",
+    "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0",
     "ember-welcome-page": "^4.0.0",
     "eslint-plugin-ember": "^7.7.1",

--- a/tests/fixtures/brocfile-tests/query/package.json
+++ b/tests/fixtures/brocfile-tests/query/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "ember-cli": "*",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-resolver": "^5.0.1",
+    "ember-resolver": "^7.0.0",
     "loader.js": "latest"
   }
 }

--- a/tests/fixtures/project-with-handlebars/package.json
+++ b/tests/fixtures/project-with-handlebars/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "ember-cli": "latest",
-    "ember-resolver": "^5.0.1",
+    "ember-resolver": "^7.0.0",
     "loader.js": "*"
   }
 }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -303,7 +303,7 @@ describe('models/project.js', function() {
       let expected = {
         'ember-cli': 'latest',
         'ember-random-addon': 'latest',
-        'ember-resolver': '^5.0.1',
+        'ember-resolver': '^7.0.0',
         'ember-non-root-addon': 'latest',
         'ember-generated-with-export-addon': 'latest',
         'non-ember-thingy': 'latest',


### PR DESCRIPTION
The primary breaking change is that it drops support for Module Unification.