### PR TITLE
Remove requirement to have `loader.js`.

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -10,7 +10,6 @@ const chalk = require('chalk');
 const resolve = require('resolve');
 
 const Project = require('../models/project');
-const SilentError = require('silent-error');
 
 let preprocessJs = p.preprocessJs;
 let isType = p.isType;
@@ -136,10 +135,6 @@ class EmberApp {
     p.setupRegistry(this);
     this._importAddonTransforms();
     this._notifyAddonIncluded();
-
-    if (!this._addonInstalled('loader.js') && !this.options._ignoreMissingLoader) {
-      throw new SilentError('The loader.js addon is missing from your project, please add it to `package.json`.');
-    }
 
     this._debugTree = BroccoliDebug.buildDebugCallback('ember-app');
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -815,41 +815,6 @@ describe('EmberApp', function () {
       });
     });
 
-    describe('loader.js missing', function () {
-      it('does not error when loader.js is present in registry.availablePlugins', function () {
-        expect(() => {
-          new EmberApp({
-            project,
-          });
-        }).to.not.throw(/loader.js addon is missing/);
-      });
-
-      it('throws an error when loader.js is not present in registry.availablePlugins', function () {
-        expect(() => {
-          new EmberApp({
-            project,
-            registry: {
-              add() {},
-              availablePlugins: {},
-            },
-          });
-        }).to.throw(/loader.js addon is missing/);
-      });
-
-      it('does not throw an error if _ignoreMissingLoader is set', function () {
-        expect(() => {
-          new EmberApp({
-            project,
-            registry: {
-              add() {},
-              availablePlugins: {},
-            },
-            _ignoreMissingLoader: true,
-          });
-        }).to.not.throw(/loader.js addon is missing/);
-      });
-    });
-
     describe('ember-resolver npm vs Bower', function () {
       it('does not load ember-resolver.js as bower dep when ember-resolver is present in registry.availablePlugins', function () {
         let app = new EmberApp({ project });
@@ -864,7 +829,7 @@ describe('EmberApp', function () {
           project,
           registry: {
             add() {},
-            availablePlugins: { 'loader.js': {} },
+            availablePlugins: {},
           },
         });
         expect(app.vendorFiles['ember-resolver.js'][0]).to.equal(
@@ -880,7 +845,7 @@ describe('EmberApp', function () {
           project,
           registry: {
             add() {},
-            availablePlugins: { 'loader.js': {} },
+            availablePlugins: {},
           },
         });
 


### PR DESCRIPTION
This was important at one point (when folks were not used to having
`loader.js` as an `npm` dependency), but that was a _looooong_ time ago.