### PR TITLE
Revert "[BUGFIX beta] Comment out IE11 for new apps to avoid deprecation"

### DIFF
--- a/blueprints/app/files/config/targets.js
+++ b/blueprints/app/files/config/targets.js
@@ -6,20 +6,12 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-// Ember's browser support policy is changing, and IE11 support will end in
-// v4.0 onwards.
-//
-// See https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy
-//
-// If you need IE11 support on a version of Ember that still offers support
-// for it, uncomment the code block below.
-//
-// const isCI = Boolean(process.env.CI);
-// const isProduction = process.env.EMBER_ENV === 'production';
-//
-// if (isCI || isProduction) {
-//   browsers.push('ie 11');
-// }
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
 
 module.exports = {
   browsers,

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -156,7 +156,7 @@ describe('Acceptance: ember new', function () {
     await ember(['new', 'foo', '--skip-npm', '--skip-bower']);
 
     process.env.CI = true;
-    const defaultTargets = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+    const defaultTargets = require('../../lib/utilities/default-targets').browsers;
     const blueprintTargets = require(path.resolve('config/targets.js')).browsers;
     expect(blueprintTargets).to.have.same.deep.members(defaultTargets);
   });


### PR DESCRIPTION
This reverts commit 4373c5c3fb623cb6c4eaac7f21710c2ecc3945c8.

The commit was accidentally pushed to the beta branch directly, and the CI run failed on Node 10 and 12. The failure seems unrelated though.

Opening this PR to run CI without the commit, if this passes feel free to land the revert and we can try the fix again through proper PR process. Otherwise, it should confirm that the CI failure is unrelated and we can probably keep the commit.