### PR TITLE
Update paambaati/codeclimate-action to v2.5.5.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,13 +18,12 @@ jobs:
       - run: yarn install --frozen-lockfile --non-interactive
 
       - name: Test && Report to Code Climate
-        uses: paambaati/codeclimate-action@v2.5.4
+        uses: paambaati/codeclimate-action@v2.5.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageCommand: yarn test:cover
           coverageLocations: "coverage/lcov.info:lcov"
-          prefix: ${{ github.workspace }}
 
       - name: Coveralls
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
This removes the need to manually specify a `prefix`.

See https://github.com/paambaati/codeclimate-action/pull/131 for details.