### PR TITLE
Ensure that `outputReady` receives the final output directory.

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -210,7 +210,10 @@ class Builder extends CoreObject {
 
       let outputChanges = await this.copyToOutputPath(buildResults.directory);
 
-      await this.processAddonBuildSteps('outputReady', Object.assign({ outputChanges }, buildResults));
+      await this.processAddonBuildSteps(
+        'outputReady',
+        Object.assign({}, buildResults, { outputChanges, directory: this.outputPath })
+      );
 
       this.checkForPostBuildEnvironmentIssues();
 

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -353,9 +353,10 @@ describe('models/builder.js', function () {
     it('allows addons to add promises outputReady', async function () {
       let outputReady = td.replace(addon, 'outputReady', td.function());
 
+      builder.outputPath = 'dist/';
       await builder.build();
 
-      let expected = Object.assign({ outputChanges: [] }, buildResults);
+      let expected = Object.assign({}, buildResults, { outputChanges: [], directory: 'dist/' });
       td.verify(outputReady(expected), { times: 1 });
     });
 
@@ -397,16 +398,23 @@ describe('models/builder.js', function () {
     it('should call outputReady after copying to output path', async function () {
       let called = [];
 
-      builder.copyToOutputPath = function () {
-        called.push('copyToOutputPath');
+      builder.copyToOutputPath = function (directory) {
+        called.push(['copyToOutputPath', directory]);
+        return [];
       };
 
-      addon.outputReady = function () {
-        called.push('outputReady');
+      addon.outputReady = function (result) {
+        called.push(['outputReady', result]);
       };
+
+      builder.outputPath = 'dist/';
 
       await builder.build();
-      expect(called).to.deep.equal(['copyToOutputPath', 'outputReady']);
+
+      expect(called).to.deep.equal([
+        ['copyToOutputPath', buildResults.directory],
+        ['outputReady', Object.assign({}, buildResults, { outputChanges: [], directory: 'dist/' })],
+      ]);
     });
 
     it('buildError receives the error object from the errored step', async function () {


### PR DESCRIPTION
Previously, it was impossible to know what the final output path was (you were forced to parse `process.argv` + `.ember-cli` manually to figure it out). This updates the argument to `outputReady` to ensure that the `results.directory` is the correct final on disk location.