### PR TITLE
Fix dev/changelog script to emit proper headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Thank you to all who took the time to contribute!
 
 Thank you to all who took the time to contribute!
 
+## v3.15.0
+
 #### Blueprint Changes
 
 - [`ember new` diff](https://github.com/ember-cli/ember-new-output/compare/v3.14.0...v3.15.0)
@@ -68,6 +70,7 @@ Thank you to all who took the time to contribute!
 - [`ember new` diff](https://github.com/ember-cli/ember-new-output/compare/v3.13.2...v3.14.0)
 - [`ember addon` diff](https://github.com/ember-cli/ember-addon-output/compare/v3.13.2...v3.14.0)
 
+#### Changelog
 
 - [#8875](https://github.com/ember-cli/ember-cli/pull/8875) Fix ember-cli-htmlbars-inline-precompile deprecation [@HeroicEric](https://github.com/HeroicEric)
 - [#8882](https://github.com/ember-cli/ember-cli/pull/8882) Simplify "Get started" message for `ember new` [@dcyriller](https://github.com/dcyriller)
@@ -88,6 +91,7 @@ Thank you to all who took the time to contribute!
 - [`ember new` diff](https://github.com/ember-cli/ember-new-output/compare/v3.13.1...v3.13.2)
 - [`ember addon` diff](https://github.com/ember-cli/ember-addon-output/compare/v3.13.1...v3.13.2)
 
+#### Changelog
 
 - [#8875](https://github.com/ember-cli/ember-cli/pull/8875) Fix ember-cli-htmlbars-inline-precompile deprecation [@HeroicEric](https://github.com/HeroicEric)
 - [#8882](https://github.com/ember-cli/ember-cli/pull/8882) Simplify "Get started" message [@dcyriller](https://github.com/dcyriller)
@@ -102,6 +106,7 @@ Thank you to all who took the time to contribute!
 - [`ember new` diff](https://github.com/ember-cli/ember-new-output/compare/v3.13.0...v3.13.1)
 - [`ember addon` diff](https://github.com/ember-cli/ember-addon-output/compare/v3.13.0...v3.13.1)
 
+#### Changelog
 
 - [#8857](https://github.com/ember-cli/ember-cli/pull/8857) Tweaks to release scripts. [@rwjblue](https://github.com/rwjblue)
 - [#8862](https://github.com/ember-cli/ember-cli/pull/8862) Adjust message for when a new app is created [@dcyriller](https://github.com/dcyriller)

--- a/dev/changelog
+++ b/dev/changelog
@@ -14,7 +14,6 @@
  * dev/changelog <remote branch-name (Default: master)> <next version>
  */
 
-const { EOL } = require('os');
 const GitHubApi = require('@octokit/rest');
 const semver = require('semver');
 
@@ -37,16 +36,20 @@ if (nextVersion[0] !== 'v') {
 }
 
 function generateChangelog(contributions) {
-  let header = `
+  return `
+## ${nextVersion}
+
 #### Blueprint Changes
 
 - [\`ember new\` diff](https://github.com/ember-cli/ember-new-output/compare/${currentVersion}...${nextVersion})
 - [\`ember addon\` diff](https://github.com/ember-cli/ember-addon-output/compare/${currentVersion}...${nextVersion})
+
+#### Changelog
+
+${contributions}
+
+Thank you to all who took the time to contribute!
 `;
-
-  let footer = 'Thank you to all who took the time to contribute!';
-
-  return header + EOL + EOL + contributions + EOL + EOL + footer;
 }
 
 // only filters when dependabot itself merges a PR


### PR DESCRIPTION
Previously, the script would output only the `#### Blueprint Changes`
header but not the actual version number or the `#### Changelog` separator
between the blueprint diffs and the changelog entries.