### PR TITLE
Move template config from Octane to Recommended

### DIFF
--- a/blueprints/app/files/.template-lintrc.js
+++ b/blueprints/app/files/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane',
+  extends: 'recommended',
 };


### PR DESCRIPTION
I've been informed by @scalvert that v3 of `ember-template-lint`, which is already included in this blueprint, moved from "octane" back to "recommended" as the default config, and that "octane" is deprecated.

cc: @MelSumner