### PR TITLE
Add ember-page-title to app blueprint

### DIFF
--- a/blueprints/app/files/app/templates/application.hbs
+++ b/blueprints/app/files/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "<%= namespace %>"}}
+
 <% if (welcome) { %>{{!-- The following component displays Ember's default welcome message. --}}
 <WelcomePage />
 {{!-- Feel free to remove this! --}}

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -44,6 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0<% if (welcome) { %>",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -43,6 +43,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-page-title": "^6.0.2",
     "ember-qunit": "^5.0.0-beta.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",

--- a/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "Dummy"}}
+
 <h2 id="title">Welcome to Ember</h2>
 
 {{outlet}}

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -43,6 +43,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-page-title": "^6.0.2",
     "ember-qunit": "^5.0.0-beta.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",

--- a/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "Dummy"}}
+
 {{!-- The following component displays Ember's default welcome message. --}}
 <WelcomePage />
 {{!-- Feel free to remove this! --}}

--- a/tests/fixtures/app/defaults/app/templates/application.hbs
+++ b/tests/fixtures/app/defaults/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "Foo"}}
+
 {{!-- The following component displays Ember's default welcome message. --}}
 <WelcomePage />
 {{!-- Feel free to remove this! --}}

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -41,6 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -44,6 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -44,6 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/npm/app/templates/application.hbs
+++ b/tests/fixtures/app/npm/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "Foo"}}
+
 <h2 id="title">Welcome to Ember</h2>
 
 {{outlet}}

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -41,6 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/yarn/app/templates/application.hbs
+++ b/tests/fixtures/app/yarn/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "Foo"}}
+
 {{!-- The following component displays Ember's default welcome message. --}}
 <WelcomePage />
 {{!-- Feel free to remove this! --}}

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -41,6 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
+    "ember-page-title": "^6.0.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",


### PR DESCRIPTION
This PR adds `ember-page-title` to app blueprint as specified in RFC - https://github.com/ember-cli/ember-cli/issues/9370

Related PR for `Ember.js` - https://github.com/emberjs/ember.js/pull/19224