### PR TITLE
Update package-info.js

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -359,11 +359,13 @@ class PackageInfo {
           msg = `${msg}\n    '${relativePath}'`;
         });
       }
-
+ 
       if (process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON) {
         throw msg;
+      } else if (this.project) {
+        this.project.ui.writeWarnLine(msg);
       } else {
-        this.cache.ui.writeWarnLine(msg);
+        console.warn(msg);
       }
     }
   }

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -359,7 +359,7 @@ class PackageInfo {
           msg = `${msg}\n    '${relativePath}'`;
         });
       }
- 
+
       if (process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON) {
         throw msg;
       } else if (this.project) {


### PR DESCRIPTION
When an addon package.json contains invalid paths (see linkedin/css-blocks/pull/378) and this.project is undefined ember-cli crashes silently. Tested on 3.15.1.