### PR TITLE
Strip `styles/**/*` out of `compiledAddon` tree

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1190,6 +1190,7 @@ let addonProto = {
 
     let scopedInput = new Funnel(tree, {
       destDir: this.moduleName(),
+      exclude: ['styles/**/*'],
       annotation: `Funnel: ${this.name}/addon`,
     });
 


### PR DESCRIPTION
Fixes #9076. Worked on this with @twokul 

This fixes the issue where the built output `ember build` contains duplicated addon styles in `dist/assets/vendor.css`.

See https://github.com/ember-cli/ember-cli/issues/9076#issuecomment-614147941 for a more detailed explanation of how this issue originally arose.
Excluding `styles/**/*` from the `compileAddon` output seems like the correct way to fix this. The `treeForAddon` method merges the `compileAddon` and `compileStyles` trees, which (imo) is an implicit contract that only the styles tree contains styles.

I don't think the failing test here is quite right — for one thing, it prints a deprecation [1] when it is run. I am happy to fix that test up if someone can point me to a better way.

[1] e.g. "DEPRECATION: Addon files were detected in `/Volumes/code/ember-cli/tests/fixtures/addon/simple/addon`, but no JavaScript preprocessors were found ..."