### PR TITLE
Ensure that the captured exit is released.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -71,77 +71,77 @@ module.exports = async function (options) {
   // may use `process.exit` work arounds for async cleanup.
   willInterruptProcess.capture(options.process || process);
 
-  let UI = options.UI || require('console-ui');
-  const CLI = require('./cli');
-  let Leek = options.Leek || require('leek');
-  const Project = require('../models/project');
-  let config = getConfig(options.Yam);
-
-  configureLogger(process.env);
-
-  // TODO: one UI (lib/models/project.js also has one for now...)
-  let ui = new UI({
-    inputStream: options.inputStream,
-    outputStream: options.outputStream,
-    errorStream: options.errorStream || process.stderr,
-    errorLog: options.errorLog || [],
-    ci: ciInfo.isCI || /^(dumb|emacs)$/.test(process.env.TERM),
-    writeLevel: process.argv.indexOf('--silent') !== -1 ? 'ERROR' : undefined,
-  });
-
-  let leekOptions;
-
-  let disableAnalytics =
-    (options.cliArgs &&
-      (options.cliArgs.indexOf('--disable-analytics') > -1 ||
-        options.cliArgs.indexOf('-v') > -1 ||
-        options.cliArgs.indexOf('--version') > -1)) ||
-    config.get('disableAnalytics');
-
-  let defaultLeekOptions = {
-    trackingCode,
-    globalName: name,
-    name: clientId(),
-    version,
-    silent: disableAnalytics,
-  };
-
-  let defaultUpdateCheckerOptions = {
-    checkForUpdates: false,
-  };
-
-  if (config.get('leekOptions')) {
-    leekOptions = merge(defaultLeekOptions, config.get('leekOptions'));
-  } else {
-    leekOptions = defaultLeekOptions;
-  }
-
-  logger.info('leek: %o', leekOptions);
-
-  let leek = new Leek(leekOptions);
-
-  let cli = new CLI({
-    ui,
-    analytics: leek,
-    testing: options.testing,
-    name: options.cli ? options.cli.name : 'ember',
-    disableDependencyChecker: options.disableDependencyChecker,
-    root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
-    npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli',
-    initInstrumentation,
-  });
-
-  let project = Project.projectOrnullProject(ui, cli);
-
-  let environment = {
-    tasks: loadTasks(),
-    cliArgs: options.cliArgs,
-    commands: loadCommands(),
-    project,
-    settings: merge(defaultUpdateCheckerOptions, config.getAll()),
-  };
-
   try {
+    let UI = options.UI || require('console-ui');
+    const CLI = require('./cli');
+    let Leek = options.Leek || require('leek');
+    const Project = require('../models/project');
+    let config = getConfig(options.Yam);
+
+    configureLogger(process.env);
+
+    // TODO: one UI (lib/models/project.js also has one for now...)
+    let ui = new UI({
+      inputStream: options.inputStream,
+      outputStream: options.outputStream,
+      errorStream: options.errorStream || process.stderr,
+      errorLog: options.errorLog || [],
+      ci: ciInfo.isCI || /^(dumb|emacs)$/.test(process.env.TERM),
+      writeLevel: process.argv.indexOf('--silent') !== -1 ? 'ERROR' : undefined,
+    });
+
+    let leekOptions;
+
+    let disableAnalytics =
+      (options.cliArgs &&
+        (options.cliArgs.indexOf('--disable-analytics') > -1 ||
+          options.cliArgs.indexOf('-v') > -1 ||
+          options.cliArgs.indexOf('--version') > -1)) ||
+      config.get('disableAnalytics');
+
+    let defaultLeekOptions = {
+      trackingCode,
+      globalName: name,
+      name: clientId(),
+      version,
+      silent: disableAnalytics,
+    };
+
+    let defaultUpdateCheckerOptions = {
+      checkForUpdates: false,
+    };
+
+    if (config.get('leekOptions')) {
+      leekOptions = merge(defaultLeekOptions, config.get('leekOptions'));
+    } else {
+      leekOptions = defaultLeekOptions;
+    }
+
+    logger.info('leek: %o', leekOptions);
+
+    let leek = new Leek(leekOptions);
+
+    let cli = new CLI({
+      ui,
+      analytics: leek,
+      testing: options.testing,
+      name: options.cli ? options.cli.name : 'ember',
+      disableDependencyChecker: options.disableDependencyChecker,
+      root: options.cli ? options.cli.root : path.resolve(__dirname, '..', '..'),
+      npmPackage: options.cli ? options.cli.npmPackage : 'ember-cli',
+      initInstrumentation,
+    });
+
+    let project = Project.projectOrnullProject(ui, cli);
+
+    let environment = {
+      tasks: loadTasks(),
+      cliArgs: options.cliArgs,
+      commands: loadCommands(),
+      project,
+      settings: merge(defaultUpdateCheckerOptions, config.getAll()),
+    };
+
     return await cli.run(environment);
   } finally {
     willInterruptProcess.release();


### PR DESCRIPTION
Prior to this, an error thrown during the bulk of `lib/cli/index.js` would have caused the process to be captured (which happens very early) but not released. This is because prior to this change we only ensured cleanup around the `cli.run` asynchrony, but not for any of the other work there.