### PR TITLE
Ensure `ember serve` property waits for the serve task.

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -103,7 +103,7 @@ module.exports = Command.extend({
     }
 
     await Win.checkIfSymlinksNeedToBeEnabled(this.ui);
-    this.runTask('Serve', commandOptions);
+    await this.runTask('Serve', commandOptions);
   },
 
   async _checkExpressPort(commandOptions) {

--- a/tests/unit/commands/serve-test.js
+++ b/tests/unit/commands/serve-test.js
@@ -226,4 +226,23 @@ describe('serve command', function () {
       expect(error.message).to.match(/You have to be inside an ember-cli project/);
     });
   });
+
+  it('waits on the serve tasks promise', async function () {
+    let serveTaskResolved = false;
+
+    tasks.Serve = class extends Task {
+      run() {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            serveTaskResolved = true;
+            resolve();
+          }, 10);
+        });
+      }
+    };
+
+    await command.validateAndRun(['--port', '0']);
+
+    expect(serveTaskResolved).to.be.ok;
+  });
 });


### PR DESCRIPTION
The issue was introduced by efa25a8df (an async/await refactor for the serve command). We didn't have tests confirming that `ember serve` properly waited for this because _normally_ this promise never resolves (that is why the server keeps running, it is waiting on this promise forever).

This adds a test that ensures the general coupling that we expect is honored (serve task can return a promise, and that promise causes the serve command to delay exiting), but we should absolutely work on a more substantial refactor to the testing system to be less mock heavy.

Fixes #9216