### PR TITLE
Remove usages of `co.wrap` in tests (in favor of `async`/`await`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-files": "^1.4.0",
-    "co": "^4.6.0",
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-internal-test-helpers": "^0.9.1",
     "eslint": "^5.16.0",

--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const fs = require('fs-extra');
@@ -27,12 +26,10 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      let tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    let tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     process.chdir(root);
@@ -57,210 +54,192 @@ describe('Acceptance: ember generate in-addon-dummy', function() {
     });
   }
 
-  it(
-    'dummy blueprint foo',
-    co.wrap(function*() {
-      yield generateInAddon(['blueprint', 'foo', '--dummy']);
+  it('dummy blueprint foo', async function() {
+    await generateInAddon(['blueprint', 'foo', '--dummy']);
 
-      expect(file('blueprints/foo/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'dummy blueprint foo/bar',
-    co.wrap(function*() {
-      yield generateInAddon(['blueprint', 'foo/bar', '--dummy']);
+  it('dummy blueprint foo/bar', async function() {
+    await generateInAddon(['blueprint', 'foo/bar', '--dummy']);
 
-      expect(file('blueprints/foo/bar/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/bar/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'dummy http-mock foo',
-    co.wrap(function*() {
-      yield generateInAddon(['http-mock', 'foo', '--dummy']);
+  it('dummy http-mock foo', async function() {
+    await generateInAddon(['http-mock', 'foo', '--dummy']);
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
 
-      expect(file('server/mocks/foo.js')).to.contain(
+    expect(file('server/mocks/foo.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooRouter = express.Router();\n' +
+        '\n' +
+        "  fooRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo', require('body-parser').json());\n" +
+        "  app.use('/api/foo', fooRouter);\n" +
+        '};\n'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('dummy http-mock foo-bar', async function() {
+    await generateInAddon(['http-mock', 'foo-bar', '--dummy']);
+
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+
+    expect(file('server/mocks/foo-bar.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooBarRouter = express.Router();\n' +
+        '\n' +
+        "  fooBarRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+        "  app.use('/api/foo-bar', fooBarRouter);\n" +
+        '};\n'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('dummy http-proxy foo', async function() {
+    await generateInAddon(['http-proxy', 'foo', 'http://localhost:5000', '--dummy']);
+
+    expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+
+    expect(file('server/proxies/foo.js')).to.contain(
+      "const proxyPath = '/foo';\n" +
+        '\n' +
         'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooRouter = express.Router();\n' +
-          '\n' +
-          "  fooRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo', require('body-parser').json());\n" +
-          "  app.use('/api/foo', fooRouter);\n" +
-          '};\n'
-      );
+        '  // For options, see:\n' +
+        '  // https://github.com/nodejitsu/node-http-proxy\n' +
+        "  let proxy = require('http-proxy').createProxyServer({});\n" +
+        '\n' +
+        "  proxy.on('error', function(err, req) {\n" +
+        '    console.error(err, req.url);\n' +
+        '  });\n' +
+        '\n' +
+        '  app.use(proxyPath, function(req, res, next){\n' +
+        '    // include root path in proxied request\n' +
+        "    req.url = proxyPath + '/' + req.url;\n" +
+        "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+        '  });\n' +
+        '};'
+    );
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
 
-  it(
-    'dummy http-mock foo-bar',
-    co.wrap(function*() {
-      yield generateInAddon(['http-mock', 'foo-bar', '--dummy']);
-
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
-
-      expect(file('server/mocks/foo-bar.js')).to.contain(
-        'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooBarRouter = express.Router();\n' +
-          '\n' +
-          "  fooBarRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-          "  app.use('/api/foo-bar', fooBarRouter);\n" +
-          '};\n'
-      );
-
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
-
-  it(
-    'dummy http-proxy foo',
-    co.wrap(function*() {
-      yield generateInAddon(['http-proxy', 'foo', 'http://localhost:5000', '--dummy']);
-
-      expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
-
-      expect(file('server/proxies/foo.js')).to.contain(
-        "const proxyPath = '/foo';\n" +
-          '\n' +
-          'module.exports = function(app) {\n' +
-          '  // For options, see:\n' +
-          '  // https://github.com/nodejitsu/node-http-proxy\n' +
-          "  let proxy = require('http-proxy').createProxyServer({});\n" +
-          '\n' +
-          "  proxy.on('error', function(err, req) {\n" +
-          '    console.error(err, req.url);\n' +
-          '  });\n' +
-          '\n' +
-          '  app.use(proxyPath, function(req, res, next){\n' +
-          '    // include root path in proxied request\n' +
-          "    req.url = proxyPath + '/' + req.url;\n" +
-          "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-          '  });\n' +
-          '};'
-      );
-
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
-
-  it(
-    'dummy server',
-    co.wrap(function*() {
-      yield generateInAddon(['server', '--dummy']);
-      expect(file('server/index.js')).to.exist;
-    })
-  );
+  it('dummy server', async function() {
+    await generateInAddon(['server', '--dummy']);
+    expect(file('server/index.js')).to.exist;
+  });
 });

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const path = require('path');
@@ -29,12 +28,10 @@ describe('Acceptance: ember generate in-addon', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      let tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    let tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     process.chdir(root);
@@ -64,263 +61,236 @@ describe('Acceptance: ember generate in-addon', function() {
     });
   }
 
-  it(
-    'in-addon addon-import cannot be called directly',
-    co.wrap(function*() {
-      try {
-        yield generateInAddon(['addon-import', 'foo']);
-      } catch (error) {
-        expect(error.name).to.equal('SilentError');
-        expect(error.message).to.equal('You cannot call the addon-import blueprint directly.');
-      }
-    })
-  );
+  it('in-addon addon-import cannot be called directly', async function() {
+    try {
+      await generateInAddon(['addon-import', 'foo']);
+    } catch (error) {
+      expect(error.name).to.equal('SilentError');
+      expect(error.message).to.equal('You cannot call the addon-import blueprint directly.');
+    }
+  });
 
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'runs the `addon-import` blueprint from a classic addon',
-      co.wrap(function*() {
-        yield initAddon('my-addon');
+    it('runs the `addon-import` blueprint from a classic addon', async function() {
+      await initAddon('my-addon');
 
-        yield outputFile(
-          'blueprints/service/files/__root__/__path__/__name__.js',
-          "import Service from '@ember/service';\n" + 'export default Service.extend({ });\n'
-        );
+      await outputFile(
+        'blueprints/service/files/__root__/__path__/__name__.js',
+        "import Service from '@ember/service';\n" + 'export default Service.extend({ });\n'
+      );
 
-        yield ember(['generate', 'service', 'session']);
+      await ember(['generate', 'service', 'session']);
 
-        expect(file('app/services/session.js')).to.exist;
-      })
-    );
+      expect(file('app/services/session.js')).to.exist;
+    });
   }
 
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'runs a custom "*-addon" blueprint from a classic addon',
-      co.wrap(function*() {
-        yield initAddon('my-addon');
+    it('runs a custom "*-addon" blueprint from a classic addon', async function() {
+      await initAddon('my-addon');
 
-        yield outputFile(
-          'blueprints/service/files/__root__/__path__/__name__.js',
-          "import Service from '@ember/service';\n" + 'export default Service.extend({ });\n'
-        );
+      await outputFile(
+        'blueprints/service/files/__root__/__path__/__name__.js',
+        "import Service from '@ember/service';\n" + 'export default Service.extend({ });\n'
+      );
 
-        yield outputFile(
-          'blueprints/service-addon/files/app/services/session.js',
-          "export { default } from 'somewhere';\n"
-        );
+      await outputFile(
+        'blueprints/service-addon/files/app/services/session.js',
+        "export { default } from 'somewhere';\n"
+      );
 
-        yield ember(['generate', 'service', 'session']);
+      await ember(['generate', 'service', 'session']);
 
-        expect(file('app/services/session.js')).to.exist;
-      })
-    );
+      expect(file('app/services/session.js')).to.exist;
+    });
   }
 
-  it(
-    'in-addon blueprint foo',
-    co.wrap(function*() {
-      yield generateInAddon(['blueprint', 'foo']);
+  it('in-addon blueprint foo', async function() {
+    await generateInAddon(['blueprint', 'foo']);
 
-      expect(file('blueprints/foo/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'in-addon blueprint foo/bar',
-    co.wrap(function*() {
-      yield generateInAddon(['blueprint', 'foo/bar']);
+  it('in-addon blueprint foo/bar', async function() {
+    await generateInAddon(['blueprint', 'foo/bar']);
 
-      expect(file('blueprints/foo/bar/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/bar/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'in-addon http-mock foo',
-    co.wrap(function*() {
-      yield generateInAddon(['http-mock', 'foo']);
+  it('in-addon http-mock foo', async function() {
+    await generateInAddon(['http-mock', 'foo']);
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
 
-      expect(file('server/mocks/foo.js')).to.contain(
+    expect(file('server/mocks/foo.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooRouter = express.Router();\n' +
+        '\n' +
+        "  fooRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo', require('body-parser').json());\n" +
+        "  app.use('/api/foo', fooRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('in-addon http-mock foo-bar', async function() {
+    await generateInAddon(['http-mock', 'foo-bar']);
+
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+
+    expect(file('server/mocks/foo-bar.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooBarRouter = express.Router();\n' +
+        '\n' +
+        "  fooBarRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+        "  app.use('/api/foo-bar', fooBarRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('in-addon http-proxy foo', async function() {
+    await generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']);
+
+    expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+
+    expect(file('server/proxies/foo.js')).to.contain(
+      "const proxyPath = '/foo';\n" +
+        '\n' +
         'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooRouter = express.Router();\n' +
-          '\n' +
-          "  fooRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo', require('body-parser').json());\n" +
-          "  app.use('/api/foo', fooRouter);\n" +
-          '};'
-      );
+        '  // For options, see:\n' +
+        '  // https://github.com/nodejitsu/node-http-proxy\n' +
+        "  let proxy = require('http-proxy').createProxyServer({});\n" +
+        '\n' +
+        "  proxy.on('error', function(err, req) {\n" +
+        '    console.error(err, req.url);\n' +
+        '  });\n' +
+        '\n' +
+        '  app.use(proxyPath, function(req, res, next){\n' +
+        '    // include root path in proxied request\n' +
+        "    req.url = proxyPath + '/' + req.url;\n" +
+        "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+        '  });\n' +
+        '};'
+    );
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
 
-  it(
-    'in-addon http-mock foo-bar',
-    co.wrap(function*() {
-      yield generateInAddon(['http-mock', 'foo-bar']);
-
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
-
-      expect(file('server/mocks/foo-bar.js')).to.contain(
-        'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooBarRouter = express.Router();\n' +
-          '\n' +
-          "  fooBarRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-          "  app.use('/api/foo-bar', fooBarRouter);\n" +
-          '};'
-      );
-
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
-
-  it(
-    'in-addon http-proxy foo',
-    co.wrap(function*() {
-      yield generateInAddon(['http-proxy', 'foo', 'http://localhost:5000']);
-
-      expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
-
-      expect(file('server/proxies/foo.js')).to.contain(
-        "const proxyPath = '/foo';\n" +
-          '\n' +
-          'module.exports = function(app) {\n' +
-          '  // For options, see:\n' +
-          '  // https://github.com/nodejitsu/node-http-proxy\n' +
-          "  let proxy = require('http-proxy').createProxyServer({});\n" +
-          '\n' +
-          "  proxy.on('error', function(err, req) {\n" +
-          '    console.error(err, req.url);\n' +
-          '  });\n' +
-          '\n' +
-          '  app.use(proxyPath, function(req, res, next){\n' +
-          '    // include root path in proxied request\n' +
-          "    req.url = proxyPath + '/' + req.url;\n" +
-          "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-          '  });\n' +
-          '};'
-      );
-
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
-
-  it(
-    'in-addon server',
-    co.wrap(function*() {
-      yield generateInAddon(['server']);
-      expect(file('server/index.js')).to.exist;
-    })
-  );
+  it('in-addon server', async function() {
+    await generateInAddon(['server']);
+    expect(file('server/index.js')).to.exist;
+  });
 });

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const Promise = require('rsvp').Promise;
 const path = require('path');
 const fs = require('fs-extra');
@@ -65,99 +64,93 @@ describe('Acceptance: addon-smoke-test', function() {
       return ember(['test']);
     });
 
-    it(
-      'works in most common scenarios for an example addon',
-      co.wrap(function*() {
-        yield copyFixtureFiles('addon/kitchen-sink');
+    it('works in most common scenarios for an example addon', async function() {
+      await copyFixtureFiles('addon/kitchen-sink');
 
-        let packageJsonPath = path.join(addonRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
+      let packageJsonPath = path.join(addonRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
 
-        expect(packageJson.devDependencies['ember-source']).to.not.be.empty;
+      expect(packageJson.devDependencies['ember-source']).to.not.be.empty;
 
-        packageJson.dependencies = packageJson.dependencies || {};
-        // add HTMLBars for templates (generators do this automatically when components/templates are added)
-        packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
+      packageJson.dependencies = packageJson.dependencies || {};
+      // add HTMLBars for templates (generators do this automatically when components/templates are added)
+      packageJson.dependencies['ember-cli-htmlbars'] = 'latest';
 
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        let result = yield runCommand('node_modules/ember-cli/bin/ember', 'build');
+      let result = await runCommand('node_modules/ember-cli/bin/ember', 'build');
 
-        expect(result.code).to.eql(0);
-        let contents;
+      expect(result.code).to.eql(0);
+      let contents;
 
-        let indexPath = path.join(addonRoot, 'dist', 'index.html');
-        contents = fs.readFileSync(indexPath, { encoding: 'utf8' });
-        expect(contents).to.contain('"SOME AWESOME STUFF"');
+      let indexPath = path.join(addonRoot, 'dist', 'index.html');
+      contents = fs.readFileSync(indexPath, { encoding: 'utf8' });
+      expect(contents).to.contain('"SOME AWESOME STUFF"');
 
-        let cssPath = path.join(addonRoot, 'dist', 'assets', 'vendor.css');
-        contents = fs.readFileSync(cssPath, { encoding: 'utf8' });
-        expect(contents).to.contain('addon/styles/app.css is present');
+      let cssPath = path.join(addonRoot, 'dist', 'assets', 'vendor.css');
+      contents = fs.readFileSync(cssPath, { encoding: 'utf8' });
+      expect(contents).to.contain('addon/styles/app.css is present');
 
-        let robotsPath = path.join(addonRoot, 'dist', 'robots.txt');
-        contents = fs.readFileSync(robotsPath, { encoding: 'utf8' });
-        expect(contents).to.contain('tests/dummy/public/robots.txt is present');
+      let robotsPath = path.join(addonRoot, 'dist', 'robots.txt');
+      contents = fs.readFileSync(robotsPath, { encoding: 'utf8' });
+      expect(contents).to.contain('tests/dummy/public/robots.txt is present');
 
-        result = yield runCommand('node_modules/ember-cli/bin/ember', 'test');
+      result = await runCommand('node_modules/ember-cli/bin/ember', 'test');
 
-        expect(result.code).to.eql(0);
-      })
-    );
+      expect(result.code).to.eql(0);
+    });
 
-    it(
-      'npm pack does not include unnecessary files',
-      co.wrap(function*() {
-        let handleError = function(error, commandName) {
-          if (error.code === 'ENOENT') {
-            console.warn(chalk.yellow(`      Your system does not provide ${commandName} -> Skipped this test.`));
-          } else {
-            throw new Error(error);
-          }
-        };
-
-        try {
-          yield npmPack();
-        } catch (error) {
-          return handleError(error, 'npm');
+    it('npm pack does not include unnecessary files', async function() {
+      let handleError = function(error, commandName) {
+        if (error.code === 'ENOENT') {
+          console.warn(chalk.yellow(`      Your system does not provide ${commandName} -> Skipped this test.`));
+        } else {
+          throw new Error(error);
         }
+      };
 
-        let output;
-        try {
-          output = yield tar();
-        } catch (error) {
-          return handleError(error, 'tar');
+      try {
+        await npmPack();
+      } catch (error) {
+        return handleError(error, 'npm');
+      }
+
+      let output;
+      try {
+        output = await tar();
+      } catch (error) {
+        return handleError(error, 'tar');
+      }
+
+      let necessaryFiles = ['package.json', 'index.js', 'LICENSE.md', 'README.md', 'config/environment.js'];
+
+      let unnecessaryFiles = [
+        '.gitkeep',
+        '.travis.yml',
+        '.editorconfig',
+        'testem.js',
+        '.ember-cli',
+        'bower.json',
+        '.bowerrc',
+      ];
+
+      let unnecessaryFolders = [/^tests\//, /^bower_components\//];
+
+      let outputFiles = output
+        .split('\n')
+        .filter(Boolean)
+        .map(f => f.replace(/^package\//, ''));
+
+      expect(outputFiles, 'verify our assumptions about the output structure').to.include.members(necessaryFiles);
+
+      expect(outputFiles).to.not.have.members(unnecessaryFiles);
+
+      for (let unnecessaryFolder of unnecessaryFolders) {
+        for (let outputFile of outputFiles) {
+          expect(outputFile).to.not.match(unnecessaryFolder);
         }
-
-        let necessaryFiles = ['package.json', 'index.js', 'LICENSE.md', 'README.md', 'config/environment.js'];
-
-        let unnecessaryFiles = [
-          '.gitkeep',
-          '.travis.yml',
-          '.editorconfig',
-          'testem.js',
-          '.ember-cli',
-          'bower.json',
-          '.bowerrc',
-        ];
-
-        let unnecessaryFolders = [/^tests\//, /^bower_components\//];
-
-        let outputFiles = output
-          .split('\n')
-          .filter(Boolean)
-          .map(f => f.replace(/^package\//, ''));
-
-        expect(outputFiles, 'verify our assumptions about the output structure').to.include.members(necessaryFiles);
-
-        expect(outputFiles).to.not.have.members(unnecessaryFiles);
-
-        for (let unnecessaryFolder of unnecessaryFolders) {
-          for (let outputFile of outputFiles) {
-            expect(outputFile).to.not.match(unnecessaryFolder);
-          }
-        }
-      })
-    );
+      }
+    });
   }
 });
 

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const path = require('path');
 const fs = require('fs-extra');
@@ -42,448 +41,376 @@ describe('Acceptance: brocfile-smoke-test', function() {
   });
 
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'a custom EmberENV in config/environment.js is used for window.EmberENV',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/custom-ember-env');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+    it('a custom EmberENV in config/environment.js is used for window.EmberENV', async function() {
+      await copyFixtureFiles('brocfile-tests/custom-ember-env');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
+      let vendorContents = fs.readFileSync(path.join('dist', 'assets', 'vendor.js'), {
+        encoding: 'utf8',
+      });
+
+      // Changes in config/optional-features.json end up being set in EmberENV
+      let expected =
+        '(window.EmberENV || {}, {"asdflkmawejf":";jlnu3yr23","_APPLICATION_TEMPLATE_WRAPPER":false,"_DEFAULT_ASYNC_OBSERVERS":true,"_JQUERY_INTEGRATION":false,"_TEMPLATE_ONLY_GLIMMER_COMPONENTS":true});';
+      expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
+    });
+
+    it('a custom environment config can be used in Brocfile.js', async function() {
+      await copyFixtureFiles('brocfile-tests/custom-environment-config');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+    });
+
+    it('without app/templates', async function() {
+      await copyFixtureFiles('brocfile-tests/pods-templates');
+      await remove(path.join(process.cwd(), 'app/templates'));
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+    });
+
+    it('strips app/styles or app/templates from JS', async function() {
+      await copyFixtureFiles('brocfile-tests/styles-and-templates-stripped');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
+        encoding: 'utf8',
+      });
+
+      expect(appFileContents).to.include('//app/templates-stuff.js');
+      expect(appFileContents).to.include('//app/styles-manager.js');
+    });
+
+    it('should throw if no build file is found', async function() {
+      fs.removeSync('./ember-cli-build.js');
+      try {
+        await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      } catch (err) {
+        expect(err.code).to.eql(1);
+      }
+    });
+
+    it('using autoRun: true', async function() {
+      await copyFixtureFiles('brocfile-tests/auto-run-true');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
+        encoding: 'utf8',
+      });
+      expect(appFileContents).to.match(/\/app"\)\["default"\]\.create\(/);
+    });
+
+    it('using autoRun: false', async function() {
+      await copyFixtureFiles('brocfile-tests/auto-run-false');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
+        encoding: 'utf8',
+      });
+
+      expect(appFileContents).to.not.match(/\/app"\)\["default"\]\.create\(/);
+    });
+
+    it('app.import works properly with test tree files', async function() {
+      await copyFixtureFiles('brocfile-tests/app-test-import');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-test-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'test-support.js'), {
+        encoding: 'utf8',
+      });
+
+      expect(subjectFileContents).to.contain('// File for test tree imported and added via postprocessTree()');
+    });
+
+    it('app.import works properly with non-js/css files', async function() {
+      await copyFixtureFiles('brocfile-tests/app-import');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-random-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'file-to-import.txt'), {
+        encoding: 'utf8',
+      });
+
+      expect(subjectFileContents).to.equal('EXAMPLE TEXT FILE CONTENT\n');
+    });
+
+    it('addons can have a public tree that is merged and returned namespaced by default', async function() {
+      await copyFixtureFiles('brocfile-tests/public-tree');
+
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-random-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
+
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+
+      let subjectFileContents = fs.readFileSync(
+        path.join(appRoot, 'dist', 'ember-random-addon', 'some-root-file.txt'),
+        {
           encoding: 'utf8',
-        });
-
-        // Changes in config/optional-features.json end up being set in EmberENV
-        let expected =
-          '(window.EmberENV || {}, {"asdflkmawejf":";jlnu3yr23","_APPLICATION_TEMPLATE_WRAPPER":false,"_DEFAULT_ASYNC_OBSERVERS":true,"_JQUERY_INTEGRATION":false,"_TEMPLATE_ONLY_GLIMMER_COMPONENTS":true});';
-        expect(vendorContents).to.contain(expected, 'EmberENV should be in assets/vendor.js');
-      })
-    );
-
-    it(
-      'a custom environment config can be used in Brocfile.js',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/custom-environment-config');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
-      })
-    );
-
-    it(
-      'without app/templates',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/pods-templates');
-        yield remove(path.join(process.cwd(), 'app/templates'));
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
-      })
-    );
-
-    it(
-      'strips app/styles or app/templates from JS',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/styles-and-templates-stripped');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
-          encoding: 'utf8',
-        });
-
-        expect(appFileContents).to.include('//app/templates-stuff.js');
-        expect(appFileContents).to.include('//app/styles-manager.js');
-      })
-    );
-
-    it(
-      'should throw if no build file is found',
-      co.wrap(function*() {
-        fs.removeSync('./ember-cli-build.js');
-        try {
-          yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-        } catch (err) {
-          expect(err.code).to.eql(1);
         }
-      })
-    );
+      );
 
-    it(
-      'using autoRun: true',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/auto-run-true');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      expect(subjectFileContents).to.equal('ROOT FILE\n');
+    });
 
-        let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
-          encoding: 'utf8',
-        });
-        expect(appFileContents).to.match(/\/app"\)\["default"\]\.create\(/);
-      })
-    );
+    it('using pods based templates', async function() {
+      await copyFixtureFiles('brocfile-tests/pods-templates');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+    });
 
-    it(
-      'using autoRun: false',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/auto-run-false');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+    it('using pods based templates with a podModulePrefix', async function() {
+      await copyFixtureFiles('brocfile-tests/pods-with-prefix-templates');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
+    });
 
-        let appFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', `${appName}.js`), {
-          encoding: 'utf8',
-        });
+    it('addon trees are not jshinted', async function() {
+      await copyFixtureFiles('brocfile-tests/jshint-addon');
 
-        expect(appFileContents).to.not.match(/\/app"\)\["default"\]\.create\(/);
-      })
-    );
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson['ember-addon'] = {
+        paths: ['./lib/ember-random-thing'],
+      };
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-    it(
-      'app.import works properly with test tree files',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-test-import');
+      let ember = path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember');
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-test-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let error = await expect(runCommand(ember, 'test', '--filter=jshint')).to.eventually.be.rejected;
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      expect(error.output.join('')).to.include('Error: No tests matched the filter "jshint"');
+    });
 
-        let subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'test-support.js'), {
-          encoding: 'utf8',
-        });
+    it('multiple css files in styles/ are output when a preprocessor is not used', async function() {
+      await copyFixtureFiles('brocfile-tests/multiple-css-files');
 
-        expect(subjectFileContents).to.contain('// File for test tree imported and added via postprocessTree()');
-      })
-    );
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-    it(
-      'app.import works properly with non-js/css files',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-import');
+      let files = ['/assets/some-cool-app.css', '/assets/other.css'];
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-random-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let basePath = path.join(appRoot, 'dist');
+      files.forEach(function(f) {
+        expect(file(path.join(basePath, f))).to.exist;
+      });
+    });
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+    it('specifying custom output paths works properly', async function() {
+      await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
-        let subjectFileContents = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'file-to-import.txt'), {
-          encoding: 'utf8',
-        });
+      let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
+      fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
 
-        expect(subjectFileContents).to.equal('EXAMPLE TEXT FILE CONTENT\n');
-      })
-    );
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-    it(
-      'addons can have a public tree that is merged and returned namespaced by default',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/public-tree');
+      let files = [
+        '/css/app.css',
+        '/css/theme/a.css',
+        '/js/app.js',
+        '/css/vendor.css',
+        '/js/vendor.js',
+        '/css/test-support.css',
+        '/js/test-support.js',
+        '/my-app.html',
+      ];
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-random-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let basePath = path.join(appRoot, 'dist');
+      files.forEach(function(f) {
+        expect(file(path.join(basePath, f))).to.exist;
+      });
+    });
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+    it('specifying outputFile results in an explicitly generated assets', async function() {
+      await copyFixtureFiles('brocfile-tests/app-import-output-file');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        let subjectFileContents = fs.readFileSync(
-          path.join(appRoot, 'dist', 'ember-random-addon', 'some-root-file.txt'),
-          {
-            encoding: 'utf8',
-          }
-        );
+      let files = ['/assets/output-file.js', '/assets/output-file.css', '/assets/vendor.css', '/assets/vendor.js'];
 
-        expect(subjectFileContents).to.equal('ROOT FILE\n');
-      })
-    );
+      let basePath = path.join(appRoot, 'dist');
+      files.forEach(function(f) {
+        expect(file(path.join(basePath, f))).to.exist;
+      });
+    });
 
-    it(
-      'using pods based templates',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/pods-templates');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
-      })
-    );
+    it('can use transformation to turn anonymous AMD into named AMD', async function() {
+      await copyFixtureFiles('brocfile-tests/app-import-anonymous-amd');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-    it(
-      'using pods based templates with a podModulePrefix',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/pods-with-prefix-templates');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
-      })
-    );
+      let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
+        encoding: 'utf8',
+      });
 
-    it(
-      'addon trees are not jshinted',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/jshint-addon');
+      (function() {
+        let defineCount = 0;
+        // eslint-disable-next-line no-unused-vars
+        function define(name, deps, factory) {
+          expect(name).to.equal('hello-world');
+          expect(deps).to.deep.equal([]);
+          expect(factory()()).to.equal('Hello World');
+          defineCount++;
+        }
+        /* eslint-disable no-eval */
+        eval(outputJS);
+        /* eslint-enable no-eval */
+        expect(defineCount).to.eql(1);
+      })();
+    });
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson['ember-addon'] = {
-          paths: ['./lib/ember-random-thing'],
-        };
-        fs.writeJsonSync(packageJsonPath, packageJson);
+    it('can do amd transform from addon', async function() {
+      await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
-        let ember = path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember');
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-transform-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        let error = yield expect(runCommand(ember, 'test', '--filter=jshint')).to.eventually.be.rejected;
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(error.output.join('')).to.include('Error: No tests matched the filter "jshint"');
-      })
-    );
+      let addonOutputJs = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'addon-output.js'), {
+        encoding: 'utf8',
+      });
 
-    it(
-      'multiple css files in styles/ are output when a preprocessor is not used',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/multiple-css-files');
+      (function() {
+        let defineCount = 0;
+        // eslint-disable-next-line no-unused-vars
+        function define(name, deps, factory) {
+          expect(name).to.equal('addon-vendor');
+          expect(deps).to.deep.equal([]);
+          expect(factory()()).to.equal('Hello World');
+          defineCount++;
+        }
+        /* eslint-disable no-eval */
+        eval(addonOutputJs);
+        /* eslint-enable no-eval */
+        expect(defineCount).to.eql(1);
+      })();
+    });
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+    it('can use transformation to turn library into custom transformation', async function() {
+      await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
-        let files = ['/assets/some-cool-app.css', '/assets/other.css'];
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-transform-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        let basePath = path.join(appRoot, 'dist');
-        files.forEach(function(f) {
-          expect(file(path.join(basePath, f))).to.exist;
-        });
-      })
-    );
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-    it(
-      'specifying custom output paths works properly',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/custom-output-paths');
+      let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
+        encoding: 'utf8',
+      });
 
-        let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
-        fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
-
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let files = [
-          '/css/app.css',
-          '/css/theme/a.css',
-          '/js/app.js',
-          '/css/vendor.css',
-          '/js/vendor.js',
-          '/css/test-support.css',
-          '/js/test-support.js',
-          '/my-app.html',
-        ];
-
-        let basePath = path.join(appRoot, 'dist');
-        files.forEach(function(f) {
-          expect(file(path.join(basePath, f))).to.exist;
-        });
-      })
-    );
-
-    it(
-      'specifying outputFile results in an explicitly generated assets',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-import-output-file');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let files = ['/assets/output-file.js', '/assets/output-file.css', '/assets/vendor.css', '/assets/vendor.js'];
-
-        let basePath = path.join(appRoot, 'dist');
-        files.forEach(function(f) {
-          expect(file(path.join(basePath, f))).to.exist;
-        });
-      })
-    );
-
-    it(
-      'can use transformation to turn anonymous AMD into named AMD',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-import-anonymous-amd');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
-          encoding: 'utf8',
-        });
-
-        (function() {
-          let defineCount = 0;
-          // eslint-disable-next-line no-unused-vars
-          function define(name, deps, factory) {
-            expect(name).to.equal('hello-world');
-            expect(deps).to.deep.equal([]);
-            expect(factory()()).to.equal('Hello World');
-            defineCount++;
-          }
-          /* eslint-disable no-eval */
-          eval(outputJS);
-          /* eslint-enable no-eval */
-          expect(defineCount).to.eql(1);
-        })();
-      })
-    );
-
-    it(
-      'can do amd transform from addon',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-import-custom-transform');
-
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-transform-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
-
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let addonOutputJs = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'addon-output.js'), {
-          encoding: 'utf8',
-        });
-
-        (function() {
-          let defineCount = 0;
-          // eslint-disable-next-line no-unused-vars
-          function define(name, deps, factory) {
-            expect(name).to.equal('addon-vendor');
-            expect(deps).to.deep.equal([]);
-            expect(factory()()).to.equal('Hello World');
-            defineCount++;
-          }
-          /* eslint-disable no-eval */
-          eval(addonOutputJs);
-          /* eslint-enable no-eval */
-          expect(defineCount).to.eql(1);
-        })();
-      })
-    );
-
-    it(
-      'can use transformation to turn library into custom transformation',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/app-import-custom-transform');
-
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-transform-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
-
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-
-        let outputJS = fs.readFileSync(path.join(appRoot, 'dist', 'assets', 'output.js'), {
-          encoding: 'utf8',
-        });
-
-        expect(outputJS).to.be.equal(
-          'if (typeof FastBoot === \'undefined\') { window.hello = "hello world"; }//# sourceMappingURL=output.map\n'
-        );
-      })
-    );
+      expect(outputJS).to.be.equal(
+        'if (typeof FastBoot === \'undefined\') { window.hello = "hello world"; }//# sourceMappingURL=output.map\n'
+      );
+    });
 
     // skipped because of potentially broken assertion that should be fixed correctly at a later point
