### PR TITLE
Remove macOS from CI matrix for slow/acceptance tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 13.x, 14.x]
-        os: [ubuntu, macOS, windows]
+        os: [ubuntu, windows]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
These seem to be plagued by ESOCKETTIMEDOUT errors during `yarn` invocation:

```
  error An unexpected error occurred:
  "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz: ESOCKETTIMEDOUT".
```

https://github.com/ember-cli/ember-cli/pull/9281/checks?check_run_id=894984991#step:5:1753

Removing for now, as I don't really think that we are gaining significant additional coverage by using macOS (in addition to linux and windows) for these slow tests.