### PR TITLE
Increase testem browser timeout.

### DIFF
--- a/blueprints/app/files/testem.js
+++ b/blueprints/app/files/testem.js
@@ -7,6 +7,7 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
Some CI systems seem to hit the default limit much more often than others. Specifically, GitHub actions seems to fail fairly consistently (5 out of 10 job runs) without increasing the timeout, but passes consistently with an increased limit.

When Testem's timeout is hit, the failure commonly looks like:

```
not ok 1 Chrome - [undefined ms] - error
    ---
        message: >
            Error: Browser failed to connect within 30s. testem.js not loaded?
            Stderr: 
             Unable to revert mtime: /usr/share/fonts
            Unable to revert mtime: /usr/share/fonts/cMap
            Unable to revert mtime: /usr/share/fonts/cmap
            Unable to revert mtime: /usr/share/fonts/truetype
            Unable to revert mtime: /usr/share/fonts/type1
            Unable to revert mtime: /usr/share/fonts/cmap/adobe-cns1
            Unable to revert mtime: /usr/share/fonts/cmap/adobe-gb1
            Unable to revert mtime: /usr/share/fonts/cmap/adobe-japan1
            Unable to revert mtime: /usr/share/fonts/cmap/adobe-japan2
            Unable to revert mtime: /usr/share/fonts/cmap/adobe-korea1
            Unable to revert mtime: /usr/share/fonts/truetype/dejavu
            Unable to revert mtime: /usr/share/fonts/truetype/droid
            Unable to revert mtime: /usr/share/fonts/truetype/liberation
            Unable to revert mtime: /usr/share/fonts/truetype/noto
```