-    it.skip(
-      'specifying partial `outputPaths` hash deep merges options correctly',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/custom-output-paths');
+    it.skip('specifying partial `outputPaths` hash deep merges options correctly', async function() {
+      await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
-        let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
-        fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
+      let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
+      fs.writeFileSync(themeCSSPath, 'html, body { margin: 20%; }');
 
-        let brocfilePath = path.join(appRoot, 'ember-cli-build.js');
-        let brocfile = fs.readFileSync(brocfilePath, 'utf8');
+      let brocfilePath = path.join(appRoot, 'ember-cli-build.js');
+      let brocfile = fs.readFileSync(brocfilePath, 'utf8');
 
-        // remove outputPaths.app.js option
-        brocfile = brocfile.replace(/js: '\/js\/app.js'/, '');
-        // remove outputPaths.app.css.app option
-        brocfile = brocfile.replace(/'app': '\/css\/app\.css',/, '');
+      // remove outputPaths.app.js option
+      brocfile = brocfile.replace(/js: '\/js\/app.js'/, '');
+      // remove outputPaths.app.css.app option
+      brocfile = brocfile.replace(/'app': '\/css\/app\.css',/, '');
 
-        fs.writeFileSync(brocfilePath, brocfile, 'utf8');
+      fs.writeFileSync(brocfilePath, brocfile, 'utf8');
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        let files = [
-          '/css/theme/a.css',
-          '/assets/some-cool-app.js',
-          '/css/vendor.css',
-          '/js/vendor.js',
-          '/css/test-support.css',
-          '/js/test-support.js',
-        ];
+      let files = [
+        '/css/theme/a.css',
+        '/assets/some-cool-app.js',
+        '/css/vendor.css',
+        '/js/vendor.js',
+        '/css/test-support.css',
+        '/js/test-support.js',
+      ];
 
-        let basePath = path.join(appRoot, 'dist');
-        files.forEach(function(f) {
-          expect(file(path.join(basePath, f))).to.exist;
-        });
+      let basePath = path.join(appRoot, 'dist');
+      files.forEach(function(f) {
+        expect(file(path.join(basePath, f))).to.exist;
+      });
 
-        expect(file(path.join(basePath, '/assets/some-cool-app.css'))).to.not.exist;
-      })
-    );
+      expect(file(path.join(basePath, '/assets/some-cool-app.css'))).to.not.exist;
+    });
 
-    it(
-      'multiple paths can be CSS preprocessed',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/multiple-sass-files');
+    it('multiple paths can be CSS preprocessed', async function() {
+      await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-cli-sass'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/main.css')).to.equal(
-          'body { background: black; }\n',
-          'main.css contains correct content'
-        );
+      expect(file('dist/assets/main.css')).to.equal(
+        'body { background: black; }\n',
+        'main.css contains correct content'
+      );
 
-        expect(file('dist/assets/theme/a.css')).to.equal(
-          '.theme { color: red; }\n',
-          'theme/a.css contains correct content'
-        );
-      })
-    );
+      expect(file('dist/assets/theme/a.css')).to.equal(
+        '.theme { color: red; }\n',
+        'theme/a.css contains correct content'
+      );
+    });
 
-    it(
-      'app.css is output to <app name>.css by default',
-      co.wrap(function*() {
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
-        expect(file(`dist/assets/${appName}.css`)).to.exist;
-      })
-    );
+    it('app.css is output to <app name>.css by default', async function() {
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      expect(file(`dist/assets/${appName}.css`)).to.exist;
+    });
 
     // for backwards compat.
-    it(
-      'app.scss is output to <app name>.css by default',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/multiple-sass-files');
+    it('app.scss is output to <app name>.css by default', async function() {
+      await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
-        let brocfilePath = path.join(appRoot, 'ember-cli-build.js');
-        let brocfile = fs.readFileSync(brocfilePath, 'utf8');
+      let brocfilePath = path.join(appRoot, 'ember-cli-build.js');
+      let brocfile = fs.readFileSync(brocfilePath, 'utf8');
 
-        // remove custom preprocessCss paths, use app.scss instead
-        brocfile = brocfile.replace(/outputPaths.*/, '');
+      // remove custom preprocessCss paths, use app.scss instead
+      brocfile = brocfile.replace(/outputPaths.*/, '');
 
-        fs.writeFileSync(brocfilePath, brocfile, 'utf8');
+      fs.writeFileSync(brocfilePath, brocfile, 'utf8');
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-cli-sass'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file(`dist/assets/${appName}.css`)).to.equal('body { background: green; }\n');
-      })
-    );
+      expect(file(`dist/assets/${appName}.css`)).to.equal('body { background: green; }\n');
+    });
 
-    it(
-      'additional trees can be passed to the app',
-      co.wrap(function*() {
-        yield copyFixtureFiles('brocfile-tests/additional-trees');
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', { verbose: true });
+    it('additional trees can be passed to the app', async function() {
+      await copyFixtureFiles('brocfile-tests/additional-trees');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', { verbose: true });
 
-        let files = [
-          '/assets/custom-output-file.js',
-          '/assets/custom-output-file.css',
-          '/assets/vendor.css',
-          '/assets/vendor.js',
-        ];
+      let files = [
+        '/assets/custom-output-file.js',
+        '/assets/custom-output-file.css',
+        '/assets/vendor.css',
+        '/assets/vendor.js',
+      ];
 
-        let basePath = path.join(appRoot, 'dist');
-        files.forEach(function(f) {
-          expect(file(path.join(basePath, f))).to.exist;
-        });
-      })
-    );
+      let basePath = path.join(appRoot, 'dist');
+      files.forEach(function(f) {
+        expect(file(path.join(basePath, f))).to.exist;
+      });
+    });
   }
 });

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const fs = require('fs-extra');
@@ -30,12 +29,10 @@ describe('Acceptance: ember destroy', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     process.chdir(root);
@@ -68,16 +65,16 @@ describe('Acceptance: ember destroy', function() {
     });
   }
 
-  const assertDestroyAfterGenerate = co.wrap(function*(args, files) {
-    yield initApp();
+  const assertDestroyAfterGenerate = async function(args, files) {
+    await initApp();
 
-    yield generate(args);
+    await generate(args);
     assertFilesExist(files);
 
-    let result = yield destroy(args);
+    let result = await destroy(args);
     expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
     assertFilesNotExist(files);
-  });
+  };
 
   it('blueprint foo', function() {
     let commandArgs = ['blueprint', 'foo'];
@@ -107,58 +104,49 @@ describe('Acceptance: ember destroy', function() {
     return assertDestroyAfterGenerate(commandArgs, files);
   });
 
-  it(
-    'deletes files generated using blueprints from the project directory',
-    co.wrap(function*() {
-      let commandArgs = ['foo', 'bar'];
-      let files = ['app/foos/bar.js'];
-      yield initApp();
+  it('deletes files generated using blueprints from the project directory', async function() {
+    let commandArgs = ['foo', 'bar'];
+    let files = ['app/foos/bar.js'];
+    await initApp();
 
-      yield outputFile(
-        'blueprints/foo/files/app/foos/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Object.extend({ foo: true });\n'
-      );
+    await outputFile(
+      'blueprints/foo/files/app/foos/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Object.extend({ foo: true });\n'
+    );
 
-      yield generate(commandArgs);
-      assertFilesExist(files);
+    await generate(commandArgs);
+    assertFilesExist(files);
 
-      yield destroy(commandArgs);
-      assertFilesNotExist(files);
-    })
-  );
+    await destroy(commandArgs);
+    assertFilesNotExist(files);
+  });
 
-  it(
-    'correctly identifies the root of the project',
-    co.wrap(function*() {
-      let commandArgs = ['controller', 'foo'];
-      let files = ['app/controllers/foo.js'];
-      yield initApp();
+  it('correctly identifies the root of the project', async function() {
+    let commandArgs = ['controller', 'foo'];
+    let files = ['app/controllers/foo.js'];
+    await initApp();
 
-      yield outputFile(
-        'blueprints/controller/files/app/controllers/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
-      );
+    await outputFile(
+      'blueprints/controller/files/app/controllers/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
+    );
 
-      yield generate(commandArgs);
-      assertFilesExist(files);
+    await generate(commandArgs);
+    assertFilesExist(files);
 
-      process.chdir(path.join(tmpdir, 'app'));
-      yield destroy(commandArgs);
+    process.chdir(path.join(tmpdir, 'app'));
+    await destroy(commandArgs);
 
-      process.chdir(tmpdir);
-      assertFilesNotExist(files);
-    })
-  );
+    process.chdir(tmpdir);
+    assertFilesNotExist(files);
+  });
 
-  it(
-    'http-mock <name> does not remove server/',
-    co.wrap(function*() {
-      yield initApp();
-      yield generate(['http-mock', 'foo']);
-      yield generate(['http-mock', 'bar']);
-      yield destroy(['http-mock', 'foo']);
+  it('http-mock <name> does not remove server/', async function() {
+    await initApp();
+    await generate(['http-mock', 'foo']);
+    await generate(['http-mock', 'bar']);
+    await destroy(['http-mock', 'foo']);
 
-      expect(file('server/index.js')).to.exist;
-    })
-  );
+    expect(file('server/index.js')).to.exist;
+  });
 });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const fs = require('fs-extra');
@@ -32,12 +31,10 @@ describe('Acceptance: ember generate', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     process.chdir(root);
@@ -62,324 +59,288 @@ describe('Acceptance: ember generate', function() {
     });
   }
 
