### PR TITLE
Fix tests writing 'undefined' as file content

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -177,7 +177,7 @@ describe('Acceptance: ember new', function() {
 
   it('ember new with blueprint uses the specified blueprint directory with a relative path', async function() {
     fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync('my_blueprint/files/gitignore');
+    fs.writeFileSync('my_blueprint/files/gitignore', '');
 
     await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
 
@@ -186,7 +186,7 @@ describe('Acceptance: ember new', function() {
 
   it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function() {
     fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync('my_blueprint/files/gitignore');
+    fs.writeFileSync('my_blueprint/files/gitignore', '');
 
     await ember([
       'new',


### PR DESCRIPTION
Node.js might soon start to validate input data passed through to `fs`. Doing so caught to errors in ember-cli (the test suite is run against Node.js using `citgm` https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/2142/nodes=osx1011/testReport/junit/(root)/citgm/ember_cli_v3_14_0/).

The tests seem to work independent of the content of these files. This is not a good idea though and it was never meant to be an optional argument.