### PR TITLE
Refactor getPort to only check required port

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -107,15 +107,25 @@ module.exports = Command.extend({
   },
 
   async _checkExpressPort(commandOptions) {
-    let foundPort = await getPort({ port: commandOptions.port, host: commandOptions.host });
-    if (commandOptions.port !== foundPort && commandOptions.port !== 0) {
-      let message = `Port ${commandOptions.port} is already in use.`;
-      return Promise.reject(new SilentError(message));
+    let portOptions = { port: commandOptions.port, host: commandOptions.host };
+    if (commandOptions.port !== 0) {
+      portOptions.stopPort = commandOptions.port;
     }
-
-    // otherwise, our found port is good
-    commandOptions.port = foundPort;
-    commandOptions.liveReloadPort = commandOptions.liveReloadPort || commandOptions.port;
-    return commandOptions;
+    try {
+      let foundPort = await getPort(portOptions);
+      commandOptions.port = foundPort;
+      commandOptions.liveReloadPort = commandOptions.liveReloadPort || commandOptions.port;
+      return commandOptions;
+    } catch (err) {
+      let message;
+      if (commandOptions.port === 0) {
+        message = `No open port found above ${commandOptions.port}`;
+      } else if (commandOptions.port < 1024) {
+        message = `Port ${commandOptions.port} is already in use or you do not have permissions to use this port.`;
+      } else {
+        message = `Port ${commandOptions.port} is already in use.`;
+      }
+      throw new SilentError(message);
+    }
   },
 });


### PR DESCRIPTION
Portfinder library gets port as follows -- 

1. `getPort({:port 0})`:
    - Returns a random port.

2. `getPort({:port <non-zero>})`:
    - Returns the first open port between `<non-zero>` and upper limit (which is `40000`)

3. `getPort({:port <lower-limit>, :stopPort <upper-limit>})`
    - Returns a first open port between the range `<lower-limit>`  and `<upper-limit>`

In the ember script, we should only check for the specified port and not check for a range.
Hence, for a non-zero required port, we check for an open port in the range -- `[portNum, portNum]`
So if this port is not available, then `getPort` will give an exception.

If the requested port is less than `1024`, then the reason for port being unavailable can be that --
- Port is already in use
- You do not have sufficient permissions available

So we set appropriate error message based on the requested port.


