### PR TITLE
release the `process` in `ember` test helper

### DIFF
--- a/tests/helpers/ember.js
+++ b/tests/helpers/ember.js
@@ -5,6 +5,7 @@ const MockAnalytics = require('./mock-analytics');
 const cli = require('../../lib/cli');
 const MockProcess = require('./mock-process');
 const path = require('path');
+const willInterruptProcess = require('../../lib/utilities/will-interrupt-process');
 
 /*
   Accepts a single array argument, that contains the
@@ -64,6 +65,8 @@ module.exports = function ember(args, options) {
   if (!options || options.skipGit !== false) {
     args.push('--skipGit');
   }
+
+  willInterruptProcess.release();
 
   cliInstance = cli({
     process: new MockProcess(),


### PR DESCRIPTION
for some reason we have sporadic test failures on CI, like:

 > process already captured

This is quite hard to reproduce and the root cause of such a failure is not clear at the moment.

This commit is an attempt to provide an alternative to #9337, so with this we do not touch `will-interrupt-process`, and try to fix it in the tests land only.