### PR TITLE
Refactor Blueprint model to avoid floating promises in `_process`.

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -417,21 +417,22 @@ let Blueprint = CoreObject.extend({
     @param {Function} process
     @param {Function} afterHook
   */
-  _process(options, beforeHook, process, afterHook) {
+  async _process(options, beforeHook, process, afterHook) {
     let intoDir = options.target;
 
-    return this._locals(options).then(locals =>
-      Promise.resolve()
-        .then(beforeHook.bind(this, options, locals))
-        .then(process.bind(this, intoDir, locals))
-        .then(async promises => {
-          let values = await Promise.all(promises);
-          let commitPromises = values.map(this._commit.bind(this));
+    let locals = await this._locals(options);
 
-          return Promise.all(commitPromises);
-        })
-        .then(afterHook.bind(this, options))
-    );
+    // run beforeInstall/beforeUninstall userland hooks
+    await beforeHook.call(this, options, locals);
+
+    // gather fileInfos to be processed
+    let fileInfos = await process.call(this, intoDir, locals);
+
+    // commit changes for each FileInfo (with prompting as needed)
+    await Promise.all(fileInfos.map(fi => this._commit(fi)));
+
+    // run afterInstall/afterUninstall userland hooks
+    await afterHook.call(this, options);
   },
 
   /**
@@ -738,6 +739,7 @@ let Blueprint = CoreObject.extend({
     @method processFiles
     @param {String} intoDir
     @param {Object} templateVariables
+    @return {Promise<FileInfo[]>}
   */
   processFiles(intoDir, templateVariables) {
     let files = this._getFilesForInstall(templateVariables.targetFiles);


### PR DESCRIPTION
The conversion for `RSVP.map` was done incorrectly leading to promises that were floated (not immediately entangled in the resulting promise chain).

Thanks to @krisselden for pointing this out.