### PR TITLE
Bump ember-page-title to v6.0.3

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0<% if (welcome) { %>",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -43,7 +43,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-qunit": "^5.0.0-beta.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -43,7 +43,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-qunit": "^5.0.0-beta.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.0.0-beta.4",
-    "ember-page-title": "^6.0.2",
+    "ember-page-title": "^6.0.3",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",


### PR DESCRIPTION
Bump ember-page-title to v6.0.3 which resolves issues with Fastboot - https://github.com/ember-cli/ember-page-title/blob/master/CHANGELOG.md#603-2020-11-02

Closes #9370 