### PR TITLE
ensure backwards compatibility is maintained with `packageRoot` and `root`

### DIFF
--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -244,7 +244,9 @@ class PackageInfoCache {
    * No copy is made.
    */
   loadAddon(addonInstance) {
-    let pkgInfo = this._readPackage(addonInstance.packageRoot, addonInstance.pkg);
+    // to maintain backwards compatibility for consumers who create a new instance
+    // of the base addon model class directly and don't set `packageRoot`
+    let pkgInfo = this._readPackage(addonInstance.packageRoot || addonInstance.root, addonInstance.pkg);
 
     // NOTE: the returned pkgInfo may contain errors, or may contain
     // other packages that have errors. We will try to process


### PR DESCRIPTION
it's possible for consumers to create an instance of the base addon model class directly; in this case, we want to maintain backwards compatibility when they bump to latest `ember-cli`, so we prefer `packageRoot`, but fallback to `root` in the case it doesn't exist