### PR TITLE
Pin QUnit to 2.13.0 due to strict mode regression in 2.14.0.

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -47,7 +47,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1<% if (welcome) { %>",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -63,7 +63,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -48,7 +48,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-source-channel-url": "^3.0.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -64,7 +64,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -48,7 +48,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-source-channel-url": "^3.0.0",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -60,7 +60,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -47,7 +47,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -47,7 +47,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "~2.13.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -44,7 +44,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",
-    "ember-qunit": "^5.1.2",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",
     "ember-template-lint": "^2.18.1",


### PR DESCRIPTION
QUnit 2.14 introduced issues when using QUnit in strict mode (in https://github.com/qunitjs/qunit/commit/2671d3f6c1c2b72a5fb9299bdce6eab70f2876a6), which causes errors during Embroider builds.

The issue has been fixed (in https://github.com/qunitjs/qunit/pull/1558) but is not yet released. This pins QUnit to `~2.13.0` while we wait for a new release with the fix. This change should be reverted (and the minimum version updated) once https://github.com/qunitjs/qunit/pull/1558 is released.
