### PR TITLE
Clean up execa utility

### DIFF
--- a/lib/utilities/execa.js
+++ b/lib/utilities/execa.js
@@ -5,7 +5,7 @@ const logger = require('heimdalljs-logger')('ember-cli:execa');
 
 function _execa(cmd, args, opts) {
   logger.info('execa(%j, %j)', cmd, args);
-  return Promise.resolve(execa(cmd, args, opts)).then((result) => {
+  return execa(cmd, args, opts).then((result) => {
     logger.info('execa(%j, %j) -> code: %d', cmd, args, result.code);
     return result;
   });

--- a/lib/utilities/execa.js
+++ b/lib/utilities/execa.js
@@ -3,12 +3,11 @@
 const execa = require('execa');
 const logger = require('heimdalljs-logger')('ember-cli:execa');
 
-function _execa(cmd, args, opts) {
+async function _execa(cmd, args, opts) {
   logger.info('execa(%j, %j)', cmd, args);
-  return execa(cmd, args, opts).then((result) => {
-    logger.info('execa(%j, %j) -> code: %d', cmd, args, result.code);
-    return result;
-  });
+  let result = await execa(cmd, args, opts);
+  logger.info('execa(%j, %j) -> code: %d', cmd, args, result.code);
+  return result;
 }
 
 _execa.sync = function (cmd, args, opts) {


### PR DESCRIPTION
It seems `Promise.resolve` was in the code because at some point it was being converted to an `RSVP.Promise`. The `RSVP` usage was then converted into native `Promise` usages, which meant that the `execa` promise was being wrapped in a native `Promise` without benefit.
Also used async/await syntax in the execa utility.