### PR TITLE
Pass options to middleware

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -27,12 +27,14 @@ class TestTask extends Task {
     });
   }
 
-  addonMiddlewares() {
+  addonMiddlewares(options) {
     this.project.initializeAddons();
 
     return this.project.addons.reduce((addons, addon) => {
       if (addon.testemMiddleware) {
-        addons.push(addon.testemMiddleware.bind(addon));
+        addons.push(function () {
+          addon.testemMiddleware(...arguments, options);
+        });
       }
 
       return addons;
@@ -54,7 +56,7 @@ class TestTask extends Task {
       port: options.port,
       debug: options.testemDebug,
       reporter: options.reporter,
-      middleware: this.addonMiddlewares(),
+      middleware: this.addonMiddlewares(options),
       launch: options.launch,
       file: options.configFile,
       /* eslint-disable camelcase */
@@ -67,7 +69,6 @@ class TestTask extends Task {
       transformed.key = options.sslKey;
       transformed.cert = options.sslCert;
     }
-
     return transformed;
   }
 

--- a/tests/fixtures/tasks/testem-config/testem-dummy.json
+++ b/tests/fixtures/tasks/testem-config/testem-dummy.json
@@ -1,0 +1,9 @@
+{
+  "framework": "qunit",
+  "launch": "Dummy",
+  "launchers": {
+    "Dummy" : {
+      "command": "exit"
+    }
+  }
+}

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -7,6 +7,32 @@ const MockProject = require('../../helpers/mock-project');
 describe('test task test', function () {
   let subject;
 
+  it('call testem middleware with options', async function () {
+    let testemMiddlewareOptions;
+    let project = new MockProject();
+
+    project.initializeAddons = function () {};
+    project.addons = [
+      {
+        testemMiddleware(_, options) {
+          testemMiddlewareOptions = options;
+        },
+      },
+    ];
+
+    let options = {
+      reporter: 'xunit',
+      configFile: 'tests/fixtures/tasks/testem-config/testem-dummy.json',
+      path: 'dist',
+      ssl: false,
+    };
+
+    subject = new TestTask({ project });
+    await subject.run(options);
+    expect(testemMiddlewareOptions).to.deep.equal(options);
+    expect(testemMiddlewareOptions.path).to.equal('dist');
+  });
+
   it('transforms options for testem configuration', function () {
     subject = new TestTask({
       project: new MockProject(),


### PR DESCRIPTION
Useful if the middleware is expensive and should be optionally started
depending on ember-cli options.

For example `ember serve` and `ember test` use a `path` flag to specify
an existing ember build to use, without rebuilding. `ember-cli-typescript`
will add typechecking middleware regardless of ember using an existing
build, the typechecking middleware is not required. This can slow
down the initial request to express server significantly. Passing the
ember options to middleware will allow middleware to optionally enable
different features depending on options

See `ember-cli-typescript` making use of this here https://github.com/typed-ember/ember-cli-typescript/pull/1148