### PR TITLE
Revert "Pass `realPath` as `root` for addons that export a function for its constructor"

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -390,17 +390,18 @@ class PackageInfo {
     // TODO: Future work - allow a time budget for loading each addon and warn
     // or error for those that take too long.
     let module = require(this.addonMainPath);
+    let mainDir = path.dirname(this.addonMainPath);
 
     let ctor;
 
     if (typeof module === 'function') {
       ctor = module;
-      ctor.prototype.root = ctor.prototype.root || this.realPath;
+      ctor.prototype.root = ctor.prototype.root || mainDir;
       ctor.prototype.pkg = ctor.prototype.pkg || this.pkg;
     } else {
       const Addon = require('../addon'); // done here because of circular dependency
 
-      ctor = Addon.extend(Object.assign({ root: this.realPath, pkg: this.pkg }, module));
+      ctor = Addon.extend(Object.assign({ root: mainDir, pkg: this.pkg }, module));
     }
 
     ctor._meta_ = {

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -395,7 +395,7 @@ class PackageInfo {
 
     if (typeof module === 'function') {
       ctor = module;
-      ctor.prototype.root = this.realPath;
+      ctor.prototype.root = ctor.prototype.root || this.realPath;
       ctor.prototype.pkg = ctor.prototype.pkg || this.pkg;
     } else {
       const Addon = require('../addon'); // done here because of circular dependency

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/lib/main.js
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/lib/main.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  name: require('../package').name,
-};

--- a/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/package.json
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/lib/ember-with-addon-main/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "ember-with-addon-main",
-  "keywords": [
-    "ember-addon"
-  ],
-  "ember-addon": {
-    "main": "lib/main.js"
-  }
-}

--- a/tests/fixtures/addon/simple/lib/ember-super-button/package.json
+++ b/tests/fixtures/addon/simple/lib/ember-super-button/package.json
@@ -4,10 +4,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "paths": [
-      "./lib/ember-ng",
-      "./lib/ember-with-addon-main"
-    ]
+    "paths": ["./lib/ember-ng"]
   },
   "dependencies": {
     "ember-yagni": "0"

--- a/tests/fixtures/addon/simple/lib/extend-from-addon-directly/index.js
+++ b/tests/fixtures/addon/simple/lib/extend-from-addon-directly/index.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const Addon = require('../../../../../../lib/models/addon');
-
-module.exports = Addon.extend({
-  name: require('./package').name,
-});

--- a/tests/fixtures/addon/simple/lib/extend-from-addon-directly/package.json
+++ b/tests/fixtures/addon/simple/lib/extend-from-addon-directly/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "extend-from-addon-directly",
-  "keywords": [
-    "ember-addon"
-  ],
-  "dependencies": {}
-}

--- a/tests/fixtures/addon/simple/lib/odd-inheritance-addon/index.js
+++ b/tests/fixtures/addon/simple/lib/odd-inheritance-addon/index.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const AddonToExtendFrom = require('../extend-from-addon-directly');
-
-module.exports = AddonToExtendFrom.extend({
-  name: require('./package').name,
-});

--- a/tests/fixtures/addon/simple/lib/odd-inheritance-addon/package.json
+++ b/tests/fixtures/addon/simple/lib/odd-inheritance-addon/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "odd-inheritance-addon",
-  "keywords": [
-    "ember-addon"
-  ],
-  "dependencies": {}
-}

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -5,10 +5,7 @@
     "something-else": "latest"
   },
   "ember-addon": {
-    "paths": [
-      "./lib/ember-super-button",
-      "./lib/ember-super-button/lib/ember-with-addon-main"
-    ]
+    "paths": ["./lib/ember-super-button"]
   },
   "devDependencies": {
     "ember-resolver": "^7.0.0",

--- a/tests/fixtures/addon/simple/package.json
+++ b/tests/fixtures/addon/simple/package.json
@@ -7,9 +7,7 @@
   "ember-addon": {
     "paths": [
       "./lib/ember-super-button",
-      "./lib/ember-super-button/lib/ember-with-addon-main",
-      "./lib/extend-from-addon-directly",
-      "./lib/odd-inheritance-addon"
+      "./lib/ember-super-button/lib/ember-with-addon-main"
     ]
   },
   "devDependencies": {

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -151,11 +151,11 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
       expect(packageAndErrorNames).to.deep.equal(devDependencyNames);
     });
 
