### PR TITLE
Add `.*/` to eslint ignore

### DIFF
--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -13,6 +13,7 @@
 # misc
 /coverage/
 !.*
+.*/
 .eslintcache
 
 # ember-try


### PR DESCRIPTION
`!.*` was added to ensure js-based config files are linted (#8070)

However, this was probably too broad. An unintended consequence of that change was that the `.git` directory is now linted by eslint. The easiest way to observe this is to create a branch with `.js` in the name:

```shell
git checkout -b "foo.js"
yarn lint:js
```

This will now error since git created a file called `foo.js` in `.git` to maintain the metadata for this branch, but the file does not contain valid JavaScript.

In addition to these error scenarios, it causes unnecessary file scans. There are probably other caches by other tools other than git that could cause problems here as well.