### PR TITLE
Pass `realPath` as `root` rather than the dirname for `addonMainPath`

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -390,18 +390,17 @@ class PackageInfo {
     // TODO: Future work - allow a time budget for loading each addon and warn
     // or error for those that take too long.
     let module = require(this.addonMainPath);
-    let mainDir = path.dirname(this.addonMainPath);
 
     let ctor;
 
     if (typeof module === 'function') {
       ctor = module;
-      ctor.prototype.root = ctor.prototype.root || mainDir;
+      ctor.prototype.root = ctor.prototype.root || this.realPath;
       ctor.prototype.pkg = ctor.prototype.pkg || this.pkg;
     } else {
       const Addon = require('../addon'); // done here because of circular dependency
 
-      ctor = Addon.extend(Object.assign({ root: mainDir, pkg: this.pkg }, module));
+      ctor = Addon.extend(Object.assign({ root: this.realPath, pkg: this.pkg }, module));
     }
 
     ctor._meta_ = {

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/lib/main.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/lib/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  name: require('../package').name,
+};

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/package.json
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-with-addon-main",
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "main": "lib/main.js"
+  }
+}

--- a/tests/fixtures/addon/simple/lib/ember-super-button/package.json
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/package.json
@@ -4,7 +4,10 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "paths": ["./lib/ember-ng"]
+    "paths": [
+      "./lib/ember-ng",
+      "./lib/ember-with-addon-main"
+    ]
   },
   "dependencies": {
     "ember-yagni": "0"

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -5,7 +5,10 @@
     "something-else": "latest"
   },
   "ember-addon": {
-    "paths": ["./lib/ember-super-button"]
+    "paths": [
+      "./lib/ember-super-button",
+      "./lib/ember-super-button/lib/ember-with-addon-main"
+    ]
   },
   "devDependencies": {
     "ember-resolver": "^7.0.0",

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -219,7 +219,7 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
         project._packageInfo,
         (packageInfo) =>
           typeof packageInfo.addonMainPath === 'string' &&
-          packageInfo.addonMainPath.endsWith('ember-with-addon-main/lib/main.js')
+          packageInfo.addonMainPath.endsWith(path.join('ember-with-addon-main', 'lib', 'main.js'))
       );
 
       let allPackageInfosForAddonWithMain = [

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -347,6 +347,7 @@ describe('models/project.js', function () {
         'ember-non-root-addon',
         'ember-random-addon',
         'ember-super-button',
+        'ember-with-addon-main',
       ];
       expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
     });


### PR DESCRIPTION
Currently it's possible for package infos representing the same addon to differ throughout the project. This is only true if an addon has an entry point located outside of `realPath` (eg, `realPath/lib/main.js`). This fixes this bug and adds a test-case to guard against this in the future.