### PR TITLE
Add timeout to CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2
@@ -31,6 +32,7 @@ jobs:
   basic-tests:
     name: "Basic Tests - ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-latest"
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -48,6 +50,7 @@ jobs:
   tests:
     name: "Node ${{ matrix.node-version }} - ${{ matrix.os }} "
     runs-on: "${{ matrix.os }}-latest"
+    timeout-minutes: 75
 
     needs: [linting, basic-tests]
 
@@ -69,6 +72,7 @@ jobs:
   feature-flags:
     name: "Feature: ${{ matrix.feature-flag }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 75
 
     needs: [linting, basic-tests]
 


### PR DESCRIPTION
Prevents CI runs from running much much longer (on accident) when they should probably just timeout.