### PR TITLE
Include API documentation `yuidoc` JSON output when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 *.log
 !/.travis.yml
 /yarn.lock
+!docs/build/data.json

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "docs": "yuidoc",
     "lint": "eslint . --cache",
+    "prepack": "yarn docs",
     "test": "node tests/runner",
     "test:all": "node tests/runner all",
     "test:cover": "nyc node tests/runner all",


### PR DESCRIPTION
The learning team would like to start publishing the latest version of the ember-cli api doc as a part of https://api.emberjs.com. To do so, we'll need the yuidoc generated `data.json` file to be published as a part of the npm package. 

This PR adds a new entry in the `.npmignore` file that enables this.
