### PR TITLE
Allows preprocessors to know what type of tree is being transpiled.

### DIFF
--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -443,6 +443,7 @@ module.exports = class DefaultPackager {
         'template',
         preprocessTemplates(preprocessedTemplatesFromAddons, {
           registry: this.registry,
+          treeType: 'templates',
         })
       );
     }
@@ -502,6 +503,7 @@ module.exports = class DefaultPackager {
 
       let preprocessedApp = preprocessJs(app, '/', this.name, {
         registry: this.registry,
+        treeType: 'app',
       });
 
       this._cachedProcessedJavascript = callAddonsPostprocessTreeHook(this.project, 'js', preprocessedApp);
@@ -550,6 +552,7 @@ module.exports = class DefaultPackager {
         outputPaths: this.distPaths.appCssFile,
         registry: this.registry,
         minifyCSS: this.minifyCSS.options,
+        treeType: 'styles',
       };
 
       let stylesAndVendor = callAddonsPreprocessTreeHook(this.project, 'css', tree);
@@ -737,6 +740,7 @@ module.exports = class DefaultPackager {
       const inputPath = '/tests';
       let preprocessedTests = preprocessJs(treeToCompile, inputPath, this.name, {
         registry: this.registry,
+        treeType: 'test',
       });
 
       let mergedTestTrees = mergeTrees([addonTestSupportTree, preprocessedTests], {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -796,6 +796,7 @@ class EmberApp {
     tree = preprocessJs(tree, '/', '/', {
       annotation: `_precompileAppJsTree`,
       registry: this.registry,
+      treeType: 'app',
     });
 
     // return the original params because there are multiple

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -944,6 +944,7 @@ let addonProto = {
     if (registryHasPreprocessor(this.registry, 'js')) {
       return this.preprocessJs(namespacedTree, '/', this.name, {
         registry: this.registry,
+        treeType: 'addon-test-support',
       });
     } else {
       this._warn(
@@ -972,6 +973,7 @@ let addonProto = {
       let processedStylesTree = preprocessCss(preprocessedStylesTree, '/', '/', {
         outputPaths: { addon: `${this.name}.css` },
         registry: this.registry,
+        treeType: 'addon-styles',
       });
       processedStylesTree = new Funnel(processedStylesTree, {
         destDir: `${this.name}/__COMPILED_STYLES__`,
@@ -1136,6 +1138,7 @@ let addonProto = {
       let processedTemplateTree = preprocessTemplates(preprocessedTemplateTree, {
         annotation: `compileTemplates(${this.name})`,
         registry: this.registry,
+        treeType: 'addon-templates',
       });
 
       let postprocessedTemplateTree = this._addonPostprocessTree('template', processedTemplateTree);
@@ -1308,6 +1311,7 @@ let addonProto = {
     let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
       annotation: `processedAddonJsFiles(${this.name})`,
       registry: this.registry,
+      treeType: 'addon',
     });
 
     let postprocessedAddonJs = this._addonPostprocessTree('js', processedAddonJS);


### PR DESCRIPTION
This will enable things like `ember-auto-import` to more appropriately understand the _type_ of thing being compiled. This is important in a number of circumstances, for example when deciding to add things to `assets/vendor.js` or to `assets/test-support.js`.

Provides information to be available for https://github.com/ef4/ember-auto-import/pull/329.
