### PR TITLE
Update blueprint for index.html

### DIFF
--- a/blueprints/app/files/app/index.html
+++ b/blueprints/app/files/app/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= namespace %></title>
     <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
 
     {{content-for "head"}}
 


### PR DESCRIPTION
Updates the blueprint for index.html to be more accessible by default, as inspired by the ember-template-lint rule that covers this issue, [no-invalid-meta](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-invalid-meta.md)