-    it('shows projectPackageInfo has 4 in-repo addons', function () {
+    it('shows projectPackageInfo has 2 in-repo addons', function () {
       let inRepoAddons = projectPackageInfo.inRepoAddons;
 
       expect(inRepoAddons).to.exist;
-      expect(inRepoAddons.length).to.equal(4);
+      expect(inRepoAddons.length).to.equal(2);
 
       expect(inRepoAddons[0].realPath.indexOf(`simple${path.sep}lib${path.sep}ember-super-button`)).to.be.above(0);
       expect(inRepoAddons[0].pkg.name).to.equal('ember-super-button');
@@ -166,14 +166,6 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
         )
       ).to.be.above(0);
       expect(inRepoAddons[1].pkg.name).to.equal('ember-with-addon-main');
-
-      expect(inRepoAddons[2].realPath.indexOf(`simple${path.sep}lib${path.sep}extend-from-addon-directly`)).to.be.above(
-        0
-      );
-      expect(inRepoAddons[2].pkg.name).to.equal('extend-from-addon-directly');
-
-      expect(inRepoAddons[3].realPath.indexOf(`simple${path.sep}lib${path.sep}odd-inheritance-addon`)).to.be.above(0);
-      expect(inRepoAddons[3].pkg.name).to.equal('odd-inheritance-addon');
     });
 
     it('shows projectPackageInfo has 7 internal addon packages', function () {
@@ -242,34 +234,6 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
       expect(allAddonsWithAddonMain.length).to.equal(2);
       expect(allPackageInfosForAddonWithMain.length).to.equal(4);
       expect(areAllPackageInfosEqual).to.equal(true);
-    });
-
-    it('returns has the correct `root` for addons that export a function for its constructor', function () {
-      project.initializeAddons();
-
-      let inRepoAddons = projectPackageInfo.inRepoAddons;
-
-      let ExtendFromAddonDirectlyConstructor = inRepoAddons[2].getAddonConstructor();
-      let OddInheritanceAddonConstructor = inRepoAddons[3].getAddonConstructor();
-
-      expect(ExtendFromAddonDirectlyConstructor.prototype.root).to.equal(
-        path.resolve(__dirname, '../../../fixtures/addon/simple/lib/extend-from-addon-directly')
-      );
-
-      expect(OddInheritanceAddonConstructor.prototype.root).to.equal(
-        path.resolve(__dirname, '../../../fixtures/addon/simple/lib/odd-inheritance-addon')
-      );
-
-      let extendFromAddonInstance = new ExtendFromAddonDirectlyConstructor(project, project);
-      let oddInheritanceAddonInstance = new OddInheritanceAddonConstructor(project, project);
-
-      expect(extendFromAddonInstance.root).to.equal(
-        path.resolve(__dirname, '../../../fixtures/addon/simple/lib/extend-from-addon-directly')
-      );
-
-      expect(oddInheritanceAddonInstance.root).to.equal(
-        path.resolve(__dirname, '../../../fixtures/addon/simple/lib/odd-inheritance-addon')
-      );
     });
   });
 

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -64,13 +64,13 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
   });
 
   describe('packageInfo contents tests on valid project', function () {
-    let project, projectPath, packageJsonPath, packageContents, projectPackageInfo;
+    let projectPath, packageJsonPath, packageContents, projectPackageInfo;
 
     beforeEach(function () {
       projectPath = path.resolve(addonFixturePath, 'simple');
       packageJsonPath = path.join(projectPath, 'package.json');
       packageContents = require(packageJsonPath);
-      project = new Project(projectPath, packageContents, ui, cli);
+      let project = new Project(projectPath, packageContents, ui, cli);
       let pic = project.packageInfoCache;
 
       projectPackageInfo = pic.getEntry(projectPath);
@@ -151,21 +151,12 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
       expect(packageAndErrorNames).to.deep.equal(devDependencyNames);
     });
 
-    it('shows projectPackageInfo has 2 in-repo addons', function () {
+    it('shows projectPackageInfo has 1 in-repo addon named "ember-super-button"', function () {
       let inRepoAddons = projectPackageInfo.inRepoAddons;
-
       expect(inRepoAddons).to.exist;
-      expect(inRepoAddons.length).to.equal(2);
-
+      expect(inRepoAddons.length).to.equal(1);
       expect(inRepoAddons[0].realPath.indexOf(`simple${path.sep}lib${path.sep}ember-super-button`)).to.be.above(0);
       expect(inRepoAddons[0].pkg.name).to.equal('ember-super-button');
-
-      expect(
-        inRepoAddons[1].realPath.indexOf(
-          `simple${path.sep}lib${path.sep}ember-super-button${path.sep}lib${path.sep}ember-with-addon-main`
-        )
-      ).to.be.above(0);
-      expect(inRepoAddons[1].pkg.name).to.equal('ember-with-addon-main');
     });
 
     it('shows projectPackageInfo has 7 internal addon packages', function () {
@@ -180,60 +171,6 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
       expect(nodeModules).to.exist;
       expect(nodeModules.entries).to.exist;
       expect(Object.keys(nodeModules.entries).length).to.equal(9);
-    });
-
-    it('returns stable package infos for a package info representing the same addon', function () {
-      project.initializeAddons();
-
-      const findAddonsByName = (projectOrAddon, addonToFind, _foundAddons = []) => {
-        if (!projectOrAddon) {
-          return _foundAddons;
-        }
-
-        projectOrAddon.addons.forEach((addon) => {
-          if (addon.name === addonToFind) {
-            _foundAddons.push(addon);
-          }
-
-          findAddonsByName(addon, addonToFind, _foundAddons);
-        });
-
-        return _foundAddons;
-      };
-
-      const findAllInRepoPackageInfosByPredicate = (packageInfo, predicate, _foundPackageInfos = []) => {
-        if (predicate(packageInfo)) {
-          _foundPackageInfos.push(packageInfo);
-        }
-
-        (packageInfo.inRepoAddons || []).forEach((addonPackageInfo) =>
-          findAllInRepoPackageInfosByPredicate(addonPackageInfo, predicate, _foundPackageInfos)
-        );
-
-        return _foundPackageInfos;
-      };
-
-      let allAddonsWithAddonMain = findAddonsByName(project, 'ember-with-addon-main');
-
-      let projectAddonWithMainPackageInfo = findAllInRepoPackageInfosByPredicate(
-        project._packageInfo,
-        (packageInfo) =>
-          typeof packageInfo.addonMainPath === 'string' &&
-          packageInfo.addonMainPath.endsWith(path.join('ember-with-addon-main', 'lib', 'main.js'))
-      );
-
-      let allPackageInfosForAddonWithMain = [
-        ...allAddonsWithAddonMain.map((addon) => addon._packageInfo),
-        ...projectAddonWithMainPackageInfo,
-      ];
-
-      let areAllPackageInfosEqual = allPackageInfosForAddonWithMain.every(
-        (packageInfo) => packageInfo === allPackageInfosForAddonWithMain[0]
-      );
-
-      expect(allAddonsWithAddonMain.length).to.equal(2);
-      expect(allPackageInfosForAddonWithMain.length).to.equal(4);
-      expect(areAllPackageInfosEqual).to.equal(true);
     });
   });
 

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -348,8 +348,6 @@ describe('models/project.js', function () {
         'ember-random-addon',
         'ember-super-button',
         'ember-with-addon-main',
-        'extend-from-addon-directly',
-        'odd-inheritance-addon',
       ];
       expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
     });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -347,7 +347,6 @@ describe('models/project.js', function () {
         'ember-non-root-addon',
         'ember-random-addon',
         'ember-super-button',
-        'ember-with-addon-main',
       ];
       expect(Object.keys(project.addonPackages)).to.deep.equal(expected);
     });


### PR DESCRIPTION
This reverts commit d84da71.
This reverts commit 8b1c2b3.

This should resolve https://github.com/ember-cli/ember-cli/issues/9522