### PR TITLE
Temporarily revert testing updates for 3.23.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -20,8 +20,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1<% if (embroider) { %>",
+    "@ember/optional-features": "^2.0.0<% if (embroider) { %>",
     "@embroider/compat": "^0.33.0",
     "@embroider/core": "^0.33.0",
     "@embroider/webpack": "^0.33.0<% } %>",
@@ -43,7 +42,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0<% if (welcome) { %>",
@@ -53,7 +52,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/blueprints/app/files/tests/index.html
+++ b/blueprints/app/files/tests/index.html
@@ -20,13 +20,6 @@
   <body>
     {{content-for "body"}}
     {{content-for "test-body"}}
-    
-    <div id="qunit"></div>
-    <div id="qunit-fixture">
-      <div id="ember-testing-container">
-        <div id="ember-testing"></div>
-      </div>
-    </div>
 
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/blueprints/app/files/tests/test-helper.js
+++ b/blueprints/app/files/tests/test-helper.js
@@ -1,12 +1,8 @@
 import Application from '<%= modulePrefix %>/app';
 import config from '<%= modulePrefix %>/config/environment';
-import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
-import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
-
-setup(QUnit.assert);
 
 start();

--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -18,6 +18,7 @@ node dev/update-blueprint-dependencies.js --filter eslint
 }
 
 const fs = require('fs');
+const path = require('path');
 const util = require('util');
 const nopt = require('nopt');
 const _latestVersion = require('latest-version');
@@ -38,15 +39,15 @@ const OPTIONS = nopt({
 });
 
 const PACKAGE_FILES = [
-  'blueprints/app/files/package.json',
-  'blueprints/addon/additional-dev-dependencies.json',
-  'tests/fixtures/app/defaults/package.json',
-  'tests/fixtures/app/npm/package.json',
-  'tests/fixtures/app/yarn/package.json',
-  'tests/fixtures/app/embroider/package.json',
-  'tests/fixtures/app/embroider-no-welcome/package.json',
-  'tests/fixtures/addon/defaults/package.json',
-  'tests/fixtures/addon/yarn/package.json',
+  '../blueprints/app/files/package.json',
+  '../blueprints/addon/additional-dev-dependencies.json',
+  '../tests/fixtures/app/defaults/package.json',
+  '../tests/fixtures/app/npm/package.json',
+  '../tests/fixtures/app/yarn/package.json',
+  '../tests/fixtures/app/embroider/package.json',
+  '../tests/fixtures/app/embroider-no-welcome/package.json',
+  '../tests/fixtures/addon/defaults/package.json',
+  '../tests/fixtures/addon/yarn/package.json',
 ];
 
 function shouldCheckDependency(dependency) {
@@ -103,14 +104,15 @@ async function updateDependencies(dependencies) {
 
 async function main() {
   for (let packageFile of PACKAGE_FILES) {
-    let pkg = JSON.parse(fs.readFileSync(packageFile, { encoding: 'utf8' }));
+    let filePath = path.join(__dirname, packageFile);
+    let pkg = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }));
 
     await updateDependencies(pkg.dependencies);
     await updateDependencies(pkg.devDependencies);
 
     let output = `${JSON.stringify(pkg, null, 2)}\n`;
 
-    fs.writeFileSync(packageFile, output, { encoding: 'utf8' });
+    fs.writeFileSync(filePath, output, { encoding: 'utf8' });
   }
 }
 

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -443,7 +443,6 @@ module.exports = class DefaultPackager {
         'template',
         preprocessTemplates(preprocessedTemplatesFromAddons, {
           registry: this.registry,
-          treeType: 'templates',
         })
       );
     }
@@ -503,7 +502,6 @@ module.exports = class DefaultPackager {
 
       let preprocessedApp = preprocessJs(app, '/', this.name, {
         registry: this.registry,
-        treeType: 'app',
       });
 
       this._cachedProcessedJavascript = callAddonsPostprocessTreeHook(this.project, 'js', preprocessedApp);
@@ -552,7 +550,6 @@ module.exports = class DefaultPackager {
         outputPaths: this.distPaths.appCssFile,
         registry: this.registry,
         minifyCSS: this.minifyCSS.options,
-        treeType: 'styles',
       };
 
       let stylesAndVendor = callAddonsPreprocessTreeHook(this.project, 'css', tree);
@@ -740,7 +737,6 @@ module.exports = class DefaultPackager {
       const inputPath = '/tests';
       let preprocessedTests = preprocessJs(treeToCompile, inputPath, this.name, {
         registry: this.registry,
-        treeType: 'test',
       });
 
       let mergedTestTrees = mergeTrees([addonTestSupportTree, preprocessedTests], {

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -796,7 +796,6 @@ class EmberApp {
     tree = preprocessJs(tree, '/', '/', {
       annotation: `_precompileAppJsTree`,
       registry: this.registry,
-      treeType: 'app',
     });
 
     // return the original params because there are multiple

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -944,7 +944,6 @@ let addonProto = {
     if (registryHasPreprocessor(this.registry, 'js')) {
       return this.preprocessJs(namespacedTree, '/', this.name, {
         registry: this.registry,
-        treeType: 'addon-test-support',
       });
     } else {
       this._warn(
@@ -973,7 +972,6 @@ let addonProto = {
       let processedStylesTree = preprocessCss(preprocessedStylesTree, '/', '/', {
         outputPaths: { addon: `${this.name}.css` },
         registry: this.registry,
-        treeType: 'addon-styles',
       });
       processedStylesTree = new Funnel(processedStylesTree, {
         destDir: `${this.name}/__COMPILED_STYLES__`,
@@ -1138,7 +1136,6 @@ let addonProto = {
       let processedTemplateTree = preprocessTemplates(preprocessedTemplateTree, {
         annotation: `compileTemplates(${this.name})`,
         registry: this.registry,
-        treeType: 'addon-templates',
       });
 
       let postprocessedTemplateTree = this._addonPostprocessTree('template', processedTemplateTree);
@@ -1311,7 +1308,6 @@ let addonProto = {
     let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {
       annotation: `processedAddonJsFiles(${this.name})`,
       registry: this.registry,
-      treeType: 'addon',
     });
 
     let postprocessedAddonJs = this._addonPostprocessTree('js', processedAddonJS);

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
@@ -43,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-source-channel-url": "^3.0.0",
@@ -54,7 +53,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
@@ -43,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-source-channel-url": "^3.0.0",
@@ -55,7 +54,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
@@ -40,7 +39,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",
@@ -50,7 +49,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@embroider/compat": "^0.33.0",
     "@embroider/core": "^0.33.0",
     "@embroider/webpack": "^0.33.0",
@@ -43,7 +42,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",
@@ -52,7 +51,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@embroider/compat": "^0.33.0",
     "@embroider/core": "^0.33.0",
     "@embroider/webpack": "^0.33.0",
@@ -43,7 +42,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",
@@ -53,7 +52,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
@@ -40,7 +39,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",
@@ -49,7 +48,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.1.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
@@ -40,7 +39,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.0",
+    "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",
@@ -50,7 +49,6 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {


### PR DESCRIPTION
Revert testing infrastructure updates (temp fix for 3.23.0).

This reverts the testing infrastructure updates that have been in the beta cycle since 3.23.0-beta.1 in order to ship ember-cli@3.23.0 (we are already weeks late). At the moment, the current implementation places `qunit` and `es6-promise` into the `assets/vendor.js` (on accident). A number of fixes are on the way but we need to release 3.23.0 before they are ready for adoption.
