### PR TITLE
Add Ember 3.20 LTS to ember-try configuration.

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -23,6 +23,14 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {
@@ -55,7 +63,7 @@ module.exports = async function() {
         },
         npm: {
           devDependencies: {
-            '@ember/jquery': '^0.5.1'
+            '@ember/jquery': '^1.1.0'
           }
         }
       },

--- a/tests/fixtures/addon/defaults/config/ember-try.js
+++ b/tests/fixtures/addon/defaults/config/ember-try.js
@@ -22,6 +22,14 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {
@@ -54,7 +62,7 @@ module.exports = async function() {
         },
         npm: {
           devDependencies: {
-            '@ember/jquery': '^0.5.1'
+            '@ember/jquery': '^1.1.0'
           }
         }
       },

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -23,6 +23,14 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {
@@ -55,7 +63,7 @@ module.exports = async function() {
         },
         npm: {
           devDependencies: {
-            '@ember/jquery': '^0.5.1'
+            '@ember/jquery': '^1.1.0'
           }
         }
       },


### PR DESCRIPTION
Targets lts-3-20 branch, and will be released as a 3.20.1 patch release.