### PR TITLE
Implement LCA host/host addons logic in `ember-cli`

### DIFF
--- a/lib/models/host-info-cache.js
+++ b/lib/models/host-info-cache.js
@@ -1,0 +1,334 @@
+'use strict';
+
+function allPkgInfosEqualAtIndex(paths, index) {
+  const itemToCheck = paths[0][index];
+  return paths.every((pathToLazyEngine) => pathToLazyEngine[index] === itemToCheck);
+}
+
+class HostInfoCache {
+  constructor(project) {
+    this.project = project;
+    this._bundledPackageInfoCache = new Map();
+    this._hostAddonInfoCache = new Map();
+    this._lcaHostCache = new Map();
+  }
+
+  /**
+   * Given a path (calculated as part of `getHostAddonInfo`), return the correct
+   * "bundle host". A bundle host is considered the project or lazy engine.
+   *
+   * For example, given the following package structure:
+   *
+   *      --Project--
+   *       /      \
+   *      /        \
+   * Lazy Engine A  \
+   *              Addon A
+   *                |
+   *                |
+   *           Lazy Engine B
+   *            /          \
+   *           /            \
+   *      Lazy Engine A   Lazy Engine C
+   *
+   * The provided paths for lazy engine A would look like:
+   *
+   * - [Project]
+   * - [Project, Addon A, Lazy Engine B]
+   *
+   * For this project structure, this function would return [Project, [Project]]
+   *
+   * Similarly, given the following project structure:
+   *
+   *            --Project--
+   *             /      \
+   *            /        \
+   *     Lazy Engine A    \
+   *          /        Lazy Engine B
+   *         /               |
+   *        /                |
+   *  Lazy Engine C     Lazy Engine C
+   *
+   * The provided paths for lazy engine C would look like:
+   *
+   * - [Project, Lazy Engine A]
+   * - [Project, Lazy Engine B]
+   *
+   * In this case, the host is the project and would also return [Project, [Project]]
+   *
+   * @method _findNearestBundleHost
+   * @param {Array<PackageInfo[]>} paths The found paths to a given bundle host
+   * @return {[PackageInfo, PackageInfo[]]}
+   * @private
+   */
+  _findNearestBundleHost(paths, pkgInfoForLazyEngine) {
+    // building an engine in isolation (it's considered the project, but it's
+    // also added as a dependency to the project by `ember-cli`)
+    if (this.project._packageInfo === pkgInfoForLazyEngine) {
+      return [this.project._packageInfo, [this.project._packageInfo]];
+    }
+
+    const shortestPath = paths.reduce(
+      (acc, pathToLazyEngine) => Math.min(acc, pathToLazyEngine.length),
+      Number.POSITIVE_INFINITY
+    );
+
+    const pathsEqualToShortest = paths.filter((pathToLazyEngine) => pathToLazyEngine.length === shortestPath);
+    const [firstPath] = pathsEqualToShortest;
+
+    for (let i = firstPath.length - 1; i >= 0; i--) {
+      const pkgInfo = firstPath[i];
+
+      if (pkgInfo.isForBundleHost() && allPkgInfosEqualAtIndex(pathsEqualToShortest, i)) {
+        return [pkgInfo, firstPath.slice(0, i + 1)];
+      }
+    }
+
+    // this should _never_ be triggered
+    throw new Error(
+      `[ember-cli] Could not find a common host for: \`${pkgInfoForLazyEngine.name}\` (located at \`${pkgInfoForLazyEngine.realPath}\`)`
+    );
+  }
+
+  /**
+   * Returns a `Set` of package-info objects that a given bundle host is
+   * _directly_ responsible for bundling (i.e., it excludes other bundle
+   * hosts/lazy engines when it encounters these)
+   *
+   * @method _getBundledPackageInfos
+   * @param {PackageInfo} pkgInfoToStartAt
+   * @return {Set<PackageInfo>}
+   * @private
+   */
+  _getBundledPackageInfos(pkgInfoToStartAt) {
+    let pkgInfos = this._bundledPackageInfoCache.get(pkgInfoToStartAt);
+
+    if (pkgInfos) {
+      return pkgInfos;
+    }
+
+    if (!pkgInfoToStartAt.isForBundleHost()) {
+      throw new Error(
+        `[ember-cli] \`${pkgInfoToStartAt.name}\` is not a bundle host; \`getBundledPackageInfos\` should only be used to find bundled package infos for a project or lazy engine`
+      );
+    }
+
+    pkgInfos = new Set();
+    this._bundledPackageInfoCache.set(pkgInfoToStartAt, pkgInfos);
+
+    let findAddons = (currentPkgInfo) => {
+      if (!currentPkgInfo.valid || !currentPkgInfo.addonMainPath) {
+        return;
+      }
+
+      if (pkgInfos.has(currentPkgInfo)) {
+        return;
+      }
+
+      if (currentPkgInfo.isForBundleHost()) {
+        return;
+      }
+
+      pkgInfos.add(currentPkgInfo);
+
+      let addonPackageList = currentPkgInfo.discoverAddonAddons();
+      addonPackageList.forEach((pkgInfo) => findAddons(pkgInfo));
+    };
+
+    let addonPackageList = pkgInfoToStartAt.project
+      ? pkgInfoToStartAt.discoverProjectAddons()
+      : pkgInfoToStartAt.discoverAddonAddons();
+
+    addonPackageList.forEach((pkgInfo) => findAddons(pkgInfo));
+
+    return pkgInfos;
+  }
+
+  /**
+   * This function intends to return a common host for a bundle host (lazy engine). The root
+   * package info should be the starting point (i.e., the project's package info). We do this
+   * by performing a breadth-first traversal until we find the intended lazy engine (represented
+   * as a package-info & the 1st argument passed to this function). As part of the traversal, we keep
+   * track of all paths to said engine; then, once we find the intended engine we use this to determine
+   * the nearest common host amongst all shortest paths.
+   *
+   * Some context:
+   *
+   * For a given engine/bundle host, this finds the lowest common ancestor that is considered a
+   * host amongst _all_ engines by the same name in the project.
+   *
+   * For example, given the following package structure:
+   *
+   *      --Project--
+   *       /      \
+   *      /        \
+   * Lazy Engine A  \
+   *              Addon A
+   *                |
+   *                |
+   *           Lazy Engine B
+   *            /          \
+   *           /            \
+   *      Lazy Engine A   Lazy Engine C
+   *
+   * - The LCA host for Lazy Engine A is the project
+   * - The LCA host for Lazy Engine B is the project
+   * - The LCA host for Lazy Engine C is Lazy Engine B
+   *
+   * This also returns `hostAndAncestorBundledPackageInfos`, which are all bundled addons above a given host:
+   *
+   * - `hostAndAncestorBundledPackageInfos` for lazy engine A includes all non-lazy dependencies of its LCA host & above (in this case, just the project)
+   * - `hostAndAncestorBundledPackageInfos` for lazy engine B includes all non-lazy dependencies of its LCA host & above (in this case, just the project)
+   * - `hostAndAncestorBundledPackageInfos` for lazy engine C includes non-lazy deps of lazy engine B & non-lazy deps of the project (LCA host & above)
+   *
+   * This is intended to mimic the behavior of `ancestorHostAddons` in `ember-engines`:
+   * https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/engine-addon.js#L333
+   *
+   * Unfortunately, we can't easily repurpose the logic in `ember-engines` since the algorithm has to be different;
+   * in `ember-engines` we need access to the actual addon instance, however, this is intended to be used _during_
+   * addon instantiation, so we only have access to package-info objects. In having said this, we _can_ repurpose
+   * the `hostPackageInfo` to determine the LCA host; see below `findLCAHost`.
+   *
+   * @method getHostAddonInfo
+   * @param {PackageInfo} packageInfoForLazyEngine
+   * @return {{ hostPackageInfo: PackageInfo, hostAndAncestorBundledPackageInfos: Set<PackageInfo> }}
+   */
+  getHostAddonInfo(packageInfoForLazyEngine) {
+    const cacheKey = `${this.project._packageInfo.realPath}-${packageInfoForLazyEngine.realPath}`;
+
+    let hostInfoCacheEntry = this._hostAddonInfoCache.get(cacheKey);
+
+    if (hostInfoCacheEntry) {
+      return hostInfoCacheEntry;
+    }
+
+    if (!packageInfoForLazyEngine.isForEngine()) {
+      throw new Error(
+        `[ember-cli] \`${packageInfoForLazyEngine.name}\` is not an engine; \`getHostAddonInfo\` should only be used to find host information about engines`
+      );
+    }
+
+    const queue = [{ pkgInfo: this.project._packageInfo, path: [] }];
+    const visited = new Set();
+    const foundPaths = [];
+
+    while (queue.length) {
+      const { pkgInfo: currentPackageInfo, path } = queue.shift();
+
+      const {
+        addonMainPath,
+        inRepoAddons = [],
+        dependencyPackages = {},
+        devDependencyPackages = {},
+      } = currentPackageInfo;
+
+      const isCurrentPackageInfoProject = this.project._packageInfo === currentPackageInfo;
+
+      // don't process non-ember addons
+      if (!isCurrentPackageInfoProject && typeof addonMainPath !== 'string') {
+        continue;
+      }
+
+      // store found paths
+      if (currentPackageInfo === packageInfoForLazyEngine) {
+        foundPaths.push([...path]);
+      }
+
+      // don't process a given `PackageInfo` object more than once
+      if (!visited.has(currentPackageInfo)) {
+        visited.add(currentPackageInfo);
+
+        // add current package info to current path
+        path.push(currentPackageInfo);
+
+        queue.push(
+          ...[
+            ...inRepoAddons,
+            ...Object.values(dependencyPackages),
+            ...Object.values(devDependencyPackages),
+          ].map((pkgInfo) => ({ pkgInfo, path: [...path] }))
+        );
+      }
+    }
+
+    const [hostPackageInfo, foundPath] = this._findNearestBundleHost(foundPaths, packageInfoForLazyEngine);
+
+    const hostAndAncestorBundledPackageInfos = foundPath
+      .filter((pkgInfo) => pkgInfo.isForBundleHost())
+      .reduce((acc, curr) => {
+        acc.push(...this._getBundledPackageInfos(curr));
+        return acc;
+      }, []);
+
+    hostInfoCacheEntry = {
+      hostPackageInfo,
+      hostAndAncestorBundledPackageInfos: new Set(hostAndAncestorBundledPackageInfos),
+    };
+
+    this._hostAddonInfoCache.set(cacheKey, hostInfoCacheEntry);
+    return hostInfoCacheEntry;
+  }
+
+  /**
+   * This returns the LCA host for a given engine; we use the associated package info
+   * to compute this (see `getHostAddonInfo` above); this finds the lowest common ancestor
+   * that is considered a host amongst _all_ engines by the same name in the project. This
+   * function is intended to replace the original behavior in `ember-engines`.
+   *
+   * For more info, see the original implementation here:
+   *
+   * https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/find-lca-host.js
+   *
+   * @method findLCAHost
+   * @param {EngineAddon} engineInstance
+   * @return {EngineAddon|EmberApp}
+   */
+  findLCAHost(engineInstance) {
+    // only compute once for a given engine
+    // we're using the engine name as the cache key here because regardless of its
+    // version, lazy engines will always get output to: `engines-dist/${engineName}`
+    let lcaHost = this._lcaHostCache.get(engineInstance.name);
+
+    if (lcaHost) {
+      return lcaHost;
+    }
+
+    if (!engineInstance._packageInfo.isForEngine()) {
+      throw new Error(
+        `[ember-cli] \`findLCAHost\` should only be used for engines; \`${engineInstance.name}\` is not an engine`
+      );
+    }
+
+    const { hostPackageInfo } = this.getHostAddonInfo(engineInstance._packageInfo);
+
+    let curr = engineInstance;
+
+    while (curr && curr.parent) {
+      if (curr.app) {
+        lcaHost = curr.app;
+        break;
+      }
+
+      if (curr._packageInfo === hostPackageInfo) {
+        lcaHost = curr;
+        break;
+      }
+
+      curr = curr.parent;
+    }
+
+    if (lcaHost) {
+      this._lcaHostCache.set(engineInstance.name, lcaHost);
+      return lcaHost;
+    }
+
+    // this should _never_ be triggered
+    throw new Error(
+      `[ember-cli] Could not find an LCA host for: \`${engineInstance.name}\` (located at \`${
+        engineInstance.packageRoot || engineInstance.root
+      }\`)`
+    );
+  }
+}
+
+module.exports = HostInfoCache;

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -245,6 +245,16 @@ class PackageInfo {
   }
 
   /**
+   * Indicate if this packageInfo represents an engine.
+   *
+   * @method isForEngine
+   * @return {Boolean} true if this pkgInfo is configured as an engine & false otherwise
+   */
+  isForEngine() {
+    return isEngine(this.pkg.keywords);
+  }
+
+  /**
    * Indicate if this packageInfo represents a lazy engine.
    *
    * @method isForLazyEngine
@@ -252,7 +262,7 @@ class PackageInfo {
    * module this represents has lazyLoading enabled, false otherwise.
    */
   isForLazyEngine() {
-    return isEngine(this.pkg.keywords) && isLazyEngine(require(this.addonMainPath));
+    return this.isForEngine() && isLazyEngine(require(this.addonMainPath));
   }
 
   /**
@@ -493,6 +503,7 @@ class PackageInfo {
       if (parent && parent.ui) {
         parent.ui.writeError(e);
       }
+
       const SilentError = require('silent-error');
       throw new SilentError(`An error occurred in the constructor for ${this.name} at ${this.realPath}`);
     }

--- a/lib/models/per-bundle-addon-cache/index.js
+++ b/lib/models/per-bundle-addon-cache/index.js
@@ -2,7 +2,6 @@
 
 const isLazyEngine = require('../../utilities/is-lazy-engine');
 const { getAddonProxy } = require('./addon-proxy');
-const PROJECT_BUNDLE_HOST_NAME = '__PROJECT__';
 const logger = require('heimdalljs-logger')('ember-cli:per-bundle-addon-cache');
 const { TARGET_INSTANCE } = require('./target-instance');
 
@@ -45,21 +44,13 @@ const { TARGET_INSTANCE } = require('./target-instance');
  * (2) Any addon that is not a lazy engine, there is only a single real instance
  * of the addon per "bundle host" (i.e. lazy engine or project).
  * (3) An optimization - any addon that is in a lazy engine but that is also
- * in the project (outside of all lazy engines) - the single instance is the
- * one in the project. All other instances (in any lazy engine) are proxies.
- * NOTE: the optimization is only enabled if the environment variable that controls that
- * ember-engine deduplication (process.env.EMBER_ENGINES_ADDON_DEDUPE) is set
- * to a truthy value.
+ * in bundled by its LCA host - the single instance is the one bundled by this
+ * host. All other instances (in any lazy engine) are proxies.
  *
- * Some implementation details given the above desired behavior:
- * (1) There are actually 2 types of caches in this object:
- * (1a) the first is keyed by lazy engine name. Note: the real instance of
- * the lazy engine is created as it is encountered while traversing the addon
- * tree (just like any real addon instance), it's just also referenced
- * in this cache so we can create proxies to this single instance from
- * anywhere in the addon tree.
- * (2) The cache (one item per lazy engine + project) of real addon instances
- * found while traversing the dependency tree.
+ * NOTE: the optimization is only enabled if the environment variable that controls
+ * `ember-engines` transitive deduplication (process.env.EMBER_ENGINES_ADDON_DEDUPE)
+ * is set to a truthy value. For more info, see:
+ * https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/engine-addon.js#L396
  *
  * @public
  * @class PerBundleAddonCache {
@@ -68,21 +59,12 @@ class PerBundleAddonCache {
   constructor(project) {
     this.project = project;
 
-    // cache of the addon packageInfos for addons that are descendants of the project
-    // (excluding going into lazy engines). Lazy engines that refer to any of these
-    // will defer to the project-level one.
-    this.bundledProjectAddonPkgInfos = this._setupBundledProjectAddonPackageInfos();
+    // The cache of bundle-host package infos and their individual addon caches.
+    // The cache is keyed by package info (representing a bundle host (project or
+    // lazy engine)) and an addon instance cache to bundle with that bundle host.
+    this.bundleHostCache = new Map();
 
-    // The cache of bundle-host instances and their individual addon caches.
-    // The cache is keyed by name (since there is only a single instance of any given
-    // engine name, even if 2 engine addons have the same engine name).
-    // To allow the project in the cache, it will use the empty string for a name,
-    // to not collide with any possible engine name.
-    // Each cache entry consists of the bundle host instance (Project or Lazy engine)
-    // and an addon instance cache to bundle with that bundle host.
-    this.bundleHostCache = this._setupBundleHostCache();
-
-    // Indicate if ember-engines deduping is supported.
+    // Indicate if ember-engines transitive dedupe is enabled.
     this.engineAddonTransitiveDedupeEnabled = !!process.env.EMBER_ENGINES_ADDON_DEDUPE;
 
     // For stats purposes, counts on the # addons and proxies created. Addons we
@@ -93,103 +75,16 @@ class PerBundleAddonCache {
   }
 
   /**
-   * Get the list of addon PackageInfo objects that are a dependency of this project,
-   * directly or transitively. Do not check any dependency that is itself a bundle host.
-   * This is used as part of the per-bundle addon-caching optimization.
-   *
-   * @private
-   * @method _setupBundledProjectAddonPackageInfos
-   * @return {Set} a Set of {PackageInfo} objects.
-   */
-  _setupBundledProjectAddonPackageInfos() {
-    let pkgInfos = new Set();
-
-    let findAddons = (pkgInfo) => {
-      if (!pkgInfo.valid || !pkgInfo.addonMainPath) {
-        return;
-      }
-
-      if (pkgInfos.has(pkgInfo)) {
-        return;
-      }
-
-      if (pkgInfo.isForBundleHost()) {
-        return;
-      }
-
-      pkgInfos.add(pkgInfo);
-
-      let addonPackageList = pkgInfo.discoverAddonAddons();
-      addonPackageList.forEach((pkgInfo) => findAddons(pkgInfo));
-    };
-
-    let addonPackageList = this.project._packageInfo.discoverProjectAddons();
-    addonPackageList.forEach((pkgInfo) => findAddons(pkgInfo));
-
-    return pkgInfos;
-  }
-
-  /**
-   * Set up the cache of bundle host instances. Each entry is keyed by name (project is given
-   * the name '__PROJECT__', the lazy engines use their engineName, since those are unique)
-   * Each cache entry has the bundle host instance (Project or lazy engine) and the addon instance
-   * cache for any addon instances to bundle with that bundle host.
-   *
-   * @private
-   * @method _setupBundleHostCache
-   * @return {Map} the bundle-host cache
-   */
-  _setupBundleHostCache() {
-    // get all the lazy engine packageInfos, but only keep the first one
-    // with any given engine name.
-    let lazyEnginePkgInfos = new Map();
-
-    let findAddons = (pkgInfo) => {
-      if (!pkgInfo.valid || !pkgInfo.addonMainPath) {
-        return;
-      }
-
-      if (pkgInfo.isForLazyEngine()) {
-        if (lazyEnginePkgInfos.has(pkgInfo.name)) {
-          return;
-        }
-
-        lazyEnginePkgInfos.set(pkgInfo.name, pkgInfo);
-      }
-
-      let addonPackageList = pkgInfo.discoverAddonAddons();
-      addonPackageList.forEach(findAddons);
-    };
-
-    let addonPackageList = this.project._packageInfo.discoverProjectAddons();
-    addonPackageList.forEach(findAddons);
-
-    // Create the cache
-    let cache = new Map();
-    cache.set(
-      PROJECT_BUNDLE_HOST_NAME,
-      this.createBundleHostCacheEntry(this.project, this.project._packageInfo.realPath)
-    );
-
-    lazyEnginePkgInfos.forEach((pkgInfo) => {
-      cache.set(pkgInfo.name, this.createBundleHostCacheEntry(null, pkgInfo.realPath));
-    });
-
-    return cache;
-  }
-
-  /**
-   * Create a cache entry the bundleHostCache. Because we want to use the same sort of proxy
+   * Creates a cache entry for the bundleHostCache. Because we want to use the same sort of proxy
    * for both bundle hosts and for 'regular' addon instances (though their cache entries have
    * slightly different structures) we'll use the Symbol from getAddonProxy.
    *
    * @method createBundleHostCacheEntry
-   * @param {Project|LazyEngine} bundleHostInstance the instance of the Project or lazy engine
-   * @param {String} bundleHostRealPath bundle host's pkgInfo.realPath
+   * @param {PackageInfo} bundleHostPkgInfo bundle host's pkgInfo.realPath
    * @return {Object} an object in the form of a bundle-host cache entry
    */
