### PR TITLE
Add Windows to GH Actions CI for test:all.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
     strategy:
       matrix:
         feature-flag:
-          - EMBER_CLI_ENABLE_ALL_EXPERIMENTS
-          - EMBER_CLI_PACKAGER
+          - ENABLE_ALL_EXPERIMENTS
+          - PACKAGER
 
     steps:
       - uses: actions/checkout@v1
@@ -87,4 +87,4 @@ jobs:
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all
         env:
-          ${{ matrix.feature-flag }}: true
+          "EMBER_CLI_${{ matrix.feature-flag }}": true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       - run: yarn lint
 
   basic-tests:
-    name: Basic Tests
-    runs-on: ${{ matrix.os }}
+    name: "Basic Tests - ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}-latest"
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu, macOS, windows]
 
     steps:
       - uses: actions/checkout@v1
@@ -46,14 +46,15 @@ jobs:
       - run: yarn test
 
   tests:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: "Node ${{ matrix.node-version }} - ${{ matrix.os }} "
+    runs-on: "${{ matrix.os }}-latest"
 
     needs: [linting, basic-tests]
 
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x]
+        os: [ubuntu, macOS, windows]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [linting, basic-tests]
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 13.x]
         os: [ubuntu, macOS, windows]
@@ -73,6 +74,7 @@ jobs:
     needs: [linting, basic-tests]
 
     strategy:
+      fail-fast: false
       matrix:
         feature-flag:
           - ENABLE_ALL_EXPERIMENTS

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const spawn = require('child_process').spawn;
+const execa = require('execa');
 const chalk = require('chalk');
 
 const runCommand = require('../helpers/run-command');
@@ -115,7 +116,8 @@ describe('Acceptance: addon-smoke-test', function() {
 
     let output;
     try {
-      output = await tar();
+      let result = await tar();
+      output = result.stdout;
     } catch (error) {
       return handleError(error, 'tar');
     }
@@ -159,16 +161,12 @@ function npmPack() {
   });
 }
 
-function tar() {
-  return new Promise((resolve, reject) => {
-    let output;
-    let fileName = `${addonName}-0.0.0.tgz`;
-    if (fs.existsSync(fileName) === false) {
-      throw new Error(`unknown file: '${path.resolve(fileName)}'`);
-    }
-    let tar = spawn('tar', ['-tf', fileName]);
-    tar.on('error', reject);
-    tar.stdout.on('data', data => (output = data.toString()));
-    tar.on('close', () => resolve(output));
-  });
+async function tar() {
+  let fileName = `${addonName}-0.0.0.tgz`;
+
+  if (fs.existsSync(fileName) === false) {
+    throw new Error(`unknown file: '${path.resolve(fileName)}'`);
+  }
+
+  return execa('tar', ['-tf', fileName]);
 }

--- a/tests/helpers/kill-cli-process.js
+++ b/tests/helpers/kill-cli-process.js
@@ -1,6 +1,12 @@
 'use strict';
 
 module.exports = function(childProcess) {
+  // Calling `.kill` or `.send` when the process has already exited causes
+  // errors on Windows, when an `.exitCode` is non-null the process has exited
+  if (childProcess.exitCode !== null) {
+    return;
+  }
+
   if (process.platform === 'win32') {
     childProcess.send({ kill: true });
   } else {


### PR DESCRIPTION
* Adds `windows-latest` and `macOS-latest` to run for each supported Node version.
* Tweaks the job names to be a bit simpler / easier to read.
* Fix issue on Windows when killing an already killed child process.