### PR TITLE
Switch from `octane` template lint config to `recommended`

### DIFF
--- a/blueprints/app/files/.template-lintrc.js
+++ b/blueprints/app/files/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane',
+  extends: 'recommended',
 };

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.template-lintrc.js
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.template-lintrc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane',
+  extends: 'recommended',
   rules: {
     'require-button-type': true, // blueprint override has missing button type
   },


### PR DESCRIPTION
ember-template-lint v3 promoted the `octane` config (now deprecated) to be `recommended`.

https://github.com/ember-template-lint/ember-template-lint/blob/master/CHANGELOG.md#v300-2021-03-02