### PR TITLE
Fix yuidoc for private APIs

### DIFF
--- a/lib/models/hardware-info.js
+++ b/lib/models/hardware-info.js
@@ -233,6 +233,7 @@ const hwinfo = {
    * Inidcates whether the host is running on battery power.  This can cause
    * performance degredation.
    *
+   * @private
    * @method isUsingBattery
    * @for HardwareInfo
    * @param {String=process.platform} platform The current hardware platform.
@@ -265,6 +266,7 @@ const hwinfo = {
   /**
    * Determines the amount of swap/virtual memory currently in use.
    *
+   * @private
    * @method memorySwapUsed
    * @param {String=process.platform} platform The current hardware platform.
    *                                           USED FOR TESTING ONLY.
@@ -296,6 +298,7 @@ const hwinfo = {
    * Determines the total amount of memory available to the host, as from
    * `os.totalmem`.
    *
+   * @private
    * @method memoryTotal
    * @return {Number} The total memory in bytes.
    */
@@ -307,6 +310,7 @@ const hwinfo = {
    * Determines the amount of memory currently being used by the current Node
    * process, as from `process.memoryUsage`.
    *
+   * @private
    * @method memoryUsed
    * @return {Object} The Resident Set Size, as reported by
    *                  `process.memoryUsage`.
@@ -319,6 +323,7 @@ const hwinfo = {
    * Determines the number of logical processors available to the host, as from
    * `os.cpus`.
    *
+   * @private
    * @method processorCount
    * @return {Number} The number of logical processors.
    */
@@ -331,6 +336,7 @@ const hwinfo = {
    * expressed as a fractional number between 0 and the number of logical
    * processors.
    *
+   * @private
    * @method processorLoad
    * @param {String=process.platform} platform The current hardware platform.
    *                                           USED FOR TESTING ONLY.
@@ -354,6 +360,7 @@ const hwinfo = {
    *
    * If more than one processor is found, the average of their speeds is taken.
    *
+   * @private
    * @method processorSpeed
    * @return {Number} The average processor speed in MHz.
    */
@@ -366,6 +373,7 @@ const hwinfo = {
   /**
    * Determines the time since the host was started, as from `os.uptime`.
    *
+   * @private
    * @method uptime
    * @return {Number} The number of seconds since the host was started.
    */

--- a/tests/helpers/acceptance.js
+++ b/tests/helpers/acceptance.js
@@ -44,9 +44,15 @@ function applyCommand(command, name /*, ...flags*/) {
 }
 
 /**
+ * @class PrivateTestHelpers
+ */
+
+/**
  * Use `createTestTargets` in the before hook to do the initial
  * setup of a project. This will ensure that we limit the amount of times
  * we go to the network to fetch dependencies.
+ *
+ * @method createTestTargets
  * @param  {String} projectName The name of the project. Can be an app or addon.
  * @param  {Object} options
  * @property {String} options.command The command you want to run
@@ -77,6 +83,8 @@ function teardownTestTargets() {
 /**
  * Creates symbolic links from the dependency temp directories
  * to the project that is under test.
+ *
+ * @method linkDependencies
  * @param  {String} projectName The name of the project under test
  * @return {String} The path to the hydrated fixture.
  */

--- a/tests/helpers/command-generator.js
+++ b/tests/helpers/command-generator.js
@@ -13,6 +13,7 @@ const execa = require('../../lib/utilities/execa');
  * bower.invoke('install', 'ember');
  * ```
  *
+ * @private
  * @class CommandGenerator
  * @constructor
  * @param {Path} program The path to the command.
@@ -26,6 +27,7 @@ module.exports = class CommandGenerator {
   /**
    * The `invoke` method is responsible for building the final executable command.
    *
+   * @private
    * @method command
    * @param {String} [...arguments] Arguments to be passed into the command.
    * @param {Object} [options={}] The options passed into child_process.spawnSync.

--- a/tests/helpers/package-cache.js
+++ b/tests/helpers/package-cache.js
@@ -25,6 +25,7 @@ let DEPENDENCY_KEYS = ['dependencies', 'devDependencies', 'peerDependencies', 'o
 /**
  * The `bower` command helper.
  *
+ * @private
  * @method bower
  * @param {String} subcommand The subcommand to be passed into bower.
  * @param {String} [...arguments] Arguments to be passed into the bower subcommand.
@@ -36,6 +37,7 @@ let bower = new CommandGenerator('bower');
 /**
  * The `npm` command helper.
  *
+ * @private
  * @method npm
  * @param {String} subcommand The subcommand to be passed into npm.
  * @param {String} [...arguments] Arguments to be passed into the npm subcommand.
@@ -47,6 +49,7 @@ let npm = new CommandGenerator('npm');
 /**
  * The `yarn` command helper.
  *
+ * @private
  * @method yarn
  * @param {String} subcommand The subcommand to be passed into yarn.
  * @param {String} [...arguments] Arguments to be passed into the yarn subcommand.
@@ -87,6 +90,7 @@ let lookups = {
  * appropriate values based upon the context in which it is used. It's
  * a convenience helper to avoid littering lookups throughout the code.
  *
+ * @private
  * @method translate
  * @param {String} type Either 'bower', 'npm', or 'yarn'.
  * @param {String} lookup Either 'manifest', 'path', or 'upgrade'.
@@ -221,6 +225,7 @@ function translate(type, lookup) {
  * code is responsible for ensuring that the cache size does not
  * grow unbounded.
  *
+ * @private
  * @class PackageCache
  * @constructor
  * @param {String} rootPath Root of the directory for `PackageCache`.
@@ -248,6 +253,7 @@ module.exports = class PackageCache {
   /**
    * The `__setupForTesting` modifies things in module scope.
    *
+   * @private
    * @method __setupForTesting
    */
   __setupForTesting(stubs) {
@@ -258,6 +264,7 @@ module.exports = class PackageCache {
   /**
    * The `__resetForTesting` puts things back in module scope.
    *
+   * @private
    * @method __resetForTesting
    */
   __resetForTesting() {
@@ -269,6 +276,7 @@ module.exports = class PackageCache {
    * Configstore and what exists on disk. Non-existent directories
    * are removed from `this.dirs`.
    *
+   * @private
    * @method _cleanDirs
    */
   _cleanDirs() {
@@ -288,6 +296,7 @@ module.exports = class PackageCache {
    * The `_readManifest` method reads the on-disk manifest for the current
    * cache and returns its value.
    *
+   * @private
    * @method _readManifest
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -319,6 +328,7 @@ module.exports = class PackageCache {
    * and saves the manifest into it. If it is a yarn package cache it will remove
    * the existing lock file.
    *
+   * @private
    * @method _writeManifest
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -356,6 +366,7 @@ module.exports = class PackageCache {
    * It is also responsible for removing these links prior to making any changes
    * to the specified cache.
    *
+   * @private
    * @method _removeLinks
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -426,6 +437,7 @@ module.exports = class PackageCache {
    *
    * It is also responsible for restoring these links into the `PackageCache`.
    *
+   * @private
    * @method _restoreLinks
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -472,6 +484,7 @@ module.exports = class PackageCache {
    * The `_checkManifest` method compares the desired manifest to that which
    * exists in the cache.
    *
+   * @private
    * @method _checkManifest
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -512,6 +525,7 @@ module.exports = class PackageCache {
    * The `_install` method installs the contents of the manifest into the
    * specified package cache.
    *
+   * @private
    * @method _install
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.
@@ -530,6 +544,7 @@ module.exports = class PackageCache {
    * allowed to drift in a SemVer compatible manner. It ensures that CI is
    * always running against the latest versions of all dependencies.
    *
+   * @private
    * @method _upgrade
    * @param {String} label The label for the cache.
    * @param {String} type The type of package cache.


### PR DESCRIPTION
Changes:
- Mark all methods private in `package-cache` except methods below the line that says `// PUBLIC API BELOW`
- Mark all methods private in `hardware-info`
- Mark all methods private in `command-generator`
- Create a fake class for some private API test helpers in acceptance.js (`PrivateTestHelpers`)

To see what this looks like as rendered docs, run `npx yuidoc . --server` from the root of the ember-cli repo.