-  createBundleHostCacheEntry(bundleHostInstance, bundleHostRealPath) {
-    return { [TARGET_INSTANCE]: bundleHostInstance, realPath: bundleHostRealPath, addonInstanceCache: new Map() };
+  createBundleHostCacheEntry(bundleHostPkgInfo) {
+    return { [TARGET_INSTANCE]: null, realPath: bundleHostPkgInfo.realPath, addonInstanceCache: new Map() };
   }
 
   /**
@@ -220,8 +115,19 @@ class PerBundleAddonCache {
    */
   findBundleHost(addonParent, addonPkgInfo) {
     let curr = addonParent;
+
     while (curr) {
-      if (curr === this.project || isLazyEngine(curr)) {
+      if (curr === this.project) {
+        return curr;
+      }
+
+      if (isLazyEngine(curr)) {
+        // if we're building a lazy engine in isolation, prefer that the bundle host is
+        // the project, not the lazy engine addon instance
+        if (curr.parent === this.project && curr._packageInfo === this.project._packageInfo) {
+          return this.project;
+        }
+
         return curr;
       }
 
@@ -235,16 +141,19 @@ class PerBundleAddonCache {
 
   /**
    * An optimization we support from lazy engines is the following:
-   * if an addon instance is supposed to be bundled with a particular lazy engine, and
-   * same addon is also to be bundled in the project, prefer the one in the project.
    *
-   * NOTE: this only applies if this.engineAddonTransitiveDedupeEnabled is truthy. If it is not, the
-   * bundle host always "owns" the addon instance.
+   * If an addon instance is supposed to be bundled with a particular lazy engine, and
+   * same addon is also to be bundled by a common LCA host, prefer the one bundled by the
+   * host (since it's ultimately going to be deduped later by `ember-engines`).
    *
-   * If deduping is enabled and the project does also depend on the same addon,
+   * NOTE: this only applies if this.engineAddonTransitiveDedupeEnabled is truthy. If it is not,
+   * the bundle host always "owns" the addon instance.
+   *
+   * If deduping is enabled and the LCA host also depends on the same addon,
    * the lazy-engine instances of the addon will all be proxies to the one in
-   * the project. This function indicates whether the bundle host passed in (either the
-   * project or a lazy engine) is really the bundle host to "own" the new addon.
+   * the LCA host. This function indicates whether the bundle host passed in
+   * (either the project or a lazy engine) is really the bundle host to "own" the
+   * new addon.
    *
    * @method bundleHostOwnsInstance
    * @param (Object} bundleHost the project or lazy engine that is trying to "own"
@@ -253,23 +162,32 @@ class PerBundleAddonCache {
    * @return {Boolean} true if the bundle host is to "own" the instance, false otherwise.
    */
   bundleHostOwnsInstance(bundleHost, addonPkgInfo) {
-    return (
-      bundleHost === this.project ||
-      !this.engineAddonTransitiveDedupeEnabled ||
-      !this.bundledProjectAddonPkgInfos.has(addonPkgInfo)
-    );
+    if (isLazyEngine(bundleHost)) {
+      return (
+        !this.engineAddonTransitiveDedupeEnabled ||
+        !this.project.hostInfoCache
+          .getHostAddonInfo(bundleHost._packageInfo)
+          .hostAndAncestorBundledPackageInfos.has(addonPkgInfo)
+      );
+    }
+
+    return true;
   }
 
-  /**
-   * Get the name of a bundle host (used as the key for the bundleHostCache).
-   * Projects have a fake name.
-   *
-   * @method getBundleHostName
-   * @param {Project|Addon} bundleHost the bundle host whose name is desired.
-   * @return {String} the name of the bundle host
-   */
-  getBundleHostName(bundleHost) {
-    return bundleHost === this.project ? PROJECT_BUNDLE_HOST_NAME : bundleHost.name;
+  findBundleOwner(bundleHost, addonPkgInfo) {
+    if (bundleHost === this.project._packageInfo) {
+      return bundleHost;
+    }
+
+    let { hostPackageInfo, hostAndAncestorBundledPackageInfos } = this.project.hostInfoCache.getHostAddonInfo(
+      bundleHost
+    );
+
+    if (!hostAndAncestorBundledPackageInfos.has(addonPkgInfo)) {
+      return bundleHost;
+    }
+
+    return this.findBundleOwner(hostPackageInfo, addonPkgInfo);
   }
 
   /**
@@ -283,8 +201,9 @@ class PerBundleAddonCache {
    * @return {Addon|Proxy} An addon instance (for the first copy of the addon) or a Proxy.
    * An addon that is a lazy engine will only ever have a single copy in the cache.
    * An addon that is not will have 1 copy per bundle host (Project or lazy engine),
-   * except if it is an addon that's also owned by the project and
-   * is truthy, in which case it will only have a single copy in the project's addon cache.
+   * except if it is an addon that's also owned by a given LCA host and transitive
+   * dedupe is enabled (`engineAddonTransitiveDedupeEnabled`), in which case it will
+   * only have a single copy in the project's addon cache.
    */
   getAddonInstance(parent, addonPkgInfo) {
     // If the new addon is itself a bundle host (i.e. lazy engine), there is only one
@@ -292,7 +211,8 @@ class PerBundleAddonCache {
     // of the 'regular' addon caches. Because 'setupBundleHostCache' ran during construction,
     // we know that an entry is in the cache with this engine name.
     if (addonPkgInfo.isForBundleHost()) {
-      let cacheEntry = this.bundleHostCache.get(addonPkgInfo.name);
+      let cacheEntry = this._getBundleHostCacheEntry(addonPkgInfo);
+
       if (cacheEntry[TARGET_INSTANCE]) {
         logger.debug(`About to construct BR PROXY to cache entry for addon at: ${addonPkgInfo.realPath}`);
         this.numProxies++;
@@ -318,15 +238,14 @@ class PerBundleAddonCache {
     //     * If so, make a proxy for it.
     //     * If not, make a new instance of the addon and cache it in the
     //       bundle host's addon cache.
-    // If not, it means the bundle host is a lazy engine but the project also uses
+    // If not, it means the bundle host is a lazy engine but the LCA host also uses
     // the addon and deduping is enabled
-    //   * If the project already has a cached entry, return a proxy to that
+    //   * If the LCA host already has a cached entry, return a proxy to that
     //   * If it does not, create a 'blank' cache entry and return a proxy to that.
-    //     When the addon is encountered later when processing the project's addons,
+    //     When the addon is encountered later when processing the LCA host's addons,
     //     fill in the instance.
     if (this.bundleHostOwnsInstance(bundleHost, addonPkgInfo)) {
-      let bundleHostName = this.getBundleHostName(bundleHost);
-      let bundleHostCacheEntry = this.bundleHostCache.get(bundleHostName);
+      let bundleHostCacheEntry = this._getBundleHostCacheEntry(bundleHost._packageInfo);
       let addonInstanceCache = bundleHostCacheEntry.addonInstanceCache;
       let addonCacheEntry = addonInstanceCache.get(addonPkgInfo.realPath);
       let addonInstance;
@@ -338,8 +257,8 @@ class PerBundleAddonCache {
           return getAddonProxy(addonCacheEntry, parent);
         } else {
           // the cache entry was created 'empty' by an earlier call, indicating
-          // an addon that is used in a lazy engine but also used in the project,
-          // and we're now creating the instance for the project.
+          // an addon that is used in a lazy engine but also used by its LCA host,
+          // and we're now creating the instance for the LCA host.
           // Fill in the entry and return the new instance.
           logger.debug(`About to fill in REGULAR ADDON EXISTING cache entry for addon at: ${addonPkgInfo.realPath}`);
           this.numAddonInstances++;
@@ -360,12 +279,15 @@ class PerBundleAddonCache {
       addonPkgInfo.initChildAddons(addonInstance);
       return addonInstance;
     } else {
-      // The bundleHost is not the project but the project bundles the addon too and
-      // deduping is enabled, so the cache entry needs to go in the project's cache.
-      // Get/create an empty cache entry and return a proxy to it. The project will
+      // The bundleHost is not the project but the some ancestor bundles the addon and
+      // deduping is enabled, so the cache entry needs to go in the bundle owner's cache.
+      // Get/create an empty cache entry and return a proxy to it. The bundle owner will
       // set the instance later (see above).
-      let bundleHostCacheEntry = this.bundleHostCache.get(PROJECT_BUNDLE_HOST_NAME);
+      let bundleHostCacheEntry = this._getBundleHostCacheEntry(
+        this.findBundleOwner(bundleHost._packageInfo, addonPkgInfo)
+      );
       let addonCacheEntry = bundleHostCacheEntry.addonInstanceCache.get(addonPkgInfo.realPath);
+
       if (!addonCacheEntry) {
         logger.debug(`About to construct REGULAR ADDON EMPTY cache entry for addon at: ${addonPkgInfo.realPath}`);
         addonCacheEntry = this.createAddonCacheEntry(null, addonPkgInfo.realPath);
@@ -376,6 +298,17 @@ class PerBundleAddonCache {
       this.numProxies++;
       return getAddonProxy(addonCacheEntry, parent);
     }
+  }
+
+  _getBundleHostCacheEntry(pkgInfo) {
+    let cacheEntry = this.bundleHostCache.get(pkgInfo);
+
+    if (!cacheEntry) {
+      cacheEntry = this.createBundleHostCacheEntry(pkgInfo);
+      this.bundleHostCache.set(pkgInfo, cacheEntry);
+    }
+
+    return cacheEntry;
   }
 }
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -16,8 +16,8 @@ const findAddonByName = require('../utilities/find-addon-by-name');
 const heimdall = require('heimdalljs');
 const PackageInfoCache = require('./package-info-cache');
 const PerBundleAddonCache = require('./per-bundle-addon-cache');
-
 const instantiateAddons = require('./instantiate-addons');
+const HostInfoCache = require('./host-info-cache');
 
 let processCwd = process.cwd();
 
@@ -49,6 +49,7 @@ class Project {
     this.liveReloadFilterPatterns = [];
     this.setupBowerDirectory();
     this.configCache = new Map();
+    this.hostInfoCache = new HostInfoCache(this);
 
     /**
       Set when the `Watcher.detectWatchman` helper method finishes running,

--- a/tests/helpers/fixturify-project.js
+++ b/tests/helpers/fixturify-project.js
@@ -76,6 +76,18 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
     return new ProjectClass(root, pkg, cli.ui, cli);
   }
 
+  buildProjectModelForInRepoAddon(addonName, ProjectClass = ProjectWithoutInternalAddons) {
+    if (!this._hasWritten) {
+      this.writeSync();
+    }
+
+    let pkg = JSON.parse(this.files.lib[addonName]['package.json']);
+    let cli = new MockCLI();
+    let root = path.join(this.root, this.name, 'lib', addonName);
+
+    return new ProjectClass(root, pkg, cli.ui, cli);
+  }
+
   /**
    * Add an entry for this object's `dependencies` list. When this object is written out, the
    * dependency will also then write out appropriate files in this object's `node_modules' subdirectory.
@@ -365,7 +377,7 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
         Object.assign(pkg.devDependencies, this._referenceDevDependencies);
       }
 
-      container['package.json'] = JSON.stringify(pkg);
+      container['package.json'] = JSON.stringify(pkg, undefined, 2);
     }
 
     // an optimization to remove any node_modules declaration that has nothing in it,

--- a/tests/helpers/per-bundle-addon-cache.js
+++ b/tests/helpers/per-bundle-addon-cache.js
@@ -166,8 +166,8 @@ function createStandardCacheFixture() {
  *
  * @name findAddonCacheEntriesByName
  */
-function findAddonCacheEntriesByName(perBundleAddonCacheInstance, bundleHostName, addonName) {
-  let bundleHostCacheEntry = perBundleAddonCacheInstance.bundleHostCache.get(bundleHostName);
+function findAddonCacheEntriesByName(perBundleAddonCacheInstance, bundleHostPkgInfo, addonName) {
+  let bundleHostCacheEntry = perBundleAddonCacheInstance.bundleHostCache.get(bundleHostPkgInfo);
 
   if (!bundleHostCacheEntry) {
     return null;

--- a/tests/unit/models/host-info-cache-test.js
+++ b/tests/unit/models/host-info-cache-test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * Tests for the various proxies and instances once the project has initialized
+ * its addons
+ */
+const expect = require('chai').expect;
+const FixturifyProject = require('../../helpers/fixturify-project');
+
+describe('Unit | host-addons-utils', function () {
+  let fixturifyProject;
+
+  beforeEach(function () {
+    fixturifyProject = new FixturifyProject('awesome-proj', '1.0.0');
+    fixturifyProject.addDevDependency('ember-cli', '*');
+  });
+
+  afterEach(function () {
+    fixturifyProject.dispose();
+  });
+
+  it('multiple lazy engines in project, including nested lazy engines', function () {
+    fixturifyProject.addEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
+
+    fixturifyProject.addAddon('addon-a', '1.0.0', {
+      enableLazyLoading: true,
+      callback: (addon) => {
+        addon.addEngine('lazy-engine-b', '1.0.0', {
+          enableLazyLoading: true,
+          callback: (engine) => {
+            engine.addReferenceDependency('lazy-engine-a');
+            engine.addEngine('lazy-engine-c', '1.0.0', { enableLazyLoading: true });
+          },
+        });
+      },
+    });
+
+    fixturifyProject.writeSync();
+    let project = fixturifyProject.buildProjectModel();
+
+    project.initializeAddons();
+
+    const app = {};
+
+    const lazyEngineA = project.addons.find((addon) => addon.name === 'lazy-engine-a');
+    lazyEngineA.app = app;
+    const pkgInfoLazyEngineA = lazyEngineA._packageInfo;
+
+    const addonA = project.addons.find((addon) => addon.name === 'addon-a');
+    addonA.app = app;
+    const pkgInfoAddonA = addonA._packageInfo;
+
+    let { hostPackageInfo, hostAndAncestorBundledPackageInfos } = project.hostInfoCache.getHostAddonInfo(
+      pkgInfoLazyEngineA
+    );
+
+    expect(hostPackageInfo).to.equal(project._packageInfo, 'host package-info for lazy-engine A is the project');
+    expect(project.hostInfoCache.findLCAHost(lazyEngineA)).to.equal(lazyEngineA.app, 'LCA host is the app');
+
+    expect(hostAndAncestorBundledPackageInfos).to.deep.equal(
+      new Set([pkgInfoAddonA]),
+      'host packge-infos for lazy-engine A includes only addon-a'
+    );
+
+    const lazyEngineB = project.addons
+      .find((addon) => addon.name === 'addon-a')
+      .addons.find((addon) => addon.name === 'lazy-engine-b');
+
+    const pkgInfoLazyEngineB = lazyEngineB._packageInfo;
+
+    ({ hostPackageInfo, hostAndAncestorBundledPackageInfos } = project.hostInfoCache.getHostAddonInfo(
+      pkgInfoLazyEngineB
+    ));
+
+    expect(hostPackageInfo).to.equal(project._packageInfo, 'host package-info for lazy-engine B is the project');
+    expect(project.hostInfoCache.findLCAHost(lazyEngineB)).to.equal(lazyEngineA.app, 'LCA host is the app');
+    expect(hostAndAncestorBundledPackageInfos).to.deep.equal(
+      new Set([pkgInfoAddonA]),
+      'host packge-infos for lazy-engine B includes only addon-a'
+    );
+
+    const lazyEngineC = project.addons
+      .find((addon) => addon.name === 'addon-a')
+      .addons.find((addon) => addon.name === 'lazy-engine-b')
+      .addons.find((addon) => addon.name === 'lazy-engine-c');
+
+    const pkgInfoLazyEngineC = lazyEngineC._packageInfo;
+
+    ({ hostPackageInfo, hostAndAncestorBundledPackageInfos } = project.hostInfoCache.getHostAddonInfo(
+      pkgInfoLazyEngineC
+    ));
+
+    expect(hostPackageInfo).to.equal(pkgInfoLazyEngineB, 'host package-info for lazy-engine C is lazy engine B');
+
+    expect(project.hostInfoCache.findLCAHost(lazyEngineC)).to.equal(
+      lazyEngineB,
+      'LCA host for lazy engine C is lazy engine B'
+    );
+
+    expect(hostAndAncestorBundledPackageInfos).to.deep.equal(
+      new Set([pkgInfoAddonA]),
+      'host packge-infos for lazy-engine C includes addon-a'
+    );
+  });
+
+  it('multiple lazy engines in project, including nested lazy engines; some nested lazy engines have non-lazy deps', function () {
+    fixturifyProject.addEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
+
+    fixturifyProject.addAddon('addon-a', '1.0.0', {
+      enableLazyLoading: true,
+      callback: (addon) => {
+        addon.addEngine('lazy-engine-b', '1.0.0', {
+          enableLazyLoading: true,
+          callback: (engine) => {
+            engine.addReferenceDependency('lazy-engine-a');
+            engine.addAddon('addon-b', '1.0.0');
+            engine.addEngine('lazy-engine-c', '1.0.0', { enableLazyLoading: true });
+          },
+        });
+      },
+    });
+
+    fixturifyProject.writeSync();
+    let project = fixturifyProject.buildProjectModel();
+
+    project.initializeAddons();
+
+    const pkgInfoAddonA = project.addons.find((addon) => addon.name === 'addon-a')._packageInfo;
+
+    const pkgInfoLazyEngineB = project.addons
+      .find((addon) => addon.name === 'addon-a')
+      .addons.find((addon) => addon.name === 'lazy-engine-b')._packageInfo;
+
+    const pkgInfoAddonB = project.addons
+      .find((addon) => addon.name === 'addon-a')
+      .addons.find((addon) => addon.name === 'lazy-engine-b')
+      .addons.find((addon) => addon.name === 'addon-b')._packageInfo;
+
+    const pkgInfoLazyEngineC = project.addons
+      .find((addon) => addon.name === 'addon-a')
+      .addons.find((addon) => addon.name === 'lazy-engine-b')
+      .addons.find((addon) => addon.name === 'lazy-engine-c')._packageInfo;
+
+    let { hostPackageInfo, hostAndAncestorBundledPackageInfos } = project.hostInfoCache.getHostAddonInfo(
+      pkgInfoLazyEngineC
+    );
+
+    expect(hostPackageInfo).to.equal(pkgInfoLazyEngineB, 'host package-info for lazy-engine C is lazy engine B');
+    expect(hostAndAncestorBundledPackageInfos).to.deep.equal(
+      new Set([pkgInfoAddonA, pkgInfoAddonB]),
+      'host packge-infos for lazy-engine C includes addon-a, addon-b'
+    );
+  });
+
+  it('multiple lazy engines at same level with a common ancestor host', function () {
+    fixturifyProject.addInRepoEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
+    fixturifyProject.pkg['ember-addon'].paths = [];
+
+    fixturifyProject.addInRepoEngine('lazy-engine-b', '1.0.0', {
+      enableLazyLoading: true,
+      callback: (engine) => {
+        engine.pkg['ember-addon'].paths = ['../lazy-engine-a'];
+      },
+    });
+
+    fixturifyProject.addInRepoEngine('lazy-engine-c', '1.0.0', {
+      enableLazyLoading: true,
+      callback: (engine) => {
+        engine.pkg['ember-addon'].paths = ['../lazy-engine-a'];
+      },
+    });
+
+    fixturifyProject.writeSync();
+    let project = fixturifyProject.buildProjectModel();
+
+    project.initializeAddons();
+
+    const pkgInfoLazyEngineA = project.addons
+      .find((addon) => addon.name === 'lazy-engine-b')
+      .addons.find((addon) => addon.name === 'lazy-engine-a')._packageInfo;
+
+    let { hostPackageInfo, hostAndAncestorBundledPackageInfos } = project.hostInfoCache.getHostAddonInfo(
+      pkgInfoLazyEngineA
+    );
+
+    expect(hostPackageInfo).to.equal(project._packageInfo, 'host package-info for lazy-engine A is the project');
+    expect(hostAndAncestorBundledPackageInfos).to.deep.equal(
+      new Set([]),
+      'host packge-infos for lazy-engine A has no non-lazy deps'
+    );
+  });
+});

--- a/tests/unit/models/per-bundle-addon-cache/cache-bundle-hosts-test.js
+++ b/tests/unit/models/per-bundle-addon-cache/cache-bundle-hosts-test.js
@@ -27,14 +27,9 @@ describe('Unit | per-bundle-addon-cache bundle host', function () {
     expect(project.perBundleAddonCache).to.exist;
   });
 
-  it('Should have 3 bundle hosts (project, lazy-engine-a, lazy-engine-b)', function () {
+  it("Should have 0 bundle hosts since they're constructed lazily", function () {
     const bundleHostCache = project.perBundleAddonCache.bundleHostCache;
-
-    expect(bundleHostCache.size).to.equal(3); // project, lazy engine A, lazy engine B
-
-    expect(bundleHostCache.has('__PROJECT__')).to.equal(true);
-    expect(bundleHostCache.has('lazy-engine-a')).to.equal(true);
-    expect(bundleHostCache.has('lazy-engine-b')).to.equal(true);
+    expect(bundleHostCache.size).to.equal(0);
   });
 
   it('Should not have any addonInstanceCache entries', function () {


### PR DESCRIPTION
This PR implements host addons/LCA host logic in `ember-cli` and updates addon bundling caching to use these host addons, rather than _only_ considered bundled addons by the project.

An LCA host in this context is defined as the lowest common ancestor that is considered a host amongst _all_ bundle hosts (engines/project) by the same name in the project.

The behavior in `ember-cli` needs to differ than the [original implementation](https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/find-lca-host.js) in `ember-engines` because we need to know this information up-front _during_ addon instantiation, rather than after all addons in the project have been instantiated. As a result, the method for determining the LCA host/host addons is different: because we don't have access to addon instances, we use `PackageInfo` objects to compute this information. It's worth noting that `PackageInfo` objects _do not_ have knowledge of their parents, so we do a breadth-first traversal, keeping track of all paths until we discover the intended engine (represented by a `PackageInfo`).

For example, given the following project addon structure:

```
        --Project--
         /      \
        /        \
   Lazy Engine A  \
                Addon A
                  |
                  |
             Lazy Engine B
              /          \
             /            \
        Lazy Engine A   Lazy Engine C
```

- The LCA host for Lazy Engine A is the project
- The LCA host for Lazy Engine B is the project
- The LCA host for Lazy Engine C is Lazy Engine B

Similarly, we're also interested in all of the host package infos for a given LCA host; in the above example: `hostAndAncestorBundledPackageInfos` for each are considered to be:

- `hostAndAncestorBundledPackageInfos` for lazy engine A includes all non-lazy dependencies of its LCA host & above (in this case, just the project)
- `hostAndAncestorBundledPackageInfos` for lazy engine B includes all non-lazy dependencies of its LCA host & above (in this case, just the project)
- `hostAndAncestorBundledPackageInfos` for lazy engine C includes non-lazy deps of lazy engine B & non-lazy deps of the project (LCA host & above)

As part of this, we also expose a `getLCAHost` method so that `ember-engines` can prefer to use this method if it exists; we prefer that the computation for all of this has a single source of truth for both `ember-engines` and bundle addon caching.