### PR TITLE
Update GitHub Actions setup to use TAP output.

### DIFF
--- a/tests/runner.js
+++ b/tests/runner.js
@@ -17,7 +17,8 @@ fs.removeSync('.deps-tmp');
 let root = 'tests/{unit,integration,acceptance}';
 let optionOrFile = process.argv[2];
 // default to `tap` reporter in CI otherwise default to `spec`
-let reporter = process.env.MOCHA_REPORTER || (process.env.CI ? 'tap' : 'spec');
+let isCI = process.env.CI || process.env.GITHUB_ACTIONS;
+let reporter = process.env.MOCHA_REPORTER || (isCI ? 'tap' : 'spec');
 let mocha = new Mocha({
   timeout: 5000,
   reporter,


### PR DESCRIPTION
The other CI systems already use TAP output, but GitHub Actions didn't (because we don't set `CI` environment variable in our config, and they don't set it automatically).

Using TAP output in CI makes it possible to Cmd+F (or Ctrl+F) for "not ok" to jump directly to the failing tests, otherwise with the standard Mocha `spec` reporter it is quite difficult to jump to the failures.