### PR TITLE
Add ability to specify a custom `ember-addon.perBundleAddonCacheUtil` utility

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -262,7 +262,7 @@ class PackageInfo {
    * module this represents has lazyLoading enabled, false otherwise.
    */
   isForLazyEngine() {
-    return this.isForEngine() && isLazyEngine(require(this.addonMainPath));
+    return this.isForEngine() && isLazyEngine(this._getAddonEntryPoint());
   }
 
   /**
@@ -435,14 +435,7 @@ class PackageInfo {
       return this.addonConstructor;
     }
 
-    if (!this.addonMainPath) {
-      throw new Error(`${this.pkg.name} at ${this.realPath} is missing its addon main file`);
-    }
-
-    // Load the addon.
-    // TODO: Future work - allow a time budget for loading each addon and warn
-    // or error for those that take too long.
-    let module = require(this.addonMainPath);
+    let module = this._getAddonEntryPoint();
     let mainDir = path.dirname(this.addonMainPath);
 
     let ctor;
@@ -516,7 +509,7 @@ class PackageInfo {
    * @return {Object} the constructed instance of the addon
    */
   getAddonInstance(parent, project) {
-    let addonEntryPointModule = require(this.addonMainPath);
+    let addonEntryPointModule = this._getAddonEntryPoint();
     let addonInstance;
 
     if (
@@ -548,6 +541,24 @@ class PackageInfo {
     } else {
       addonInstance.addons = [];
     }
+  }
+
+  /**
+   * Gets the addon entry point
+   *
+   * @method _getAddonEntryPoint
+   * @return {Object|Function} The exported addon entry point
+   * @private
+   */
+  _getAddonEntryPoint() {
+    if (!this.addonMainPath) {
+      throw new Error(`${this.pkg.name} at ${this.realPath} is missing its addon main file`);
+    }
+
+    // Load the addon.
+    // TODO: Future work - allow a time budget for loading each addon and warn
+    // or error for those that take too long.
+    return require(this.addonMainPath);
   }
 }
 

--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -466,20 +466,6 @@ class PackageInfo {
   }
 
   /**
-   * Indicate if a constructor (function or class) has the 'allowCachingPerBundle' flag
-   * set either on itself or on its prototype. Depending on how addon modules or constructor
-   * functions are set up, it could be in either. Needed for per-bundle addon caching.
-   *
-   * @method allowCachingPerBundle
-   * @param {Function|Class} ctor
-   * @return {Boolean} true if the given constructor function or class supports caching per bundle, false otherwise
-   */
-  allowCachingPerBundle(ctor) {
-    let val = !!ctor && (ctor.allowCachingPerBundle || ctor.prototype.allowCachingPerBundle);
-    return val;
-  }
-
-  /**
    * Construct an addon instance.
    *
    * NOTE: this does NOT call constructors for the child addons. That is left to
@@ -530,10 +516,14 @@ class PackageInfo {
    * @return {Object} the constructed instance of the addon
    */
   getAddonInstance(parent, project) {
-    let ctor = this.getAddonConstructor();
+    let addonEntryPointModule = require(this.addonMainPath);
     let addonInstance;
 
-    if (PerBundleAddonCache.isEnabled() && this.allowCachingPerBundle(ctor)) {
+    if (
+      PerBundleAddonCache.isEnabled() &&
+      project &&
+      project.perBundleAddonCache.allowCachingPerBundle(addonEntryPointModule)
+    ) {
       addonInstance = project.perBundleAddonCache.getAddonInstance(parent, this);
     } else {
       addonInstance = this.constructAddonInstance(parent, project);

--- a/lib/models/per-bundle-addon-cache/index.js
+++ b/lib/models/per-bundle-addon-cache/index.js
@@ -1,9 +1,47 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const isLazyEngine = require('../../utilities/is-lazy-engine');
 const { getAddonProxy } = require('./addon-proxy');
 const logger = require('heimdalljs-logger')('ember-cli:per-bundle-addon-cache');
 const { TARGET_INSTANCE } = require('./target-instance');
+
+function defaultAllowCachingPerBundle({ addonEntryPointModule }) {
+  return (
+    addonEntryPointModule.allowCachingPerBundle ||
+    (addonEntryPointModule.prototype && addonEntryPointModule.prototype.allowCachingPerBundle)
+  );
+}
+
+/**
+ * Resolves the perBundleAddonCacheUtil; this prefers the custom provided version by
+ * the consuming application, and defaults to an internal implementation here.
+ *
+ * @method resolvePerBundleAddonCacheUtil
+ * @param {Project} project
+ * @return {{allowCachingPerBundle: Function}}
+ */
+function resolvePerBundleAddonCacheUtil(project) {
+  const relativePathToUtil =
+    project.pkg && project.pkg['ember-addon'] && project.pkg['ember-addon'].perBundleAddonCacheUtil;
+
+  if (typeof relativePathToUtil === 'string') {
+    const absolutePathToUtil = path.resolve(project.root, relativePathToUtil);
+
+    if (!fs.existsSync(absolutePathToUtil)) {
+      throw new Error(
+        `[ember-cli] the provided \`${relativePathToUtil}\` for \`ember-addon.perBundleAddonCacheUtil\` does not exist`
+      );
+    }
+
+    return require(absolutePathToUtil);
+  }
+
+  return {
+    allowCachingPerBundle: defaultAllowCachingPerBundle,
+  };
+}
 
 /**
  * For large applications with many addons (and many instances of each, resulting in
@@ -66,12 +104,29 @@ class PerBundleAddonCache {
 
     // Indicate if ember-engines transitive dedupe is enabled.
     this.engineAddonTransitiveDedupeEnabled = !!process.env.EMBER_ENGINES_ADDON_DEDUPE;
+    this._perBundleAddonCacheUtil = resolvePerBundleAddonCacheUtil(this.project);
 
     // For stats purposes, counts on the # addons and proxies created. Addons we
     // can compare against the bundleHostCache addon caches. Proxies, not so much,
     // but we'll count them here.
     this.numAddonInstances = 0;
     this.numProxies = 0;
+  }
+
+  /**
+   * The default implementation here is to indicate if the original addon entry point has
+   * the `allowCachingPerBundle` flag set either on itself or on its prototype.
+   *
+   * If a consuming application specifies a relative path to a custom utility via the
+   * `ember-addon.perBundleAddonCacheUtil` configuration, we prefer the custom implementation
+   * provided by the consumer.
+   *
+   * @method allowCachingPerBundle
+   * @param {Object|Function} addonEntryPointModule
+   * @return {Boolean} true if the given constructor function or class supports caching per bundle, false otherwise
+   */
+  allowCachingPerBundle(addonEntryPointModule) {
+    return this._perBundleAddonCacheUtil.allowCachingPerBundle({ addonEntryPointModule });
   }
 
   /**

--- a/tests/helpers/fixturify-project.js
+++ b/tests/helpers/fixturify-project.js
@@ -17,7 +17,9 @@ class ProjectWithoutInternalAddons extends Project {
 function prepareAddon(addon, options) {
   addon.pkg.keywords.push('ember-addon');
   addon.pkg['ember-addon'] = {};
-  addon.files['index.js'] = `module.exports = {
+  addon.files['index.js'] =
+    options.addonEntryPoint ||
+    `module.exports = {
     name: require("./package").name,
     allowCachingPerBundle: ${Boolean(options.allowCachingPerBundle)},
     ${options.additionalContent || ''}


### PR DESCRIPTION
This PR adds the ability to specify a custom configuration in the project's `package.json` via the `ember-addon.perBundleAddonCacheUtil` configuration.

If a consuming application specifies a relative path to a custom utility via the `ember-addon.perBundleAddonCacheUtil` configuration, we prefer the custom implementation provided by the consumer; however, the default implementation here is to indicate if the original addon entry point has the `allowCachingPerBundle` flag set either on itself or on its prototype.