### PR TITLE
Ensure tests fixtures transpile to be evaluated in Node

### DIFF
--- a/tests/fixtures/brocfile-tests/auto-run-false/config/targets.js
+++ b/tests/fixtures/brocfile-tests/auto-run-false/config/targets.js
@@ -1,0 +1,10 @@
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions',
+];
+
+module.exports = {
+  browsers,
+  node: 'current',
+};

--- a/tests/fixtures/brocfile-tests/auto-run-true/config/targets.js
+++ b/tests/fixtures/brocfile-tests/auto-run-true/config/targets.js
@@ -1,0 +1,10 @@
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions',
+];
+
+module.exports = {
+  browsers,
+  node: 'current',
+};

--- a/tests/fixtures/brocfile-tests/custom-ember-env/config/targets.js
+++ b/tests/fixtures/brocfile-tests/custom-ember-env/config/targets.js
@@ -1,0 +1,10 @@
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions',
+];
+
+module.exports = {
+  browsers,
+  node: 'current',
+};


### PR DESCRIPTION
These specific test fixutres are evaluated in a Node context (by the `DistChecker` using JSDom), so the resulting assets must be transpiled for the current Node environment.

Closes https://github.com/ember-cli/ember-cli/pull/9572
