### PR TITLE
[BETA] Move travis from trusty to xenial

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/tests/fixtures/addon/npm/.travis.yml
+++ b/tests/fixtures/addon/npm/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/tests/fixtures/app/npm/.travis.yml
+++ b/tests/fixtures/app/npm/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "10"
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable


### PR DESCRIPTION
This is in response to issue https://travis-ci.community/t/you-can-no-longer-install-chrome-stable-on-trusty-machines/8521