### PR TITLE
[minor] Adds link to CLI commands doc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Usage
 After installation the `ember` CLI tool will be available to you. It is the
 entrypoint for all the functionality mentioned above.
 
-You can call `ember <command> --help` to find out more about all of the
-following commands or visit <https://cli.emberjs.com/release/> to read
+You can call `ember <command> --help` to find out more about [all of the
+following commands](https://cli.emberjs.com/release/basic-use/cli-commands/) or visit <https://cli.emberjs.com/release/> to read
 the in-depth documentation.
 
 


### PR DESCRIPTION
This adds a direct link to the basic CLI commands doc.

Rationale:

1. The readme says, "You can call `ember <command> --help` to find out more about all of the following commands..." but no command list follows.

2. From the project page/readme, it takes 3 clicks to find what the actual `ember-cli` commands are, one of which is hidden inside an accordion.