### PR TITLE
Fix PackageInfoCache assertions to work properly in Windows.

### DIFF
--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -205,14 +205,14 @@ describe('models/package-info-cache/package-info-cache-test.js', function() {
       it('shows a warning with invalid ember-addon#path', function() {
         project.discoverAddons();
         expect(project.cli.ui.output).to.include(
-          "specifies an invalid, malformed or missing addon at relative path 'lib/no-such-path'"
+          `specifies an invalid, malformed or missing addon at relative path 'lib${path.sep}no-such-path'`
         );
       });
 
       it('throws an error with flag on', function() {
         process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON = 'true';
         expect(() => project.discoverAddons()).to.throw(
-          /specifies an invalid, malformed or missing addon at relative path 'lib\/no-such-path'/
+          /specifies an invalid, malformed or missing addon at relative path 'lib[\\/]no-such-path'/
         );
       });
     });


### PR DESCRIPTION
This issue was introduced in https://github.com/ember-cli/ember-cli/pull/8907.