### PR TITLE
Use relative override paths in blueprint ESLint config

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -24,24 +24,18 @@ module.exports = {
     // node files
     {
       files: [
-        '.eslintrc.js',
-        '.prettierrc.js',
-        '.template-lintrc.js',
-        'ember-cli-build.js',<% if (blueprint !== 'app') { %>
-        'index.js',<% } %>
-        'testem.js',
-        'blueprints/*/index.js',
-        'config/**/*.js',<% if (blueprint === 'app') { %>
-        'lib/*/index.js',
-        'server/**/*.js',<% } else { %>
-        'tests/dummy/config/**/*.js',<% } %>
-      ],<% if (blueprint !== 'app') { %>
-      excludedFiles: [
-        'addon/**',
-        'addon-test-support/**',
-        'app/**',
-        'tests/dummy/app/**',
-      ],<% } %>
+        './.eslintrc.js',
+        './.prettierrc.js',
+        './.template-lintrc.js',
+        './ember-cli-build.js',<% if (blueprint !== 'app') { %>
+        './index.js',<% } %>
+        './testem.js',
+        './blueprints/*/index.js',
+        './config/**/*.js',<% if (blueprint === 'app') { %>
+        './lib/*/index.js',
+        './server/**/*.js',<% } else { %>
+        './tests/dummy/config/**/*.js',<% } %>
+      ],
       parserOptions: {
         sourceType: 'script',
       },

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -24,21 +24,15 @@ module.exports = {
     // node files
     {
       files: [
-        '.eslintrc.js',
-        '.prettierrc.js',
-        '.template-lintrc.js',
-        'ember-cli-build.js',
-        'index.js',
-        'testem.js',
-        'blueprints/*/index.js',
-        'config/**/*.js',
-        'tests/dummy/config/**/*.js',
-      ],
-      excludedFiles: [
-        'addon/**',
-        'addon-test-support/**',
-        'app/**',
-        'tests/dummy/app/**',
+        './.eslintrc.js',
+        './.prettierrc.js',
+        './.template-lintrc.js',
+        './ember-cli-build.js',
+        './index.js',
+        './testem.js',
+        './blueprints/*/index.js',
+        './config/**/*.js',
+        './tests/dummy/config/**/*.js',
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -24,15 +24,15 @@ module.exports = {
     // node files
     {
       files: [
-        '.eslintrc.js',
-        '.prettierrc.js',
-        '.template-lintrc.js',
-        'ember-cli-build.js',
-        'testem.js',
-        'blueprints/*/index.js',
-        'config/**/*.js',
-        'lib/*/index.js',
-        'server/**/*.js',
+        './.eslintrc.js',
+        './.prettierrc.js',
+        './.template-lintrc.js',
+        './ember-cli-build.js',
+        './testem.js',
+        './blueprints/*/index.js',
+        './config/**/*.js',
+        './lib/*/index.js',
+        './server/**/*.js',
       ],
       parserOptions: {
         sourceType: 'script',

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.eslintrc.js
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.eslintrc.js
@@ -24,15 +24,15 @@ module.exports = {
     // node files
     {
       files: [
-        '.eslintrc.js',
-        '.prettierrc.js',
-        '.template-lintrc.js',
-        'ember-cli-build.js',
-        'testem.js',
-        'blueprints/*/index.js',
-        'config/**/*.js',
-        'lib/*/index.js',
-        'server/**/*.js',
+        './.eslintrc.js',
+        './.prettierrc.js',
+        './.template-lintrc.js',
+        './ember-cli-build.js',
+        './testem.js',
+        './blueprints/*/index.js',
+        './config/**/*.js',
+        './lib/*/index.js',
+        './server/**/*.js',
       ],
       parserOptions: {
         sourceType: 'script',


### PR DESCRIPTION
Since eslint/eslint#11799 landed in ESLint v6 some time back, we can now use relative paths in the ESLint override configuration in the blueprints.

ESLint didn't previously support relative paths in overrides, so we had to list directories containing files (which are Ember files) with the same names as those listed in `files` (Node files in the root directory) in `excludedFiles` (see #7529). Now that the paths in `files` are relative, we can be sure that it will only match against the files in the root directory, not files with the same name in subdirectories.

For good measure, I've also changed the subdirectory globs to be relative to the root as well, in case e.g. there are other directories in the tree with the same name that should not be matched.