### PR TITLE
Remove `actions/cache` from CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,6 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn lint
 
@@ -52,17 +41,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test
@@ -82,17 +60,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all
@@ -115,17 +82,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all


### PR DESCRIPTION
Initial testing shows that caching can often be more costly than installing (especially on macOS and Windows hosts).

We can always bring this back if we find that it _is_ faster, tweak config, etc.