### PR TITLE
Update CONTRIBUTING.md to reference cli.emberjs.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,8 +210,8 @@ updating or writing new documentation:
 
 #### Website
 
-The codebase for the website [ember-cli.com](https://ember-cli.com) is located
-at: https://github.com/ember-cli/ember-cli.github.io
+The codebase for the website [cli.emberjs.com](https://cli.emberjs.com) is located
+at: https://github.com/ember-learn/cli-guides
 
 #### Code Words
 


### PR DESCRIPTION
It currently references ember-cli.com (and its archived source repo). I've updated it to reference cli.emberjs.com and its corresponding source repo.