### PR TITLE
[BUGFIX release] Remove IE11 from targets

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
Ember 3.26 started emitting the following warning:

> Internet Explorer 11 is listed in your compilation targets, but it will no longer be supported in the next major version of Ember. Please update your targets to remove IE 11 and include new targets that are within the updated support policy. For details on the new browser support policy, see:
>
> - The official documentation: http://emberjs.com/browser-support
> - the deprecation guide: https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy

To avoid triggering this warning out-of-the-box, we will stop including IE11 in the targets for new apps.