### PR TITLE
defer tests warning

### DIFF
--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -129,7 +129,7 @@ function contentFor(config, match, type, options) {
       break;
     case 'test-body-footer':
       content.push(
-        `<script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>`
+        `<script>document.addEventListener('DOMContentLoaded', function() { Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);});</script>`
       );
 
       break;

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -211,7 +211,7 @@ describe('ember-app-utils', function () {
         let output = contentFor(config, defaultMatch, 'test-body-footer', defaultOptions);
 
         expect(output, 'includes `<script>` tag').to.equal(
-          `<script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>`
+          `<script>document.addEventListener('DOMContentLoaded', function() { Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);});</script>`
         );
       });
     });


### PR DESCRIPTION
If you load your tests via `<script type="module">` (which is becoming possible under advanced scenarios with embroider), that implicitly acts like `<script defer>`, and it causes this check to run too early.

DOMContentLoaded fires after all the deferred scripts have finished.