### PR TITLE
Add CLASSIC as a case for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - ENABLE_ALL_EXPERIMENTS
           - PACKAGER
           - EMBROIDER
+          - CLASSIC
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const availableExperiments = Object.freeze(['PACKAGER', 'EMBROIDER']);
+const availableExperiments = Object.freeze(['PACKAGER', 'EMBROIDER', 'CLASSIC']);
 
 const deprecatedExperiments = Object.freeze(['BROCCOLI_WATCHER', 'PACKAGER']);
 const enabledExperiments = Object.freeze([]);

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -20,6 +20,10 @@ function isExperimentEnabled(experimentName) {
     return true;
   }
 
+  if (process.env.EMBER_CLI_CLASSIC && experimentName === 'EMBROIDER') {
+    return false;
+  }
+
   let experimentEnvironmentVariable = `EMBER_CLI_${experimentName}`;
   let experimentValue = process.env[experimentEnvironmentVariable];
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -413,22 +413,24 @@ describe('Acceptance: ember new', function () {
     expect(pkgJson.name).to.equal('@foo/bar', 'uses addon name for package name');
   });
 
-  it('embroider experiment creates the correct files', async function () {
-    let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
-    process.env['EMBER_CLI_EMBROIDER'] = 'true';
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--skip-bower']);
+  if (!isExperimentEnabled('CLASSIC')) {
+    it('embroider experiment creates the correct files', async function () {
+      let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
+      process.env['EMBER_CLI_EMBROIDER'] = 'true';
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--skip-bower']);
 
-    if (ORIGINAL_PROCESS_ENV === undefined) {
-      delete process.env['EMBER_CLI_EMBROIDER'];
-    } else {
-      process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
-    }
+      if (ORIGINAL_PROCESS_ENV === undefined) {
+        delete process.env['EMBER_CLI_EMBROIDER'];
+      } else {
+        process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
+      }
 
-    let pkgJson = fs.readJsonSync('package.json');
-    expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-    expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-    expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
-  });
+      let pkgJson = fs.readJsonSync('package.json');
+      expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+    });
+  }
 
   it('embroider enabled with --embroider', async function () {
     await ember(['new', 'foo', '--skip-npm', '--skip-git', '--skip-bower', '--embroider']);

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -32,6 +32,7 @@ describe('experiments', function () {
       // afterEach
       delete process.env.EMBER_CLI_ENABLE_ALL_EXPERIMENTS;
       delete process.env.EMBER_CLI_EMBROIDER;
+      delete process.env.EMBER_CLI_CLASSIC;
 
       warnings = [];
       console.warn = (warning) => warnings.push(warning);
@@ -53,6 +54,12 @@ describe('experiments', function () {
 
     it('should return true when an experiment is enabled via environment variable', function () {
       process.env.EMBER_CLI_EMBROIDER = 'true';
+      process.env.CLASSIC = 'true';
+
+      // classic experiment will disable embroider
+      expect(isExperimentEnabled('EMBROIDER')).to.be.false;
+
+      delete process.env.CLASSIC;
 
       expect(isExperimentEnabled('EMBROIDER')).to.be.true;
 

--- a/tests/unit/experiments-test.js
+++ b/tests/unit/experiments-test.js
@@ -54,12 +54,12 @@ describe('experiments', function () {
 
     it('should return true when an experiment is enabled via environment variable', function () {
       process.env.EMBER_CLI_EMBROIDER = 'true';
-      process.env.CLASSIC = 'true';
+      process.env.EMBER_CLI_CLASSIC = 'true';
 
       // classic experiment will disable embroider
       expect(isExperimentEnabled('EMBROIDER')).to.be.false;
 
-      delete process.env.CLASSIC;
+      delete process.env.EMBER_CLI_CLASSIC;
 
       expect(isExperimentEnabled('EMBROIDER')).to.be.true;
 


### PR DESCRIPTION
This allows to keep classic compatibility while we transition towards Embroider as the default.