### PR TITLE
Remove `ember-default` ember-try scenario

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -46,16 +46,6 @@ module.exports = async function() {
           }
         }
       },
-      // The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
       {
         name: 'ember-default-with-jquery',
         env: {

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -2,93 +2,88 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-const scenarios = [
-  {
-    name: 'ember-lts-3.12',
-    npm: {
-      devDependencies: {
-        'ember-source': '~3.12.0'
-      }
-    }
-  },
-  {
-    name: 'ember-lts-3.16',
-    npm: {
-      devDependencies: {
-        'ember-source': '~3.16.0'
-      }
-    }
-  },
-  {
-    name: 'ember-release',
-    npm: {
-      devDependencies: {
-        'ember-source': await getChannelURL('release')
-      }
-    }
-  },
-  {
-    name: 'ember-beta',
-    npm: {
-      devDependencies: {
-        'ember-source': await getChannelURL('beta')
-      }
-    }
-  },
-  {
-    name: 'ember-canary',
-    npm: {
-      devDependencies: {
-        'ember-source': await getChannelURL('canary')
-      }
-    }
-  },
-  {
-    name: 'ember-default-with-jquery',
-    env: {
-      EMBER_OPTIONAL_FEATURES: JSON.stringify({
-        'jquery-integration': true
-      })
-    },
-    npm: {
-      devDependencies: {
-        '@ember/jquery': '^0.5.1'
-      }
-    }
-  },
-  {
-    name: 'ember-classic',
-    env: {
-      EMBER_OPTIONAL_FEATURES: JSON.stringify({
-        'application-template-wrapper': true,
-        'default-async-observers': false,
-        'template-only-glimmer-components': false
-      })
-    },
-    npm: {
-      ember: {
-        edition: 'classic'
-      }
-    }
-  }
-];
-
-// The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
-// not via `ember try`, so we don't need it include it in CI. Other than that, we will include it
-// so that running `ember try:each` manually will run it along with all the other scenarios, and
-// ember try:one can still pick up this config.
-if (!process.env.CI) {
-  scenarios.push({
-    name: 'ember-default',
-    npm: {
-      devDependencies: {}
-    }
-  })
-};
-
 module.exports = async function() {
   return {
     <% if (yarn) { %>useYarn: true,
-    <% } %>scenarios: scenarios
+    <% } %>scenarios: [
+      {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release')
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta')
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary')
+          }
+        }
+      },
+      // The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
+      // not via `ember try`. It's still included here so that running
+      // `ember try:each` manually or from a customized CI config will run it
+      // along with all the other scenarios.
+      {
+        name: 'ember-default',
+        npm: {
+          devDependencies: {}
+        }
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true
+          })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1'
+          }
+        }
+      },
+      {
+        name: 'ember-classic',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'application-template-wrapper': true,
+            'default-async-observers': false,
+            'template-only-glimmer-components': false
+          })
+        },
+        npm: {
+          ember: {
+            edition: 'classic'
+          }
+        }
+      }
+    ]
   };
 };

--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -2,88 +2,93 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
+const scenarios = [
+  {
+    name: 'ember-lts-3.12',
+    npm: {
+      devDependencies: {
+        'ember-source': '~3.12.0'
+      }
+    }
+  },
+  {
+    name: 'ember-lts-3.16',
+    npm: {
+      devDependencies: {
+        'ember-source': '~3.16.0'
+      }
+    }
+  },
+  {
+    name: 'ember-release',
+    npm: {
+      devDependencies: {
+        'ember-source': await getChannelURL('release')
+      }
+    }
+  },
+  {
+    name: 'ember-beta',
+    npm: {
+      devDependencies: {
+        'ember-source': await getChannelURL('beta')
+      }
+    }
+  },
+  {
+    name: 'ember-canary',
+    npm: {
+      devDependencies: {
+        'ember-source': await getChannelURL('canary')
+      }
+    }
+  },
+  {
+    name: 'ember-default-with-jquery',
+    env: {
+      EMBER_OPTIONAL_FEATURES: JSON.stringify({
+        'jquery-integration': true
+      })
+    },
+    npm: {
+      devDependencies: {
+        '@ember/jquery': '^0.5.1'
+      }
+    }
+  },
+  {
+    name: 'ember-classic',
+    env: {
+      EMBER_OPTIONAL_FEATURES: JSON.stringify({
+        'application-template-wrapper': true,
+        'default-async-observers': false,
+        'template-only-glimmer-components': false
+      })
+    },
+    npm: {
+      ember: {
+        edition: 'classic'
+      }
+    }
+  }
+];
+
+// The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
+// not via `ember try`, so we don't need it include it in CI. Other than that, we will include it
+// so that running `ember try:each` manually will run it along with all the other scenarios, and
+// ember try:one can still pick up this config.
+if (!process.env.CI) {
+  scenarios.push({
+    name: 'ember-default',
+    npm: {
+      devDependencies: {}
+    }
+  })
+};
+
 module.exports = async function() {
   return {
     <% if (yarn) { %>useYarn: true,
-    <% } %>scenarios: [
-      {
-        name: 'ember-lts-3.12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.12.0'
-          }
-        }
-      },
-      {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0'
-          }
-        }
-      },
-      {
-        name: 'ember-release',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('release')
-          }
-        }
-      },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('beta')
-          }
-        }
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary')
-          }
-        }
-      },
-      // The default `.travis.yml` runs this scenario via `<% if (yarn) { %>yarn<% } else { %>npm<% } %> test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true
-          })
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1'
-          }
-        }
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false
-          })
-        },
-        npm: {
-          ember: {
-            edition: 'classic'
-          }
-        }
-      }
-    ]
+    <% } %>scenarios: scenarios
   };
 };

--- a/tests/fixtures/addon/defaults/config/ember-try.js
+++ b/tests/fixtures/addon/defaults/config/ember-try.js
@@ -45,16 +45,6 @@ module.exports = async function() {
           }
         }
       },
-      // The default `.travis.yml` runs this scenario via `npm test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
       {
         name: 'ember-default-with-jquery',
         env: {

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -46,16 +46,6 @@ module.exports = async function() {
           }
         }
       },
-      // The default `.travis.yml` runs this scenario via `yarn test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
       {
         name: 'ember-default-with-jquery',
         env: {


### PR DESCRIPTION
As of the changes in https://github.com/ember-cli/ember-cli/pull/9009, `npm test` and `yarn test` run _both_ `ember test` and `ember try:each`. This PR ensures that running `npm test` / `yarn test` doesn't do wasted work (by testing `ember-default` both as part of `ember test` and `ember try:each`).

PR's affecting `ember-default` over the years:

* https://github.com/ember-cli/ember-cli/pull/6483
* https://github.com/ember-cli/ember-cli/pull/8165
* https://github.com/ember-cli/ember-cli/pull/8288