### PR TITLE
Add support for specifying a path for the generate command

### DIFF
--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -9,6 +9,11 @@ const _ = require('ember-cli-lodash-subset');
 const EOL = require('os').EOL;
 const SilentError = require('silent-error');
 
+const UNKNOWN_BLUEPRINT_ERROR =
+  'The `ember generate` command requires a ' +
+  'blueprint name to be specified. ' +
+  'For more details, use `ember help`';
+
 module.exports = Command.extend({
   name: 'generate',
   description: 'Generates new code from blueprints.',
@@ -40,13 +45,7 @@ module.exports = Command.extend({
     let blueprintName = rawArgs[0];
 
     if (!blueprintName) {
-      return Promise.reject(
-        new SilentError(
-          'The `ember generate` command requires a ' +
-            'blueprint name to be specified. ' +
-            'For more details, use `ember help`.'
-        )
-      );
+      return Promise.reject(new SilentError(UNKNOWN_BLUEPRINT_ERROR));
     }
 
     let taskArgs = {
@@ -166,3 +165,7 @@ module.exports = Command.extend({
     }
   },
 });
+
+module.exports.ERRORS = {
+  UNKNOWN_BLUEPRINT_ERROR,
+};

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1318,6 +1318,23 @@ let Blueprint = CoreObject.extend({
 Blueprint.lookup = function (name, options) {
   options = options || {};
 
+  if (name.includes(path.sep)) {
+    let blueprintPath = path.resolve(name);
+    let isNameAPath = Boolean(blueprintPath);
+
+    if (isNameAPath) {
+      if (Blueprint._existsSync(blueprintPath)) {
+        return Blueprint.load(blueprintPath);
+      }
+
+      if (!options.ignoreMissing) {
+        throw new SilentError(`Unknown blueprint: ${name}`);
+      }
+
+      return;
+    }
+  }
+
   let lookupPaths = generateLookupPaths(options.paths);
 
   let lookupPath;

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -101,6 +101,13 @@ describe('Acceptance: ember destroy', function () {
     return assertDestroyAfterGenerate(commandArgs, files);
   });
 
+  it('deletes files generated using blueprint paths', function () {
+    let commandArgs = [`${__dirname}/../../blueprints/http-proxy`, 'foo', 'bar'];
+    let files = ['server/proxies/foo.js'];
+
+    return assertDestroyAfterGenerate(commandArgs, files);
+  });
+
   it('deletes files generated using blueprints from the project directory', async function () {
     let commandArgs = ['foo', 'bar'];
     let files = ['app/foos/bar.js'];

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -144,6 +144,16 @@ describe('Acceptance: ember generate', function () {
     expect(file('app/controllers/foo.js')).to.contain('custom: true');
   });
 
+  it('allows a path to be specified to a blueprint', async function () {
+    await outputFile(
+      'blueprints/http-proxy/files/server/proxies/__name__.js',
+      "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
+    );
+    await generate([path.resolve(`${__dirname}/../../blueprints/http-proxy`), 'foo', 'http://localhost:5000']);
+
+    expect(file('server/index.js')).to.not.contain('foo: true', 'the local blueprint is not used');
+  });
+
   it('passes custom cli arguments to blueprint options', async function () {
     await initApp();
 

--- a/tests/unit/commands/generate-test.js
+++ b/tests/unit/commands/generate-test.js
@@ -11,6 +11,7 @@ const GenerateCommand = require('../../../lib/commands/generate');
 const td = require('testdouble');
 const ROOT = process.cwd();
 const { createTempDir } = require('broccoli-test-helper');
+const { ERRORS } = GenerateCommand;
 
 describe('generate command', function () {
   let input, options, command;
@@ -98,11 +99,7 @@ describe('generate command', function () {
 
   it('complains if no blueprint name is given', function () {
     return expect(command.validateAndRun([])).to.be.rejected.then((error) => {
-      expect(error.message).to.equal(
-        'The `ember generate` command requires a ' +
-          'blueprint name to be specified. ' +
-          'For more details, use `ember help`.'
-      );
+      expect(error.message).to.equal(ERRORS.UNKNOWN_BLUEPRINT_ERROR);
     });
   });
 


### PR DESCRIPTION
This is needed for this project: 
  - https://github.com/NullVoxPopuli/ember-codemod-blueprint

Which has [these remaining TODOs](https://github.com/NullVoxPopuli/ember-codemod-blueprint/pull/4/files) before the idea can even work
- [ ] add an API to allow accessing what files are generated in `afterInstall` (not the focus of _this_ PR)
- [x] add a path in place of the blueprint name, similar to how `new` can use a path to a local blueprint, 
   rather than rely on the name resolution system currently in place.
   this is useful, for wanting to chain blueprint executions, as is the focus of ember-codemod-blueprint
   (what this PR is focused on)

I'm open to advice on approach here, but those two bullets are what I need to be able to build more straightforward and extensible blueprint in user-space.

I'm kind of thinking about blueprints being like this at a high level (after the above work):
```
generateBaseBlueprint('ember-source/blueprints/component')
 |> renameToTypeScript
 |> addTypeArgument
 |> etc
```
actual api in https://github.com/NullVoxPopuli/ember-codemod-blueprint -- main difference is no pipes, and you'd want to work with specific file paths, rather than whatever the blueprint output is.
So a snippet from ember-codemod-blueprint,

```ts
module.exports = codemodBlueprint({
  upstream: 'ember-source/blueprints/component',
 
  transform(options, helpers) {
    let { transformScript, transformTemplate } = helpers;
    let { generatedFiles } = options;

    for (let fileInfo of generatedFiles) {
      
      if (fileInfo.name.includes('app/components') && fileInfo.name.endsWith('.js')) {
        await transformScript(
          scriptPath, 
          transformA, 
          transformB, 
          transformC
       );
     }
     // etc, and more transforms for the other files
    }
});
```

This approach should work for app-generation as well, but the `transform` hook may be _much_ bigger, depending on how different your team's default app is from the base blueprint