### PR TITLE
Add maybeMakeCommand method for CLI

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -84,13 +84,54 @@ class CLI {
 
   /**
    * @private
+   * @method maybeMakeCommand
+   * @param commandName
+   * @param commandArgs
+   * @return {null|CurrentCommand}
+   */
+  maybeMakeCommand(commandName, commandArgs) {
+    if (this._environment === undefined) {
+      throw new Error('Unable to make command without environment, you have to execute "run" method first.');
+    }
+    let CurrentCommand = lookupCommand(this._environment.commands, commandName, commandArgs, {
+      project: this._environment.project,
+      ui: this.ui,
+    });
+
+    /*
+     * XXX Need to decide what to do here about showing errors. For
+     * a non-CLI project the cache is local and probably should. For
+     * a CLI project the cache is there, but not sure when we'll know
+     * about all the errors, because there may be multiple projects.
+     *   if (this.packageInfoCache.hasErrors()) {
+     *     this.packageInfoCache.showErrors();
+     *   }
+     */
+    let command = new CurrentCommand({
+      ui: this.ui,
+      analytics: this.analytics,
+      commands: this._environment.commands,
+      tasks: this._environment.tasks,
+      project: this._environment.project,
+      settings: this._environment.settings,
+      testing: this.testing,
+      cli: this,
+    });
+
+    return command;
+  }
+  /**
+   * @private
    * @method run
    * @param environment
    * @return {Promise}
    */
   run(environment) {
+    if (environment === undefined) {
+      return RSVP.reject(new Error('Unable to execute "run" command without environment argument'));
+    }
+    this._environment = environment;
     let shutdownOnExit = null;
-
     return RSVP.hash(environment)
       .then(environment => {
         let args = environment.cliArgs.slice();
@@ -100,30 +141,7 @@ class CLI {
 
         let commandLookupCreationToken = heimdall.start('lookup-command');
 
-        let CurrentCommand = lookupCommand(environment.commands, commandName, commandArgs, {
-          project: environment.project,
-          ui: this.ui,
-        });
-
-        /*
-         * XXX Need to decide what to do here about showing errors. For
-         * a non-CLI project the cache is local and probably should. For
-         * a CLI project the cache is there, but not sure when we'll know
-         * about all the errors, because there may be multiple projects.
-         *   if (this.packageInfoCache.hasErrors()) {
-         *     this.packageInfoCache.showErrors();
-         *   }
-         */
-        let command = new CurrentCommand({
-          ui: this.ui,
-          analytics: this.analytics,
-          commands: environment.commands,
-          tasks: environment.tasks,
-          project: environment.project,
-          settings: environment.settings,
-          testing: this.testing,
-          cli: this,
-        });
+        let command = this.maybeMakeCommand(commandName, commandArgs);
 
         commandLookupCreationToken.stop();
 

--- a/tests/unit/cli/cli-test.js
+++ b/tests/unit/cli/cli-test.js
@@ -194,6 +194,47 @@ describe('Unit: CLI', function() {
       });
   });
 
+  it('"run" method must throw error if no evironment provided', function() {
+    stubValidateAndRun('help');
+
+    let cli = new CLI({
+      ui,
+      analytics,
+      testing: true,
+    });
+
+    let wasResolved = false;
+    cli
+      .run()
+      .then(() => {
+        wasResolved = true;
+      })
+      .catch(err => {
+        expect(err.toString()).to.be.equal('Error: Unable to execute "run" command without environment argument');
+      })
+      .finally(() => {
+        expect(wasResolved).to.be.false;
+      });
+  });
+
+  it('errors correctly if "run" method not called before "maybeMakeCommand" execution', function() {
+    stubValidateAndRun('help');
+
+    let cli = new CLI({
+      ui,
+      analytics,
+      testing: true,
+    });
+
+    try {
+      cli.maybeMakeCommand('foo', ['bar']);
+    } catch (err) {
+      expect(err.toString()).to.be.equal(
+        'Error: Unable to make command without environment, you have to execute "run" method first.'
+      );
+    }
+  });
+
   describe('custom addon command', function() {
     it('beforeRun can return a promise', function() {
       let CustomCommand = Command.extend({


### PR DESCRIPTION
@stefanpenner @Turbo87 

looks like we can't use `cli` constructor for `evironment`, because `environment` needs `project` and `project` needs `cli`.

`setEnvironment` solve this