### PR TITLE
Prevent build cycles when app is within a watched dir

### DIFF
--- a/lib/models/watcher.js
+++ b/lib/models/watcher.js
@@ -42,7 +42,7 @@ module.exports = class Watcher extends CoreObject {
     const { Watcher } = require('broccoli');
     const { watchedSourceNodeWrappers } = this.builder.builder;
 
-    let watcher = new Watcher(this.builder, watchedSourceNodeWrappers, { saneOptions: options });
+    let watcher = new Watcher(this.builder, watchedSourceNodeWrappers, { saneOptions: options, ignored: this.ignored });
 
     watcher.start();
 

--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const path = require('path');
 const Task = require('../models/task');
 const Watcher = require('../models/watcher');
 const Builder = require('../models/builder');
@@ -39,6 +40,7 @@ class BuildWatchTask extends Task {
         builder,
         analytics: this.analytics,
         options,
+        ignored: [path.resolve(this.project.root, options.outputPath)],
       });
 
     await watcher;

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -61,6 +61,7 @@ class ServeTask extends Task {
         analytics: this.analytics,
         options,
         serving: true,
+        ignored: [path.resolve(this.project.root, options.outputPath)],
       });
 
     let serverRoot = './server';

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "bower-config": "^1.4.3",
     "bower-endpoint-parser": "0.2.2",
-    "broccoli": "^3.4.2",
+    "broccoli": "^3.5.0",
     "broccoli-amd-funnel": "^2.0.1",
     "broccoli-babel-transpiler": "^7.8.0",
     "broccoli-builder": "^0.18.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,10 +1429,10 @@ broccoli@^2.0.0:
     underscore.string "^3.2.2"
     watch-detector "^0.1.0"
 
-broccoli@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-3.4.2.tgz#a0c2605bea285c50cac304f482b86670630f4701"
-  integrity sha512-OZ0QEyL2i08xJWwhg9Fe0x5IScjBur986QRWrj5mAyHRZqF1nShEz01BPFoLt6L2tqJT0gyZsf8nfUvm8CcJgA==
+broccoli@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-3.5.0.tgz#bdf96dc32980d1ad9f7ef5e68aaaa19e8d47b602"
+  integrity sha512-qGYirIs6W5NGzDPMTRtoOnveP3UQJKWFjAWdRRZJjCoAJYN872sXuO48cnNfnc/c1nd9fCR8et4knlTPgI+9yQ==
   dependencies:
     "@types/chai" "^4.2.9"
     "@types/chai-as-promised" "^7.1.2"


### PR DESCRIPTION
Embroider v2 packages can put their source code wherever they want to (as they are "just regular node packages"). That means when we're interactively rebuilding them, we need to watch their root. But if a v2 addon contains its own test suite, and that test suite emits a `dist` folder, we will end up watching our own output, and cause an infinite build loop.

This fixes that by always ignoring the build's own output directory.  This depends on https://github.com/broccolijs/broccoli/pull/474 and will be updated to stop pointing at my fork once we have a broccoli release.

I'm unsure where you want to put test coverage for this. It will necessarily be covered by embroider's own tests, and here we are really just threading one option down to the layers that actually implement this behavior, so IMO I don't think an expensive end-to-end test here is necessary.