### PR TITLE
Enable Embroider by default for new projects

### DIFF
--- a/blueprints/addon/additional-dev-dependencies.json
+++ b/blueprints/addon/additional-dev-dependencies.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@embroider/test-setup": "^0.39.0",
+    "@embroider/test-setup": "^0.39.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^1.4.0",
     "ember-source-channel-url": "^3.0.0"

--- a/blueprints/addon/additional-dev-dependencies.json
+++ b/blueprints/addon/additional-dev-dependencies.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@embroider/test-setup": "^0.37.0",
+    "@embroider/test-setup": "^0.38.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^1.4.0",
     "ember-source-channel-url": "^3.0.0"

--- a/blueprints/addon/additional-dev-dependencies.json
+++ b/blueprints/addon/additional-dev-dependencies.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@embroider/test-setup": "^0.38.0",
+    "@embroider/test-setup": "^0.39.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^1.4.0",
     "ember-source-channel-url": "^3.0.0"

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0<% if (embroider) { %>",
-    "@embroider/compat": "^0.37.0",
-    "@embroider/core": "^0.37.0",
-    "@embroider/webpack": "^0.37.0<% } %>",
+    "@embroider/compat": "^0.38.0",
+    "@embroider/core": "^0.38.0",
+    "@embroider/webpack": "^0.38.0<% } %>",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0<% if (embroider) { %>",
-    "@embroider/compat": "^0.38.0",
-    "@embroider/core": "^0.38.0",
-    "@embroider/webpack": "^0.38.0<% } %>",
+    "@embroider/compat": "^0.39.0",
+    "@embroider/core": "^0.39.0",
+    "@embroider/webpack": "^0.39.0<% } %>",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0<% if (embroider) { %>",
-    "@embroider/compat": "^0.39.0",
-    "@embroider/core": "^0.39.0",
-    "@embroider/webpack": "^0.39.0<% } %>",
+    "@embroider/compat": "^0.39.1",
+    "@embroider/core": "^0.39.1",
+    "@embroider/webpack": "^0.39.1<% } %>",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const availableExperiments = Object.freeze(['PACKAGER', 'EMBROIDER', 'CLASSIC']);
 
 const deprecatedExperiments = Object.freeze(['BROCCOLI_WATCHER', 'PACKAGER']);
-const enabledExperiments = Object.freeze([]);
+const enabledExperiments = Object.freeze(['EMBROIDER']);
 const deprecatedExperimentsDeprecationsIssued = [];
 
 function isExperimentEnabled(experimentName) {

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.38.0",
+    "@embroider/test-setup": "^0.39.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.39.0",
+    "@embroider/test-setup": "^0.39.1",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.37.0",
+    "@embroider/test-setup": "^0.38.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.38.0",
+    "@embroider/test-setup": "^0.39.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.39.0",
+    "@embroider/test-setup": "^0.39.1",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/test-setup": "^0.37.0",
+    "@embroider/test-setup": "^0.38.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.39.0",
-    "@embroider/core": "^0.39.0",
-    "@embroider/webpack": "^0.39.0",
+    "@embroider/compat": "^0.39.1",
+    "@embroider/core": "^0.39.1",
+    "@embroider/webpack": "^0.39.1",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.37.0",
-    "@embroider/core": "^0.37.0",
-    "@embroider/webpack": "^0.37.0",
+    "@embroider/compat": "^0.38.0",
+    "@embroider/core": "^0.38.0",
+    "@embroider/webpack": "^0.38.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.38.0",
-    "@embroider/core": "^0.38.0",
-    "@embroider/webpack": "^0.38.0",
+    "@embroider/compat": "^0.39.0",
+    "@embroider/core": "^0.39.0",
+    "@embroider/webpack": "^0.39.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.39.0",
-    "@embroider/core": "^0.39.0",
-    "@embroider/webpack": "^0.39.0",
+    "@embroider/compat": "^0.39.1",
+    "@embroider/core": "^0.39.1",
+    "@embroider/webpack": "^0.39.1",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.37.0",
-    "@embroider/core": "^0.37.0",
-    "@embroider/webpack": "^0.37.0",
+    "@embroider/compat": "^0.38.0",
+    "@embroider/core": "^0.38.0",
+    "@embroider/webpack": "^0.38.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.38.0",
-    "@embroider/core": "^0.38.0",
-    "@embroider/webpack": "^0.38.0",
+    "@embroider/compat": "^0.39.0",
+    "@embroider/core": "^0.39.0",
+    "@embroider/webpack": "^0.39.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.39.0",
-    "@embroider/core": "^0.39.0",
-    "@embroider/webpack": "^0.39.0",
+    "@embroider/compat": "^0.39.1",
+    "@embroider/core": "^0.39.1",
+    "@embroider/webpack": "^0.39.1",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.37.0",
-    "@embroider/core": "^0.37.0",
-    "@embroider/webpack": "^0.37.0",
+    "@embroider/compat": "^0.38.0",
+    "@embroider/core": "^0.38.0",
+    "@embroider/webpack": "^0.38.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
-    "@embroider/compat": "^0.38.0",
-    "@embroider/core": "^0.38.0",
-    "@embroider/webpack": "^0.38.0",
+    "@embroider/compat": "^0.39.0",
+    "@embroider/core": "^0.39.0",
+    "@embroider/webpack": "^0.39.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
New apps generated via `ember new` will now default to use Embroider's build system.