### PR TITLE
Ensure processed addon styles are not doubly-included in vendor.css

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -562,7 +562,7 @@ module.exports = class DefaultPackager {
       for (let outputFile in this.styleOutputFiles) {
         let isMainVendorFile = outputFile === this.distPaths.vendorCssFile;
         let headerFiles = this.styleOutputFiles[outputFile];
-        let inputFiles = isMainVendorFile ? ['addon-tree-output/**/__COMPILED_STYLES__/*.css'] : [];
+        let inputFiles = isMainVendorFile ? ['addon-tree-output/**/__COMPILED_STYLES__/**/*.css'] : [];
 
         vendorStyles.push(
           concat(stylesAndVendor, {

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -562,7 +562,7 @@ module.exports = class DefaultPackager {
       for (let outputFile in this.styleOutputFiles) {
         let isMainVendorFile = outputFile === this.distPaths.vendorCssFile;
         let headerFiles = this.styleOutputFiles[outputFile];
-        let inputFiles = isMainVendorFile ? ['addon-tree-output/**/*.css'] : [];
+        let inputFiles = isMainVendorFile ? ['addon-tree-output/**/__COMPILED_STYLES__/*.css'] : [];
 
         vendorStyles.push(
           concat(stylesAndVendor, {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -856,9 +856,7 @@ let addonProto = {
     let addonTree = this.compileAddon(tree);
     let stylesTree = this.compileStyles(this._treeFor('addon-styles'));
 
-    return mergeTrees([addonTree, stylesTree], {
-      annotation: `Addon#treeForAddon(${this.name})`,
-    });
+    return mergeTrees([addonTree, stylesTree], { annotation: `Addon#treeForAddon(${this.name})` });
   },
 
   /**
@@ -974,6 +972,9 @@ let addonProto = {
       let processedStylesTree = preprocessCss(preprocessedStylesTree, '/', '/', {
         outputPaths: { addon: `${this.name}.css` },
         registry: this.registry,
+      });
+      processedStylesTree = new Funnel(processedStylesTree, {
+        destDir: `${this.name}/__COMPILED_STYLES__`,
       });
 
       return this._addonPostprocessTree('css', processedStylesTree);

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -88,7 +88,7 @@ describe('Acceptance: addon-smoke-test', function () {
 
     let cssPath = path.join(addonRoot, 'dist', 'assets', 'vendor.css');
     contents = fs.readFileSync(cssPath, { encoding: 'utf8' });
-    expect(contents).to.contain('addon/styles/app.css is present');
+    expect(contents).to.equal('/* addon/styles/app.css is present */\n');
 
     let robotsPath = path.join(addonRoot, 'dist', 'robots.txt');
     contents = fs.readFileSync(robotsPath, { encoding: 'utf8' });


### PR DESCRIPTION
This is an alternate fix for #9076, and supersedes the related PR #9170.

This PR:
  * Changes the addon acceptance test "works in most common scenarios for an example addon" to make an assertion about the exact contents of the vendor.css file to ensure that it doesn't have duplicated contents
  * Uses a broccoli funnel in `Addon#compileStyles` to move all of the processed styles tree to `/ADDON_NAME/__COMPILED_STYLES__/`. The default-packager's `packageStyles` method is likewise updated to restrict its `include` glob pattern to only CSS files that are in that directory.

Here's a comparison of the differences in the intermediate broccoli trees:

### Before this PR
<table>
<tr>
<th>Phase</th>
<th>Tree</th>
</tr>
<tr>
<td>in compileStyles, before processing</td>
<td><pre>/
└── addon.css</pre></td>
</tr>
<tr>
<td>returned tree from compileStyles (after processing)</td>
<td><pre>/
└── webcore-243.css</pre></td>
</tr>
</table>

### After this PR
<table>
<tr>
<th>Phase</th>
<th>Tree</th>
</tr>
<tr>
<td>in compileStyles, before processing</td>
<td><pre>/
└── addon.css</pre></td>
</tr>
<tr>
<td>in compileStyles, after processing</td>
<td><pre>/
└── ADDON-NAME.css</pre></td>
</tr>
<tr>
<td>returned tree from compileStyles (after processing + funneling)</td>
<td><pre>/
└── ADDON-NAME
    └── __COMPILED_STYLES__
        └── ADDON-NAME.css</pre></td>
</tr>
</table>