### PR TITLE
use travis build matrix/expansion instead of include

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -22,11 +22,26 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+  jobs:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-3.16
+    - EMBER_TRY_SCENARIO=ember-lts-3.20
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - EMBER_TRY_SCENARIO=ember-classic
+
 branches:
   only:
     - master
     # npm version tags
     - /^v\d+\.\d+\.\d+/
+
+stages:
+- "Basic Tests"
+- test
 
 jobs:
   fast_finish: true
@@ -35,29 +50,19 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-    - stage: "Tests"
+    - stage: "Basic Tests"
       name: "Tests"
       script:
         - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> lint
         - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> test:ember
 
-    - stage: "Additional Tests"
+    - stage: test
       name: "Floating Dependencies"
       install:<% if (yarn) { %>
         - yarn install --no-lockfile --non-interactive<% } else { %>
         - npm install --no-package-lock<% } %>
       script:
         - <% if (yarn) { %>yarn<% } else { %>npm run<% } %> test:ember
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.20
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-    - env: EMBER_TRY_SCENARIO=ember-classic
 <% if (yarn) { %>
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/tests/fixtures/addon/defaults/.travis.yml
+++ b/tests/fixtures/addon/defaults/.travis.yml
@@ -19,11 +19,26 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+  jobs:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-3.16
+    - EMBER_TRY_SCENARIO=ember-lts-3.20
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - EMBER_TRY_SCENARIO=ember-classic
+
 branches:
   only:
     - master
     # npm version tags
     - /^v\d+\.\d+\.\d+/
+
+stages:
+- "Basic Tests"
+- test
 
 jobs:
   fast_finish: true
@@ -32,28 +47,18 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-    - stage: "Tests"
+    - stage: "Basic Tests"
       name: "Tests"
       script:
         - npm run lint
         - npm run test:ember
 
-    - stage: "Additional Tests"
+    - stage: test
       name: "Floating Dependencies"
       install:
         - npm install --no-package-lock
       script:
         - npm run test:ember
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.20
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-    - env: EMBER_TRY_SCENARIO=ember-classic
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -18,11 +18,26 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+  jobs:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-3.16
+    - EMBER_TRY_SCENARIO=ember-lts-3.20
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - EMBER_TRY_SCENARIO=ember-classic
+
 branches:
   only:
     - master
     # npm version tags
     - /^v\d+\.\d+\.\d+/
+
+stages:
+- "Basic Tests"
+- test
 
 jobs:
   fast_finish: true
@@ -31,28 +46,18 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
-    - stage: "Tests"
+    - stage: "Basic Tests"
       name: "Tests"
       script:
         - yarn lint
         - yarn test:ember
 
-    - stage: "Additional Tests"
+    - stage: test
       name: "Floating Dependencies"
       install:
         - yarn install --no-lockfile --non-interactive
       script:
         - yarn test:ember
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.20
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-    - env: EMBER_TRY_SCENARIO=ember-classic
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
I learned more about Travis CI stages and wanted to share. Travis has a default stage called "test". This is were all build matrix expansion jobs go. If we move all the `include` env jobs to the real env section, we can allow Travis to expand them into the "test" stage. You can see how it looks [here](https://github.com/kellyselden/ember-a11y-blueprint/pull/58).

Even though this is technically more "correct", it's a little more verbose, and you are stuck with the name "test" instead of how we preferred to name the stages. I'll leave this here for debate on whether it's a good change or not.