### PR TITLE
Remove "process already captured" errors.

### DIFF
--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -16,12 +16,12 @@ const EventEmitter = require('events');
 
 const handlers = [];
 
-let _process, _processCapturedLocation, windowsCtrlCTrap, originalIsRaw;
+let _process, windowsCtrlCTrap, originalIsRaw;
 
 module.exports = {
   capture(outerProcess) {
-    if (_process) {
-      throw new Error(`process already captured at: \n\n${_processCapturedLocation.stack}`);
+    if (_process !== outerProcess) {
+      this.release();
     }
 
     if (outerProcess instanceof EventEmitter === false) {
@@ -29,7 +29,6 @@ module.exports = {
     }
 
     _process = outerProcess;
-    _processCapturedLocation = new Error();
 
     // ember-cli and user apps have many dependencies, many of which require
     // process.addListener('exit', ....) for cleanup, by default this limit for
@@ -63,7 +62,6 @@ module.exports = {
     }
 
     _process = null;
-    _processCapturedLocation = null;
   },
 
   /**

--- a/tests/unit/utilities/will-interrupt-process-test.js
+++ b/tests/unit/utilities/will-interrupt-process-test.js
@@ -20,19 +20,6 @@ describe('will interrupt process', function () {
   });
 
   describe('capture', function () {
-    it('throws if already captured', function () {
-      const mockProcess = new MockProcess();
-
-      willInterruptProcess.capture(mockProcess);
-      try {
-        willInterruptProcess.capture(mockProcess);
-        expect(true).to.equal(false);
-      } catch (e) {
-        expect(e.message).to.include('process already captured');
-        expect(e.message).to.include('will-interrupt-process-test.js');
-      }
-    });
-
     it('throws if the process is not an EventEmitter instance', function () {
       const dissallowedArgs = [null, true, '', [], {}];
 


### PR DESCRIPTION
This has been a very annoying source of CI failures. If it were technically more correct I'd say we should keep it around and attempt to fix the underlying issue, but I do not think it is. In most cases, we are either setting up on the same object (in which case no need to release any existing handlers) or we are providing a custom `MockProcess` object which really won't ever _need_ capturing.