### PR TITLE
Better error message for missing addon main

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -382,6 +382,10 @@ class PackageInfo {
       return this.addonConstructor;
     }
 
+    if (!this.addonMainPath) {
+      throw new Error(`${this.pkg.name} at ${this.realPath} is missing its addon main file`);
+    }
+
     // Load the addon.
     // TODO: Future work - allow a time budget for loading each addon and warn
     // or error for those that take too long.


### PR DESCRIPTION
When an addon's main file is missing, you get a very cryptic message and stack trace that don't tell  you which addon is responsible:

```
- stack: TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received undefined
    at validateString (internal/validators.js:124:11)
    at Module.require (internal/modules/cjs/loader.js:945:3)
    at require (internal/modules/cjs/helpers.js:88:18)
    at PackageInfo.getAddonConstructor (/Users/edward/hacking/ember-auto-import/node_modules/ember-cli/lib/models/package-info-cache/package-info.js:384:18)
    at /Users/edward/hacking/ember-auto-import/node_modules/ember-cli/lib/models/instantiate-addons.js:71:38
    at Vertices.each (/Users/edward/hacking/ember-auto-import/node_modules/dag-map/dag-map.umd.js:197:13)
    at Vertices.walk (/Users/edward/hacking/ember-auto-import/node_modules/dag-map/dag-map.umd.js:125:14)
    at DAG.each (/Users/edward/hacking/ember-auto-import/node_modules/dag-map/dag-map.umd.js:68:24)
    at instantiateAddons (/Users/edward/hacking/ember-auto-import/node_modules/ember-cli/lib/models/instantiate-addons.js:52:9)
    at Project.initializeAddons (/Users/edward/hacking/ember-auto-import/node_modules/ember-cli/lib/models/project.js:476:19)
```

This is especially painful if it's happening in CI because, for example, some precompile step is being missed.

This PR makes the error much nicer:

```
- stack: Error: ember-auto-import at /Users/edward/hacking/ember-auto-import/packages/ember-auto-import is missing its addon main file
    at PackageInfo.getAddonConstructor (/Users/edward/hacking/ember-cli/lib/models/package-info-cache/package-info.js:386:13)
    at /Users/edward/hacking/ember-cli/lib/models/instantiate-addons.js:71:38
    at Vertices.each (/Users/edward/hacking/ember-cli/node_modules/dag-map/dag-map.umd.js:197:13)
    at Vertices.walk (/Users/edward/hacking/ember-cli/node_modules/dag-map/dag-map.umd.js:125:14)
    at DAG.each (/Users/edward/hacking/ember-cli/node_modules/dag-map/dag-map.umd.js:68:24)
    at instantiateAddons (/Users/edward/hacking/ember-cli/lib/models/instantiate-addons.js:52:9)
    at Project.initializeAddons (/Users/edward/hacking/ember-cli/lib/models/project.js:457:19)
    at Project.eachAddonCommand (/Users/edward/hacking/ember-cli/lib/models/project.js:518:12)
    at module.exports (/Users/edward/hacking/ember-cli/lib/cli/lookup-command.js:33:13)
    at CLI.maybeMakeCommand (/Users/edward/hacking/ember-cli/lib/cli/cli.js:94:26)
```

I found that there was [already some code](https://github.com/ember-cli/ember-cli/blob/7217cf7ed29fccf33a1187e08477d7ac271fa434/lib/models/package-info-cache/index.js#L535) to detect this error condition, but the only place that actually checks that error status is in a test.