### PR TITLE
Revert "test version-utils"

### DIFF
--- a/lib/utilities/version-utils.js
+++ b/lib/utilities/version-utils.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const getRepoInfo = require('git-repo-info');
 
 module.exports = {
   emberCLIVersion() {
@@ -9,7 +10,6 @@ module.exports = {
     let output = [require('../../package.json').version];
 
     if (fs.existsSync(gitPath)) {
-      const getRepoInfo = require('git-repo-info');
       let { branch, abbreviatedSha } = getRepoInfo(gitPath);
 
       if (branch) {

--- a/tests/unit/utilities/version-utils-test.js
+++ b/tests/unit/utilities/version-utils-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const expect = require('chai').expect;
-const td = require('testdouble');
 const versionUtils = require('../../../lib/utilities/version-utils');
 
 describe('version-utils', function () {
@@ -11,28 +10,5 @@ describe('version-utils', function () {
 
   it('`isDevelopment` returns true if a development version was passed in', function () {
     expect(versionUtils.isDevelopment('0.0.5-master-237cc6024d')).to.equal(true);
-  });
-
-  describe('emberCLIVersion', function () {
-    let gitRepoInfo;
-
-    beforeEach(function () {
-      gitRepoInfo = td.replace('git-repo-info');
-      td.replace('../../../package.json', { version: '1.0.0' });
-    });
-
-    afterEach(function () {
-      td.reset();
-    });
-
-    it('handles git branches with slashes in the name', function () {
-      td.when(gitRepoInfo(td.matchers.anything())).thenReturn({
-        branch: 'my/slashed/name',
-        abbreviatedSha: 'abbvSha',
-      });
-
-      let version = versionUtils.emberCLIVersion();
-      expect(version).to.equal('1.0.0-my-slashed-name-abbvSha');
-    });
   });
 });


### PR DESCRIPTION
This reverts commit 5a8152a645622b5ea1e4172535825ef44e672c10.

This is being reverted as it causes a failure when ember-cli is ran as part of CITGM (see https://github.com/nodejs/citgm/pull/804). We should rework the test to avoid mocking `require('git-repo-info')` in order to bring it back.

/cc @locks