### PR TITLE
Update gitignore to include .lint-todo folder

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -13,6 +13,7 @@
 /.pnp*
 /.sass-cache
 /.eslintcache
+/.lint-todo
 /connect.lock
 /coverage/
 /libpeerconnection.log


### PR DESCRIPTION
Since `ember-template-lint` is installed by default, it would be helpful to have the `.lint-todo` folder already in the .gitignore file. It's consistent with the experience we designed for developers.