### PR TITLE
GitHub Actions CI Tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn lint
 
   basic-tests:
@@ -60,7 +60,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test
 
   tests:
@@ -90,8 +90,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
-        continue-on-error: ${{ matrix['continue-on-error'] == true }}
+      - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all
         continue-on-error: ${{ matrix['continue-on-error'] == true }}
 
@@ -128,7 +127,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all
         env:
           ${{ matrix.feature-flag }}: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,30 @@ on:
     - cron:  '0 3 * * *' # daily, at 3am
 
 jobs:
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: get yarn cache dir
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+      - run: yarn lint
+
   basic-tests:
     name: Basic Tests
     runs-on: ubuntu-latest
@@ -37,14 +61,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - run: yarn install
-      - run: yarn lint
       - run: yarn test
 
   tests:
     name: Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
 
-    needs: [basic-tests]
+    needs: [linting, basic-tests]
 
     strategy:
       matrix:
@@ -76,7 +99,7 @@ jobs:
     name: "Feature Flag: ${{ matrix.feature-flag }}"
     runs-on: ubuntu-latest
 
-    needs: [basic-tests]
+    needs: [linting, basic-tests]
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 13.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: ${{ matrix['continue-on-error'] == true }}
 
   feature-flags:
-    name: "Feature Flag: ${{ matrix.feature-flag }}"
+    name: "Feature: ${{ matrix.feature-flag }}"
     runs-on: ubuntu-latest
 
     needs: [linting, basic-tests]


### PR DESCRIPTION
* Add specific job for `linting` (this makes it a bit easier to quickly
  spot linting issues vs actual test failures)
* Add `--frozen-lockfile` and `--non-interactive` to CI
* Add Node 13.x testing
* Split slow and fast tests into separate CI jobs