### PR TITLE
Bump embroider to 0.37.0

### DIFF
--- a/blueprints/addon/additional-dev-dependencies.json
+++ b/blueprints/addon/additional-dev-dependencies.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@embroider/test-setup": "^0.36.0",
+    "@embroider/test-setup": "^0.37.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^1.4.0",
     "ember-source-channel-url": "^3.0.0"

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0<% if (embroider) { %>",
-    "@embroider/compat": "^0.36.0",
-    "@embroider/core": "^0.36.0",
-    "@embroider/webpack": "^0.36.0<% } %>",
+    "@embroider/compat": "^0.37.0",
+    "@embroider/core": "^0.37.0",
+    "@embroider/webpack": "^0.37.0<% } %>",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.36.0",
+    "@embroider/test-setup": "^0.37.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.36.0",
+    "@embroider/test-setup": "^0.37.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.36.0",
-    "@embroider/core": "^0.36.0",
-    "@embroider/webpack": "^0.36.0",
+    "@embroider/compat": "^0.37.0",
+    "@embroider/core": "^0.37.0",
+    "@embroider/webpack": "^0.37.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.36.0",
-    "@embroider/core": "^0.36.0",
-    "@embroider/webpack": "^0.36.0",
+    "@embroider/compat": "^0.37.0",
+    "@embroider/core": "^0.37.0",
+    "@embroider/webpack": "^0.37.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
This includes a fix for when a project's node_modules are symlinked which is the case for how ember-cli's test suite works:
https://github.com/embroider-build/embroider/pull/702. This will allow us to remove many of the isExperimentEnabled('EMBROIDER') guards that are skipping tests currently.