### PR TITLE
Use a better dummy package than fs-extra in a test

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -321,7 +321,10 @@ describe('Acceptance: ember new', function () {
 
     fs.mkdirsSync('my_blueprint/files');
     fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
-    fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}');
+    fs.writeFileSync(
+      'my_blueprint/files/package.json',
+      '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}'
+    );
     fs.writeFileSync('my_blueprint/files/yarn.lock', '');
 
     await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -321,13 +321,13 @@ describe('Acceptance: ember new', function () {
 
     fs.mkdirsSync('my_blueprint/files');
     fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
-    fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "fs-extra": "*" }}');
+    fs.writeFileSync('my_blueprint/files/package.json', '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}');
     fs.writeFileSync('my_blueprint/files/yarn.lock', '');
 
     await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
 
     expect(file('yarn.lock')).to.not.be.empty;
-    expect(dir('node_modules/fs-extra')).to.not.be.empty;
+    expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
   });
 
   it('ember new without skip-git flag creates .git dir', async function () {


### PR DESCRIPTION
The 'fs-extra' package, as of version 10, has dropped Node 10 support, leading to failing builds for beta (which still has Node 10 support).

This changes the test that uses that package (via a blueprint) to instead use the 'ember-try-test-suite-helper' package (which was created as a dummy package for ember-try to use). Since that package doesn't have any dependencies/devDependencies or an 'engines' statement it should not end up with any conflicts down the line.