### PR TITLE
Avoid errors when `ui` is not present and a warning will be emitted.

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -363,7 +363,7 @@ class PackageInfo {
       if (process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON) {
         throw msg;
       } else {
-        this.project.ui.writeWarnLine(msg);
+        this.cache.ui.writeWarnLine(msg);
       }
     }
   }


### PR DESCRIPTION
Addon packageInfos do not have a project. All packageInfos have a cache.ui.

(cherry picked from commit 1652f93ed738168c9a0ce0b25e36063d5f99043c)