### PR TITLE
Allow failure of Node 8 CI jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
+        include:
+          - node-version: 8.x
+            continue-on-error: true
 
     steps:
       - uses: actions/checkout@v1
@@ -68,7 +71,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - run: yarn install
+        continue-on-error: ${{ matrix['continue-on-error'] == true }}
       - run: yarn test:all
+        continue-on-error: ${{ matrix['continue-on-error'] == true }}
 
   feature-flags:
     name: "Feature Flag: ${{ matrix.feature-flag }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ stages:
     if: type IN (push) AND branch = release
 
 jobs:
+  allow_failures:
+    - node_js: 8
+
   include:
     - stage: basic test
       name: Basic Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - nodejs_version: "8"
 
 branches:
   only:


### PR DESCRIPTION
Node 8 is EOL and dependencies are releasing versions that require Node 10+ without bumping major versions.

This allows Node 8 failures, so that we can continue to have a passing CI for the other supported platforms (so that as we land bugfixes and whatnot, we can be certain they work properly).