### PR TITLE
Move embroider experiment checks to each test

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -41,7 +41,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('a custom EmberENV in config/environment.js is used for window.EmberENV', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/custom-ember-env');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -58,7 +58,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('a custom environment config can be used in Brocfile.js', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/custom-environment-config');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -66,7 +66,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('without app/templates', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await fs.remove(path.join(process.cwd(), 'app/templates'));
@@ -75,7 +75,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('strips app/styles or app/templates from JS', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/styles-and-templates-stripped');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -90,7 +90,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('should throw if no build file is found', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     fs.removeSync('./ember-cli-build.js');
     try {
@@ -102,7 +102,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('using autoRun: true', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/auto-run-true');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -115,7 +115,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('using autoRun: false', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/auto-run-false');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -129,7 +129,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('app.import works properly with test tree files', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-test-import');
 
@@ -149,7 +149,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('app.import works properly with non-js/css files', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import');
 
@@ -169,7 +169,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('addons can have a public tree that is merged and returned namespaced by default', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/public-tree');
 
@@ -189,7 +189,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('using pods based templates', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -197,7 +197,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('using pods based templates with a podModulePrefix', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/pods-with-prefix-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -205,7 +205,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('addon trees are not jshinted', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/jshint-addon');
 
@@ -225,7 +225,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('multiple css files in styles/ are output when a preprocessor is not used', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/multiple-css-files');
 
@@ -241,7 +241,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('specifying custom output paths works properly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
@@ -269,7 +269,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('specifying outputFile results in an explicitly generated assets', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import-output-file');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -284,7 +284,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('can use transformation to turn anonymous AMD into named AMD', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import-anonymous-amd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -311,7 +311,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('can use transformation to turn named UMD into named AMD', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import-named-umd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -338,7 +338,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('can do amd transform from addon', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
@@ -371,7 +371,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('can use transformation to turn library into custom transformation', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
@@ -394,7 +394,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
@@ -432,7 +432,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('multiple paths can be CSS preprocessed', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
@@ -453,7 +453,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('app.css is output to <app name>.css by default', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
     expect(file(`dist/assets/${appName}.css`)).to.exist;
@@ -462,7 +462,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
   // for backwards compat.
   it('app.scss is output to <app name>.css by default', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
@@ -486,7 +486,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   it('additional trees can be passed to the app', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('brocfile-tests/additional-trees');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', { verbose: true });

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -24,9 +24,6 @@ describe('Acceptance: brocfile-smoke-test', function () {
   this.timeout(500000);
 
   before(function () {
-    if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
-    }
     return createTestTargets(appName);
   });
 
@@ -43,6 +40,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('a custom EmberENV in config/environment.js is used for window.EmberENV', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/custom-ember-env');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -57,17 +57,26 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('a custom environment config can be used in Brocfile.js', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/custom-environment-config');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('without app/templates', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await fs.remove(path.join(process.cwd(), 'app/templates'));
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('strips app/styles or app/templates from JS', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/styles-and-templates-stripped');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -80,6 +89,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('should throw if no build file is found', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     fs.removeSync('./ember-cli-build.js');
     try {
       await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -89,6 +101,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using autoRun: true', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/auto-run-true');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -99,6 +114,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using autoRun: false', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/auto-run-false');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -110,6 +128,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('app.import works properly with test tree files', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-test-import');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -127,6 +148,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('app.import works properly with non-js/css files', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -144,6 +168,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('addons can have a public tree that is merged and returned namespaced by default', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/public-tree');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -161,16 +188,25 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using pods based templates', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('using pods based templates with a podModulePrefix', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/pods-with-prefix-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('addon trees are not jshinted', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/jshint-addon');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -188,6 +224,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('multiple css files in styles/ are output when a preprocessor is not used', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/multiple-css-files');
 
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -201,6 +240,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('specifying custom output paths works properly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
     let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
@@ -226,6 +268,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('specifying outputFile results in an explicitly generated assets', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import-output-file');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -238,6 +283,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn anonymous AMD into named AMD', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import-anonymous-amd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -262,6 +310,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn named UMD into named AMD', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import-named-umd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -286,6 +337,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can do amd transform from addon', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -316,6 +370,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn library into custom transformation', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -336,6 +393,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
   // skipped because of potentially broken assertion that should be fixed correctly at a later point
   it.skip('specifying partial `outputPaths` hash deep merges options correctly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/custom-output-paths');
 
     let themeCSSPath = path.join(appRoot, 'app', 'styles', 'theme.css');
@@ -371,6 +431,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('multiple paths can be CSS preprocessed', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -389,12 +452,18 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('app.css is output to <app name>.css by default', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
     expect(file(`dist/assets/${appName}.css`)).to.exist;
   });
 
   // for backwards compat.
   it('app.scss is output to <app name>.css by default', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
     let brocfilePath = path.join(appRoot, 'ember-cli-build.js');
@@ -416,6 +485,9 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('additional trees can be passed to the app', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('brocfile-tests/additional-trees');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', { verbose: true });
 

--- a/tests/acceptance/nested-addons-smoke-test-slow.js
+++ b/tests/acceptance/nested-addons-smoke-test-slow.js
@@ -24,9 +24,6 @@ describe('Acceptance: nested-addons-smoke-test', function () {
   this.timeout(360000);
 
   before(function () {
-    if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
-    }
     return createTestTargets(appName);
   });
 
@@ -43,6 +40,9 @@ describe('Acceptance: nested-addons-smoke-test', function () {
   });
 
   it('addons with nested addons compile correctly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('addon/with-nested-addons');
 
     let packageJsonPath = path.join(appRoot, 'package.json');

--- a/tests/acceptance/nested-addons-smoke-test-slow.js
+++ b/tests/acceptance/nested-addons-smoke-test-slow.js
@@ -41,7 +41,7 @@ describe('Acceptance: nested-addons-smoke-test', function () {
 
   it('addons with nested addons compile correctly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('addon/with-nested-addons');
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -41,7 +41,7 @@ describe('Acceptance: preprocessor-smoke-test', function () {
 
   it('addons with standard preprocessors compile correctly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors`);
 
@@ -59,7 +59,7 @@ describe('Acceptance: preprocessor-smoke-test', function () {
 
   it('addon registry entries are added in the proper order', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles(`preprocessor-tests/app-registry-ordering`);
 
@@ -79,7 +79,7 @@ describe('Acceptance: preprocessor-smoke-test', function () {
 
   it('addons without preprocessors compile correctly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-without-preprocessors`);
 
@@ -104,7 +104,7 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   */
   it('addons depending on preprocessor addon preprocesses addon but not app', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-2`);
 
@@ -135,7 +135,7 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   */
   it('addon N levels deep depending on preprocessor preprocesses that parent addon only', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-3`);
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -24,9 +24,6 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   this.timeout(360000);
 
   before(function () {
-    if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
-    }
     return createTestTargets(appName);
   });
 
@@ -43,6 +40,9 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   });
 
   it('addons with standard preprocessors compile correctly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -58,6 +58,9 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   });
 
   it('addon registry entries are added in the proper order', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles(`preprocessor-tests/app-registry-ordering`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -75,6 +78,9 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   });
 
   it('addons without preprocessors compile correctly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-without-preprocessors`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -97,6 +103,9 @@ describe('Acceptance: preprocessor-smoke-test', function () {
       |-- preprocessor should not apply to this
   */
   it('addons depending on preprocessor addon preprocesses addon but not app', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-2`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -125,6 +134,9 @@ describe('Acceptance: preprocessor-smoke-test', function () {
       |-- preprocessor should not apply to this
   */
   it('addon N levels deep depending on preprocessor preprocesses that parent addon only', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-3`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -46,14 +46,14 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember new foo, clean from scratch', function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('ember new foo, make sure addon template overwrites', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await ember(['generate', 'template', 'foo']);
     await ember(['generate', 'in-repo-addon', 'my-addon']);
@@ -82,7 +82,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember test still runs when a JavaScript testem config exists', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('smoke-tests/js-testem-config');
 
@@ -97,7 +97,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('eslint passes after running ember new', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let result = await runCommand(path.join('.', 'node_modules', 'eslint', 'bin', 'eslint.js'), appRoot);
 
@@ -113,7 +113,7 @@ describe('Acceptance: smoke-test', function () {
   // test-support-80f2fe63fae0c44478fe0f8af73200a7.js contains the fingerprint (2871106928f813936fdd64f4d16005ac): expected 'test-support-80f2fe63fae0c44478fe0f8af73200a7.js' to include '2871106928f813936fdd64f4d16005ac'
   it.skip('ember new foo, build production and verify fingerprint', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 
@@ -145,7 +145,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember test --environment=production', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('smoke-tests/passing-test');
 
@@ -165,7 +165,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember test --path with previous build', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let originalWrite = process.stdout.write;
     let output = [];
@@ -199,7 +199,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember test wasm', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let originalWrite = process.stdout.write;
     let output = [];
@@ -233,7 +233,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember new foo, build development, and verify generated files', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -245,7 +245,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember build exits with non-zero code when build fails', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let appJsPath = path.join(appRoot, 'app', 'app.js');
 
@@ -263,7 +263,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('ember build generates instrumentation files when viz is enabled', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     process.env.BROCCOLI_VIZ = '1';
 
@@ -294,7 +294,7 @@ describe('Acceptance: smoke-test', function () {
 
   it.skip('ember new foo, build --watch development, and verify rebuilt after change', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let touched = false;
     let appJsPath = path.join(appRoot, 'app', 'app.js');
@@ -326,7 +326,7 @@ describe('Acceptance: smoke-test', function () {
 
   it.skip('ember new foo, build --watch development, and verify rebuilt after multiple changes', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let buildCount = 0;
     let touched = false;
@@ -371,7 +371,7 @@ describe('Acceptance: smoke-test', function () {
 
   it('build failures should be logged correctly', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     fs.writeFileSync(
       `${process.cwd()}/ember-cli-build.js`,
@@ -413,7 +413,7 @@ module.exports = function() {
 
   it.skip('ember new foo, server, SIGINT clears tmp/', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let result = await runCommand(
       path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'),
@@ -444,7 +444,7 @@ module.exports = function() {
 
   it('ember new foo, test, SIGINT exits with error and clears tmp/', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     let result = await expect(
       runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--test-port=25522', {
@@ -472,7 +472,7 @@ module.exports = function() {
 
   it('ember new foo, build production and verify css files are concatenated', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('with-styles');
 
@@ -492,7 +492,7 @@ module.exports = function() {
 
   it('ember new foo, build production and verify css files are minified', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('with-unminified-styles');
 
@@ -511,7 +511,7 @@ module.exports = function() {
 
   it('ember new foo, build production and verify single "use strict";', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 
@@ -529,7 +529,7 @@ module.exports = function() {
 
   it('ember can override and reuse the built-in blueprints', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('addon/with-blueprint-override');
 
@@ -543,7 +543,7 @@ module.exports = function() {
 
   it('template linting works properly for pods and classic structured templates', async function () {
     if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
+      return this.skip();
     }
     await copyFixtureFiles('smoke-tests/with-template-failing-linting');
 

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -28,9 +28,6 @@ let appRoot;
 describe('Acceptance: smoke-test', function () {
   this.timeout(500000);
   before(function () {
-    if (isExperimentEnabled('EMBROIDER')) {
-      this.skip();
-    }
     return createTestTargets(appName);
   });
 
@@ -48,10 +45,16 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember new foo, clean from scratch', function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('ember new foo, make sure addon template overwrites', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await ember(['generate', 'template', 'foo']);
     await ember(['generate', 'in-repo-addon', 'my-addon']);
 
@@ -78,6 +81,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test still runs when a JavaScript testem config exists', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('smoke-tests/js-testem-config');
 
     let result = await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -90,6 +96,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('eslint passes after running ember new', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let result = await runCommand(path.join('.', 'node_modules', 'eslint', 'bin', 'eslint.js'), appRoot);
 
     let exitCode = result.code;
@@ -103,6 +112,9 @@ describe('Acceptance: smoke-test', function () {
   // here is the error:
   // test-support-80f2fe63fae0c44478fe0f8af73200a7.js contains the fingerprint (2871106928f813936fdd64f4d16005ac): expected 'test-support-80f2fe63fae0c44478fe0f8af73200a7.js' to include '2871106928f813936fdd64f4d16005ac'
   it.skip('ember new foo, build production and verify fingerprint', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 
     let dirPath = path.join(appRoot, 'dist', 'assets');
@@ -132,6 +144,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test --environment=production', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('smoke-tests/passing-test');
 
     let result = await runCommand(
@@ -149,6 +164,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test --path with previous build', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let originalWrite = process.stdout.write;
     let output = [];
 
@@ -180,6 +198,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test wasm', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let originalWrite = process.stdout.write;
     let output = [];
 
@@ -211,6 +232,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember new foo, build development, and verify generated files', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
     let dirPath = path.join(appRoot, 'dist');
@@ -220,6 +244,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember build exits with non-zero code when build fails', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let appJsPath = path.join(appRoot, 'app', 'app.js');
 
     let result = await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -235,6 +262,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember build generates instrumentation files when viz is enabled', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     process.env.BROCCOLI_VIZ = '1';
 
     try {
@@ -263,6 +293,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it.skip('ember new foo, build --watch development, and verify rebuilt after change', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let touched = false;
     let appJsPath = path.join(appRoot, 'app', 'app.js');
     let builtJsPath = path.join(appRoot, 'dist', 'assets', 'some-cool-app.js');
@@ -292,6 +325,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it.skip('ember new foo, build --watch development, and verify rebuilt after multiple changes', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let buildCount = 0;
     let touched = false;
     let appJsPath = path.join(appRoot, 'app', 'app.js');
@@ -334,6 +370,9 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('build failures should be logged correctly', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     fs.writeFileSync(
       `${process.cwd()}/ember-cli-build.js`,
       `
@@ -373,6 +412,9 @@ module.exports = function() {
   });
 
   it.skip('ember new foo, server, SIGINT clears tmp/', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let result = await runCommand(
       path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'),
       'server',
@@ -401,6 +443,9 @@ module.exports = function() {
   });
 
   it('ember new foo, test, SIGINT exits with error and clears tmp/', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     let result = await expect(
       runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--test-port=25522', {
         onOutput(string, child) {
@@ -426,6 +471,9 @@ module.exports = function() {
   });
 
   it('ember new foo, build production and verify css files are concatenated', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('with-styles');
 
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
@@ -443,6 +491,9 @@ module.exports = function() {
   });
 
   it('ember new foo, build production and verify css files are minified', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('with-unminified-styles');
 
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
@@ -459,6 +510,9 @@ module.exports = function() {
   });
 
   it('ember new foo, build production and verify single "use strict";', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build', '--environment=production');
 
     let dirPath = path.join(appRoot, 'dist', 'assets');
@@ -474,6 +528,9 @@ module.exports = function() {
   });
 
   it('ember can override and reuse the built-in blueprints', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('addon/with-blueprint-override');
 
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'generate', 'component', 'foo-bar');
@@ -485,6 +542,9 @@ module.exports = function() {
   });
 
   it('template linting works properly for pods and classic structured templates', async function () {
+    if (isExperimentEnabled('EMBROIDER')) {
+      this.skip();
+    }
     await copyFixtureFiles('smoke-tests/with-template-failing-linting');
 
     let packageJsonPath = 'package.json';


### PR DESCRIPTION
As we work to enable each test to work under embroider moving the guards down a level will allow us to introduce smaller PRs enabling a few tests at a time.