### PR TITLE
Migrate to ember-cli-terser

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -36,7 +36,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -289,6 +289,7 @@ class EmberApp {
         enabled: this.isProduction,
         options: { processImport: false },
       },
+      // TODO: remove this with a deprecation (nothing in the default app/addon setup consumes it)
       minifyJS: {
         enabled: this.isProduction,
         options: {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -37,7 +37,7 @@
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -37,7 +37,7 @@
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -33,7 +33,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -36,7 +36,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -36,7 +36,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -33,7 +33,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -33,7 +33,7 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-uglify": "^3.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-data": "~3.21.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",


### PR DESCRIPTION
Migrate to `ember-cli-terser` (replacing `ember-cli-uglify`).

Fixes https://github.com/ember-cli/ember-cli/issues/9290