### PR TITLE
Handle unexpected errors in development mode proxy

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -47,10 +47,7 @@ class ProxyServerAddon {
   handleProxiedRequest({ req, socket, head, options, proxy }) {
     if (!isLiveReloadRequest(req.url, options.liveReloadPrefix)) {
       options.ui.writeLine(`Proxying websocket to ${req.url}`);
-      socket.on('error', (e) => {
-        options.ui.writeLine(`Error proxying to ${options.proxy}`);
-        options.ui.writeError(e);
-      });
+      socket.on('error', (e) => proxy.emit('error', e));
       proxy.ws(req, socket, head);
     }
   }

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -47,6 +47,10 @@ class ProxyServerAddon {
   handleProxiedRequest({ req, socket, head, options, proxy }) {
     if (!isLiveReloadRequest(req.url, options.liveReloadPrefix)) {
       options.ui.writeLine(`Proxying websocket to ${req.url}`);
+      socket.on('error', (e) => {
+        options.ui.writeLine(`Error proxying to ${options.proxy}`);
+        options.ui.writeError(e);
+      });
       proxy.ws(req, socket, head);
     }
   }


### PR DESCRIPTION
After upgrade ember-cli from 3.2 to 3.18, the running dev server often interrupted when target server restart. the following error message is :

```
Proxying websocket to /rest/realtime
events.js:298
      throw er; // Unhandled 'error' event
      ^
Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:205:27)
Emitted 'error' event on TLSSocket instance at:
    at errorOrDestroy (internal/streams/destroy.js:108:12)
    at TLSSocket.onerror (_stream_readable.js:746:7)
    at TLSSocket.emit (events.js:321:20)
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'ECONNRESET',
  code: 'ECONNRESET',
  syscall: 'read'
}
```

I debug the reason is a commit in `http-proxy` module, and a pr is open (https://github.com/http-party/node-http-proxy/pull/1439), but it's not active repo, so i commit this.

And the other way to fix is downgrade `http-proxy` to 1.16.2.
