### PR TITLE
Migrate supported Node version detection to use GitHub Actions config.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,12 @@
 /tmp/
 /.*
 *.log
-!/.travis.yml
 /yarn.lock
 !docs/build/data.json
+
+# the GitHub Action CI configuration is used by
+# lib/utilities/platform-checker.js to determine what versions of Node are
+# under test by the current version of ember-cli being used, this means we
+# **must** publish this file (but it would be ignored by the `/.*` line just
+# above)
+!/.github/workflows/ci.yml

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -29,8 +29,6 @@ Node.js](https://github.com/nodejs/LTS#lts_schedule).
 
 ## Current support:
 
-* v8: Released as stable version then converted to LTS.
-  * Supported by ember-cli/ember-cli#master until: 2019-12-31.
 * v10: Released as stable version then converted to LTS.
   * Supported by ember-cli/ember-cli#master until: 2021-04-30.
 * v12: Released as stable version then converted to LTS.

--- a/lib/utilities/platform-checker.js
+++ b/lib/utilities/platform-checker.js
@@ -4,23 +4,25 @@ const semver = require('semver');
 const logger = require('heimdalljs-logger')('ember-cli:platform-checker:');
 const loadConfig = require('./load-config');
 
-let testedEngines;
-if (process.platform === 'win32') {
-  testedEngines = loadConfig('appveyor.yml')
-    .environment.matrix.map(element => element.nodejs_version)
-    .join(' || ');
-} else {
-  let travisConfig = loadConfig('.travis.yml');
-  let nodeVersions = new Set(travisConfig.node_js);
+const ci = loadConfig('.github/workflows/ci.yml');
+const nodeVersions = new Set();
 
-  travisConfig.jobs.include.forEach(job => {
-    if (job.node_js) {
-      nodeVersions.add(job.node_js);
+for (let jobName in ci.jobs) {
+  let job = ci.jobs[jobName];
+
+  job.steps.forEach(step => {
+    let isSetupNode = step.uses === 'actions/setup-node@v1';
+    if (isSetupNode && step.with['node-version'].includes('${{') === false) {
+      nodeVersions.add(step.with['node-version']);
     }
   });
 
-  testedEngines = Array.from(nodeVersions).join(' || ');
+  if (job.strategy && job.strategy.matrix && job.strategy.matrix['node-version']) {
+    job.strategy.matrix['node-version'].forEach(version => nodeVersions.add(version));
+  }
 }
+
+const testedEngines = Array.from(nodeVersions).join(' || ');
 
 let supportedEngines = loadConfig('package.json').engines.node;
 

--- a/tests/unit/utilities/load-config-test.js
+++ b/tests/unit/utilities/load-config-test.js
@@ -55,6 +55,6 @@ describe('publishes the appropriate config files', function() {
   let npmignore = loadConfig('.npmignore', EmberCLIDir);
 
   it('has the config files', function() {
-    expect(npmignore).to.include('!/.travis.yml');
+    expect(npmignore).to.include('!/.github/workflows/ci.yml');
   });
 });

--- a/tests/unit/utilities/platform-checker-test.js
+++ b/tests/unit/utilities/platform-checker-test.js
@@ -4,6 +4,23 @@ const expect = require('chai').expect;
 const PlatformChecker = require('../../../lib/utilities/platform-checker');
 
 describe('platform-checker', function() {
+  describe('known versions', function() {
+    function check(version, { isTested, isDeprecated, isValid }) {
+      it(`${version}`, function() {
+        let checker = new PlatformChecker(version);
+        expect(checker.isDeprecated).to.equal(isDeprecated);
+        expect(checker.isValid).to.equal(isValid);
+        expect(checker.isTested).to.equal(isTested);
+      });
+    }
+
+    check('v8.0.0', { isTested: false, isDeprecated: true, isValid: false });
+    check('v10.0.0', { isTested: true, isDeprecated: false, isValid: true });
+    check('v12.0.0', { isTested: true, isDeprecated: false, isValid: true });
+    check('v13.0.0', { isTested: true, isDeprecated: false, isValid: true });
+    check('v14.0.0', { isTested: false, isDeprecated: false, isValid: true });
+  });
+
   it('checkIsDeprecated', function() {
     expect(new PlatformChecker('v0.10.1').checkIsDeprecated('4 || 6')).to.be.equal(
       true,


### PR DESCRIPTION
The `PlatformChecker` reads the Node versions that are being tested in CI to decide if we should print a message to the console upon booting.

When running on a supported (based on our `package.json`'s `engines.node`) but untested (e.g. not tested in CI) the following message is printed:

> Node ${process.version} is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.

However, when running on an unsupported version of Node (e.g. a version not covered by our `package.json`s `engines.node`) the following message is printed:

> Node ${process.version} is no longer supported by Ember CLI.  We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.

---

This change updates the `PlatformChecker` to use the GitHub Actions configuration (`.github/workflows/ci.yml`) instead of using `.travis.yml` and `appveyor.yml`.