### PR TITLE
[do not merge] investigate "process already captured"

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -140,6 +140,7 @@ describe('Acceptance: ember new', function () {
     expect(file('app/index.html')).to.contain('<html>');
   });
 
+  // will you fail again?
   it('ember new npm blueprint with old version', async function () {
     await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm', '--skip-bower']);
 


### PR DESCRIPTION
It seems to be a persistent issue:
 - MacOS https://github.com/ember-cli/ember-cli/pull/9336/checks?check_run_id=1150804964#step:5:91
 - MacOS - https://github.com/ember-cli/ember-cli/pull/9338/checks?check_run_id=1151483704#step:5:91
 - Windows - https://github.com/ember-cli/ember-cli/pull/9300/checks?check_run_id=948998976#step:5:81

At the moment, the same test does always introduce the problem for the following tests.

However, unfortunately I can't reproduce it locally. So I'd like to make few test runs, and try to find all the tests that initiate the problem. If the issue is reproducible, I'd like to exclude the problematic tests one by one, and detect all of them, to gather some more info. Hopefully, there are just few of them. 