### PR TITLE
Make "process already captured" error more useful.

### DIFF
--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -16,12 +16,12 @@ const EventEmitter = require('events');
 
 const handlers = [];
 
-let _process, windowsCtrlCTrap, originalIsRaw;
+let _process, _processCapturedLocation, windowsCtrlCTrap, originalIsRaw;
 
 module.exports = {
   capture(outerProcess) {
     if (_process) {
-      throw new Error('process already captured');
+      throw new Error(`process already captured at: \n\n${_processCapturedLocation.stack}`);
     }
 
     if (outerProcess instanceof EventEmitter === false) {
@@ -29,6 +29,7 @@ module.exports = {
     }
 
     _process = outerProcess;
+    _processCapturedLocation = new Error();
 
     // ember-cli and user apps have many dependencies, many of which require
     // process.addListener('exit', ....) for cleanup, by default this limit for
@@ -62,6 +63,7 @@ module.exports = {
     }
 
     _process = null;
+    _processCapturedLocation = null;
   },
 
   /**

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -28,7 +28,8 @@ describe('will interrupt process', function() {
         willInterruptProcess.capture(mockProcess);
         expect(true).to.equal(false);
       } catch (e) {
-        expect(e.message).to.equal('process already captured');
+        expect(e.message).to.include('process already captured');
+        expect(e.message).to.include('will-interrupt-process-test.js');
       }
     });
 


### PR DESCRIPTION
This ensures that the stack that captured the process originally is included in the error message. Without this you only know the source for the _second_ (and errant) call to `.capture()`.