-  it(
-    'blueprint foo',
-    co.wrap(function*() {
-      yield generate(['blueprint', 'foo']);
+  it('blueprint foo', async function() {
+    await generate(['blueprint', 'foo']);
 
-      expect(file('blueprints/foo/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'blueprint foo/bar',
-    co.wrap(function*() {
-      yield generate(['blueprint', 'foo/bar']);
+  it('blueprint foo/bar', async function() {
+    await generate(['blueprint', 'foo/bar']);
 
-      expect(file('blueprints/foo/bar/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/bar/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'http-mock foo',
-    co.wrap(function*() {
-      yield generate(['http-mock', 'foo']);
+  it('http-mock foo', async function() {
+    await generate(['http-mock', 'foo']);
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
 
-      expect(file('server/mocks/foo.js')).to.contain(
+    expect(file('server/mocks/foo.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooRouter = express.Router();\n' +
+        '\n' +
+        "  fooRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo', require('body-parser').json());\n" +
+        "  app.use('/api/foo', fooRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('http-mock foo-bar', async function() {
+    await generate(['http-mock', 'foo-bar']);
+
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+
+    expect(file('server/mocks/foo-bar.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooBarRouter = express.Router();\n' +
+        '\n' +
+        "  fooBarRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+        "  app.use('/api/foo-bar', fooBarRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('http-proxy foo', async function() {
+    await generate(['http-proxy', 'foo', 'http://localhost:5000']);
+
+    expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+
+    expect(file('server/proxies/foo.js')).to.contain(
+      "const proxyPath = '/foo';\n" +
+        '\n' +
         'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooRouter = express.Router();\n' +
-          '\n' +
-          "  fooRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo', require('body-parser').json());\n" +
-          "  app.use('/api/foo', fooRouter);\n" +
-          '};'
-      );
+        '  // For options, see:\n' +
+        '  // https://github.com/nodejitsu/node-http-proxy\n' +
+        "  let proxy = require('http-proxy').createProxyServer({});\n" +
+        '\n' +
+        "  proxy.on('error', function(err, req) {\n" +
+        '    console.error(err, req.url);\n' +
+        '  });\n' +
+        '\n' +
+        '  app.use(proxyPath, function(req, res, next){\n' +
+        '    // include root path in proxied request\n' +
+        "    req.url = proxyPath + '/' + req.url;\n" +
+        "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+        '  });\n' +
+        '};'
+    );
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
 
-  it(
-    'http-mock foo-bar',
-    co.wrap(function*() {
-      yield generate(['http-mock', 'foo-bar']);
+  it('uses blueprints from the project directory', async function() {
+    await initApp();
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    await outputFile(
+      'blueprints/foo/files/app/foos/__name__.js',
+      "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
+    );
 
-      expect(file('server/mocks/foo-bar.js')).to.contain(
-        'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooBarRouter = express.Router();\n' +
-          '\n' +
-          "  fooBarRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-          "  app.use('/api/foo-bar', fooBarRouter);\n" +
-          '};'
-      );
+    await ember(['generate', 'foo', 'bar']);
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    expect(file('app/foos/bar.js')).to.contain('foo: true');
+  });
 
-  it(
-    'http-proxy foo',
-    co.wrap(function*() {
-      yield generate(['http-proxy', 'foo', 'http://localhost:5000']);
+  it('allows custom blueprints to override built-ins', async function() {
+    await initApp();
+    await outputFile(
+      'blueprints/controller/files/app/controllers/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
+    );
 
-      expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+    await ember(['generate', 'controller', 'foo']);
 
-      expect(file('server/proxies/foo.js')).to.contain(
-        "const proxyPath = '/foo';\n" +
-          '\n' +
-          'module.exports = function(app) {\n' +
-          '  // For options, see:\n' +
-          '  // https://github.com/nodejitsu/node-http-proxy\n' +
-          "  let proxy = require('http-proxy').createProxyServer({});\n" +
-          '\n' +
-          "  proxy.on('error', function(err, req) {\n" +
-          '    console.error(err, req.url);\n' +
-          '  });\n' +
-          '\n' +
-          '  app.use(proxyPath, function(req, res, next){\n' +
-          '    // include root path in proxied request\n' +
-          "    req.url = proxyPath + '/' + req.url;\n" +
-          "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-          '  });\n' +
-          '};'
-      );
+    expect(file('app/controllers/foo.js')).to.contain('custom: true');
+  });
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+  it('passes custom cli arguments to blueprint options', async function() {
+    await initApp();
 
-  it(
-    'uses blueprints from the project directory',
-    co.wrap(function*() {
-      yield initApp();
+    await outputFile(
+      'blueprints/customblue/files/app/__name__.js',
+      'Q: Can I has custom command? A: <%= hasCustomCommand %>'
+    );
 
-      yield outputFile(
-        'blueprints/foo/files/app/foos/__name__.js',
-        "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
-      );
+    await outputFile(
+      'blueprints/customblue/index.js',
+      'module.exports = {\n' +
+        '  locals(options) {\n' +
+        '    var loc = {};\n' +
+        "    loc.hasCustomCommand = (options.customCommand) ? 'Yes!' : 'No. :C';\n" +
+        '    return loc;\n' +
+        '  },\n' +
+        '};\n'
+    );
 
-      yield ember(['generate', 'foo', 'bar']);
+    await ember(['generate', 'customblue', 'foo', '--custom-command']);
 
-      expect(file('app/foos/bar.js')).to.contain('foo: true');
-    })
-  );
+    expect(file('app/foo.js')).to.contain('A: Yes!');
+  });
 
-  it(
-    'allows custom blueprints to override built-ins',
-    co.wrap(function*() {
-      yield initApp();
-      yield outputFile(
-        'blueprints/controller/files/app/controllers/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
-      );
+  it('correctly identifies the root of the project', async function() {
+    await initApp();
 
-      yield ember(['generate', 'controller', 'foo']);
+    await outputFile(
+      'blueprints/controller/files/app/controllers/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
+    );
 
-      expect(file('app/controllers/foo.js')).to.contain('custom: true');
-    })
-  );
+    process.chdir(path.join(tmpdir, 'app'));
+    await ember(['generate', 'controller', 'foo']);
 
-  it(
-    'passes custom cli arguments to blueprint options',
-    co.wrap(function*() {
-      yield initApp();
+    process.chdir(tmpdir);
+    expect(file('app/controllers/foo.js')).to.contain('custom: true');
+  });
 
-      yield outputFile(
-        'blueprints/customblue/files/app/__name__.js',
-        'Q: Can I has custom command? A: <%= hasCustomCommand %>'
-      );
+  it('server', async function() {
+    await generate(['server']);
+    expect(file('server/index.js')).to.exist;
+  });
 
-      yield outputFile(
-        'blueprints/customblue/index.js',
-        'module.exports = {\n' +
-          '  locals(options) {\n' +
-          '    var loc = {};\n' +
-          "    loc.hasCustomCommand = (options.customCommand) ? 'Yes!' : 'No. :C';\n" +
-          '    return loc;\n' +
-          '  },\n' +
-          '};\n'
-      );
+  it('lib', async function() {
+    await generate(['lib']);
+    expect(dir('lib')).to.exist;
+  });
 
-      yield ember(['generate', 'customblue', 'foo', '--custom-command']);
+  it('custom blueprint availableOptions', async function() {
+    await initApp();
+    await ember(['generate', 'blueprint', 'foo']);
 
-      expect(file('app/foo.js')).to.contain('A: Yes!');
-    })
-  );
+    replaceFile(
+      'blueprints/foo/index.js',
+      'module.exports = {',
+      'module.exports = {\navailableOptions: [ \n' +
+        "{ name: 'foo',\ntype: String, \n" +
+        "values: ['one', 'two'],\n" +
+        "default: 'one',\n" +
+        "aliases: [ {'one': 'one'}, {'two': 'two'} ] } ],\n" +
+        'locals(options) {\n' +
+        'return { foo: options.foo };\n' +
+        '},'
+    );
 
-  it(
-    'correctly identifies the root of the project',
-    co.wrap(function*() {
-      yield initApp();
+    await outputFile(
+      'blueprints/foo/files/app/foos/__name__.js',
+      "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: <%= foo %> });\n'
+    );
 
-      yield outputFile(
-        'blueprints/controller/files/app/controllers/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
-      );
+    await ember(['generate', 'foo', 'bar', '-two']);
 
-      process.chdir(path.join(tmpdir, 'app'));
-      yield ember(['generate', 'controller', 'foo']);
-
-      process.chdir(tmpdir);
-      expect(file('app/controllers/foo.js')).to.contain('custom: true');
-    })
-  );
-
-  it(
-    'server',
-    co.wrap(function*() {
-      yield generate(['server']);
-      expect(file('server/index.js')).to.exist;
-    })
-  );
-
-  it(
-    'lib',
-    co.wrap(function*() {
-      yield generate(['lib']);
-      expect(dir('lib')).to.exist;
-    })
-  );
-
-  it(
-    'custom blueprint availableOptions',
-    co.wrap(function*() {
-      yield initApp();
-      yield ember(['generate', 'blueprint', 'foo']);
-
-      replaceFile(
-        'blueprints/foo/index.js',
-        'module.exports = {',
-        'module.exports = {\navailableOptions: [ \n' +
-          "{ name: 'foo',\ntype: String, \n" +
-          "values: ['one', 'two'],\n" +
-          "default: 'one',\n" +
-          "aliases: [ {'one': 'one'}, {'two': 'two'} ] } ],\n" +
-          'locals(options) {\n' +
-          'return { foo: options.foo };\n' +
-          '},'
-      );
-
-      yield outputFile(
-        'blueprints/foo/files/app/foos/__name__.js',
-        "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: <%= foo %> });\n'
-      );
-
-      yield ember(['generate', 'foo', 'bar', '-two']);
-
-      expect(file('app/foos/bar.js')).to.contain('export default Ember.Object.extend({ foo: two });');
-    })
-  );
+    expect(file('app/foos/bar.js')).to.contain('export default Ember.Object.extend({ foo: two });');
+  });
 });

--- a/tests/acceptance/in-option-destroy-test.js
+++ b/tests/acceptance/in-option-destroy-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const fs = require('fs-extra');
@@ -32,12 +31,10 @@ describe('Acceptance: ember destroy with --in option', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     this.timeout(10000);
@@ -68,18 +65,18 @@ describe('Acceptance: ember destroy with --in option', function() {
     });
   }
 
-  const assertDestroyAfterGenerate = co.wrap(function*(args, addonPath, files) {
-    yield initApp();
-    yield generateUtils.inRepoAddon(addonPath);
-    yield generateUtils.tempBlueprint();
-    yield generate(args);
+  const assertDestroyAfterGenerate = async function(args, addonPath, files) {
+    await initApp();
+    await generateUtils.inRepoAddon(addonPath);
+    await generateUtils.tempBlueprint();
+    await generate(args);
 
     assertFilesExist(files);
 
-    let result = yield destroy(args);
+    let result = await destroy(args);
     expect(result, 'destroy command did not exit with errorCode').to.be.an('object');
     assertFilesNotExist(files);
-  });
+  };
 
   it('blueprint foo --in lib/other-thing', function() {
     let addonPath = './lib/other-thing';

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const ember = require('../helpers/ember');
 const walkSync = require('walk-sync');
 const glob = require('glob');
@@ -27,14 +26,12 @@ let tmpPath = './tmp/init-test';
 describe('Acceptance: ember init', function() {
   this.timeout(20000);
 
-  beforeEach(
-    co.wrap(function*() {
-      Blueprint.ignoredFiles = defaultIgnoredFiles;
+  beforeEach(async function() {
+    Blueprint.ignoredFiles = defaultIgnoredFiles;
 
-      yield tmp.setup(tmpPath);
-      process.chdir(tmpPath);
-    })
-  );
+    await tmp.setup(tmpPath);
+    process.chdir(tmpPath);
+  });
 
   afterEach(function() {
     return tmp.teardown(tmpPath);
@@ -108,92 +105,65 @@ describe('Acceptance: ember init', function() {
     });
   }
 
-  it(
-    'ember init',
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it('ember init', async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      confirmBlueprinted();
-    })
-  );
+    confirmBlueprinted();
+  });
 
-  it(
-    "init an already init'd folder",
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it("init an already init'd folder", async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      confirmBlueprinted();
-    })
-  );
+    confirmBlueprinted();
+  });
 
-  it(
-    'init a single file',
-    co.wrap(function*() {
-      yield ember(['init', 'app.js', '--skip-npm', '--skip-bower']);
+  it('init a single file', async function() {
+    await ember(['init', 'app.js', '--skip-npm', '--skip-bower']);
 
-      confirmGlobBlueprinted('app.js');
-    })
-  );
+    confirmGlobBlueprinted('app.js');
+  });
 
-  it(
-    "init a single file on already init'd folder",
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it("init a single file on already init'd folder", async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      yield ember(['init', 'app.js', '--skip-npm', '--skip-bower']);
+    await ember(['init', 'app.js', '--skip-npm', '--skip-bower']);
 
-      confirmBlueprinted();
-    })
-  );
+    confirmBlueprinted();
+  });
 
-  it(
-    'init multiple files by glob pattern',
-    co.wrap(function*() {
-      yield ember(['init', 'app/**', '--skip-npm', '--skip-bower']);
+  it('init multiple files by glob pattern', async function() {
+    await ember(['init', 'app/**', '--skip-npm', '--skip-bower']);
 
-      confirmGlobBlueprinted('app/**');
-    })
-  );
+    confirmGlobBlueprinted('app/**');
+  });
 
-  it(
-    "init multiple files by glob pattern on already init'd folder",
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it("init multiple files by glob pattern on already init'd folder", async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      yield ember(['init', 'app/**', '--skip-npm', '--skip-bower']);
+    await ember(['init', 'app/**', '--skip-npm', '--skip-bower']);
 
-      confirmBlueprinted();
-    })
-  );
+    confirmBlueprinted();
+  });
 
-  it(
-    'init multiple files by glob patterns',
-    co.wrap(function*() {
-      yield ember(['init', 'app/**', '{package,bower}.json', 'resolver.js', '--skip-npm', '--skip-bower']);
+  it('init multiple files by glob patterns', async function() {
+    await ember(['init', 'app/**', '{package,bower}.json', 'resolver.js', '--skip-npm', '--skip-bower']);
 
-      confirmGlobBlueprinted('{app/**,{package,bower}.json,resolver.js}');
-    })
-  );
+    confirmGlobBlueprinted('{app/**,{package,bower}.json,resolver.js}');
+  });
 
-  it(
-    "init multiple files by glob patterns on already init'd folder",
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it("init multiple files by glob patterns on already init'd folder", async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      yield ember(['init', 'app/**', '{package,bower}.json', 'resolver.js', '--skip-npm', '--skip-bower']);
+    await ember(['init', 'app/**', '{package,bower}.json', 'resolver.js', '--skip-npm', '--skip-bower']);
 
-      confirmBlueprinted();
-    })
-  );
+    confirmBlueprinted();
+  });
 
-  it(
-    'should not create .git folder',
-    co.wrap(function*() {
-      yield ember(['init', '--skip-npm', '--skip-bower']);
+  it('should not create .git folder', async function() {
+    await ember(['init', '--skip-npm', '--skip-bower']);
 
-      expect(dir('.git')).to.not.exist;
-    })
-  );
+    expect(dir('.git')).to.not.exist;
+  });
 });

--- a/tests/acceptance/nested-addons-smoke-test-slow.js
+++ b/tests/acceptance/nested-addons-smoke-test-slow.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -40,41 +39,38 @@ describe('Acceptance: nested-addons-smoke-test', function() {
   });
 
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'addons with nested addons compile correctly',
-      co.wrap(function*() {
-        yield copyFixtureFiles('addon/with-nested-addons');
+    it('addons with nested addons compile correctly', async function() {
+      await copyFixtureFiles('addon/with-nested-addons');
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-top-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-top-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_APP_IMPORT');
-        expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_THIS_IMPORT');
+      expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_APP_IMPORT');
+      expect(file('dist/assets/vendor.js')).to.contain('INNER_ADDON_IMPORT_WITH_THIS_IMPORT');
 
-        // RAW comments should have been converted to PREPROCESSED by
-        // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon
-        // then from PREPROCESSED to POSTPROCESSED by
-        // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon
-        expect(file('dist/assets/vendor.js')).to.contain(
-          'POSTPROCESSED node_modules/ember-top-addon/addon/templates/application.hbs'
-        );
-        expect(file('dist/assets/vendor.js')).to.contain('POSTPROCESSED node_modules/ember-top-addon/addon/index.js');
-        expect(file('dist/assets/vendor.css')).to.contain(
-          'POSTPROCESSED node_modules/ember-top-addon/addon/styles/app.css'
-        );
+      // RAW comments should have been converted to PREPROCESSED by
+      // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/preprocesstree-addon
+      // then from PREPROCESSED to POSTPROCESSED by
+      // tests/fixtures/addon/with-nested-addons/node_modules/ember-top-addon/node_modules/postprocesstree-addon
+      expect(file('dist/assets/vendor.js')).to.contain(
+        'POSTPROCESSED node_modules/ember-top-addon/addon/templates/application.hbs'
+      );
+      expect(file('dist/assets/vendor.js')).to.contain('POSTPROCESSED node_modules/ember-top-addon/addon/index.js');
+      expect(file('dist/assets/vendor.css')).to.contain(
+        'POSTPROCESSED node_modules/ember-top-addon/addon/styles/app.css'
+      );
 
-        // the pre/post process tree hooks above should *not* have changed RAW's in the current app
-        expect(file('dist/assets/some-cool-app.js')).to.contain('RAW app/foo.js');
+      // the pre/post process tree hooks above should *not* have changed RAW's in the current app
+      expect(file('dist/assets/some-cool-app.js')).to.contain('RAW app/foo.js');
 
-        // should *not* have changed RAW's in sibling addons
-        expect(file('dist/assets/vendor.js')).to.contain(
-          'RAW node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js'
-        );
-      })
-    );
+      // should *not* have changed RAW's in sibling addons
+      expect(file('dist/assets/vendor.js')).to.contain(
+        'RAW node_modules/ember-top-addon/node_modules/ember-inner-addon/addon/index.js'
+      );
+    });
   }
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const fs = require('fs-extra');
 const ember = require('../helpers/ember');
 const walkSync = require('walk-sync');
@@ -26,13 +25,11 @@ describe('Acceptance: ember new', function() {
   this.timeout(10000);
   let ORIGINAL_PROCESS_ENV_CI;
 
-  beforeEach(
-    co.wrap(function*() {
-      yield tmp.setup(tmpDir);
-      process.chdir(tmpDir);
-      ORIGINAL_PROCESS_ENV_CI = process.env.CI;
-    })
-  );
+  beforeEach(async function() {
+    await tmp.setup(tmpDir);
+    process.chdir(tmpDir);
+    ORIGINAL_PROCESS_ENV_CI = process.env.CI;
+  });
 
   afterEach(function() {
     if (ORIGINAL_PROCESS_ENV_CI === undefined) {
@@ -62,337 +59,268 @@ describe('Acceptance: ember new', function() {
     );
   }
 
-  it(
-    'ember new adds ember-welcome-page by default',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
-
-      expect(file('package.json')).to.match(/"ember-welcome-page"/);
-
-      expect(file('app/templates/application.hbs')).to.contain('<WelcomePage />');
-    })
-  );
-
-  it(
-    'ember new --no-welcome skips installation of ember-welcome-page',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--no-welcome']);
-
-      expect(file('package.json')).not.to.match(/"ember-welcome-page"/);
-
-      expect(file('app/templates/application.hbs')).to.contain('Welcome to Ember');
-    })
-  );
-
-  it(
-    'ember new npm blueprint with old version',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm', '--skip-bower']);
-
-      expect(dir('src')).to.exist;
-    })
-  );
-
-  it(
-    'ember new foo, where foo does not yet exist, works',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower']);
-
-      confirmBlueprintedForDir('blueprints/app');
-    })
-  );
-
-  it(
-    'ember new foo, blueprint targets match the default ember-cli targets',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower']);
-
-      process.env.CI = true;
-      const defaultTargets = require('../../lib/utilities/default-targets').browsers;
-      const blueprintTargets = require(path.resolve('config/targets.js')).browsers;
-      expect(blueprintTargets).to.have.same.deep.members(defaultTargets);
-    })
-  );
-
-  it(
-    'ember new with empty app name fails with a warning',
-    co.wrap(function*() {
-      let err = yield expect(ember(['new', ''])).to.be.rejected;
-
-      expect(err.name).to.equal('SilentError');
-      expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
-    })
-  );
-
-  it(
-    'ember new without app name fails with a warning',
-    co.wrap(function*() {
-      let err = yield expect(ember(['new'])).to.be.rejected;
-
-      expect(err.name).to.equal('SilentError');
-      expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
-    })
-  );
-
-  it(
-    'ember new with app name creates new directory and has a dasherized package name',
-    co.wrap(function*() {
-      yield ember(['new', 'FooApp', '--skip-npm', '--skip-bower', '--skip-git']);
-
-      expect(dir('FooApp')).to.not.exist;
-      expect(file('package.json')).to.exist;
-
-      let pkgJson = fs.readJsonSync('package.json');
-      expect(pkgJson.name).to.equal('foo-app');
-    })
-  );
-
-  it(
-    'Can create new ember project in an existing empty directory',
-    co.wrap(function*() {
-      fs.mkdirsSync('bar');
-
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
-    })
-  );
-
-  it(
-    'Cannot create new ember project in a populated directory',
-    co.wrap(function*() {
-      fs.mkdirsSync('bar');
-      fs.writeFileSync(path.join('bar', 'package.json'), '{}');
-
-      let error = yield expect(ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar'])).to
-        .be.rejected;
-
-      expect(error.name).to.equal('SilentError');
-      expect(error.message).to.equal("Directory 'bar' already exists.");
-    })
-  );
-
-  it(
-    'Cannot run ember new, inside of ember-cli project',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
-
-      let error = yield expect(ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git'])).to.be.rejected;
-
-      expect(dir('foo')).to.not.exist;
-      expect(error.name).to.equal('SilentError');
-      expect(error.message).to.equal(`You cannot use the ${chalk.green('new')} command inside an ember-cli project.`);
-
-      confirmBlueprintedForDir('blueprints/app');
-    })
-  );
-
-  it(
-    'ember new with blueprint uses the specified blueprint directory with a relative path',
-    co.wrap(function*() {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/files/gitignore');
-
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
-
-      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-    })
-  );
-
-  it(
-    'ember new with blueprint uses the specified blueprint directory with an absolute path',
-    co.wrap(function*() {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/files/gitignore');
-
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
-      ]);
-
-      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-    })
-  );
-
-  it(
-    'ember new with git blueprint checks out the blueprint and uses it',
-    co.wrap(function*() {
-      this.timeout(20000); // relies on GH network stuff
-
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
-      ]);
-
-      expect(file('.ember-cli')).to.exist;
-    })
-  );
-
-  it(
-    'ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it',
-    co.wrap(function*() {
-      this.timeout(20000); // relies on GH network stuff
-
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
-      ]);
-
-      expect(file('.named-ref')).to.exist;
-    })
-  );
-
-  it(
-    'ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it',
-    co.wrap(function*() {
-      this.timeout(20000); // relies on GH network stuff
-
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--blueprint=ember-cli/app-blueprint-test#named-ref',
-      ]);
-
-      expect(file('.named-ref')).to.exist;
-    })
-  );
-
-  it(
-    'ember new passes blueprint options through to blueprint',
-    co.wrap(function*() {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync(
-        'my_blueprint/index.js',
-        [
-          'module.exports = {',
-          "  availableOptions: [ { name: 'custom-option' } ],",
-          '  locals(options) {',
-          '    return {',
-          '      customOption: options.customOption',
-          '    };',
-          '  }',
-          '};',
-        ].join('\n')
-      );
-      fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
-
-      yield ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-bower',
-        '--skip-git',
-        '--blueprint=./my_blueprint',
-        '--custom-option=customValue',
-      ]);
-
-      expect(file('.gitignore')).to.contain('customValue');
-    })
-  );
-
-  it(
-    'ember new uses yarn when blueprint has yarn.lock',
-    co.wrap(function*() {
-      if (!hasGlobalYarn) {
-        this.skip();
-      }
-
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
-      fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "fs-extra": "*" }}');
-      fs.writeFileSync('my_blueprint/files/yarn.lock', '');
-
-      yield ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
-
-      expect(file('yarn.lock')).to.not.be.empty;
-      expect(dir('node_modules/fs-extra')).to.not.be.empty;
-    })
-  );
-
-  it(
-    'ember new without skip-git flag creates .git dir',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower'], {
-        skipGit: false,
-      });
-
-      expect(dir('.git')).to.exist;
-    })
-  );
-
-  it(
-    'ember new cleans up after itself on error',
-    co.wrap(function*() {
-      fs.mkdirsSync('my_blueprint');
-      fs.writeFileSync('my_blueprint/index.js', 'throw("this will break");');
-
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
-
-      expect(dir('foo')).to.not.exist;
-    })
-  );
-
-  it(
-    'ember new with --dry-run does not create new directory',
-    co.wrap(function*() {
-      yield ember(['new', 'foo', '--dry-run']);
-
-      expect(process.cwd()).to.not.match(/foo/, 'does not change cwd to foo in a dry run');
-      expect(dir('foo')).to.not.exist;
-      expect(dir('.git')).to.not.exist;
-    })
-  );
-
-  it(
-    'ember new with --directory uses given directory name and has correct package name',
-    co.wrap(function*() {
-      let workdir = process.cwd();
-
-      yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
-
-      expect(dir(path.join(workdir, 'foo'))).to.not.exist;
-      expect(dir(path.join(workdir, 'bar'))).to.exist;
-
-      let cwd = process.cwd();
-      expect(cwd).to.not.match(/foo/, 'does not use app name for directory name');
-      expect(cwd).to.match(/bar/, 'uses given directory name');
-
-      let pkgJson = fs.readJsonSync('package.json');
-      expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
-    })
-  );
-
-  it(
-    'ember addon with --directory uses given directory name and has correct package name',
-    co.wrap(function*() {
-      let workdir = process.cwd();
-
-      yield ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
-
-      expect(dir(path.join(workdir, 'foo'))).to.not.exist;
-      expect(dir(path.join(workdir, 'bar'))).to.exist;
-
-      let cwd = process.cwd();
-      expect(cwd).to.not.match(/foo/, 'does not use addon name for directory name');
-      expect(cwd).to.match(/bar/, 'uses given directory name');
-
-      let pkgJson = fs.readJsonSync('package.json');
-      expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
-    })
-  );
+  it('ember new adds ember-welcome-page by default', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
+
+    expect(file('package.json')).to.match(/"ember-welcome-page"/);
+
+    expect(file('app/templates/application.hbs')).to.contain('<WelcomePage />');
+  });
+
+  it('ember new --no-welcome skips installation of ember-welcome-page', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--no-welcome']);
+
+    expect(file('package.json')).not.to.match(/"ember-welcome-page"/);
+
+    expect(file('app/templates/application.hbs')).to.contain('Welcome to Ember');
+  });
+
+  it('ember new npm blueprint with old version', async function() {
+    await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm', '--skip-bower']);
+
+    expect(dir('src')).to.exist;
+  });
+
+  it('ember new foo, where foo does not yet exist, works', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower']);
+
+    confirmBlueprintedForDir('blueprints/app');
+  });
+
+  it('ember new foo, blueprint targets match the default ember-cli targets', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower']);
+
+    process.env.CI = true;
+    const defaultTargets = require('../../lib/utilities/default-targets').browsers;
+    const blueprintTargets = require(path.resolve('config/targets.js')).browsers;
+    expect(blueprintTargets).to.have.same.deep.members(defaultTargets);
+  });
+
+  it('ember new with empty app name fails with a warning', async function() {
+    let err = await expect(ember(['new', ''])).to.be.rejected;
+
+    expect(err.name).to.equal('SilentError');
+    expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
+  });
+
+  it('ember new without app name fails with a warning', async function() {
+    let err = await expect(ember(['new'])).to.be.rejected;
+
+    expect(err.name).to.equal('SilentError');
+    expect(err.message).to.contain('The `ember new` command requires a name to be specified.');
+  });
+
+  it('ember new with app name creates new directory and has a dasherized package name', async function() {
+    await ember(['new', 'FooApp', '--skip-npm', '--skip-bower', '--skip-git']);
+
+    expect(dir('FooApp')).to.not.exist;
+    expect(file('package.json')).to.exist;
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('foo-app');
+  });
+
+  it('Can create new ember project in an existing empty directory', async function() {
+    fs.mkdirsSync('bar');
+
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
+  });
+
+  it('Cannot create new ember project in a populated directory', async function() {
+    fs.mkdirsSync('bar');
+    fs.writeFileSync(path.join('bar', 'package.json'), '{}');
+
+    let error = await expect(ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar'])).to.be
+      .rejected;
+
+    expect(error.name).to.equal('SilentError');
+    expect(error.message).to.equal("Directory 'bar' already exists.");
+  });
+
+  it('Cannot run ember new, inside of ember-cli project', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
+
+    let error = await expect(ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git'])).to.be.rejected;
+
+    expect(dir('foo')).to.not.exist;
+    expect(error.name).to.equal('SilentError');
+    expect(error.message).to.equal(`You cannot use the ${chalk.green('new')} command inside an ember-cli project.`);
+
+    confirmBlueprintedForDir('blueprints/app');
+  });
+
+  it('ember new with blueprint uses the specified blueprint directory with a relative path', async function() {
+    fs.mkdirsSync('my_blueprint/files');
+    fs.writeFileSync('my_blueprint/files/gitignore');
+
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
+
+    confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+  });
+
+  it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function() {
+    fs.mkdirsSync('my_blueprint/files');
+    fs.writeFileSync('my_blueprint/files/gitignore');
+
+    await ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
+    ]);
+
+    confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+  });
+
+  it('ember new with git blueprint checks out the blueprint and uses it', async function() {
+    this.timeout(20000); // relies on GH network stuff
+
+    await ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
+    ]);
+
+    expect(file('.ember-cli')).to.exist;
+  });
+
+  it('ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it', async function() {
+    this.timeout(20000); // relies on GH network stuff
+
+    await ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
+    ]);
+
+    expect(file('.named-ref')).to.exist;
+  });
+
+  it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function() {
+    this.timeout(20000); // relies on GH network stuff
+
+    await ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--blueprint=ember-cli/app-blueprint-test#named-ref',
+    ]);
+
+    expect(file('.named-ref')).to.exist;
+  });
+
+  it('ember new passes blueprint options through to blueprint', async function() {
+    fs.mkdirsSync('my_blueprint/files');
+    fs.writeFileSync(
+      'my_blueprint/index.js',
+      [
+        'module.exports = {',
+        "  availableOptions: [ { name: 'custom-option' } ],",
+        '  locals(options) {',
+        '    return {',
+        '      customOption: options.customOption',
+        '    };',
+        '  }',
+        '};',
+      ].join('\n')
+    );
+    fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
+
+    await ember([
+      'new',
+      'foo',
+      '--skip-npm',
+      '--skip-bower',
+      '--skip-git',
+      '--blueprint=./my_blueprint',
+      '--custom-option=customValue',
+    ]);
+
+    expect(file('.gitignore')).to.contain('customValue');
+  });
+
+  it('ember new uses yarn when blueprint has yarn.lock', async function() {
+    if (!hasGlobalYarn) {
+      this.skip();
+    }
+
+    fs.mkdirsSync('my_blueprint/files');
+    fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
+    fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "fs-extra": "*" }}');
+    fs.writeFileSync('my_blueprint/files/yarn.lock', '');
+
+    await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
+
+    expect(file('yarn.lock')).to.not.be.empty;
+    expect(dir('node_modules/fs-extra')).to.not.be.empty;
+  });
+
+  it('ember new without skip-git flag creates .git dir', async function() {
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower'], {
+      skipGit: false,
+    });
+
+    expect(dir('.git')).to.exist;
+  });
+
+  it('ember new cleans up after itself on error', async function() {
+    fs.mkdirsSync('my_blueprint');
+    fs.writeFileSync('my_blueprint/index.js', 'throw("this will break");');
+
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
+
+    expect(dir('foo')).to.not.exist;
+  });
+
+  it('ember new with --dry-run does not create new directory', async function() {
+    await ember(['new', 'foo', '--dry-run']);
+
+    expect(process.cwd()).to.not.match(/foo/, 'does not change cwd to foo in a dry run');
+    expect(dir('foo')).to.not.exist;
+    expect(dir('.git')).to.not.exist;
+  });
+
+  it('ember new with --directory uses given directory name and has correct package name', async function() {
+    let workdir = process.cwd();
+
+    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
+
+    expect(dir(path.join(workdir, 'foo'))).to.not.exist;
+    expect(dir(path.join(workdir, 'bar'))).to.exist;
+
+    let cwd = process.cwd();
+    expect(cwd).to.not.match(/foo/, 'does not use app name for directory name');
+    expect(cwd).to.match(/bar/, 'uses given directory name');
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
+  });
+
+  it('ember addon with --directory uses given directory name and has correct package name', async function() {
+    let workdir = process.cwd();
+
+    await ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--directory=bar']);
+
+    expect(dir(path.join(workdir, 'foo'))).to.not.exist;
+    expect(dir(path.join(workdir, 'bar'))).to.exist;
+
+    let cwd = process.cwd();
+    expect(cwd).to.not.match(/foo/, 'does not use addon name for directory name');
+    expect(cwd).to.match(/bar/, 'uses given directory name');
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
+  });
 
   describe('verify fixtures', function() {
     function checkEslintConfig(fixturePath) {
@@ -409,98 +337,83 @@ describe('Acceptance: ember new', function() {
       expect(file('package.json')).to.equal(fixtureContents);
     }
 
-    it(
-      'app + npm + !welcome',
-      co.wrap(function*() {
-        yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--no-welcome']);
+    it('app + npm + !welcome', async function() {
+      await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--no-welcome']);
 
-        let namespace = 'app';
-        let fixturePath = `${namespace}/npm`;
+      let namespace = 'app';
+      let fixturePath = `${namespace}/npm`;
 
-        ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
-          expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-        });
+      ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
+        expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+      });
 
-        checkPackageJson(fixturePath);
+      checkPackageJson(fixturePath);
 
-        // option independent, but piggy-backing on an existing generate for speed
-        checkEslintConfig(namespace);
-      })
-    );
+      // option independent, but piggy-backing on an existing generate for speed
+      checkEslintConfig(namespace);
+    });
 
