### PR TITLE
Prevent window.Ember deprecation on Ember 3.27+.

### DIFF
--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -129,7 +129,13 @@ function contentFor(config, match, type, options) {
       break;
     case 'test-body-footer':
       content.push(
-        `<script>document.addEventListener('DOMContentLoaded', function() { Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);});</script>`
+        `<script>
+document.addEventListener('DOMContentLoaded', function() {
+  if (!EmberENV.TESTS_FILE_LOADED) {
+    throw new Error('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".');
+  }
+});
+</script>`
       );
 
       break;

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -211,7 +211,13 @@ describe('ember-app-utils', function () {
         let output = contentFor(config, defaultMatch, 'test-body-footer', defaultOptions);
 
         expect(output, 'includes `<script>` tag').to.equal(
-          `<script>document.addEventListener('DOMContentLoaded', function() { Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);});</script>`
+          `<script>
+document.addEventListener('DOMContentLoaded', function() {
+  if (!EmberENV.TESTS_FILE_LOADED) {
+    throw new Error('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".');
+  }
+});
+</script>`
         );
       });
     });


### PR DESCRIPTION
Accessing `window.Ember` (e.g. without importing) will issue a deprecation in Ember 3.27 and higher, and ultimately removed in Ember 4.
