### PR TITLE
Ensure local testing can run smoke tests "back to back".

### DIFF
--- a/tests/helpers/package-cache.js
+++ b/tests/helpers/package-cache.js
@@ -539,9 +539,9 @@ module.exports = class PackageCache {
       return;
     }
 
-    // Only way to get repeatable behavior in npm: start over.
-    // We turn an `_upgrade` task into an `_install` task.
-    if (type === 'npm') {
+    if (!this._canUpgrade(label, type)) {
+      // Only way to get repeatable behavior in npm: start over.
+      // We turn an `_upgrade` task into an `_install` task.
       fs.removeSync(path.join(this.dirs[label], translate(type, 'path')));
       return this._install(label, type);
     }
@@ -551,6 +551,10 @@ module.exports = class PackageCache {
     this._restoreLinks(label, type);
 
     upgraded[label] = true;
+  }
+
+  _canUpgrade(label, type) {
+    return type === 'bower' || (type === 'yarn' && fs.existsSync(path.join(this.dirs[label], 'yarn.lock')));
   }
 
   // PUBLIC API BELOW

--- a/tests/helpers/run-command.js
+++ b/tests/helpers/run-command.js
@@ -6,7 +6,12 @@ const defaults = require('ember-cli-lodash-subset').defaults;
 const killCliProcess = require('./kill-cli-process');
 const logOnFailure = require('./log-on-failure');
 let debug = require('heimdalljs-logger')('run-command');
-const captureExit = require('capture-exit');
+const { captureExit, onExit } = require('capture-exit');
+
+// when running the full test suite, `process.exit` has already been captured
+// however, when running specific files (e.g. `mocha some/path/to/file.js`)
+// exit may not be captured before `runCommand` attempts to call `onExit`
+captureExit();
 
 let RUNS = [];
 module.exports = function run(/* command, args, options */) {
@@ -60,7 +65,7 @@ module.exports = function run(/* command, args, options */) {
     child = spawn(command, args, opts);
     RUNS.push(child);
     // ensure we tear down the child process on exit;
-    captureExit.onExit(() => killCliProcess(child));
+    onExit(() => killCliProcess(child));
 
     let result = {
       output: [],


### PR DESCRIPTION
* Ensure `captureExit` is always called before `onExit` is used.
* Ensure that `yarn upgrade` is only called when it can be used.