-    it(
-      'app + yarn + welcome',
-      co.wrap(function*() {
-        yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn']);
+    it('app + yarn + welcome', async function() {
+      await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn']);
 
-        let fixturePath = 'app/yarn';
+      let fixturePath = 'app/yarn';
 
-        ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
-          expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-        });
+      ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
+        expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+      });
 
-        checkPackageJson(fixturePath);
-      })
-    );
+      checkPackageJson(fixturePath);
+    });
 
-    it(
-      'addon + yarn + welcome',
-      co.wrap(function*() {
-        yield ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn', '--welcome']);
+    it('addon + yarn + welcome', async function() {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn', '--welcome']);
 
-        let fixturePath = 'addon/yarn';
+      let fixturePath = 'addon/yarn';
 
-        [
-          'config/ember-try.js',
-          'tests/dummy/app/templates/application.hbs',
-          '.travis.yml',
-          'README.md',
-          'CONTRIBUTING.md',
-        ].forEach(filePath => {
-          expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-        });
+      [
+        'config/ember-try.js',
+        'tests/dummy/app/templates/application.hbs',
+        '.travis.yml',
+        'README.md',
+        'CONTRIBUTING.md',
+      ].forEach(filePath => {
+        expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+      });
 
-        checkPackageJson(fixturePath);
-      })
-    );
+      checkPackageJson(fixturePath);
+    });
 
-    it(
-      'addon + npm + !welcome',
-      co.wrap(function*() {
-        yield ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
+    it('addon + npm + !welcome', async function() {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-bower', '--skip-git']);
 
-        let namespace = 'addon';
-        let fixturePath = `${namespace}/npm`;
+      let namespace = 'addon';
+      let fixturePath = `${namespace}/npm`;
 
-        [
-          'config/ember-try.js',
-          'tests/dummy/app/templates/application.hbs',
-          '.travis.yml',
-          'README.md',
-          'CONTRIBUTING.md',
-        ].forEach(filePath => {
-          expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
-        });
+      [
+        'config/ember-try.js',
+        'tests/dummy/app/templates/application.hbs',
+        '.travis.yml',
+        'README.md',
+        'CONTRIBUTING.md',
+      ].forEach(filePath => {
+        expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
+      });
 
-        checkPackageJson(fixturePath);
+      checkPackageJson(fixturePath);
 
-        // option independent, but piggy-backing on an existing generate for speed
-        checkEslintConfig(namespace);
-      })
-    );
+      // option independent, but piggy-backing on an existing generate for speed
+      checkEslintConfig(namespace);
+    });
   });
 
   describe('verify dependencies', function() {
-    it(
-      'are locked down for pre-1.0 versions',
-      co.wrap(function*() {
-        yield ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn', '--welcome']);
+    it('are locked down for pre-1.0 versions', async function() {
+      await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--yarn', '--welcome']);
 
-        let pkg = fs.readJsonSync('package.json');
+      let pkg = fs.readJsonSync('package.json');
 
-        assertVersionLock(pkg.dependencies);
-        assertVersionLock(pkg.devDependencies);
-      })
-    );
+      assertVersionLock(pkg.dependencies);
+      assertVersionLock(pkg.devDependencies);
+    });
   });
 });

--- a/tests/acceptance/pods-generate-test.js
+++ b/tests/acceptance/pods-generate-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const RSVP = require('rsvp');
 const ember = require('../helpers/ember');
 const replaceFile = require('ember-cli-internal-test-helpers/lib/helpers/file-utils').replaceFile;
