### PR TITLE
Adds missing qunit-dom setup invocation

### DIFF
--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -1,8 +1,12 @@
 import Application from '<%= modulePrefix %>/app';
 import config from '<%= modulePrefix %>/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();


### PR DESCRIPTION
Fixes missing `qunit-dom` `setup` import and invocation from #9340.