### PR TITLE
Update supported Ember version in addon blueprint

### DIFF
--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.20 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
 

--- a/tests/fixtures/addon/defaults/README.md
+++ b/tests/fixtures/addon/defaults/README.md
@@ -7,7 +7,7 @@ foo
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.20 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
 

--- a/tests/fixtures/addon/yarn/README.md
+++ b/tests/fixtures/addon/yarn/README.md
@@ -7,7 +7,7 @@ foo
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.20 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
 


### PR DESCRIPTION
Forgot to update this when doing https://github.com/ember-cli/ember-cli/pull/9485.