@@ -32,12 +31,10 @@ describe('Acceptance: ember generate pod', function() {
     BlueprintNpmTask.restoreNPM(Blueprint);
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      tmpdir = yield mkTmpDirIn(tmproot);
-      process.chdir(tmpdir);
-    })
-  );
+  beforeEach(async function() {
+    tmpdir = await mkTmpDirIn(tmproot);
+    process.chdir(tmpdir);
+  });
 
   afterEach(function() {
     process.chdir(root);
@@ -71,296 +68,266 @@ describe('Acceptance: ember generate pod', function() {
     });
   }
 
-  it(
-    'blueprint foo --pod',
-    co.wrap(function*() {
-      yield generate(['blueprint', 'foo', '--pod']);
+  it('blueprint foo --pod', async function() {
+    await generate(['blueprint', 'foo', '--pod']);
 
-      expect(file('blueprints/foo/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'blueprint foo/bar --pod',
-    co.wrap(function*() {
-      yield generate(['blueprint', 'foo/bar', '--pod']);
+  it('blueprint foo/bar --pod', async function() {
+    await generate(['blueprint', 'foo/bar', '--pod']);
 
-      expect(file('blueprints/foo/bar/index.js')).to.contain(
-        'module.exports = {\n' +
-          "  description: ''\n" +
-          '\n' +
-          '  // locals(options) {\n' +
-          '  //   // Return custom template variables here.\n' +
-          '  //   return {\n' +
-          '  //     foo: options.entity.options.foo\n' +
-          '  //   };\n' +
-          '  // }\n' +
-          '\n' +
-          '  // afterInstall(options) {\n' +
-          '  //   // Perform extra work here.\n' +
-          '  // }\n' +
-          '};'
-      );
-    })
-  );
+    expect(file('blueprints/foo/bar/index.js')).to.contain(
+      'module.exports = {\n' +
+        "  description: ''\n" +
+        '\n' +
+        '  // locals(options) {\n' +
+        '  //   // Return custom template variables here.\n' +
+        '  //   return {\n' +
+        '  //     foo: options.entity.options.foo\n' +
+        '  //   };\n' +
+        '  // }\n' +
+        '\n' +
+        '  // afterInstall(options) {\n' +
+        '  //   // Perform extra work here.\n' +
+        '  // }\n' +
+        '};'
+    );
+  });
 
-  it(
-    'http-mock foo --pod',
-    co.wrap(function*() {
-      yield generate(['http-mock', 'foo', '--pod']);
+  it('http-mock foo --pod', async function() {
+    await generate(['http-mock', 'foo', '--pod']);
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
 
-      expect(file('server/mocks/foo.js')).to.contain(
+    expect(file('server/mocks/foo.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooRouter = express.Router();\n' +
+        '\n' +
+        "  fooRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo', require('body-parser').json());\n" +
+        "  app.use('/api/foo', fooRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('http-mock foo-bar --pod', async function() {
+    await generate(['http-mock', 'foo-bar', '--pod']);
+
+    expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+
+    expect(file('server/mocks/foo-bar.js')).to.contain(
+      'module.exports = function(app) {\n' +
+        "  const express = require('express');\n" +
+        '  let fooBarRouter = express.Router();\n' +
+        '\n' +
+        "  fooBarRouter.get('/', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': []\n" +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.post('/', function(req, res) {\n" +
+        '    res.status(201).end();\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.get('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.put('/:id', function(req, res) {\n" +
+        '    res.send({\n' +
+        "      'foo-bar': {\n" +
+        '        id: req.params.id\n' +
+        '      }\n' +
+        '    });\n' +
+        '  });\n' +
+        '\n' +
+        "  fooBarRouter.delete('/:id', function(req, res) {\n" +
+        '    res.status(204).end();\n' +
+        '  });\n' +
+        '\n' +
+        '  // The POST and PUT call will not contain a request body\n' +
+        '  // because the body-parser is not included by default.\n' +
+        '  // To use req.body, run:\n' +
+        '\n' +
+        '  //    npm install --save-dev body-parser\n' +
+        '\n' +
+        '  // After installing, you need to `use` the body-parser for\n' +
+        '  // this mock uncommenting the following line:\n' +
+        '  //\n' +
+        "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
+        "  app.use('/api/foo-bar', fooBarRouter);\n" +
+        '};'
+    );
+
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
+
+  it('http-proxy foo --pod', async function() {
+    await generate(['http-proxy', 'foo', 'http://localhost:5000', '--pod']);
+
+    expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+
+    expect(file('server/proxies/foo.js')).to.contain(
+      "const proxyPath = '/foo';\n" +
+        '\n' +
         'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooRouter = express.Router();\n' +
-          '\n' +
-          "  fooRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo', require('body-parser').json());\n" +
-          "  app.use('/api/foo', fooRouter);\n" +
-          '};'
-      );
+        '  // For options, see:\n' +
+        '  // https://github.com/nodejitsu/node-http-proxy\n' +
+        "  let proxy = require('http-proxy').createProxyServer({});\n" +
+        '\n' +
+        "  proxy.on('error', function(err, req) {\n" +
+        '    console.error(err, req.url);\n' +
+        '  });\n' +
+        '\n' +
+        '  app.use(proxyPath, function(req, res, next){\n' +
+        '    // include root path in proxied request\n' +
+        "    req.url = proxyPath + '/' + req.url;\n" +
+        "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
+        '  });\n' +
+        '};'
+    );
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
+  });
 
-  it(
-    'http-mock foo-bar --pod',
-    co.wrap(function*() {
-      yield generate(['http-mock', 'foo-bar', '--pod']);
+  it('uses blueprints from the project directory', async function() {
+    await initApp();
+    await outputFile(
+      'blueprints/foo/files/app/foos/__name__.js',
+      "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
+    );
 
-      expect(file('server/index.js')).to.contain('mocks.forEach(route => route(app));');
+    await ember(['generate', 'foo', 'bar', '--pod']);
 
-      expect(file('server/mocks/foo-bar.js')).to.contain(
-        'module.exports = function(app) {\n' +
-          "  const express = require('express');\n" +
-          '  let fooBarRouter = express.Router();\n' +
-          '\n' +
-          "  fooBarRouter.get('/', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': []\n" +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.post('/', function(req, res) {\n" +
-          '    res.status(201).end();\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.get('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.put('/:id', function(req, res) {\n" +
-          '    res.send({\n' +
-          "      'foo-bar': {\n" +
-          '        id: req.params.id\n' +
-          '      }\n' +
-          '    });\n' +
-          '  });\n' +
-          '\n' +
-          "  fooBarRouter.delete('/:id', function(req, res) {\n" +
-          '    res.status(204).end();\n' +
-          '  });\n' +
-          '\n' +
-          '  // The POST and PUT call will not contain a request body\n' +
-          '  // because the body-parser is not included by default.\n' +
-          '  // To use req.body, run:\n' +
-          '\n' +
-          '  //    npm install --save-dev body-parser\n' +
-          '\n' +
-          '  // After installing, you need to `use` the body-parser for\n' +
-          '  // this mock uncommenting the following line:\n' +
-          '  //\n' +
-          "  //app.use('/api/foo-bar', require('body-parser').json());\n" +
-          "  app.use('/api/foo-bar', fooBarRouter);\n" +
-          '};'
-      );
+    expect(file('app/foos/bar.js')).to.contain('foo: true');
+  });
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+  it('allows custom blueprints to override built-ins', async function() {
+    await initApp();
+    await outputFile(
+      'blueprints/controller/files/app/__path__/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
+    );
 
-  it(
-    'http-proxy foo --pod',
-    co.wrap(function*() {
-      yield generate(['http-proxy', 'foo', 'http://localhost:5000', '--pod']);
+    await ember(['generate', 'controller', 'foo', '--pod']);
 
-      expect(file('server/index.js')).to.contain('proxies.forEach(route => route(app));');
+    expect(file('app/foo/controller.js')).to.contain('custom: true');
+  });
 
-      expect(file('server/proxies/foo.js')).to.contain(
-        "const proxyPath = '/foo';\n" +
-          '\n' +
-          'module.exports = function(app) {\n' +
-          '  // For options, see:\n' +
-          '  // https://github.com/nodejitsu/node-http-proxy\n' +
-          "  let proxy = require('http-proxy').createProxyServer({});\n" +
-          '\n' +
-          "  proxy.on('error', function(err, req) {\n" +
-          '    console.error(err, req.url);\n' +
-          '  });\n' +
-          '\n' +
-          '  app.use(proxyPath, function(req, res, next){\n' +
-          '    // include root path in proxied request\n' +
-          "    req.url = proxyPath + '/' + req.url;\n" +
-          "    proxy.web(req, res, { target: 'http://localhost:5000' });\n" +
-          '  });\n' +
-          '};'
-      );
+  it('passes custom cli arguments to blueprint options', async function() {
+    await initApp();
+    await outputFile(
+      'blueprints/customblue/files/app/__name__.js',
+      'Q: Can I has custom command? A: <%= hasCustomCommand %>'
+    );
 
-      expect(file('server/.jshintrc')).to.contain('{\n  "node": true\n}');
-    })
-  );
+    await outputFile(
+      'blueprints/customblue/index.js',
+      'module.exports = {\n' +
+        '  fileMapTokens(options) {\n' +
+        '    return {\n' +
+        '      __name__(options) {\n' +
+        '         return options.dasherizedModuleName;\n' +
+        '      }\n' +
+        '    };\n' +
+        '  },\n' +
+        '  locals(options) {\n' +
+        '    var loc = {};\n' +
+        "    loc.hasCustomCommand = (options.customCommand) ? 'Yes!' : 'No. :C';\n" +
+        '    return loc;\n' +
+        '  },\n' +
+        '};\n'
+    );
 
-  it(
-    'uses blueprints from the project directory',
-    co.wrap(function*() {
-      yield initApp();
-      yield outputFile(
-        'blueprints/foo/files/app/foos/__name__.js',
-        "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
-      );
+    await ember(['generate', 'customblue', 'foo', '--custom-command', '--pod']);
 
-      yield ember(['generate', 'foo', 'bar', '--pod']);
+    expect(file('app/foo.js')).to.contain('A: Yes!');
+  });
 
-      expect(file('app/foos/bar.js')).to.contain('foo: true');
-    })
-  );
+  it('correctly identifies the root of the project', async function() {
+    await initApp();
+    await outputFile(
+      'blueprints/controller/files/app/__path__/__name__.js',
+      "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
+    );
 
-  it(
-    'allows custom blueprints to override built-ins',
-    co.wrap(function*() {
-      yield initApp();
-      yield outputFile(
-        'blueprints/controller/files/app/__path__/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
-      );
+    process.chdir(path.join(tmpdir, 'app'));
+    await ember(['generate', 'controller', 'foo', '--pod']);
 
-      yield ember(['generate', 'controller', 'foo', '--pod']);
-
-      expect(file('app/foo/controller.js')).to.contain('custom: true');
-    })
-  );
-
-  it(
-    'passes custom cli arguments to blueprint options',
-    co.wrap(function*() {
-      yield initApp();
-      yield outputFile(
-        'blueprints/customblue/files/app/__name__.js',
-        'Q: Can I has custom command? A: <%= hasCustomCommand %>'
-      );
-
-      yield outputFile(
-        'blueprints/customblue/index.js',
-        'module.exports = {\n' +
-          '  fileMapTokens(options) {\n' +
-          '    return {\n' +
-          '      __name__(options) {\n' +
-          '         return options.dasherizedModuleName;\n' +
-          '      }\n' +
-          '    };\n' +
-          '  },\n' +
-          '  locals(options) {\n' +
-          '    var loc = {};\n' +
-          "    loc.hasCustomCommand = (options.customCommand) ? 'Yes!' : 'No. :C';\n" +
-          '    return loc;\n' +
-          '  },\n' +
-          '};\n'
-      );
-
-      yield ember(['generate', 'customblue', 'foo', '--custom-command', '--pod']);
-
-      expect(file('app/foo.js')).to.contain('A: Yes!');
-    })
-  );
-
-  it(
-    'correctly identifies the root of the project',
-    co.wrap(function*() {
-      yield initApp();
-      yield outputFile(
-        'blueprints/controller/files/app/__path__/__name__.js',
-        "import Ember from 'ember';\n\n" + 'export default Ember.Controller.extend({ custom: true });\n'
-      );
-
-      process.chdir(path.join(tmpdir, 'app'));
-      yield ember(['generate', 'controller', 'foo', '--pod']);
-
-      process.chdir(tmpdir);
-      expect(file('app/foo/controller.js')).to.contain('custom: true');
-    })
-  );
+    process.chdir(tmpdir);
+    expect(file('app/foo/controller.js')).to.contain('custom: true');
+  });
 
   // Skip until podModulePrefix is deprecated
-  it.skip(
-    'podModulePrefix deprecation warning',
-    co.wrap(function*() {
-      let result = yield generateWithPrefix(['controller', 'foo', '--pod']);
+  it.skip('podModulePrefix deprecation warning', async function() {
+    let result = await generateWithPrefix(['controller', 'foo', '--pod']);
 
-      expect(result.outputStream.join()).to.include(
-        '`podModulePrefix` is deprecated and will be' +
-          ' removed from future versions of ember-cli. Please move existing pods from' +
-          " 'app/pods/' to 'app/'."
-      );
-    })
-  );
+    expect(result.outputStream.join()).to.include(
+      '`podModulePrefix` is deprecated and will be' +
+        ' removed from future versions of ember-cli. Please move existing pods from' +
+        " 'app/pods/' to 'app/'."
+    );
+  });
 });

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -40,61 +39,52 @@ describe('Acceptance: preprocessor-smoke-test', function() {
   });
 
   if (!isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'addons with standard preprocessors compile correctly',
-      co.wrap(function*() {
-        yield copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors`);
+    it('addons with standard preprocessors compile correctly', async function() {
+      await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors`);
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-cli-sass'] = 'latest';
-        packageJson.devDependencies['ember-cool-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
-        expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
-      })
-    );
+      expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
+      expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
+    });
 
-    it(
-      'addon registry entries are added in the proper order',
-      co.wrap(function*() {
-        yield copyFixtureFiles(`preprocessor-tests/app-registry-ordering`);
+    it('addon registry entries are added in the proper order', async function() {
+      await copyFixtureFiles(`preprocessor-tests/app-registry-ordering`);
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
-        packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['first-dummy-preprocessor'] = 'latest';
+      packageJson.devDependencies['second-dummy-preprocessor'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/some-cool-app.js'))
-          .to.contain('replacedByPreprocessor', 'token should have been replaced in app bundle')
-          .to.not.contain('__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained')
-          .to.not.contain('__FIRST_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained');
-      })
-    );
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('replacedByPreprocessor', 'token should have been replaced in app bundle')
+        .to.not.contain('__SECOND_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained')
+        .to.not.contain('__FIRST_PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not be contained');
+    });
 
-    it(
-      'addons without preprocessors compile correctly',
-      co.wrap(function*() {
-        yield copyFixtureFiles(`preprocessor-tests/app-with-addon-without-preprocessors`);
+    it('addons without preprocessors compile correctly', async function() {
+      await copyFixtureFiles(`preprocessor-tests/app-with-addon-without-preprocessors`);
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-cli-sass'] = 'latest';
-        packageJson.devDependencies['ember-cool-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cli-sass'] = 'latest';
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
-        expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
-      })
-    );
+      expect(file('dist/assets/some-cool-app.css')).to.contain('app styles included');
+      expect(file('dist/assets/vendor.css')).to.contain('addon styles included');
+    });
 
     /*
     [ app ]  -> [ addon ] -> [ preprocessor addon ]
@@ -103,27 +93,24 @@ describe('Acceptance: preprocessor-smoke-test', function() {
       |
       |-- preprocessor should not apply to this
   */
-    it(
-      'addons depending on preprocessor addon preprocesses addon but not app',
-      co.wrap(function*() {
-        yield copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-2`);
+    it('addons depending on preprocessor addon preprocesses addon but not app', async function() {
+      await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-2`);
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-cool-addon'] = 'latest';
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-cool-addon'] = 'latest';
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/some-cool-app.js'))
-          .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
-          .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
+        .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
 
-        expect(file('dist/assets/vendor.js'))
-          .to.contain('replacedByPreprocessor', 'token should have been replaced in vendor bundle')
-          .to.not.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in vendor bundle');
-      })
-    );
+      expect(file('dist/assets/vendor.js'))
+        .to.contain('replacedByPreprocessor', 'token should have been replaced in vendor bundle')
+        .to.not.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in vendor bundle');
+    });
 
     /*
     [ app ]  -> [ addon ] ->  [ addon ] -> [ preprocessor addon ]
@@ -134,38 +121,32 @@ describe('Acceptance: preprocessor-smoke-test', function() {
       |
       |-- preprocessor should not apply to this
   */
-    it(
-      'addon N levels deep depending on preprocessor preprocesses that parent addon only',
-      co.wrap(function*() {
-        yield copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-3`);
+    it('addon N levels deep depending on preprocessor preprocesses that parent addon only', async function() {
+      await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-3`);
 
-        let packageJsonPath = path.join(appRoot, 'package.json');
-        let packageJson = fs.readJsonSync(packageJsonPath);
-        packageJson.devDependencies['ember-shallow-addon'] = 'latest';
+      let packageJsonPath = path.join(appRoot, 'package.json');
+      let packageJson = fs.readJsonSync(packageJsonPath);
+      packageJson.devDependencies['ember-shallow-addon'] = 'latest';
 
-        fs.writeJsonSync(packageJsonPath, packageJson);
+      fs.writeJsonSync(packageJsonPath, packageJson);
 
-        yield runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
+      await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
-        expect(file('dist/assets/some-cool-app.js'))
-          .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
-          .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
+      expect(file('dist/assets/some-cool-app.js'))
+        .to.contain('__PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should not have been replaced in app bundle')
+        .to.not.contain('replacedByPreprocessor', 'token should not have been replaced in app bundle');
 
-        expect(file('dist/assets/vendor.js'))
-          .to.contain('deep: "replacedByPreprocessor"', 'token should have been replaced in deep component')
-          .to.contain(
-            'shallow: __PREPROCESSOR_REPLACEMENT_TOKEN__',
-            'token should not have been replaced in shallow component'
-          )
-          .to.not.contain(
-            'deep: __PREPROCESSOR_REPLACEMENT_TOKEN__',
-            'token should have been replaced in deep component'
-          )
-          .to.not.contain(
-            'shallow: "replacedByPreprocessor"',
-            'token should not have been replaced in shallow component'
-          );
-      })
-    );
+      expect(file('dist/assets/vendor.js'))
+        .to.contain('deep: "replacedByPreprocessor"', 'token should have been replaced in deep component')
+        .to.contain(
+          'shallow: __PREPROCESSOR_REPLACEMENT_TOKEN__',
+          'token should not have been replaced in shallow component'
+        )
+        .to.not.contain('deep: __PREPROCESSOR_REPLACEMENT_TOKEN__', 'token should have been replaced in deep component')
+        .to.not.contain(
+          'shallow: "replacedByPreprocessor"',
+          'token should not have been replaced in shallow component'
+        );
+    });
   }
 });

--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -6,14 +6,14 @@ import { module, test } from 'qunit';
 module('Acceptance', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('renders properly', async function(assert) {
+  test('renders properly', async function (assert) {
     await visit('/');
 
     var element = this.element.querySelector('.basic-thing');
     assert.equal(element.textContent.trim(), 'WOOT!!');
   });
 
-  test('renders imported component', async function(assert) {
+  test('renders imported component', async function (assert) {
     await visit('/');
 
     var element = this.element.querySelector('.second-thing');

--- a/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 module('Acceptance', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('renders properly', async function(assert) {
+  test('renders properly', async function (assert) {
     await visit('/');
 
     var element = this.element.querySelector('.basic-thing');
@@ -14,7 +14,7 @@ module('Acceptance', function(hooks) {
     assert.ok(truthyHelper(), 'addon-test-support helper');
   });
 
-  test('renders imported component', async function(assert) {
+  test('renders imported component', async function (assert) {
     await visit('/');
 
     var element = this.element.querySelector('.second-thing');

--- a/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
+++ b/tests/fixtures/brocfile-tests/default-development/tests/integration/app-boots-test.js
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 module('default-development - Integration', function(hook) {
   setupApplicationTest(hooks);
 
-  test('renders properly', async function(assert) {
+  test('renders properly', async function (assert) {
     await visit('/');
 
     var elements = this.element.querySelectorAll('.ember-view');

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('pods based templates', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('the application boots properly with pods based templates', async function(assert) {
+  test('the application boots properly with pods based templates', async function (assert) {
     assert.expect(1);
 
     await visit('/');

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('pods based templates', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('the application boots properly with pods based templates with a podModulePrefix set', async function(assert) {
+  test('the application boots properly with pods based templates with a podModulePrefix set', async function (assert) {
     assert.expect(1);
 
     await visit('/');

--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const broccoliTestHelper = require('broccoli-test-helper');
 const expect = require('chai').expect;
 
@@ -14,236 +13,211 @@ const createTempDir = broccoliTestHelper.createTempDir;
 describe('Addon - linting', function() {
   let input, output, addon, lintTrees;
 
-  beforeEach(
-    co.wrap(function*() {
-      input = yield createTempDir();
-      let MockAddon = Addon.extend({
-        name: 'first',
-        root: input.path(),
-      });
-      lintTrees = [];
-      let cli = new MockCLI();
-      let pkg = { name: 'ember-app-test' };
+  beforeEach(async function() {
+    input = await createTempDir();
+    let MockAddon = Addon.extend({
+      name: 'first',
+      root: input.path(),
+    });
+    lintTrees = [];
+    let cli = new MockCLI();
+    let pkg = { name: 'ember-app-test' };
 
-      let project = new Project(input.path(), pkg, cli.ui, cli);
-      project.addons = [
-        {
-          name: 'fake-linter-addon',
-          lintTree(type, tree) {
-            lintTrees.push(tree);
-          },
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+    project.addons = [
+      {
+        name: 'fake-linter-addon',
+        lintTree(type, tree) {
+          lintTrees.push(tree);
         },
-      ];
+      },
+    ];
 
-      addon = new MockAddon(project, project);
-    })
-  );
+    addon = new MockAddon(project, project);
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield input.dispose();
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await input.dispose();
+    await output.dispose();
+  });
 
-  it(
-    'calls lintTree on project addons for app directory',
-    co.wrap(function*() {
-      input.write({
-        app: {
-          'derp.js': '// slerpy',
+  it('calls lintTree on project addons for app directory', async function() {
+    input.write({
+      app: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
+
+    output = await buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      app: {
+        'derp.js': '// slerpy',
+      },
+    });
+  });
+
+  it('calls lintTree on project addons for addon directory', async function() {
+    input.write({
+      addon: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
+
+    output = await buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    await output.dispose();
+
+    output = await buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {},
+      },
+    });
+  });
+
+  it('calls lintTree on project addons for addon directory with only templates', async function() {
+    input.write({
+      addon: {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
         },
-      });
+      },
+    });
 
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(1);
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
 
-      output = yield buildOutput(lintTrees[0]);
+    output = await buildOutput(lintTrees[0]);
 
-      expect(output.read()).to.deep.equal({
-        app: {
-          'derp.js': '// slerpy',
+    expect(output.read()).to.deep.equal({});
+
+    await output.dispose();
+
+    output = await buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
         },
-      });
-    })
-  );
+      },
+    });
+  });
 
-  it(
-    'calls lintTree on project addons for addon directory',
-    co.wrap(function*() {
-      input.write({
-        addon: {
-          'derp.js': '// slerpy',
+  it('calls lintTree on project addons for addon directory with templates', async function() {
+    input.write({
+      addon: {
+        'derp.js': '// slerpy',
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
         },
-      });
+      },
+    });
 
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(2);
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(2);
 
-      output = yield buildOutput(lintTrees[0]);
+    output = await buildOutput(lintTrees[0]);
 
-      expect(output.read()).to.deep.equal({
-        addon: {
-          'derp.js': '// slerpy',
+    expect(output.read()).to.deep.equal({
+      addon: {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    await output.dispose();
+
+    output = await buildOutput(lintTrees[1]);
+
+    expect(output.read()).to.deep.equal({
+      addon: {
+        templates: {
+          'foo.hbs': '{{huzzzah}}',
         },
-      });
+      },
+    });
+  });
 
-      yield output.dispose();
+  it('calls lintTree on project addons for addon-test-support directory', async function() {
+    input.write({
+      'addon-test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
 
-      output = yield buildOutput(lintTrees[1]);
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
 
-      expect(output.read()).to.deep.equal({
-        addon: {
-          templates: {},
+    output = await buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      'addon-test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+  });
+
+  it('calls lintTree on project addons for test-support directory', async function() {
+    input.write({
+      'test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+
+    addon.jshintAddonTree();
+    expect(lintTrees.length).to.equal(1);
+
+    output = await buildOutput(lintTrees[0]);
+
+    expect(output.read()).to.deep.equal({
+      'test-support': {
+        'derp.js': '// slerpy',
+      },
+    });
+  });
+
+  it('calls lintTree for trees in an addon', async function() {
+    addon.project.addons[0].lintTree = function(type, tree) {
+      return tree;
+    };
+    let addonRootContents = {
+      app: {
+        'app-foo.js': '// hoo-foo',
+      },
+      addon: {
+        'addon-bar.js': '// bar-dar',
+        templates: {
+          'addon-templates-quux.hbs': '{{! quux-books }}',
         },
-      });
-    })
-  );
+      },
+      'addon-test-support': {
+        'addon-test-support-baz.js': '// baz-jazz',
+      },
+      'test-support': {
+        'test-support-qux.js': '// qux-bucks',
+      },
+    };
+    input.write(addonRootContents);
 
-  it(
-    'calls lintTree on project addons for addon directory with only templates',
-    co.wrap(function*() {
-      input.write({
-        addon: {
-          templates: {
-            'foo.hbs': '{{huzzzah}}',
-          },
-        },
-      });
-
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(2);
-
-      output = yield buildOutput(lintTrees[0]);
-
-      expect(output.read()).to.deep.equal({});
-
-      yield output.dispose();
-
-      output = yield buildOutput(lintTrees[1]);
-
-      expect(output.read()).to.deep.equal({
-        addon: {
-          templates: {
-            'foo.hbs': '{{huzzzah}}',
-          },
-        },
-      });
-    })
-  );
-
-  it(
-    'calls lintTree on project addons for addon directory with templates',
-    co.wrap(function*() {
-      input.write({
-        addon: {
-          'derp.js': '// slerpy',
-          templates: {
-            'foo.hbs': '{{huzzzah}}',
-          },
-        },
-      });
-
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(2);
-
-      output = yield buildOutput(lintTrees[0]);
-
-      expect(output.read()).to.deep.equal({
-        addon: {
-          'derp.js': '// slerpy',
-        },
-      });
-
-      yield output.dispose();
-
-      output = yield buildOutput(lintTrees[1]);
-
-      expect(output.read()).to.deep.equal({
-        addon: {
-          templates: {
-            'foo.hbs': '{{huzzzah}}',
-          },
-        },
-      });
-    })
-  );
-
-  it(
-    'calls lintTree on project addons for addon-test-support directory',
-    co.wrap(function*() {
-      input.write({
-        'addon-test-support': {
-          'derp.js': '// slerpy',
-        },
-      });
-
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(1);
-
-      output = yield buildOutput(lintTrees[0]);
-
-      expect(output.read()).to.deep.equal({
-        'addon-test-support': {
-          'derp.js': '// slerpy',
-        },
-      });
-    })
-  );
-
-  it(
-    'calls lintTree on project addons for test-support directory',
-    co.wrap(function*() {
-      input.write({
-        'test-support': {
-          'derp.js': '// slerpy',
-        },
-      });
-
-      addon.jshintAddonTree();
-      expect(lintTrees.length).to.equal(1);
-
-      output = yield buildOutput(lintTrees[0]);
-
-      expect(output.read()).to.deep.equal({
-        'test-support': {
-          'derp.js': '// slerpy',
-        },
-      });
-    })
-  );
-
-  it(
-    'calls lintTree for trees in an addon',
-    co.wrap(function*() {
-      addon.project.addons[0].lintTree = function(type, tree) {
-        return tree;
-      };
-      let addonRootContents = {
-        app: {
-          'app-foo.js': '// hoo-foo',
-        },
-        addon: {
-          'addon-bar.js': '// bar-dar',
-          templates: {
-            'addon-templates-quux.hbs': '{{! quux-books }}',
-          },
-        },
-        'addon-test-support': {
-          'addon-test-support-baz.js': '// baz-jazz',
-        },
-        'test-support': {
-          'test-support-qux.js': '// qux-bucks',
-        },
-      };
-      input.write(addonRootContents);
-
-      output = yield buildOutput(addon.jshintAddonTree());
-      expect(output.read()).to.deep.equal({
-        first: {
-          tests: addonRootContents,
-        },
-      });
-    })
-  );
+    output = await buildOutput(addon.jshintAddonTree());
+    expect(output.read()).to.deep.equal({
+      first: {
+        tests: addonRootContents,
+      },
+    });
+  });
 });

--- a/tests/unit/broccoli/addon/module-name-test.js
+++ b/tests/unit/broccoli/addon/module-name-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const path = require('path');
 const broccoliTestHelper = require('broccoli-test-helper');
 const expect = require('chai').expect;
@@ -15,63 +14,56 @@ const createTempDir = broccoliTestHelper.createTempDir;
 describe('Addon - moduleName', function() {
   let input, output, addon;
 
-  beforeEach(
-    co.wrap(function*() {
-      input = yield createTempDir();
-      let MockAddon = Addon.extend({
-        root: input.path(),
-        name: 'fake-addon',
-        moduleName() {
-          return 'totes-not-fake-addon';
+  beforeEach(async function() {
+    input = await createTempDir();
+    let MockAddon = Addon.extend({
+      root: input.path(),
+      name: 'fake-addon',
+      moduleName() {
+        return 'totes-not-fake-addon';
+      },
+    });
+    let cli = new MockCLI();
+    let pkg = { name: 'ember-app-test' };
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+
+    addon = new MockAddon(project, project);
+
+    // override the registry so it just returns the input for everything
+    // and doesn't whine about not finding template preprocessors
+    addon.registry.load = () => [
+      {
+        toTree(t) {
+          return t;
         },
-      });
-      let cli = new MockCLI();
-      let pkg = { name: 'ember-app-test' };
-      let project = new Project(input.path(), pkg, cli.ui, cli);
+      },
+    ];
+  });
 
-      addon = new MockAddon(project, project);
+  afterEach(async function() {
+    await input.dispose();
+    await output.dispose();
+  });
 
-      // override the registry so it just returns the input for everything
-      // and doesn't whine about not finding template preprocessors
-      addon.registry.load = () => [
-        {
-          toTree(t) {
-            return t;
-          },
+  it('uses the module name function', async function() {
+    input.write({
+      addon: {
+        'herp.js': '// slerpy',
+        templates: {
+          'derp.hbs': '<!-- flerpy -->',
         },
-      ];
-    })
-  );
+      },
+    });
 
-  afterEach(
-    co.wrap(function*() {
-      yield input.dispose();
-      yield output.dispose();
-    })
-  );
+    output = await buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
 
-  it(
-    'uses the module name function',
-    co.wrap(function*() {
-      input.write({
-        addon: {
-          'herp.js': '// slerpy',
-          templates: {
-            'derp.hbs': '<!-- flerpy -->',
-          },
+    expect(output.read()).to.deep.equal({
+      'totes-not-fake-addon': {
+        'herp.js': '// slerpy',
+        templates: {
+          'derp.hbs': '<!-- flerpy -->',
         },
-      });
-
-      output = yield buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
-
-      expect(output.read()).to.deep.equal({
-        'totes-not-fake-addon': {
-          'herp.js': '// slerpy',
-          templates: {
-            'derp.hbs': '<!-- flerpy -->',
-          },
-        },
-      });
-    })
-  );
+      },
+    });
+  });
 });

--- a/tests/unit/broccoli/builder-test.js
+++ b/tests/unit/broccoli/builder-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const broccoliTestHelper = require('broccoli-test-helper');
 const expect = require('chai').expect;
 const ci = require('ci-info');
@@ -14,30 +13,26 @@ const ROOT = process.cwd();
 describe('Builder - broccoli tests', function() {
   let projectRoot, builderOutputPath, output, project, builder;
 
-  beforeEach(
-    co.wrap(function*() {
-      projectRoot = yield createTempDir();
-      builderOutputPath = yield createTempDir();
+  beforeEach(async function() {
+    projectRoot = await createTempDir();
+    builderOutputPath = await createTempDir();
 
-      project = new MockProject({ root: projectRoot.path() });
-    })
-  );
+    project = new MockProject({ root: projectRoot.path() });
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield projectRoot.dispose();
-      yield builderOutputPath.dispose();
-      yield output.dispose();
+  afterEach(async function() {
+    await projectRoot.dispose();
+    await builderOutputPath.dispose();
+    await output.dispose();
 
-      // this is needed because lib/utilities/find-build-file.js does a
-      // `process.chdir` when it looks for the `ember-cli-build.js`
-      process.chdir(ROOT);
-    })
-  );
+    // this is needed because lib/utilities/find-build-file.js does a
+    // `process.chdir` when it looks for the `ember-cli-build.js`
+    process.chdir(ROOT);
+  });
 
   (ci.APPVEYOR ? it.skip : it)(
     'falls back to broccoli-builder@0.18 when legacy plugins exist in build',
-    co.wrap(function*() {
+    async function() {
       projectRoot.write({
         'ember-cli-build.js': `
         const fs = require('fs');
@@ -91,7 +86,7 @@ describe('Builder - broccoli tests', function() {
       });
 
       output = fromBuilder(builder);
-      yield output.build();
+      await output.build();
 
       expect(output.read()).to.deep.equal({
         'hello.txt': '// hello!',
@@ -104,6 +99,6 @@ describe('Builder - broccoli tests', function() {
       expect(builder.ui.output).to.include(
         'LegacyPlugin: The .read/.rebuild API is no longer supported as of Broccoli 1.0. Plugins must now derive from broccoli-plugin. https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md'
       );
-    })
+    }
   );
 });

--- a/tests/unit/broccoli/default-packager/additional-assets-test.js
+++ b/tests/unit/broccoli/default-packager/additional-assets-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const Funnel = require('broccoli-funnel');
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
@@ -59,121 +58,109 @@ describe('Default Packager: Additional Assets', function() {
     addons: [],
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(MODULES);
-    })
-  );
+    input.write(MODULES);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged javascript tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+  it('caches packaged javascript tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
 
-        distPaths: {
-          appJsFile: '/assets/the-best-app-ever.js',
-          vendorJsFile: '/assets/vendor.js',
+      distPaths: {
+        appJsFile: '/assets/the-best-app-ever.js',
+        vendorJsFile: '/assets/vendor.js',
+      },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
+      additionalAssetPaths: [
+        {
+          src: 'vendor/font-awesome/fonts',
+          file: 'FontAwesome.otf',
+          dest: 'fonts',
         },
-
-        registry: setupRegistryFor('template', function(tree) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/hbs$/g, 'js');
-            },
-          });
-        }),
-
-        additionalAssetPaths: [
-          {
-            src: 'vendor/font-awesome/fonts',
-            file: 'FontAwesome.otf',
-            dest: 'fonts',
-          },
-          {
-            src: 'vendor/font-awesome/fonts',
-            file: 'FontAwesome.woff',
-            dest: 'fonts',
-          },
-        ],
-
-        project,
-      });
-
-      expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.importAdditionalAssets(input.path()));
-
-      expect(defaultPackager._cachedProcessedAdditionalAssets).to.not.equal(null);
-      expect(defaultPackager._cachedProcessedAdditionalAssets._annotation).to.equal(
-        'vendor/font-awesome/fonts/{FontAwesome.otf,FontAwesome.woff} => fonts/{FontAwesome.otf,FontAwesome.woff}'
-      );
-    })
-  );
-
-  it(
-    'imports additional assets properly',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appJsFile: '/assets/the-best-app-ever.js',
-          vendorJsFile: '/assets/vendor.js',
+        {
+          src: 'vendor/font-awesome/fonts',
+          file: 'FontAwesome.woff',
+          dest: 'fonts',
         },
+      ],
 
-        registry: setupRegistryFor('template', function(tree) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/hbs$/g, 'js');
-            },
-          });
-        }),
+      project,
+    });
 
-        additionalAssetPaths: [
-          {
-            src: 'vendor/font-awesome/fonts',
-            file: 'FontAwesome.otf',
-            dest: 'fonts',
+    expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
+
+    output = await buildOutput(defaultPackager.importAdditionalAssets(input.path()));
+
+    expect(defaultPackager._cachedProcessedAdditionalAssets).to.not.equal(null);
+    expect(defaultPackager._cachedProcessedAdditionalAssets._annotation).to.equal(
+      'vendor/font-awesome/fonts/{FontAwesome.otf,FontAwesome.woff} => fonts/{FontAwesome.otf,FontAwesome.woff}'
+    );
+  });
+
+  it('imports additional assets properly', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appJsFile: '/assets/the-best-app-ever.js',
+        vendorJsFile: '/assets/vendor.js',
+      },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
           },
-          {
-            src: 'vendor/font-awesome/fonts',
-            file: 'FontAwesome.woff',
-            dest: 'fonts',
-          },
-        ],
+        });
+      }),
 
-        project,
-      });
-
-      expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.importAdditionalAssets(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(outputFiles).to.deep.equal({
-        fonts: {
-          'FontAwesome.otf': '',
-          'FontAwesome.woff': '',
+      additionalAssetPaths: [
+        {
+          src: 'vendor/font-awesome/fonts',
+          file: 'FontAwesome.otf',
+          dest: 'fonts',
         },
-      });
-    })
-  );
+        {
+          src: 'vendor/font-awesome/fonts',
+          file: 'FontAwesome.woff',
+          dest: 'fonts',
+        },
+      ],
+
+      project,
+    });
+
+    expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
+
+    output = await buildOutput(defaultPackager.importAdditionalAssets(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles).to.deep.equal({
+      fonts: {
+        'FontAwesome.otf': '',
+        'FontAwesome.woff': '',
+      },
+    });
+  });
 });

--- a/tests/unit/broccoli/default-packager/bower-test.js
+++ b/tests/unit/broccoli/default-packager/bower-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -29,59 +28,46 @@ describe('Default Packager: Bower', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(BOWER_PACKAGES);
-    })
-  );
+    input.write(BOWER_PACKAGES);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  it(
-    'caches packaged bower tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('caches packaged bower tree', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      expect(defaultPackager._cachedBower).to.equal(null);
+    expect(defaultPackager._cachedBower).to.equal(null);
 
-      yield buildOutput(defaultPackager.packageBower(input.path()));
+    await buildOutput(defaultPackager.packageBower(input.path()));
 
-      expect(defaultPackager._cachedBower).to.not.equal(null);
-      expect(defaultPackager._cachedBower._annotation).to.equal('Packaged Bower');
-    })
-  );
+    expect(defaultPackager._cachedBower).to.not.equal(null);
+    expect(defaultPackager._cachedBower._annotation).to.equal('Packaged Bower');
+  });
 
-  it(
-    'packages bower files with default folder',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('packages bower files with default folder', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      let packagedBower = yield buildOutput(defaultPackager.packageBower(input.path()));
-      let output = packagedBower.read();
+    let packagedBower = await buildOutput(defaultPackager.packageBower(input.path()));
+    let output = packagedBower.read();
 
-      expect(output).to.deep.equal({
-        bower_components: BOWER_PACKAGES,
-      });
-    })
-  );
+    expect(output).to.deep.equal({
+      bower_components: BOWER_PACKAGES,
+    });
+  });
 
-  it(
-    'packages bower files with custom folder',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('packages bower files with custom folder', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      let packagedBower = yield buildOutput(defaultPackager.packageBower(input.path(), 'foobar'));
-      let output = packagedBower.read();
+    let packagedBower = await buildOutput(defaultPackager.packageBower(input.path(), 'foobar'));
+    let output = packagedBower.read();
 
-      expect(output).to.deep.equal({
-        foobar: BOWER_PACKAGES,
-      });
-    })
-  );
+    expect(output).to.deep.equal({
+      foobar: BOWER_PACKAGES,
+    });
+  });
 });

--- a/tests/unit/broccoli/default-packager/config-test.js
+++ b/tests/unit/broccoli/default-packager/config-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -28,94 +27,79 @@ describe('Default Packager: Config', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(CONFIG);
-    })
-  );
+    input.write(CONFIG);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged config tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name,
-        project,
-        env,
-      });
+  it('caches packaged config tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+    });
 
-      expect(defaultPackager._cachedConfig).to.equal(null);
+    expect(defaultPackager._cachedConfig).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageConfig());
+    output = await buildOutput(defaultPackager.packageConfig());
 
-      expect(defaultPackager._cachedConfig).to.not.equal(null);
-      expect(defaultPackager._cachedConfig._annotation).to.equal('Packaged Config');
-    })
-  );
+    expect(defaultPackager._cachedConfig).to.not.equal(null);
+    expect(defaultPackager._cachedConfig._annotation).to.equal('Packaged Config');
+  });
 
-  it(
-    'packages config files w/ tests disabled',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name,
-        project,
-        env,
-        areTestsEnabled: false,
-      });
+  it('packages config files w/ tests disabled', async function() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+      areTestsEnabled: false,
+    });
 
-      output = yield buildOutput(defaultPackager.packageConfig());
+    output = await buildOutput(defaultPackager.packageConfig());
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        [name]: {
-          config: {
-            environments: {
-              'development.json': '{"a":1}',
-            },
+    expect(outputFiles).to.deep.equal({
+      [name]: {
+        config: {
+          environments: {
+            'development.json': '{"a":1}',
           },
         },
-      });
-    })
-  );
+      },
+    });
+  });
 
-  it(
-    'packages config files w/ tests enabled',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name,
-        project,
-        env,
-        areTestsEnabled: true,
-      });
+  it('packages config files w/ tests enabled', async function() {
+    let defaultPackager = new DefaultPackager({
+      name,
+      project,
+      env,
+      areTestsEnabled: true,
+    });
 
-      output = yield buildOutput(defaultPackager.packageConfig());
+    output = await buildOutput(defaultPackager.packageConfig());
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        [name]: {
-          config: {
-            environments: {
-              'development.json': '{"a":1}',
-              'test.json': '{"a":1}',
-            },
+    expect(outputFiles).to.deep.equal({
+      [name]: {
+        config: {
+          environments: {
+            'development.json': '{"a":1}',
+            'test.json': '{"a":1}',
           },
         },
-      });
-    })
-  );
+      },
+    });
+  });
 });

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -30,218 +29,197 @@ describe('Default Packager: Ember CLI Internal', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(CONFIG);
-    })
-  );
+    input.write(CONFIG);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged ember cli internal tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        env: 'development',
-        name: 'the-best-app-ever',
-        project,
-        autoRun: false,
-        areTestsEnabled: true,
-        storeConfigInMeta: false,
-        isModuleUnificationEnabled: false,
-      });
+  it('caches packaged ember cli internal tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      env: 'development',
+      name: 'the-best-app-ever',
+      project,
+      autoRun: false,
+      areTestsEnabled: true,
+      storeConfigInMeta: false,
+      isModuleUnificationEnabled: false,
+    });
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
+    expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.not.equal(null);
-      expect(defaultPackager._cachedEmberCliInternalTree._annotation).to.equal('Packaged Ember CLI Internal Files');
-    })
-  );
+    expect(defaultPackager._cachedEmberCliInternalTree).to.not.equal(null);
+    expect(defaultPackager._cachedEmberCliInternalTree._annotation).to.equal('Packaged Ember CLI Internal Files');
+  });
 
-  it(
-    'packages internal files properly',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        env: 'development',
-        name: 'the-best-app-ever',
-        project,
-        autoRun: false,
-        areTestsEnabled: true,
-        storeConfigInMeta: false,
-        isModuleUnificationEnabled: false,
-      });
+  it('packages internal files properly', async function() {
+    let defaultPackager = new DefaultPackager({
+      env: 'development',
+      name: 'the-best-app-ever',
+      project,
+      autoRun: false,
+      areTestsEnabled: true,
+      storeConfigInMeta: false,
+      isModuleUnificationEnabled: false,
+    });
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
+    expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      let emberCliFiles = outputFiles.vendor['ember-cli'];
+    let emberCliFiles = outputFiles.vendor['ember-cli'];
 
-      expect(Object.keys(emberCliFiles)).to.deep.equal([
-        'app-boot.js',
-        'app-config.js',
-        'app-prefix.js',
-        'app-suffix.js',
-        'test-support-prefix.js',
-        'test-support-suffix.js',
-        'tests-prefix.js',
-        'tests-suffix.js',
-        'vendor-prefix.js',
-        'vendor-suffix.js',
-      ]);
-    })
-  );
+    expect(Object.keys(emberCliFiles)).to.deep.equal([
+      'app-boot.js',
+      'app-config.js',
+      'app-prefix.js',
+      'app-suffix.js',
+      'test-support-prefix.js',
+      'test-support-suffix.js',
+      'tests-prefix.js',
+      'tests-suffix.js',
+      'vendor-prefix.js',
+      'vendor-suffix.js',
+    ]);
+  });
 
-  it(
-    'populates the contents of internal files correctly',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        env: 'development',
-        name: 'the-best-app-ever',
-        project,
-        autoRun: false,
-        areTestsEnabled: false,
-        storeConfigInMeta: false,
-        isModuleUnificationEnabled: false,
-      });
+  it('populates the contents of internal files correctly', async function() {
+    let defaultPackager = new DefaultPackager({
+      env: 'development',
+      name: 'the-best-app-ever',
+      project,
+      autoRun: false,
+      areTestsEnabled: false,
+      storeConfigInMeta: false,
+      isModuleUnificationEnabled: false,
+    });
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
+    expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      let emberCliFiles = outputFiles.vendor['ember-cli'];
+    let emberCliFiles = outputFiles.vendor['ember-cli'];
 
-      let appBootFileContent = emberCliFiles['app-boot.js'].trim();
-      let appConfigFileContent = emberCliFiles['app-config.js'].trim();
-      let appPrefixFileContent = emberCliFiles['app-prefix.js'].trim();
-      let appSuffixFileContent = emberCliFiles['app-suffix.js'].trim();
+    let appBootFileContent = emberCliFiles['app-boot.js'].trim();
+    let appConfigFileContent = emberCliFiles['app-config.js'].trim();
+    let appPrefixFileContent = emberCliFiles['app-prefix.js'].trim();
+    let appSuffixFileContent = emberCliFiles['app-suffix.js'].trim();
 
-      let testPrefixFileContent = emberCliFiles['tests-prefix.js'].trim();
-      let testSuffixFileContent = emberCliFiles['tests-suffix.js'].trim();
-      let testSupportPrefixFileContent = emberCliFiles['test-support-prefix.js'].trim();
-      let testSupportSuffixFileContent = emberCliFiles['test-support-suffix.js'].trim();
+    let testPrefixFileContent = emberCliFiles['tests-prefix.js'].trim();
+    let testSuffixFileContent = emberCliFiles['tests-suffix.js'].trim();
+    let testSupportPrefixFileContent = emberCliFiles['test-support-prefix.js'].trim();
+    let testSupportSuffixFileContent = emberCliFiles['test-support-suffix.js'].trim();
 
-      let vendorPrefixFileContent = emberCliFiles['vendor-prefix.js'].trim();
-      let vendorSuffixFileContent = emberCliFiles['vendor-suffix.js'].trim();
+    let vendorPrefixFileContent = emberCliFiles['vendor-prefix.js'].trim();
+    let vendorSuffixFileContent = emberCliFiles['vendor-suffix.js'].trim();
 
-      expect(appBootFileContent).to.equal('');
-      expect(appConfigFileContent).to.contain(`'default': {"modulePrefix":"the-best-app-ever"}`);
-      expect(appPrefixFileContent).to.contain(`'use strict';`);
-      expect(appSuffixFileContent).to.equal('');
+    expect(appBootFileContent).to.equal('');
+    expect(appConfigFileContent).to.contain(`'default': {"modulePrefix":"the-best-app-ever"}`);
+    expect(appPrefixFileContent).to.contain(`'use strict';`);
+    expect(appSuffixFileContent).to.equal('');
 
-      expect(testPrefixFileContent).to.contain(`'use strict';`);
-      expect(testSuffixFileContent).to.contain(
-        `require('the-best-app-ever/tests/test-helper');\nEmberENV.TESTS_FILE_LOADED = true;`
-      );
-      expect(testSupportPrefixFileContent).to.equal('');
-      expect(testSupportSuffixFileContent).to.contain(
-        'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
-      );
+    expect(testPrefixFileContent).to.contain(`'use strict';`);
+    expect(testSuffixFileContent).to.contain(
+      `require('the-best-app-ever/tests/test-helper');\nEmberENV.TESTS_FILE_LOADED = true;`
+    );
+    expect(testSupportPrefixFileContent).to.equal('');
+    expect(testSupportSuffixFileContent).to.contain(
+      'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
+    );
 
-      expect(vendorPrefixFileContent).to.contain(
-        'window.EmberENV = (function(EmberENV, extra) {\n  for (var key in extra) {\n    EmberENV[key] = extra[key];\n  }\n\n  return EmberENV;\n})(window.EmberENV || {}, {});\n\nvar runningTests = false;'
-      );
-      expect(vendorSuffixFileContent).to.equal('');
-    })
-  );
+    expect(vendorPrefixFileContent).to.contain(
+      'window.EmberENV = (function(EmberENV, extra) {\n  for (var key in extra) {\n    EmberENV[key] = extra[key];\n  }\n\n  return EmberENV;\n})(window.EmberENV || {}, {});\n\nvar runningTests = false;'
+    );
+    expect(vendorSuffixFileContent).to.equal('');
+  });
 
-  it(
-    'populates the contents of internal files correctly when `storeConfigInMeta` is enabled',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        env: 'development',
-        name: 'the-best-app-ever',
-        project,
-        autoRun: false,
-        areTestsEnabled: true,
-        storeConfigInMeta: true,
-        isModuleUnificationEnabled: false,
-      });
+  it('populates the contents of internal files correctly when `storeConfigInMeta` is enabled', async function() {
+    let defaultPackager = new DefaultPackager({
+      env: 'development',
+      name: 'the-best-app-ever',
+      project,
+      autoRun: false,
+      areTestsEnabled: true,
+      storeConfigInMeta: true,
+      isModuleUnificationEnabled: false,
+    });
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
+    expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      let emberCliFiles = outputFiles.vendor['ember-cli'];
-      let appConfigFileContent = emberCliFiles['app-config.js'].trim();
+    let emberCliFiles = outputFiles.vendor['ember-cli'];
+    let appConfigFileContent = emberCliFiles['app-config.js'].trim();
 
-      expect(appConfigFileContent).to.contain(`var rawConfig = document.querySelector(`);
-      expect(appConfigFileContent).to.contain(`var config = JSON.parse(decodeURIComponent(rawConfig));`);
-    })
-  );
+    expect(appConfigFileContent).to.contain(`var rawConfig = document.querySelector(`);
+    expect(appConfigFileContent).to.contain(`var config = JSON.parse(decodeURIComponent(rawConfig));`);
+  });
 
-  it(
-    'populates the contents of internal files correctly, including content from add-ons',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        env: 'development',
-        name: 'the-best-app-ever',
-        project: {
-          addons: [
-            {
-              contentFor(type) {
-                if (type === 'app-prefix') {
-                  return 'CUSTOM APP PREFIX CODE';
-                }
-              },
+  it('populates the contents of internal files correctly, including content from add-ons', async function() {
+    let defaultPackager = new DefaultPackager({
+      env: 'development',
+      name: 'the-best-app-ever',
+      project: {
+        addons: [
+          {
+            contentFor(type) {
+              if (type === 'app-prefix') {
+                return 'CUSTOM APP PREFIX CODE';
+              }
             },
-            {
-              contentFor(type) {
-                if (type === 'app-boot') {
-                  return 'CUSTOM APP BOOT CODE';
-                }
-              },
+          },
+          {
+            contentFor(type) {
+              if (type === 'app-boot') {
+                return 'CUSTOM APP BOOT CODE';
+              }
             },
-          ],
-
-          configPath() {
-            return `${input.path()}/config/environment`;
           },
+        ],
 
-          config() {
-            return {
-              modulePrefix: 'the-best-app-ever',
-            };
-          },
+        configPath() {
+          return `${input.path()}/config/environment`;
         },
-        autoRun: false,
-        areTestsEnabled: true,
-        storeConfigInMeta: false,
-        isModuleUnificationEnabled: false,
-      });
 
-      expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
+        config() {
+          return {
+            modulePrefix: 'the-best-app-ever',
+          };
+        },
+      },
+      autoRun: false,
+      areTestsEnabled: true,
+      storeConfigInMeta: false,
+      isModuleUnificationEnabled: false,
+    });
 
-      output = yield buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-      let outputFiles = output.read();
+    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
 
-      let emberCliFiles = outputFiles.vendor['ember-cli'];
-      let appBootFileContent = emberCliFiles['app-boot.js'].trim();
-      let appPrefixFileContent = emberCliFiles['app-prefix.js'].trim();
+    let outputFiles = output.read();
 
-      expect(appBootFileContent).to.equal('CUSTOM APP BOOT CODE');
-      expect(appPrefixFileContent).to.equal(`'use strict';\n\nCUSTOM APP PREFIX CODE`);
-    })
-  );
+    let emberCliFiles = outputFiles.vendor['ember-cli'];
+    let appBootFileContent = emberCliFiles['app-boot.js'].trim();
+    let appPrefixFileContent = emberCliFiles['app-prefix.js'].trim();
+
+    expect(appBootFileContent).to.equal('CUSTOM APP BOOT CODE');
+    expect(appPrefixFileContent).to.equal(`'use strict';\n\nCUSTOM APP PREFIX CODE`);
+  });
 });

--- a/tests/unit/broccoli/default-packager/external-test.js
+++ b/tests/unit/broccoli/default-packager/external-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -21,69 +20,60 @@ describe('Default Packager: External', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(EXTERNAL);
-    })
-  );
+    input.write(EXTERNAL);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'applies transforms to an external tree',
-    co.wrap(function*() {
-      let customTransformsMap = new Map();
+  it('applies transforms to an external tree', async function() {
+    let customTransformsMap = new Map();
 
-      customTransformsMap.set('amd', {
-        files: ['vendor/auth0-js.js', 'vendor/auth0-lock.js', 'vendor/auth0-lock-passwordless.js'],
-        callback(tree, options) {
-          const stew = require('broccoli-stew');
+    customTransformsMap.set('amd', {
+      files: ['vendor/auth0-js.js', 'vendor/auth0-lock.js', 'vendor/auth0-lock-passwordless.js'],
+      callback(tree, options) {
+        const stew = require('broccoli-stew');
 
-          return stew.map(tree, (content, relativePath) => {
-            const name = options[relativePath].as;
+        return stew.map(tree, (content, relativePath) => {
+          const name = options[relativePath].as;
 
-            return `${name} was transformed`;
-          });
+          return `${name} was transformed`;
+        });
+      },
+      processOptions() {},
+      options: {
+        'vendor/auth0-js.js': {
+          as: 'auth0',
         },
-        processOptions() {},
-        options: {
-          'vendor/auth0-js.js': {
-            as: 'auth0',
-          },
-          'vendor/auth0-lock-passwordless.js': {
-            as: 'auth0-lock-passwordless',
-          },
-          'vendor/auth0-lock.js': {
-            as: 'auth0-lock',
-          },
+        'vendor/auth0-lock-passwordless.js': {
+          as: 'auth0-lock-passwordless',
         },
-      });
+        'vendor/auth0-lock.js': {
+          as: 'auth0-lock',
+        },
+      },
+    });
 
-      let defaultPackager = new DefaultPackager({
-        customTransformsMap,
-      });
+    let defaultPackager = new DefaultPackager({
+      customTransformsMap,
+    });
 
-      output = yield buildOutput(defaultPackager.applyCustomTransforms(input.path()));
+    output = await buildOutput(defaultPackager.applyCustomTransforms(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles.vendor).to.deep.equal({
-        'auth0-js.js': 'auth0 was transformed',
-        'auth0-lock.js': 'auth0-lock was transformed',
-        'auth0-lock-passwordless.js': 'auth0-lock-passwordless was transformed',
-      });
-    })
-  );
+    expect(outputFiles.vendor).to.deep.equal({
+      'auth0-js.js': 'auth0 was transformed',
+      'auth0-lock.js': 'auth0-lock was transformed',
+      'auth0-lock-passwordless.js': 'auth0-lock-passwordless was transformed',
+    });
+  });
 });

--- a/tests/unit/broccoli/default-packager/index-test.js
+++ b/tests/unit/broccoli/default-packager/index-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -30,240 +29,213 @@ describe('Default Packager: Index', function() {
   let META_TAG =
     '/best-url-ever/\n<meta name="the-best-app-ever/config/environment" content="{"rootURL":"/best-url-ever/","modulePrefix":"the-best-app-ever"}" />';
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      let indexContent = `
+    let indexContent = `
       {{rootURL}}{{content-for "head"}}
       {{content-for "head-footer"}}
       {{content-for "body"}}
       {{content-for "body-footer"}}
     `;
-      input.write({
-        'addon-tree-output': {},
-        'the-best-app-ever': {
-          'router.js': 'router.js',
-          'app.js': 'app.js',
-          'index.html': indexContent,
-          config: {
-            'environment.js': 'environment.js',
-          },
-          templates: {},
+    input.write({
+      'addon-tree-output': {},
+      'the-best-app-ever': {
+        'router.js': 'router.js',
+        'app.js': 'app.js',
+        'index.html': indexContent,
+        config: {
+          'environment.js': 'environment.js',
         },
-      });
-    })
-  );
+        templates: {},
+      },
+    });
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches processed index tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+  it('caches processed index tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
 
-        autoRun: true,
-        storeConfigInMeta: true,
-        isModuleUnificationEnabled: false,
-        areTestsEnabled: true,
+      autoRun: true,
+      storeConfigInMeta: true,
+      isModuleUnificationEnabled: false,
+      areTestsEnabled: true,
 
-        distPaths: {
-          appHtmlFile: 'index.html',
-        },
+      distPaths: {
+        appHtmlFile: 'index.html',
+      },
 
-        project,
-      });
+      project,
+    });
 
-      expect(defaultPackager._cachedProcessedIndex).to.equal(null);
+    expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.processIndex(input.path()));
+    output = await buildOutput(defaultPackager.processIndex(input.path()));
 
-      expect(defaultPackager._cachedProcessedIndex).to.not.equal(null);
-    })
-  );
+    expect(defaultPackager._cachedProcessedIndex).to.not.equal(null);
+  });
 
-  it(
-    'works with a custom path',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+  it('works with a custom path', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
 
-        autoRun: true,
-        storeConfigInMeta: true,
-        isModuleUnificationEnabled: false,
-        areTestsEnabled: true,
+      autoRun: true,
+      storeConfigInMeta: true,
+      isModuleUnificationEnabled: false,
+      areTestsEnabled: true,
 
-        distPaths: {
-          appHtmlFile: 'custom/index.html',
-        },
+      distPaths: {
+        appHtmlFile: 'custom/index.html',
+      },
 
-        project,
-      });
+      project,
+    });
 
-      expect(defaultPackager._cachedProcessedIndex).to.equal(null);
+    expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.processIndex(input.path()));
+    output = await buildOutput(defaultPackager.processIndex(input.path()));
 
-      let outputFiles = output.read();
-      let indexContent = decodeURIComponent(outputFiles.custom['index.html'].trim());
+    let outputFiles = output.read();
+    let indexContent = decodeURIComponent(outputFiles.custom['index.html'].trim());
 
-      expect(indexContent).to.equal(META_TAG);
-    })
-  );
+    expect(indexContent).to.equal(META_TAG);
+  });
 
-  it(
-    'populates `index.html` according to settings',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+  it('populates `index.html` according to settings', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
 
-        autoRun: true,
-        storeConfigInMeta: true,
-        isModuleUnificationEnabled: false,
-        areTestsEnabled: true,
+      autoRun: true,
+      storeConfigInMeta: true,
+      isModuleUnificationEnabled: false,
+      areTestsEnabled: true,
 
-        distPaths: {
-          appHtmlFile: 'index.html',
-        },
+      distPaths: {
+        appHtmlFile: 'index.html',
+      },
 
-        project,
-      });
+      project,
+    });
 
-      expect(defaultPackager._cachedProcessedIndex).to.equal(null);
+    expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.processIndex(input.path()));
+    output = await buildOutput(defaultPackager.processIndex(input.path()));
 
-      let outputFiles = output.read();
-      let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
+    let outputFiles = output.read();
+    let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
 
-      expect(indexContent).to.equal(META_TAG);
-    })
-  );
+    expect(indexContent).to.equal(META_TAG);
+  });
 
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     describe('with module unification', function() {
       let input, output;
 
-      before(
-        co.wrap(function*() {
-          input = yield createTempDir();
+      before(async function() {
+        input = await createTempDir();
 
-          let indexContent = `
+        let indexContent = `
           {{rootURL}}{{content-for "head"}}
           {{content-for "head-footer"}}
           {{content-for "body"}}
           {{content-for "body-footer"}}
         `;
-          input.write({
-            'addon-tree-output': {},
-            'the-best-app-ever': {
-              'router.js': 'router.js',
-              'app.js': 'app.js',
-              'index.html': indexContent,
-              config: {
-                'environment.js': 'environment.js',
-              },
-              templates: {},
+        input.write({
+          'addon-tree-output': {},
+          'the-best-app-ever': {
+            'router.js': 'router.js',
+            'app.js': 'app.js',
+            'index.html': indexContent,
+            config: {
+              'environment.js': 'environment.js',
             },
-            src: {
-              ui: {
-                'index.html': 'src',
-              },
+            templates: {},
+          },
+          src: {
+            ui: {
+              'index.html': 'src',
             },
-          });
-        })
-      );
+          },
+        });
+      });
 
-      after(
-        co.wrap(function*() {
-          yield input.dispose();
-        })
-      );
+      after(async function() {
+        await input.dispose();
+      });
 
-      afterEach(
-        co.wrap(function*() {
-          yield output.dispose();
-        })
-      );
+      afterEach(async function() {
+        await output.dispose();
+      });
 
-      it(
-        'prefers `src/ui/index.html` over `app/index.html`',
-        co.wrap(function*() {
-          let defaultPackager = new DefaultPackager({
-            name: 'the-best-app-ever',
-            env: 'development',
+      it('prefers `src/ui/index.html` over `app/index.html`', async function() {
+        let defaultPackager = new DefaultPackager({
+          name: 'the-best-app-ever',
+          env: 'development',
 
-            autoRun: true,
-            storeConfigInMeta: true,
-            isModuleUnificationEnabled: true,
-            areTestsEnabled: true,
+          autoRun: true,
+          storeConfigInMeta: true,
+          isModuleUnificationEnabled: true,
+          areTestsEnabled: true,
 
-            distPaths: {
-              appHtmlFile: 'index.html',
+          distPaths: {
+            appHtmlFile: 'index.html',
+          },
+
+          project,
+        });
+
+        output = await buildOutput(defaultPackager.processIndex(input.path()));
+
+        let outputFiles = output.read();
+        let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
+
+        expect(indexContent).to.equal('src');
+      });
+
+      it('works if only `src/ui/index.html` exists', async function() {
+        input.dispose();
+        input.write({
+          'addon-tree-output': {},
+          src: {
+            ui: {
+              'index.html': 'src',
             },
+          },
+        });
+        let defaultPackager = new DefaultPackager({
+          name: 'the-best-app-ever',
+          env: 'development',
 
-            project,
-          });
+          autoRun: true,
+          storeConfigInMeta: true,
+          isModuleUnificationEnabled: true,
+          areTestsEnabled: true,
 
-          output = yield buildOutput(defaultPackager.processIndex(input.path()));
+          distPaths: {
+            appHtmlFile: 'index.html',
+          },
 
-          let outputFiles = output.read();
-          let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
+          project,
+        });
 
-          expect(indexContent).to.equal('src');
-        })
-      );
+        output = await buildOutput(defaultPackager.processIndex(input.path()));
 
-      it(
-        'works if only `src/ui/index.html` exists',
-        co.wrap(function*() {
-          input.dispose();
-          input.write({
-            'addon-tree-output': {},
-            src: {
-              ui: {
-                'index.html': 'src',
-              },
-            },
-          });
-          let defaultPackager = new DefaultPackager({
-            name: 'the-best-app-ever',
-            env: 'development',
+        let outputFiles = output.read();
+        let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
 
-            autoRun: true,
-            storeConfigInMeta: true,
-            isModuleUnificationEnabled: true,
-            areTestsEnabled: true,
-
-            distPaths: {
-              appHtmlFile: 'index.html',
-            },
-
-            project,
-          });
-
-          output = yield buildOutput(defaultPackager.processIndex(input.path()));
-
-          let outputFiles = output.read();
-          let indexContent = decodeURIComponent(outputFiles['index.html'].trim());
-
-          expect(indexContent).to.equal('src');
-        })
-      );
+        expect(indexContent).to.equal('src');
+      });
     });
   }
 });

--- a/tests/unit/broccoli/default-packager/process-test.js
+++ b/tests/unit/broccoli/default-packager/process-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const Funnel = require('broccoli-funnel');
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
@@ -73,31 +72,101 @@ describe('Default Packager: Process Javascript', function() {
     ],
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(MODULES);
-    })
-  );
+    input.write(MODULES);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      if (output) {
-        yield output.dispose();
-      }
-    })
-  );
+  afterEach(async function() {
+    if (output) {
+      await output.dispose();
+    }
+  });
 
-  it(
-    'caches packaged application tree',
-    co.wrap(function*() {
+  it('caches packaged application tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appJsFile: '/assets/the-best-app-ever.js',
+        vendorJsFile: '/assets/vendor.js',
+      },
+
+      registry: setupRegistryFor('template', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/hbs$/g, 'js');
+          },
+        });
+      }),
+
+      customTransformsMap: new Map(),
+
+      scriptOutputFiles,
+      project,
+    });
+
+    expect(defaultPackager._cachedProcessedAppAndDependencies).to.equal(null);
+
+    output = await buildOutput(defaultPackager.processAppAndDependencies(input.path()));
+
+    expect(defaultPackager._cachedProcessedAppAndDependencies).to.not.equal(null);
+    expect(defaultPackager._cachedProcessedAppAndDependencies._annotation).to.equal(
+      'Processed Application and Dependencies'
+    );
+  });
+
+  if (isExperimentEnabled('MODULE_UNIFICATION')) {
+    it('merges src with with app', async function() {
+      let input = await createTempDir();
+
+      input.write({
+        'addon-tree-output': {},
+        'the-best-app-ever': {
+          'router.js': 'router.js',
+          'app.js': 'app.js',
+          components: {
+            'x-foo.js': 'export default class {}',
+          },
+          routes: {
+            'application.js': 'export default class {}',
+          },
+          config: {
+            'environment.js': 'environment.js',
+          },
+          templates: {},
+        },
+        vendor: {},
+        src: {
+          'main.js': '',
+          'resolver.js': '',
+          'router.js': '',
+          ui: {
+            components: {
+              'login-form': {
+                'component.js': '',
+                'template.hbs': '',
+              },
+            },
+            'index.html': '',
+            routes: {
+              application: {
+                'template.hbs': '',
+              },
+            },
+            styles: {
+              'app.css': '',
+            },
+          },
+        },
+      });
+
       let defaultPackager = new DefaultPackager({
         name: 'the-best-app-ever',
         env: 'development',
@@ -106,6 +175,8 @@ describe('Default Packager: Process Javascript', function() {
           appJsFile: '/assets/the-best-app-ever.js',
           vendorJsFile: '/assets/vendor.js',
         },
+
+        isModuleUnificationEnabled: true,
 
         registry: setupRegistryFor('template', function(tree) {
           return new Funnel(tree, {
@@ -121,97 +192,13 @@ describe('Default Packager: Process Javascript', function() {
         project,
       });
 
-      expect(defaultPackager._cachedProcessedAppAndDependencies).to.equal(null);
+      output = await buildOutput(defaultPackager.processAppAndDependencies(input.path()));
 
-      output = yield buildOutput(defaultPackager.processAppAndDependencies(input.path()));
+      let outputFiles = output.read();
 
-      expect(defaultPackager._cachedProcessedAppAndDependencies).to.not.equal(null);
-      expect(defaultPackager._cachedProcessedAppAndDependencies._annotation).to.equal(
-        'Processed Application and Dependencies'
-      );
-    })
-  );
+      expect(Object.keys(outputFiles)).to.deep.equal(['addon-tree-output', 'src', 'the-best-app-ever', 'vendor']);
 
-  if (isExperimentEnabled('MODULE_UNIFICATION')) {
-    it(
-      'merges src with with app',
-      co.wrap(function*() {
-        let input = yield createTempDir();
-
-        input.write({
-          'addon-tree-output': {},
-          'the-best-app-ever': {
-            'router.js': 'router.js',
-            'app.js': 'app.js',
-            components: {
-              'x-foo.js': 'export default class {}',
-            },
-            routes: {
-              'application.js': 'export default class {}',
-            },
-            config: {
-              'environment.js': 'environment.js',
-            },
-            templates: {},
-          },
-          vendor: {},
-          src: {
-            'main.js': '',
-            'resolver.js': '',
-            'router.js': '',
-            ui: {
-              components: {
-                'login-form': {
-                  'component.js': '',
-                  'template.hbs': '',
-                },
-              },
-              'index.html': '',
-              routes: {
-                application: {
-                  'template.hbs': '',
-                },
-              },
-              styles: {
-                'app.css': '',
-              },
-            },
-          },
-        });
-
-        let defaultPackager = new DefaultPackager({
-          name: 'the-best-app-ever',
-          env: 'development',
-
-          distPaths: {
-            appJsFile: '/assets/the-best-app-ever.js',
-            vendorJsFile: '/assets/vendor.js',
-          },
-
-          isModuleUnificationEnabled: true,
-
-          registry: setupRegistryFor('template', function(tree) {
-            return new Funnel(tree, {
-              getDestinationPath(relativePath) {
-                return relativePath.replace(/hbs$/g, 'js');
-              },
-            });
-          }),
-
-          customTransformsMap: new Map(),
-
-          scriptOutputFiles,
-          project,
-        });
-
-        output = yield buildOutput(defaultPackager.processAppAndDependencies(input.path()));
-
-        let outputFiles = output.read();
-
-        expect(Object.keys(outputFiles)).to.deep.equal(['addon-tree-output', 'src', 'the-best-app-ever', 'vendor']);
-
-        input.dispose();
-      })
-    );
+      input.dispose();
+    });
   }
 });

--- a/tests/unit/broccoli/default-packager/public-test.js
+++ b/tests/unit/broccoli/default-packager/public-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -22,49 +21,37 @@ describe('Default Packager: Public', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(PUBLIC);
-    })
-  );
+    input.write(PUBLIC);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged public tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('caches packaged public tree', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      expect(defaultPackager._cachedPublic).to.equal(null);
+    expect(defaultPackager._cachedPublic).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packagePublic(input.path()));
+    output = await buildOutput(defaultPackager.packagePublic(input.path()));
 
-      expect(defaultPackager._cachedPublic).to.not.equal(null);
-    })
-  );
+    expect(defaultPackager._cachedPublic).to.not.equal(null);
+  });
 
-  it(
-    'packages public files',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('packages public files', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      output = yield buildOutput(defaultPackager.packagePublic(input.path()));
+    output = await buildOutput(defaultPackager.packagePublic(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal(PUBLIC.public);
-    })
-  );
+    expect(outputFiles).to.deep.equal(PUBLIC.public);
+  });
 });

--- a/tests/unit/broccoli/default-packager/styles-test.js
+++ b/tests/unit/broccoli/default-packager/styles-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const Funnel = require('broccoli-funnel');
 const { isExperimentEnabled } = require('../../../../lib/experiments');
@@ -63,343 +62,314 @@ describe('Default Packager: Styles', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(MODULES);
-    })
-  );
+    input.write(MODULES);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      if (output) {
-        yield output.dispose();
-      }
-    })
-  );
+  afterEach(async function() {
+    if (output) {
+      await output.dispose();
+    }
+  });
 
-  it(
-    'caches packaged styles tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+  it('caches packaged styles tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
 
-        distPaths: {
-          appCssFile: '/assets/the-best-app-ever.css',
-          vendorCssFile: '/assets/vendor.css',
+      distPaths: {
+        appCssFile: '/assets/the-best-app-ever.css',
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: setupRegistryFor('css', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/scss$/g, 'css');
+          },
+        });
+      }),
+
+      minifyCSS: {
+        enabled: true,
+        options: { processImport: false },
+      },
+
+      styleOutputFiles,
+
+      project: { addons: [] },
+    });
+
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    expect(defaultPackager._cachedProcessedStyles).to.not.equal(null);
+    expect(defaultPackager._cachedProcessedStyles._annotation).to.equal('Packaged Styles');
+  });
+
+  it('does not minify css files when minification is disabled', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: {
+        load: () => [],
+      },
+
+      minifyCSS: {
+        enabled: false,
+        options: {
+          processImport: false,
+          relativeTo: 'assets',
         },
+      },
 
-        registry: setupRegistryFor('css', function(tree) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/scss$/g, 'css');
+      styleOutputFiles,
+
+      project: { addons: [] },
+    });
+
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(Object.keys(outputFiles.assets)).to.deep.equal(['extra.css', 'the-best-app-ever.css', 'vendor.css']);
+    expect(outputFiles.assets['vendor.css'].trim()).to.equal('body { height: 100%; }');
+    expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.equal('@import "extra.css";\nhtml { height: 100%; }');
+  });
+
+  it('minifies css files when minification is enabled', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: {
+        load: () => [],
+      },
+
+      minifyCSS: {
+        enabled: true,
+        options: {
+          processImport: false,
+          relativeTo: 'assets',
+        },
+      },
+
+      styleOutputFiles,
+
+      project: { addons: [] },
+    });
+
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(Object.keys(outputFiles.assets)).to.deep.equal(['extra.css', 'the-best-app-ever.css', 'vendor.css']);
+    expect(outputFiles.assets['vendor.css'].trim()).to.match(/^\S+$/, 'css file is minified');
+    expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.match(/^@import \S+$/, 'css file is minified');
+  });
+
+  it('processes css according to the registry', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: setupRegistryFor('css', function(tree, inputPath, outputPath, options) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            if (relativePath.includes('app.css')) {
+              return options.outputPaths.app.replace(/css$/g, 'zss');
+            }
+
+            return relativePath;
+          },
+        });
+      }),
+
+      minifyCSS: {
+        enabled: true,
+        options: {
+          processImport: false,
+          relativeTo: 'assets',
+        },
+      },
+
+      styleOutputFiles,
+
+      project: { addons: [] },
+    });
+
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(Object.keys(outputFiles.assets)).to.deep.equal(['the-best-app-ever.zss', 'vendor.css']);
+  });
+
+  it('inlines css imports', async function() {
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: {
+        load: () => [],
+      },
+
+      minifyCSS: {
+        enabled: true,
+        options: {
+          processImport: true,
+          relativeTo: 'assets',
+        },
+      },
+
+      styleOutputFiles,
+
+      project: { addons: [] },
+    });
+
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.not.include('@import');
+    expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.equal('body{position:relative}html{height:100%}');
+  });
+
+  it('runs pre/post-process add-on hooks', async function() {
+    let addonPreprocessTreeHookCalled = false;
+    let addonPostprocessTreeHookCalled = false;
+
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: {
+        load: () => [],
+      },
+
+      minifyCSS: {
+        enabled: true,
+        options: {
+          processImport: false,
+          relativeTo: 'assets',
+        },
+      },
+
+      styleOutputFiles,
+
+      // avoid using `testdouble.js` here on purpose; it does not have a "proxy"
+      // option, where a function call would be registered and the original
+      // would be returned
+      project: {
+        addons: [
+          {
+            preprocessTree(type, tree) {
+              addonPreprocessTreeHookCalled = true;
+
+              return tree;
             },
-          });
-        }),
+            postprocessTree(type, tree) {
+              addonPostprocessTreeHookCalled = true;
 
-        minifyCSS: {
-          enabled: true,
-          options: { processImport: false },
-        },
-
-        styleOutputFiles,
-
-        project: { addons: [] },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      expect(defaultPackager._cachedProcessedStyles).to.not.equal(null);
-      expect(defaultPackager._cachedProcessedStyles._annotation).to.equal('Packaged Styles');
-    })
-  );
-
-  it(
-    'does not minify css files when minification is disabled',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
-        },
-
-        registry: {
-          load: () => [],
-        },
-
-        minifyCSS: {
-          enabled: false,
-          options: {
-            processImport: false,
-            relativeTo: 'assets',
-          },
-        },
-
-        styleOutputFiles,
-
-        project: { addons: [] },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(Object.keys(outputFiles.assets)).to.deep.equal(['extra.css', 'the-best-app-ever.css', 'vendor.css']);
-      expect(outputFiles.assets['vendor.css'].trim()).to.equal('body { height: 100%; }');
-      expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.equal(
-        '@import "extra.css";\nhtml { height: 100%; }'
-      );
-    })
-  );
-
-  it(
-    'minifies css files when minification is enabled',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
-        },
-
-        registry: {
-          load: () => [],
-        },
-
-        minifyCSS: {
-          enabled: true,
-          options: {
-            processImport: false,
-            relativeTo: 'assets',
-          },
-        },
-
-        styleOutputFiles,
-
-        project: { addons: [] },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(Object.keys(outputFiles.assets)).to.deep.equal(['extra.css', 'the-best-app-ever.css', 'vendor.css']);
-      expect(outputFiles.assets['vendor.css'].trim()).to.match(/^\S+$/, 'css file is minified');
-      expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.match(/^@import \S+$/, 'css file is minified');
-    })
-  );
-
-  it(
-    'processes css according to the registry',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
-        },
-
-        registry: setupRegistryFor('css', function(tree, inputPath, outputPath, options) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              if (relativePath.includes('app.css')) {
-                return options.outputPaths.app.replace(/css$/g, 'zss');
-              }
-
-              return relativePath;
+              return tree;
             },
-          });
-        }),
-
-        minifyCSS: {
-          enabled: true,
-          options: {
-            processImport: false,
-            relativeTo: 'assets',
           },
-        },
-
-        styleOutputFiles,
-
-        project: { addons: [] },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(Object.keys(outputFiles.assets)).to.deep.equal(['the-best-app-ever.zss', 'vendor.css']);
-    })
-  );
-
-  it(
-    'inlines css imports',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
-        },
-
-        registry: {
-          load: () => [],
-        },
-
-        minifyCSS: {
-          enabled: true,
-          options: {
-            processImport: true,
-            relativeTo: 'assets',
-          },
-        },
-
-        styleOutputFiles,
-
-        project: { addons: [] },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.not.include('@import');
-      expect(outputFiles.assets['the-best-app-ever.css'].trim()).to.equal('body{position:relative}html{height:100%}');
-    })
-  );
-
-  it(
-    'runs pre/post-process add-on hooks',
-    co.wrap(function*() {
-      let addonPreprocessTreeHookCalled = false;
-      let addonPostprocessTreeHookCalled = false;
-
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
-
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
-        },
-
-        registry: {
-          load: () => [],
-        },
-
-        minifyCSS: {
-          enabled: true,
-          options: {
-            processImport: false,
-            relativeTo: 'assets',
-          },
-        },
-
-        styleOutputFiles,
-
-        // avoid using `testdouble.js` here on purpose; it does not have a "proxy"
-        // option, where a function call would be registered and the original
-        // would be returned
-        project: {
-          addons: [
-            {
-              preprocessTree(type, tree) {
-                addonPreprocessTreeHookCalled = true;
-
-                return tree;
-              },
-              postprocessTree(type, tree) {
-                addonPostprocessTreeHookCalled = true;
-
-                return tree;
-              },
-            },
-          ],
-        },
-      });
-
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
-
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      expect(addonPreprocessTreeHookCalled).to.equal(true);
-      expect(addonPostprocessTreeHookCalled).to.equal(true);
-    })
-  );
-
-  it(
-    'prevents duplicate inclusion, maintains order: CSS',
-    co.wrap(function*() {
-      let importFilesMap = {
-        '/assets/vendor.css': [
-          'bower_components/1.css',
-          'bower_components/2.css',
-          'bower_components/3.css',
-          'bower_components/1.css',
         ],
-      };
-      let defaultPackager = new DefaultPackager({
-        name: 'the-best-app-ever',
-        env: 'development',
+      },
+    });
 
-        distPaths: {
-          appCssFile: { app: '/assets/the-best-app-ever.css' },
-          vendorCssFile: '/assets/vendor.css',
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+
+    expect(addonPreprocessTreeHookCalled).to.equal(true);
+    expect(addonPostprocessTreeHookCalled).to.equal(true);
+  });
+
+  it('prevents duplicate inclusion, maintains order: CSS', async function() {
+    let importFilesMap = {
+      '/assets/vendor.css': [
+        'bower_components/1.css',
+        'bower_components/2.css',
+        'bower_components/3.css',
+        'bower_components/1.css',
+      ],
+    };
+    let defaultPackager = new DefaultPackager({
+      name: 'the-best-app-ever',
+      env: 'development',
+
+      distPaths: {
+        appCssFile: { app: '/assets/the-best-app-ever.css' },
+        vendorCssFile: '/assets/vendor.css',
+      },
+
+      registry: {
+        load: () => [],
+      },
+
+      minifyCSS: {
+        enabled: true,
+        options: {
+          processImport: false,
+          relativeTo: 'assets',
         },
+      },
 
-        registry: {
-          load: () => [],
-        },
+      styleOutputFiles: importFilesMap,
 
-        minifyCSS: {
-          enabled: true,
-          options: {
-            processImport: false,
-            relativeTo: 'assets',
-          },
-        },
+      project: { addons: [] },
+    });
 
-        styleOutputFiles: importFilesMap,
+    expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-        project: { addons: [] },
-      });
+    output = await buildOutput(defaultPackager.packageStyles(input.path()));
 
-      expect(defaultPackager._cachedProcessedStyles).to.equal(null);
+    let outputFiles = output.read();
 
-      output = yield buildOutput(defaultPackager.packageStyles(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(outputFiles.assets['vendor.css']).to.equal('.third{position:absolute}');
-    })
-  );
+    expect(outputFiles.assets['vendor.css']).to.equal('.third{position:absolute}');
+  });
 
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     describe('with module unification layout', function() {
@@ -475,46 +445,37 @@ describe('Default Packager: Styles', function() {
         project: { addons: [] },
       });
 
-      before(
-        co.wrap(function*() {
-          input = yield createTempDir();
-          processedSrc = yield createTempDir();
+      before(async function() {
+        input = await createTempDir();
+        processedSrc = await createTempDir();
 
-          input.write(MU_LAYOUT);
-          processedSrc.write(processedSrcFolder);
-        })
-      );
+        input.write(MU_LAYOUT);
+        processedSrc.write(processedSrcFolder);
+      });
 
-      after(
-        co.wrap(function*() {
-          yield input.dispose();
-          yield processedSrc.dispose();
-        })
-      );
+      after(async function() {
+        await input.dispose();
+        await processedSrc.dispose();
+      });
 
-      afterEach(
-        co.wrap(function*() {
-          yield output.dispose();
-        })
-      );
+      afterEach(async function() {
+        await output.dispose();
+      });
 
-      it(
-        'processes styles according to the registry',
-        co.wrap(function*() {
-          defaultPackager._cachedProcessedSrc = processedSrc.path();
+      it('processes styles according to the registry', async function() {
+        defaultPackager._cachedProcessedSrc = processedSrc.path();
 
-          output = yield buildOutput(defaultPackager.packageStyles(input.path()));
+        output = await buildOutput(defaultPackager.packageStyles(input.path()));
 
-          let outputFiles = output.read();
+        let outputFiles = output.read();
 
-          expect(outputFiles).to.deep.equal({
-            assets: {
-              'the-best-app-ever.css': 'html{height:100%}',
-              'vendor.css': 'body{height:100%}',
-            },
-          });
-        })
-      );
+        expect(outputFiles).to.deep.equal({
+          assets: {
+            'the-best-app-ever.css': 'html{height:100%}',
+            'vendor.css': 'body{height:100%}',
+          },
+        });
+      });
     });
   }
 });

--- a/tests/unit/broccoli/default-packager/tests-test.js
+++ b/tests/unit/broccoli/default-packager/tests-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const stew = require('broccoli-stew');
 const Funnel = require('broccoli-funnel');
 const expect = require('chai').expect;
@@ -116,478 +115,448 @@ describe('Default Packager: Tests', function() {
     ],
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(TESTS);
-    })
-  );
+    input.write(TESTS);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged tests tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
+  it('caches packaged tests tree', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
 
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
-          },
-          testSupportCssFile: '/assets/test-support.css',
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
         },
+        testSupportCssFile: '/assets/test-support.css',
+      },
 
-        customTransformsMap: new Map(),
+      customTransformsMap: new Map(),
 
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
 
-        registry: setupRegistryFor('js', tree => tree),
-      });
+      registry: setupRegistryFor('js', tree => tree),
+    });
 
-      expect(defaultPackager._cachedTests).to.equal(null);
+    expect(defaultPackager._cachedTests).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
 
-      expect(defaultPackager._cachedTests).to.not.equal(null);
-    })
-  );
+    expect(defaultPackager._cachedTests).to.not.equal(null);
+  });
 
-  it(
-    'packages test files (with sourcemaps)',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
+  it('packages test files (with sourcemaps)', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
 
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
-          },
-          testSupportCssFile: '/assets/test-support.css',
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
         },
+        testSupportCssFile: '/assets/test-support.css',
+      },
 
-        customTransformsMap: new Map(),
+      customTransformsMap: new Map(),
 
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
 
-        registry: setupRegistryFor('js', tree => tree),
-      });
+      registry: setupRegistryFor('js', tree => tree),
+    });
 
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
+    expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
 
-      expect(Object.keys(outputFiles.assets)).to.deep.equal([
-        'test-support.js',
-        'test-support.map',
-        'tests.js',
-        'tests.map',
-      ]);
+    expect(Object.keys(outputFiles.assets)).to.deep.equal([
+      'test-support.js',
+      'test-support.map',
+      'tests.js',
+      'tests.map',
+    ]);
 
-      expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
+    expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
 
-      expect(outputFiles.assets['tests.js']).to.include('login-test.js');
-      expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
-      expect(outputFiles.assets['tests.js']).to.include('test-helper');
-      expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
-      expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
-      expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
-    })
-  );
+    expect(outputFiles.assets['tests.js']).to.include('login-test.js');
+    expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
+    expect(outputFiles.assets['tests.js']).to.include('test-helper');
+    expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
+    expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
+    expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
+  });
 
-  it(
-    'packages test files (without sourcemaps)',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
-        sourcemaps: { enabled: false },
+  it('packages test files (without sourcemaps)', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
+      sourcemaps: { enabled: false },
 
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
-          },
-          testSupportCssFile: '/assets/test-support.css',
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
         },
+        testSupportCssFile: '/assets/test-support.css',
+      },
 
-        customTransformsMap: new Map(),
+      customTransformsMap: new Map(),
 
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
 
-        registry: setupRegistryFor('js', tree => tree),
-      });
+      registry: setupRegistryFor('js', tree => tree),
+    });
 
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
+    expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
 
-      expect(Object.keys(outputFiles.assets)).to.deep.equal(['test-support.js', 'tests.js']);
+    expect(Object.keys(outputFiles.assets)).to.deep.equal(['test-support.js', 'tests.js']);
 
-      expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
+    expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
 
-      expect(outputFiles.assets['tests.js']).to.include('login-test.js');
-      expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
-      expect(outputFiles.assets['tests.js']).to.include('test-helper');
-      expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
-      expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
-      expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
-    })
-  );
+    expect(outputFiles.assets['tests.js']).to.include('login-test.js');
+    expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
+    expect(outputFiles.assets['tests.js']).to.include('test-helper');
+    expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
+    expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
+    expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
+  });
 
-  it(
-    'does not process `addon-test-support` folder',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
+  it('does not process `addon-test-support` folder', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
 
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
-          },
-          testSupportCssFile: '/assets/test-support.css',
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
         },
+        testSupportCssFile: '/assets/test-support.css',
+      },
 
-        customTransformsMap: new Map(),
+      customTransformsMap: new Map(),
 
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
 
-        registry: setupRegistryFor('js', function(tree) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/js/g, 'js-test');
-            },
-          });
-        }),
-      });
+      registry: setupRegistryFor('js', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/js/g, 'js-test');
+          },
+        });
+      }),
+    });
 
-      output = yield buildOutput(defaultPackager.processTests(input.path()));
+    output = await buildOutput(defaultPackager.processTests(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        'addon-test-support': {
-          '@ember': {
-            'test-helpers': {
-              'global.js':
-                'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
-            },
+    expect(outputFiles).to.deep.equal({
+      'addon-test-support': {
+        '@ember': {
+          'test-helpers': {
+            'global.js':
+              'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
           },
         },
-        [name]: {
-          tests: {
-            acceptance: {
-              'login-test.js-test': ' // login-test.js',
-              'logout-test.js-test': '',
-            },
-            lint: {
-              'login-test.lint.js-test': ' // login-test.lint.js',
-              'logout-test.lint.js-test': '',
-            },
-            helpers: {
-              'resolver.js-test': '',
-              'start-app.js-test': '',
-            },
-            'index.html': 'index',
-            integration: {
-              components: {
-                'login-form-test.js-test': '',
-                'user-menu-test.js-test': '',
-              },
-            },
-            'test-helper.js-test': '// test-helper.js',
-            unit: {
-              services: {
-                'session-test.js-test': '',
-              },
-            },
-          },
-        },
-      });
-    })
-  );
-
-  it(
-    'processes tests files according to the registry',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
-
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
-          },
-          testSupportCssFile: '/assets/test-support.css',
-        },
-
-        customTransformsMap: new Map(),
-
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
-
-        registry: setupRegistryFor('js', function(tree) {
-          return new Funnel(tree, {
-            getDestinationPath(relativePath) {
-              return relativePath.replace(/js/g, 'js-test');
-            },
-          });
-        }),
-      });
-
-      output = yield buildOutput(defaultPackager.processTests(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(outputFiles).to.deep.equal({
-        'addon-test-support': {
-          '@ember': {
-            'test-helpers': {
-              'global.js':
-                'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
-            },
-          },
-        },
-        [name]: {
-          tests: {
-            acceptance: {
-              'login-test.js-test': ' // login-test.js',
-              'logout-test.js-test': '',
-            },
-            lint: {
-              'login-test.lint.js-test': ' // login-test.lint.js',
-              'logout-test.lint.js-test': '',
-            },
-            helpers: {
-              'resolver.js-test': '',
-              'start-app.js-test': '',
-            },
-            'index.html': 'index',
-            integration: {
-              components: {
-                'login-form-test.js-test': '',
-                'user-menu-test.js-test': '',
-              },
-            },
-            'test-helper.js-test': '// test-helper.js',
-            unit: {
-              services: {
-                'session-test.js-test': '',
-              },
-            },
-          },
-        },
-      });
-    })
-  );
-
-  it(
-    'emits dist/assets/tests.js by default',
-    co.wrap(function*() {
-      let emptyInput = yield createTempDir();
-      let emptyTestFolder = {
-        'addon-tree-output': {},
-        bower_components: {},
-        'the-best-app-ever': {
-          'router.js': 'router.js',
-          'app.js': 'app.js',
-          components: {
-            'x-foo.js': 'export default class {}',
-          },
-          routes: {
-            'application.js': 'export default class {}',
-          },
-          config: {
-            'environment.js': 'environment.js',
-          },
-          templates: {},
-        },
-        vendor: {
-          'ember-cli': {
-            'app-boot.js': 'app-boot.js',
-            'app-config.js': 'app-config.js',
-            'app-prefix.js': 'app-prefix.js',
-            'app-suffix.js': 'app-suffix.js',
-            'test-support-prefix.js': 'test-support-prefix.js',
-            'test-support-suffix.js': 'test-support-suffix.js',
-            'tests-prefix.js': 'tests-prefix.js',
-            'tests-suffix.js': 'tests-suffix.js',
-            'vendor-prefix.js': 'vendor-prefix.js',
-            'vendor-suffix.js': 'vendor-suffix.js',
-          },
-        },
+      },
+      [name]: {
         tests: {
-          'test-helper.js': '// test-helper.js',
-        },
-      };
-
-      emptyInput.write(emptyTestFolder);
-
-      let project = {
-        configPath() {
-          return `${emptyInput.path()}/the-best-app-ever/config/environment`;
-        },
-
-        config() {
-          return { a: 1 };
-        },
-
-        addons: [],
-      };
-
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
-
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
+          acceptance: {
+            'login-test.js-test': ' // login-test.js',
+            'logout-test.js-test': '',
           },
-          testSupportCssFile: '/assets/test-support.css',
-        },
-
-        customTransformsMap: new Map(),
-
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
-
-        registry: setupRegistryFor('js', tree => tree),
-      });
-
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
-
-      let outputFiles = output.read();
-
-      expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
-
-      expect(Object.keys(outputFiles.assets)).to.deep.equal([
-        'test-support.js',
-        'test-support.map',
-        'tests.js',
-        'tests.map',
-      ]);
-
-      expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
-
-      emptyInput.dispose();
-    })
-  );
-
-  it(
-    'lintTree results do not "win" over app tests',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
-
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
+          lint: {
+            'login-test.lint.js-test': ' // login-test.lint.js',
+            'logout-test.lint.js-test': '',
           },
-          testSupportCssFile: '/assets/test-support.css',
-        },
-
-        customTransformsMap: new Map(),
-
-        vendorTestStaticStyles: [],
-        legacyTestFilesToAppend: [],
-
-        registry: setupRegistryFor('js', tree => tree),
-      });
-
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
-
-      let outputFiles = output.read();
-
-      // confirm this contains the original value
-      // unmodified by the `lintTree` added above
-      expect(outputFiles.assets['tests.js']).to.include('// login-test.js');
-    })
-  );
-
-  it(
-    'maintains the concatenation order',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager({
-        project,
-        name,
-        env,
-        areTestsEnabled: true,
-
-        distPaths: {
-          testJsFile: '/assets/tests.js',
-          testSupportJsFile: {
-            testSupport: '/assets/test-support.js',
-            testLoader: '/assets/test-loader.js',
+          helpers: {
+            'resolver.js-test': '',
+            'start-app.js-test': '',
           },
-          testSupportCssFile: '/assets/test-support.css',
+          'index.html': 'index',
+          integration: {
+            components: {
+              'login-form-test.js-test': '',
+              'user-menu-test.js-test': '',
+            },
+          },
+          'test-helper.js-test': '// test-helper.js',
+          unit: {
+            services: {
+              'session-test.js-test': '',
+            },
+          },
         },
+      },
+    });
+  });
 
-        customTransformsMap: new Map(),
+  it('processes tests files according to the registry', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
 
-        vendorTestStaticStyles: ['vendor/custom/a.css', 'vendor/custom/b.css'],
-        legacyTestFilesToAppend: ['vendor/custom/a.js', 'vendor/custom/b.js'],
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
+        },
+        testSupportCssFile: '/assets/test-support.css',
+      },
 
-        registry: setupRegistryFor('js', tree => tree),
-      });
+      customTransformsMap: new Map(),
 
-      output = yield buildOutput(defaultPackager.packageTests(input.path()));
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
 
-      let outputFiles = output.read();
+      registry: setupRegistryFor('js', function(tree) {
+        return new Funnel(tree, {
+          getDestinationPath(relativePath) {
+            return relativePath.replace(/js/g, 'js-test');
+          },
+        });
+      }),
+    });
 
-      expect(outputFiles.assets['test-support.js']).to.include('a.js\nb.js');
-      expect(outputFiles.assets['test-support.css']).to.include('a.css\nb.css');
-    })
-  );
+    output = await buildOutput(defaultPackager.processTests(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles).to.deep.equal({
+      'addon-test-support': {
+        '@ember': {
+          'test-helpers': {
+            'global.js':
+              'define("@ember/test-helpers/global", ["exports"], function(exports) { Object.defineProperty(exports, "__esModule", { value: true }); });',
+          },
+        },
+      },
+      [name]: {
+        tests: {
+          acceptance: {
+            'login-test.js-test': ' // login-test.js',
+            'logout-test.js-test': '',
+          },
+          lint: {
+            'login-test.lint.js-test': ' // login-test.lint.js',
+            'logout-test.lint.js-test': '',
+          },
+          helpers: {
+            'resolver.js-test': '',
+            'start-app.js-test': '',
+          },
+          'index.html': 'index',
+          integration: {
+            components: {
+              'login-form-test.js-test': '',
+              'user-menu-test.js-test': '',
+            },
+          },
+          'test-helper.js-test': '// test-helper.js',
+          unit: {
+            services: {
+              'session-test.js-test': '',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('emits dist/assets/tests.js by default', async function() {
+    let emptyInput = await createTempDir();
+    let emptyTestFolder = {
+      'addon-tree-output': {},
+      bower_components: {},
+      'the-best-app-ever': {
+        'router.js': 'router.js',
+        'app.js': 'app.js',
+        components: {
+          'x-foo.js': 'export default class {}',
+        },
+        routes: {
+          'application.js': 'export default class {}',
+        },
+        config: {
+          'environment.js': 'environment.js',
+        },
+        templates: {},
+      },
+      vendor: {
+        'ember-cli': {
+          'app-boot.js': 'app-boot.js',
+          'app-config.js': 'app-config.js',
+          'app-prefix.js': 'app-prefix.js',
+          'app-suffix.js': 'app-suffix.js',
+          'test-support-prefix.js': 'test-support-prefix.js',
+          'test-support-suffix.js': 'test-support-suffix.js',
+          'tests-prefix.js': 'tests-prefix.js',
+          'tests-suffix.js': 'tests-suffix.js',
+          'vendor-prefix.js': 'vendor-prefix.js',
+          'vendor-suffix.js': 'vendor-suffix.js',
+        },
+      },
+      tests: {
+        'test-helper.js': '// test-helper.js',
+      },
+    };
+
+    emptyInput.write(emptyTestFolder);
+
+    let project = {
+      configPath() {
+        return `${emptyInput.path()}/the-best-app-ever/config/environment`;
+      },
+
+      config() {
+        return { a: 1 };
+      },
+
+      addons: [],
+    };
+
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
+
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
+        },
+        testSupportCssFile: '/assets/test-support.css',
+      },
+
+      customTransformsMap: new Map(),
+
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
+
+      registry: setupRegistryFor('js', tree => tree),
+    });
+
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
+
+    expect(Object.keys(outputFiles.assets)).to.deep.equal([
+      'test-support.js',
+      'test-support.map',
+      'tests.js',
+      'tests.map',
+    ]);
+
+    expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
+
+    emptyInput.dispose();
+  });
+
+  it('lintTree results do not "win" over app tests', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
+
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
+        },
+        testSupportCssFile: '/assets/test-support.css',
+      },
+
+      customTransformsMap: new Map(),
+
+      vendorTestStaticStyles: [],
+      legacyTestFilesToAppend: [],
+
+      registry: setupRegistryFor('js', tree => tree),
+    });
+
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
+
+    let outputFiles = output.read();
+
+    // confirm this contains the original value
+    // unmodified by the `lintTree` added above
+    expect(outputFiles.assets['tests.js']).to.include('// login-test.js');
+  });
+
+  it('maintains the concatenation order', async function() {
+    let defaultPackager = new DefaultPackager({
+      project,
+      name,
+      env,
+      areTestsEnabled: true,
+
+      distPaths: {
+        testJsFile: '/assets/tests.js',
+        testSupportJsFile: {
+          testSupport: '/assets/test-support.js',
+          testLoader: '/assets/test-loader.js',
+        },
+        testSupportCssFile: '/assets/test-support.css',
+      },
+
+      customTransformsMap: new Map(),
+
+      vendorTestStaticStyles: ['vendor/custom/a.css', 'vendor/custom/b.css'],
+      legacyTestFilesToAppend: ['vendor/custom/a.js', 'vendor/custom/b.js'],
+
+      registry: setupRegistryFor('js', tree => tree),
+    });
+
+    output = await buildOutput(defaultPackager.packageTests(input.path()));
+
+    let outputFiles = output.read();
+
+    expect(outputFiles.assets['test-support.js']).to.include('a.js\nb.js');
+    expect(outputFiles.assets['test-support.css']).to.include('a.css\nb.css');
+  });
 
   if (isExperimentEnabled('MODULE_UNIFICATION')) {
     describe('with module unification layout', function() {
@@ -645,78 +614,69 @@ describe('Default Packager: Tests', function() {
         },
       };
 
-      before(
-        co.wrap(function*() {
-          input = yield createTempDir();
+      before(async function() {
+        input = await createTempDir();
 
-          input.write(MU_LAYOUT);
-        })
-      );
+        input.write(MU_LAYOUT);
+      });
 
-      after(
-        co.wrap(function*() {
-          yield input.dispose();
-        })
-      );
+      after(async function() {
+        await input.dispose();
+      });
 
-      afterEach(
-        co.wrap(function*() {
-          yield output.dispose();
-        })
-      );
+      afterEach(async function() {
+        await output.dispose();
+      });
 
-      it(
-        'packages test files',
-        co.wrap(function*() {
-          let defaultPackager = new DefaultPackager({
-            project,
-            name,
-            env,
-            areTestsEnabled: true,
+      it('packages test files', async function() {
+        let defaultPackager = new DefaultPackager({
+          project,
+          name,
+          env,
+          areTestsEnabled: true,
 
-            distPaths: {
-              testJsFile: '/assets/tests.js',
-              testSupportJsFile: {
-                testSupport: '/assets/test-support.js',
-                testLoader: '/assets/test-loader.js',
-              },
-              testSupportCssFile: '/assets/test-support.css',
+          distPaths: {
+            testJsFile: '/assets/tests.js',
+            testSupportJsFile: {
+              testSupport: '/assets/test-support.js',
+              testLoader: '/assets/test-loader.js',
             },
+            testSupportCssFile: '/assets/test-support.css',
+          },
 
-            customTransformsMap: new Map(),
+          customTransformsMap: new Map(),
 
-            isModuleUnificationEnabled: true,
+          isModuleUnificationEnabled: true,
 
-            vendorTestStaticStyles: [],
-            legacyTestFilesToAppend: [],
+          vendorTestStaticStyles: [],
+          legacyTestFilesToAppend: [],
 
-            registry: setupRegistryFor('js', tree => tree),
-          });
+          registry: setupRegistryFor('js', tree => tree),
+        });
 
-          output = yield buildOutput(defaultPackager.packageTests(input.path()));
+        output = await buildOutput(defaultPackager.packageTests(input.path()));
 
-          let outputFiles = output.read();
+        let outputFiles = output.read();
 
-          expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
+        expect(Object.keys(outputFiles.tests)).to.deep.equal(['index.html']);
 
-          expect(Object.keys(outputFiles.assets)).to.deep.equal([
-            'test-support.js',
-            'test-support.map',
-            'tests.js',
-            'tests.map',
-          ]);
+        expect(Object.keys(outputFiles.assets)).to.deep.equal([
+          'test-support.js',
+          'test-support.map',
+          'tests.js',
+          'tests.map',
+        ]);
 
-          expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
+        expect(Object.keys(outputFiles)).to.deep.equal(['assets', 'testem.js', 'tests']);
 
-          expect(outputFiles.assets['tests.js']).to.include('login-form-component-test');
-          expect(outputFiles.assets['tests.js']).to.include('login-test.js');
-          expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
-          expect(outputFiles.assets['tests.js']).to.include('test-helper');
-          expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
-          expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
-          expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
-        })
-      );
+        expect(outputFiles.assets['tests.js']).to.include('login-form-component-test');
+        expect(outputFiles.assets['tests.js']).to.include('login-test.js');
+        expect(outputFiles.assets['tests.js']).to.include('login-test.lint.js');
+        expect(outputFiles.assets['tests.js']).to.include('test-helper');
+        expect(outputFiles.assets['tests.js']).to.include(`define('the-best-app-ever/config/environment'`);
+        expect(outputFiles.assets['tests.js']).to.include(`require('the-best-app-ever/tests/test-helper');`);
+        expect(outputFiles.assets['tests.js']).to.include('EmberENV.TESTS_FILE_LOADED = true;');
+      });
     });
   }
 });

--- a/tests/unit/broccoli/default-packager/vendor-test.js
+++ b/tests/unit/broccoli/default-packager/vendor-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
@@ -43,52 +42,40 @@ describe('Default Packager: Vendor', function() {
     },
   };
 
-  before(
-    co.wrap(function*() {
-      input = yield createTempDir();
+  before(async function() {
+    input = await createTempDir();
 
-      input.write(VENDOR_PACKAGES);
-    })
-  );
+    input.write(VENDOR_PACKAGES);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield input.dispose();
-    })
-  );
+  after(async function() {
+    await input.dispose();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await output.dispose();
+  });
 
-  it(
-    'caches packaged vendor tree',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('caches packaged vendor tree', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      expect(defaultPackager._cachedVendor).to.equal(null);
+    expect(defaultPackager._cachedVendor).to.equal(null);
 
-      output = yield buildOutput(defaultPackager.packageVendor(input.path()));
+    output = await buildOutput(defaultPackager.packageVendor(input.path()));
 
-      expect(defaultPackager._cachedVendor).to.not.equal(null);
-      expect(defaultPackager._cachedVendor._annotation).to.equal('Packaged Vendor');
-    })
-  );
+    expect(defaultPackager._cachedVendor).to.not.equal(null);
+    expect(defaultPackager._cachedVendor._annotation).to.equal('Packaged Vendor');
+  });
 
-  it(
-    'packages vendor files',
-    co.wrap(function*() {
-      let defaultPackager = new DefaultPackager();
+  it('packages vendor files', async function() {
+    let defaultPackager = new DefaultPackager();
 
-      output = yield buildOutput(defaultPackager.packageVendor(input.path()));
+    output = await buildOutput(defaultPackager.packageVendor(input.path()));
 
-      let outputFiles = output.read();
+    let outputFiles = output.read();
 
-      expect(outputFiles).to.deep.equal({
-        vendor: VENDOR_PACKAGES,
-      });
-    })
-  );
+    expect(outputFiles).to.deep.equal({
+      vendor: VENDOR_PACKAGES,
+    });
+  });
 });

--- a/tests/unit/broccoli/ember-app/import-test.js
+++ b/tests/unit/broccoli/ember-app/import-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const path = require('path');
 const broccoliTestHelper = require('broccoli-test-helper');
 const expect = require('chai').expect;
@@ -25,148 +24,132 @@ describe('EmberApp: Bower Dependencies', function() {
     'moment.min.js': 'window.moment = "verysmallmoment"',
   });
 
-  beforeEach(
-    co.wrap(function*() {
-      applicationDirectory = yield createTempDir();
-    })
-  );
+  beforeEach(async function() {
+    applicationDirectory = await createTempDir();
+  });
 
-  afterEach(
-    co.wrap(function*() {
-      yield applicationDirectory.dispose();
-      yield output.dispose();
-    })
-  );
+  afterEach(async function() {
+    await applicationDirectory.dispose();
+    await output.dispose();
+  });
 
   /*
    * Both Ember.js and jQuery are packaged by default (when distriburted
    * through bower). `ember-source` takes precedent over bower though.
    */
-  it(
-    'are not packaged unless explicitly imported',
-    co.wrap(function*() {
-      // Given
-      applicationDirectory.write(
-        getDefaultUnpackagedDist('the-best-app-ever', {
-          bowerComponents: Object.assign({}, moment),
-        })
-      );
+  it('are not packaged unless explicitly imported', async function() {
+    // Given
+    applicationDirectory.write(
+      getDefaultUnpackagedDist('the-best-app-ever', {
+        bowerComponents: Object.assign({}, moment),
+      })
+    );
 
-      let applicationInstance = new EmberApp({
-        name: 'the-best-app-ever',
-        project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
-      });
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
+    });
 
-      // When
-      let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-      // Then
-      output = yield buildOutput(packagedApplicationJs);
-      let results = output.read();
+    // Then
+    output = await buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-      expect(() => {
-        validateDefaultPackagedDist('the-best-app-ever', results);
-      }).not.to.throw();
-      expect(results.assets['vendor.js']).to.contain('window.Ember = {');
-      expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
-      expect(results.assets['vendor.js']).to.not.contain('window.moment');
-    })
-  );
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.Ember = {');
+    expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
+    expect(results.assets['vendor.js']).to.not.contain('window.moment');
+  });
 
-  it(
-    'are packaged when explicitly imported',
-    co.wrap(function*() {
-      // Given
-      applicationDirectory.write(
-        getDefaultUnpackagedDist('the-best-app-ever', {
-          bowerComponents: Object.assign({}, moment),
-        })
-      );
-      let applicationInstance = new EmberApp({
-        name: 'the-best-app-ever',
-        project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
-      });
-      applicationInstance.import('bower_components/moment/moment.js');
+  it('are packaged when explicitly imported', async function() {
+    // Given
+    applicationDirectory.write(
+      getDefaultUnpackagedDist('the-best-app-ever', {
+        bowerComponents: Object.assign({}, moment),
+      })
+    );
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
+    });
+    applicationInstance.import('bower_components/moment/moment.js');
 
-      // When
-      let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-      // Then
-      output = yield buildOutput(packagedApplicationJs);
-      let results = output.read();
+    // Then
+    output = await buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-      expect(() => {
-        validateDefaultPackagedDist('the-best-app-ever', results);
-      }).not.to.throw();
-      expect(results.assets['vendor.js']).to.contain('window.Ember = {');
-      expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
-      expect(results.assets['vendor.js']).to.contain('window.moment');
-    })
-  );
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.Ember = {');
+    expect(results.assets['vendor.js']).to.contain('window.$ = function() {');
+    expect(results.assets['vendor.js']).to.contain('window.moment');
+  });
 
-  it(
-    'are packaged when explicitly imported for production',
-    co.wrap(function*() {
-      // Given
-      applicationDirectory.write(
-        getDefaultUnpackagedDist('the-best-app-ever', {
-          bowerComponents: Object.assign({}, moment),
-        })
-      );
+  it('are packaged when explicitly imported for production', async function() {
+    // Given
+    applicationDirectory.write(
+      getDefaultUnpackagedDist('the-best-app-ever', {
+        bowerComponents: Object.assign({}, moment),
+      })
+    );
 
-      let applicationInstance = new EmberApp({
-        name: 'the-best-app-ever',
-        project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
-      });
-      applicationInstance.env = 'production';
-      applicationInstance.import({
-        development: 'bower_components/moment/moment.js',
-        production: 'bower_components/moment/moment.min.js',
-      });
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
+    });
+    applicationInstance.env = 'production';
+    applicationInstance.import({
+      development: 'bower_components/moment/moment.js',
+      production: 'bower_components/moment/moment.min.js',
+    });
 
-      // When
-      let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-      // Then
-      output = yield buildOutput(packagedApplicationJs);
-      let results = output.read();
+    // Then
+    output = await buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-      expect(() => {
-        validateDefaultPackagedDist('the-best-app-ever', results);
-      }).not.to.throw();
-      expect(results.assets['vendor.js']).to.contain('verysmallmoment');
-    })
-  );
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('verysmallmoment');
+  });
 
-  it(
-    'are packaged when explicitly imported for development',
-    co.wrap(function*() {
-      // Given
-      applicationDirectory.write(
-        getDefaultUnpackagedDist('the-best-app-ever', {
-          bowerComponents: Object.assign({}, moment),
-        })
-      );
-      let applicationInstance = new EmberApp({
-        name: 'the-best-app-ever',
-        project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
-      });
-      applicationInstance.import({
-        development: 'bower_components/moment/moment.js',
-        production: 'bower_components/moment/moment.min.js',
-      });
+  it('are packaged when explicitly imported for development', async function() {
+    // Given
+    applicationDirectory.write(
+      getDefaultUnpackagedDist('the-best-app-ever', {
+        bowerComponents: Object.assign({}, moment),
+      })
+    );
+    let applicationInstance = new EmberApp({
+      name: 'the-best-app-ever',
+      project: setupProject(path.join(applicationDirectory.path(), 'the-best-app-ever')),
+    });
+    applicationInstance.import({
+      development: 'bower_components/moment/moment.js',
+      production: 'bower_components/moment/moment.min.js',
+    });
 
-      // When
-      let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
+    // When
+    let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
-      // Then
-      output = yield buildOutput(packagedApplicationJs);
-      let results = output.read();
+    // Then
+    output = await buildOutput(packagedApplicationJs);
+    let results = output.read();
 
-      expect(() => {
-        validateDefaultPackagedDist('the-best-app-ever', results);
-      }).not.to.throw();
-      expect(results.assets['vendor.js']).to.contain('window.moment');
-    })
-  );
+    expect(() => {
+      validateDefaultPackagedDist('the-best-app-ever', results);
+    }).not.to.throw();
+    expect(results.assets['vendor.js']).to.contain('window.moment');
+  });
 });

--- a/tests/unit/settings-file/leek-options-test.js
+++ b/tests/unit/settings-file/leek-options-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const MockUI = require('console-ui/mock');
 const Yam = require('yam');
@@ -13,48 +12,44 @@ const createTempDir = broccoliTestHelper.createTempDir;
 describe('.ember-cli leek options', function() {
   let passedOptions, leekConfigFolder;
 
-  before(
-    co.wrap(function*() {
-      leekConfigFolder = yield createTempDir();
+  before(async function() {
+    leekConfigFolder = await createTempDir();
 
-      leekConfigFolder.write({
-        '.ember-cli': JSON.stringify({
-          leekOptions: {
-            adapterUrls: {
-              event: 'http://www.example.com/event',
-              exception: 'http://www.example.com/error',
-              timing: 'http://www.example.com/timing',
-              appview: 'http://www.example.com/track',
-            },
+    leekConfigFolder.write({
+      '.ember-cli': JSON.stringify({
+        leekOptions: {
+          adapterUrls: {
+            event: 'http://www.example.com/event',
+            exception: 'http://www.example.com/error',
+            timing: 'http://www.example.com/timing',
+            appview: 'http://www.example.com/track',
           },
-        }),
-      });
+        },
+      }),
+    });
 
-      let primaryPath = leekConfigFolder.path();
+    let primaryPath = leekConfigFolder.path();
 
-      yield buildOutput(primaryPath);
+    await buildOutput(primaryPath);
 
-      let mockedYam = new Yam('ember-cli', {
-        primary: primaryPath,
-      });
+    let mockedYam = new Yam('ember-cli', {
+      primary: primaryPath,
+    });
 
-      let mockedLeek = function(options) {
-        passedOptions = options;
-      };
+    let mockedLeek = function(options) {
+      passedOptions = options;
+    };
 
-      cliEntry({
-        UI: MockUI,
-        Leek: mockedLeek,
-        Yam: mockedYam,
-      });
-    })
-  );
+    cliEntry({
+      UI: MockUI,
+      Leek: mockedLeek,
+      Yam: mockedYam,
+    });
+  });
 
-  after(
-    co.wrap(function*() {
-      yield leekConfigFolder.dispose();
-    })
-  );
+  after(async function() {
+    await leekConfigFolder.dispose();
+  });
 
   it('should contain the leek options from .ember-cli file', function() {
     expect(passedOptions.adapterUrls).to.contain.keys(['event', 'exception', 'timing', 'appview']);

--- a/tests/unit/utilities/load-config-test.js
+++ b/tests/unit/utilities/load-config-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const expect = require('chai').expect;
 const path = require('path');
 const loadConfig = require('../../../lib/utilities/load-config');
@@ -12,30 +11,26 @@ const createTempDir = broccoliTestHelper.createTempDir;
 describe('load-config', function() {
   let fixtureDirectoryPath, fixtureDirectory;
 
-  before(
-    co.wrap(function*() {
-      fixtureDirectory = yield createTempDir();
-      fixtureDirectoryPath = fixtureDirectory.path();
+  before(async function() {
+    fixtureDirectory = await createTempDir();
+    fixtureDirectoryPath = fixtureDirectory.path();
 
-      fixtureDirectory.write({
-        '.something': 'hello: world\n',
-        '.travis.yaml': 'hello: world',
-        '.travis.yml': 'hello: world',
-        'package.json': '{ "hello": "world" }',
-        child: {
-          'test.json': '{ "hello": "world" }',
-        },
-      });
+    fixtureDirectory.write({
+      '.something': 'hello: world\n',
+      '.travis.yaml': 'hello: world',
+      '.travis.yml': 'hello: world',
+      'package.json': '{ "hello": "world" }',
+      child: {
+        'test.json': '{ "hello": "world" }',
+      },
+    });
 
-      yield buildOutput(fixtureDirectoryPath);
-    })
-  );
+    await buildOutput(fixtureDirectoryPath);
+  });
 
-  after(
-    co.wrap(function*() {
-      yield fixtureDirectory.dispose();
-    })
-  );
+  after(async function() {
+    await fixtureDirectory.dispose();
+  });
 
   it('loads and parses a yml file', function() {
     expect(loadConfig('.travis.yml', fixtureDirectoryPath).hello).to.equal('world');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,11 +1423,6 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"


### PR DESCRIPTION
This commit is the result of running these commands:

```
yarn remove co
npx jscodeshift --transform https://raw.githubusercontent.com/albinekb/co-to-async/master/codemod.js tests/**/*.js
yarn lint --fix
```