### PR TITLE
avoid setting `root` as `realPath` from the package-info object

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -317,9 +317,6 @@ let addonProto = {
 
     this._packageInfo = this.packageInfoCache.loadAddon(this);
 
-    // force us to use the real path as the root.
-    this.root = this._packageInfo.realPath;
-
     p.setupRegistry(this);
 
     this._initDefaultBabelOptions();
@@ -444,7 +441,10 @@ let addonProto = {
    * @method discoverAddons
    */
   discoverAddons() {
-    let pkgInfo = this.packageInfoCache.getEntry(this.root);
+    // prefer `packageRoot`, fallback to `root`; this is to maintain backwards compatibility for
+    // consumers who create a new instance of the base addon model class directly and don't set
+    // `packageRoot`
+    let pkgInfo = this.packageInfoCache.getEntry(this.packageRoot || this.root);
 
     if (pkgInfo) {
       let addonPackageList = pkgInfo.discoverAddonAddons();

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -99,6 +99,27 @@ describe('Acceptance: addon-smoke-test', function () {
     expect(result.code).to.eql(0);
   });
 
+  it("works for addon's that specify a nested addon entry point", async function () {
+    await copyFixtureFiles('addon/nested-addon-main');
+
+    let packageJsonPath = path.join(addonRoot, 'package.json');
+    let packageJson = fs.readJsonSync(packageJsonPath);
+
+    expect(packageJson.devDependencies['ember-source']).to.not.be.empty;
+    expect(packageJson.devDependencies['ember-cli']).to.not.be.empty;
+
+    fs.writeJsonSync(packageJsonPath, packageJson);
+
+    let result = await runCommand('node_modules/ember-cli/bin/ember', 'build');
+
+    expect(result.code).to.eql(0);
+    let contents;
+
+    let indexPath = path.join(addonRoot, 'dist', 'assets', 'vendor.js');
+    contents = fs.readFileSync(indexPath, { encoding: 'utf8' });
+    expect(contents).to.contain('"nested-addon-main/components/simple-component"');
+  });
+
   it('npm pack does not include unnecessary files', async function () {
     let handleError = function (error, commandName) {
       if (error.code === 'ENOENT') {

--- a/tests/fixtures/addon/nested-addon-main/package.json
+++ b/tests/fixtures/addon/nested-addon-main/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nested-addon-main",
+  "version": "0.0.1",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "latest",
+    "ember-cli-babel": "latest"
+  },
+  "devDependencies": {
+    "ember-source": "latest",
+    "ember-cli": "latest"
+  },
+  "ember-addon": {
+    "main": "src/main.js"
+  }
+}

--- a/tests/fixtures/addon/nested-addon-main/src/addon/components/simple-component.js
+++ b/tests/fixtures/addon/nested-addon-main/src/addon/components/simple-component.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from '../templates/components/simple-component';
+
+export default Component.extend({
+  layout
+});

--- a/tests/fixtures/addon/nested-addon-main/src/addon/templates/components/simple-component.hbs
+++ b/tests/fixtures/addon/nested-addon-main/src/addon/templates/components/simple-component.hbs
@@ -1,0 +1,1 @@
+<p>This is a simple component</p>

--- a/tests/fixtures/addon/nested-addon-main/src/main.js
+++ b/tests/fixtures/addon/nested-addon-main/src/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  name: require('../package').name,
+};


### PR DESCRIPTION
This PR avoids setting `root` as `realPath` from the pkg info object; currently we expect `realPath` & `root` to differ in some cases (specifically when an addon specifies an entry point outside the dir w/ its `package.json`). I've also added a test-case to cover this use-case to prevent future regressions.