### PR TITLE
remove explicit `yarn install` in `.travis.yml`

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -62,9 +62,6 @@ jobs:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-
-install:
-  - yarn install --non-interactive
 <% } %>
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -27,9 +27,6 @@ branches:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-
-install:
-  - yarn install --non-interactive
 <% } %>
 script:
   - <% if (yarn) { %>yarn<% } else { %>npm<% } %> test

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -58,8 +58,5 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 
-install:
-  - yarn install --non-interactive
-
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/tests/fixtures/app/yarn/.travis.yml
+++ b/tests/fixtures/app/yarn/.travis.yml
@@ -24,8 +24,5 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 
-install:
-  - yarn install --non-interactive
-
 script:
   - yarn test


### PR DESCRIPTION
I accidentally screwed up the lockfile, and realized the yarn command is missing `--frozen-lockfile`. The default travis command for yarn is `yarn --frozen-lockfile` https://travis-ci.org/github/ember-vr/ember-vr-shopping/jobs/714192550#L511. Instead of trying to match what Travis is doing, I propose removing the line, and allowing Travis to handle it, just like it does for NPM (`npm ci`).