### PR TITLE
gitignore .eslintcache

### DIFF
--- a/blueprints/addon/files/npmignore
+++ b/blueprints/addon/files/npmignore
@@ -10,6 +10,7 @@
 /.editorconfig
 /.ember-cli
 /.env*
+/.eslintcache
 /.eslintignore
 /.eslintrc.js
 /.git/

--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -12,6 +12,7 @@
 /.env*
 /.pnp*
 /.sass-cache
+/.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log


### PR DESCRIPTION
#9391 added the `-cache` flag to the eslint script, so we should ignore the cache file.