### PR TITLE
Update blueprint to eslint-plugin-ember v10

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -50,7 +50,7 @@
     "ember-template-lint": "^2.14.0<% if (welcome) { %>",
     "ember-welcome-page": "^4.0.0<% } %>",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -51,7 +51,7 @@
     "ember-template-lint": "^2.14.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -52,7 +52,7 @@
     "ember-try": "^1.4.0",
     "ember-welcome-page": "^4.0.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -47,7 +47,7 @@
     "ember-template-lint": "^2.14.0",
     "ember-welcome-page": "^4.0.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -49,7 +49,7 @@
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -50,7 +50,7 @@
     "ember-template-lint": "^2.14.0",
     "ember-welcome-page": "^4.0.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -46,7 +46,7 @@
     "ember-source": "~3.23.0-beta.1",
     "ember-template-lint": "^2.14.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -47,7 +47,7 @@
     "ember-template-lint": "^2.14.0",
     "ember-welcome-page": "^4.0.0",
     "eslint": "^7.11.0",
-    "eslint-plugin-ember": "^9.3.0",
+    "eslint-plugin-ember": "^10.0.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
https://github.com/ember-cli/eslint-plugin-ember/releases/tag/v10.0.0

This includes Ember Octane linting enabled by default in the recommended configuration since all supported Ember LTS versions are Ember Octane now (3.16, 3.20, and soon-to-be-released 3.24).