### PR TITLE
Drop support for Node 13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu, windows]
 
     steps:

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -10,12 +10,12 @@
 | 5.x              | 1.13.9 - 2.6.3               |
 | 6.x              | 2.9.0 - 3.9.x                |
 | 7.x              | 2.10.0 - 2.16.x              |
-| 8.x              | 2.13.3 - 3.16.x             |
+| 8.x              | 2.13.3 - 3.16.x              |
 | 9.x              | 2.16.2 - 3.2.x               |
 | 10.x             | 3.1.3 - Current              |
 | 11.x             | 3.9.0 - 3.13.0               |
 | 12.x             | 3.10.0 - Current             |
-| 13.x             | 3.15.0 - Current             |
+| 13.x             | 3.15.0 - 3.20.0              |
 | 14.x             | 3.19.0 - Current             |
 
 
@@ -34,8 +34,6 @@ Node.js](https://github.com/nodejs/LTS#lts_schedule).
   * Supported by ember-cli/ember-cli#master until: 2021-04-30.
 * v12: Released as stable version then converted to LTS.
   * Supported by ember-cli/ember-cli#master until: 2022-04-30.
-* v13: Released as stable (not an LTS)
-  * Supported by ember-cli/ember-cli#master until: 2020-06-30.
 * v14: Released as stable version then converted to LTS.
   * Supported by ember-cli/ember-cli#master until: 2023-04-30.
 

--- a/tests/unit/utilities/platform-checker-test.js
+++ b/tests/unit/utilities/platform-checker-test.js
@@ -17,7 +17,7 @@ describe('platform-checker', function () {
     check('v8.0.0', { isTested: false, isDeprecated: true, isValid: false });
     check('v10.0.0', { isTested: true, isDeprecated: false, isValid: true });
     check('v12.0.0', { isTested: true, isDeprecated: false, isValid: true });
-    check('v13.0.0', { isTested: true, isDeprecated: false, isValid: true });
+    check('v13.0.0', { isTested: false, isDeprecated: false, isValid: true });
     check('v14.0.0', { isTested: true, isDeprecated: false, isValid: true });
     check('v15.0.0', { isTested: false, isDeprecated: false, isValid: true });
   });


### PR DESCRIPTION
It is no longer supported by Node itself.

The blueprints (and ember-cli's engines) will be updated in a follow up PR (that will land in ~ 3.21, not 3.20).