### PR TITLE
include "yarn": true in .ember-cli if using yarn

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -395,7 +395,7 @@ describe('Acceptance: ember new', function() {
       let namespace = 'app';
       let fixturePath = `${namespace}/npm`;
 
-      ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
+      ['app/templates/application.hbs', '.ember-cli', '.travis.yml', 'README.md'].forEach(filePath => {
         expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
 
@@ -410,7 +410,7 @@ describe('Acceptance: ember new', function() {
 
       let fixturePath = 'app/yarn';
 
-      ['app/templates/application.hbs', '.travis.yml', 'README.md'].forEach(filePath => {
+      ['app/templates/application.hbs', '.ember-cli', '.travis.yml', 'README.md'].forEach(filePath => {
         expect(file(filePath)).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, filePath)));
       });
 

--- a/tests/fixtures/app/npm/.ember-cli
+++ b/tests/fixtures/app/npm/.ember-cli
@@ -5,6 +5,5 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false<% if (yarn) { %>,
-  "yarn": true<% } %>
+  "disableAnalytics": false
 }

--- a/tests/fixtures/app/yarn/.ember-cli
+++ b/tests/fixtures/app/yarn/.ember-cli
@@ -5,6 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false<% if (yarn) { %>,
-  "yarn": true<% } %>
+  "disableAnalytics": false,
+  "yarn": true
 }


### PR DESCRIPTION
Normally this isn't a problem, because you have a yarn.lock. But in certain cases (automation/testing), you might not have the lockfile (you're using fixtures you generated with `--skip-npm --yarn`), and stuff like `addPackagesToProject` will use npm instead of yarn.