### PR TITLE
fixes #9502

### DIFF
--- a/lib/models/instantiate-addons.js
+++ b/lib/models/instantiate-addons.js
@@ -49,6 +49,8 @@ function instantiateAddons(parent, project, addonPackages) {
   });
 
   let addons = [];
+  let timings = new Map();
+
   graph.each((key, value) => {
     let addonInfo = value;
     if (addonInfo) {
@@ -88,8 +90,10 @@ function instantiateAddons(parent, project, addonPackages) {
         addon.addons = [];
       }
 
-      AddonConstructor._meta_.initializeIn = Date.now() - start;
       addon.constructor = AddonConstructor;
+
+      timings.set(addon, Date.now() - start);
+
       initializeAddonToken.stop();
 
       addons.push(addon);
@@ -100,10 +104,7 @@ function instantiateAddons(parent, project, addonPackages) {
     ' addon info %o',
     addons.map((addon) => ({
       name: addon.name,
-      times: {
-        initialize: addon.constructor._meta_.initializeIn,
-        lookup: addon.constructor._meta_.lookupIn,
-      },
+      initializeTotalMillis: timings.get(addon),
     }))
   );
 

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -404,13 +404,8 @@ class PackageInfo {
       ctor = Addon.extend(Object.assign({ root: mainDir, pkg: this.pkg }, module));
     }
 
-    // XXX Probably want to store the timings here in PackageInfo,
-    // rather than adding _meta_ to the constructor.
-    // XXX Will also need to remove calls to it from various places.
     ctor._meta_ = {
       modulePath: this.addonMainPath,
-      lookupDuration: 0,
-      initializeIn: 0,
     };
 
     return (this.addonConstructor = ctor);


### PR DESCRIPTION
Moved the \_meta\_ timing code from package-info-cache/package-info.js to instantiate-addons.js, because adding timing to the constructor and then trying to use it later doesn't work (a later sibling with a child of the same type will write over the timing data). Tested that things work by enabling debug msgs. NOTE: the 'modulePath' value DOES have to stay on the constructor - various things fail if it does not. Also changed the reporting - instead of a 'timings' object with 'initialize' and 'lookup', there is now only a single field "initializeTotalMillis". Seems better since there is no non-zero value set for 'lookup' and 'initialize' doesn't tell you what it is actually signifying.