### PR TITLE
Revert pin of QUnit from #9481 and bump to 2.14.1

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -63,7 +63,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -63,7 +63,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -64,7 +64,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -64,7 +64,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -60,7 +60,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -60,7 +60,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -57,7 +57,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^1",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "~2.13.0",
+    "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -58,7 +58,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "qunit": "^2.14.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0"
   },
   "engines": {


### PR DESCRIPTION
Bumping to the version of QUnit (2.14.1) which contains: https://github.com/qunitjs/qunit/pull/1558. This reverts the PR from @rwjblue that pinned it to the older version (2.13.0)