### PR TITLE
Add `--ci-provider` option to `ember new` and `ember addon`

### DIFF
--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -8,37 +8,48 @@ on:
   pull_request: {}
 
 jobs:
-
-  lint:
-    name: "Lint"
-    env:
-      CI: true
+  test:
+    name: "Tests"
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - uses: actions/cache@v2
-      with:
-        path: <%= yarn ? '${{ steps.yarn-cache-dir-path.outputs.dir }}' : '~/.npm' %>
-        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
-    - name: Install Dependencies
-      run: <%= yarn ? 'yarn' : 'npm' %> install
-    - name: Lint
-      run: <%= yarn ? 'yarn' : 'npm run' %> lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: <%= yarn ? 'yarn' : 'npm' %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
+      - name: Lint
+        run: <%= yarn ? 'yarn' : 'npm run' %> lint
+      - name: Run Tests
+        run: <%= yarn ? 'yarn' : 'npm run' %> test:ember
 
   floating:
-    name: "Floating dependencies"
-    env:
-      CI: true
+    name: "Floating Dependencies"
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: <%= yarn ? 'yarn' : 'npm' %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --no-lockfile' : 'npm install --no-shrinkwrap' %>
+      - name: Run Tests
+        run: <%= yarn ? 'yarn' : 'npm run' %> test:ember
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: 'test'
+
     strategy:
       fail-fast: true
       matrix:
-        try-scenario: 
+        try-scenario:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-release
@@ -48,18 +59,15 @@ jobs:
           - ember-default-with-jquery
           - embroider-safe
           - embroider-optimized
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - uses: actions/cache@v2
-      with:
-        path: <%= yarn ? '${{ steps.yarn-cache-dir-path.outputs.dir }}' : '~/.npm' %>
-        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
-    - name: Install Dependencies
-      run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
-    - name: Run Tests
-      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: <%= yarn ? 'yarn' : 'npm' %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: <%= yarn ? '${{ steps.yarn-cache-dir-path.outputs.dir }}' : '~/.npm' %>
+        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
+    - name: Install Dependencies
+      run: <%= yarn ? 'yarn' : 'npm' %> install
+    - name: Lint
+      run: <%= yarn ? 'yarn' : 'npm run' %> lint
+
+  floating:
+    name: "Floating dependencies"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        try-scenario: 
+          - ember-lts-3.20
+          - ember-lts-3.24
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-classic
+          - ember-default-with-jquery
+          - embroider-safe
+          - embroider-optimized
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: <%= yarn ? '${{ steps.yarn-cache-dir-path.outputs.dir }}' : '~/.npm' %>
+        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
+    - name: Install Dependencies
+      run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
+    - name: Run Tests
+      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -132,7 +132,7 @@ module.exports = {
     let addonName = stringUtil.dasherize(addonRawName);
     let addonNamespace = stringUtil.classify(addonRawName);
 
-    let hasOptions = options.welcome || options.yarn;
+    let hasOptions = options.welcome || options.yarn || options.ciProvider;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -140,7 +140,13 @@ module.exports = {
 
       blueprintOptions =
         indent +
-        [options.welcome && '"--welcome"', options.yarn && '"--yarn"'].filter(Boolean).join(',\n            ') +
+        [
+          options.welcome && '"--welcome"',
+          options.yarn && '"--yarn"',
+          options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
+        ]
+          .filter(Boolean)
+          .join(',\n            ') +
         outdent;
     }
 
@@ -158,13 +164,16 @@ module.exports = {
       blueprintOptions,
       embroider: false,
       lang: options.lang,
+      ciProvider: options.ciProvider,
     };
   },
 
-  files() {
-    let appFiles = this.lookupBlueprint(this.appBlueprintName).files();
+  files(options) {
+    let appFiles = this.lookupBlueprint(this.appBlueprintName).files(options);
     let addonFilesPath = this.filesPath(this.options);
-    let addonFiles = walkSync(addonFilesPath);
+    let ignoredCITemplate = this.options.ciProvider !== 'travis' ? '.travis.yml' : '.github';
+
+    let addonFiles = walkSync(addonFilesPath, { ignore: [ignoredCITemplate] });
 
     return uniq(appFiles.concat(addonFiles));
   },

--- a/blueprints/app/files/.github/workflows/ci.yml
+++ b/blueprints/app/files/.github/workflows/ci.yml
@@ -8,53 +8,34 @@ on:
   pull_request: {}
 
 jobs:
-
   lint:
     name: "Lint"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get <%= yarn ? 'yarn' : 'npm' %> cache directory path
-      id: <%= yarn ? 'yarn' : 'npm' %>-cache-dir-path
-      run: echo "::set-output name=dir::$(<%= yarn ? 'yarn config get cacheFolder' : 'npm config get cache' %>)"
-    - uses: actions/cache@v2
-      id: <%= yarn ? 'yarn' : 'npm' %>-cache
-      with:
-        path: ${{ steps.<%= yarn ? 'yarn' : 'npm' %>-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
-    - name: Install Dependencies
-      run: <%= yarn ? 'yarn' : 'npm' %> install
-    - name: Lint
-      run: <%= yarn ? 'yarn' : 'npm run' %> lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: <%= yarn ? 'yarn' : 'npm' %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
+      - name: Lint
+        run: <%= yarn ? 'yarn' : 'npm run' %> lint
 
   test:
     name: "Test"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get <%= yarn ? 'yarn' : 'npm' %> cache directory path
-      id: <%= yarn ? 'yarn' : 'npm' %>-cache-dir-path
-      run: echo "::set-output name=dir::$(<%= yarn ? 'yarn config get cacheFolder' : 'npm config get cache' %>)"
-    - uses: actions/cache@v2
-      id: <%= yarn ? 'yarn' : 'npm' %>-cache
-      with:
-        path: ${{ steps.<%= yarn ? 'yarn' : 'npm' %>-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
-    - name: Install Dependencies
-      run: <%= yarn ? 'yarn' : 'npm' %> install
-    - name: Run Tests
-      run: <%= yarn ? 'yarn' : 'npm' %> test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: <%= yarn ? 'yarn' : 'npm' %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
+      - name: Run Tests
+        run: <%= yarn ? 'yarn' : 'npm' %> test

--- a/blueprints/app/files/.github/workflows/ci.yml
+++ b/blueprints/app/files/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get <%= yarn ? 'yarn' : 'npm' %> cache directory path
+      id: <%= yarn ? 'yarn' : 'npm' %>-cache-dir-path
+      run: echo "::set-output name=dir::$(<%= yarn ? 'yarn config get cacheFolder' : 'npm config get cache' %>)"
+    - uses: actions/cache@v2
+      id: <%= yarn ? 'yarn' : 'npm' %>-cache
+      with:
+        path: ${{ steps.<%= yarn ? 'yarn' : 'npm' %>-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
+    - name: Install Dependencies
+      run: <%= yarn ? 'yarn' : 'npm' %> install
+    - name: Lint
+      run: <%= yarn ? 'yarn' : 'npm run' %> lint
+
+  test:
+    name: "Test"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get <%= yarn ? 'yarn' : 'npm' %> cache directory path
+      id: <%= yarn ? 'yarn' : 'npm' %>-cache-dir-path
+      run: echo "::set-output name=dir::$(<%= yarn ? 'yarn config get cacheFolder' : 'npm config get cache' %>)"
+    - uses: actions/cache@v2
+      id: <%= yarn ? 'yarn' : 'npm' %>-cache
+      with:
+        path: ${{ steps.<%= yarn ? 'yarn' : 'npm' %>-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('<%= yarn ? '**/yarn.lock' : '**/package-lock.json' %>') }}
+    - name: Install Dependencies
+      run: <%= yarn ? 'yarn' : 'npm' %> install
+    - name: Run Tests
+      run: <%= yarn ? 'yarn' : 'npm' %> test

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -23,7 +23,7 @@ module.exports = {
     let namespace = stringUtil.classify(rawName);
     let embroider = isExperimentEnabled('EMBROIDER') || options.embroider;
 
-    let hasOptions = !options.welcome || options.yarn || embroider;
+    let hasOptions = !options.welcome || options.yarn || embroider || options.ciProvider;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -31,7 +31,12 @@ module.exports = {
 
       blueprintOptions =
         indent +
-        [!options.welcome && '"--no-welcome"', options.yarn && '"--yarn"', embroider && '"--embroider"']
+        [
+          !options.welcome && '"--no-welcome"',
+          options.yarn && '"--yarn"',
+          embroider && '"--embroider"',
+          options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
+        ]
           .filter(Boolean)
           .join(',\n            ') +
         outdent;
@@ -48,7 +53,23 @@ module.exports = {
       blueprintOptions,
       embroider,
       lang: options.lang,
+      ciProvider: options.ciProvider,
     };
+  },
+
+  files(options) {
+    if (this._files) {
+      return this._files;
+    }
+
+    let files = this._super();
+    if (options.ciProvider !== 'travis') {
+      this._files = files.filter((file) => file !== '.travis.yml');
+    } else {
+      this._files = files.filter((file) => file.indexOf('.github') < 0);
+    }
+
+    return this._files;
   },
 
   beforeInstall() {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -37,6 +37,12 @@ module.exports = Command.extend({
       description: 'Sets the base human language of the application via index.html',
     },
     { name: 'embroider', type: Boolean, default: false, description: 'Enables the build system to use Embroider' },
+    {
+      name: 'ci-provider',
+      type: ['travis', 'github'],
+      default: 'travis',
+      description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+    },
   ],
 
   anonymousOptions: ['<glob-pattern>'],
@@ -59,6 +65,7 @@ module.exports = Command.extend({
 
     let project = this.project;
     let packageName = (commandOptions.name !== '.' && commandOptions.name) || project.name();
+    let ciProvider = commandOptions.ciProvider || 'travis';
 
     if (!packageName) {
       let message =
@@ -84,6 +91,7 @@ module.exports = Command.extend({
       targetFiles: rawArgs || '',
       rawArgs: rawArgs.toString(),
       blueprint: normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint()),
+      ciProvider,
     });
 
     if (!isValidProjectName(packageName)) {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -35,6 +35,12 @@ module.exports = Command.extend({
       description: 'Sets the base human language of the application via index.html',
     },
     { name: 'embroider', type: Boolean, default: false, description: 'Enables the build system to use Embroider' },
+    {
+      name: 'ci-provider',
+      type: ['travis', 'github'],
+      default: 'travis',
+      description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+    },
   ],
 
   anonymousOptions: ['<app-name>'],

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -446,7 +446,7 @@ let Blueprint = CoreObject.extend({
     this.project = options.project;
     this.pod = options.pod;
     this.options = options;
-    this.hasPathToken = hasPathToken(this.files());
+    this.hasPathToken = hasPathToken(this.files(this.options));
 
     ui.writeLine(`installing ${this.name}`);
 
@@ -476,7 +476,7 @@ let Blueprint = CoreObject.extend({
     this.project = options.project;
     this.pod = options.pod;
     this.options = options;
-    this.hasPathToken = hasPathToken(this.files());
+    this.hasPathToken = hasPathToken(this.files(this.options));
 
     ui.writeLine(`uninstalling ${this.name}`);
 
@@ -717,7 +717,7 @@ let Blueprint = CoreObject.extend({
     @return {Array} files
   */
   _getFilesForInstall(targetFiles) {
-    let files = this.files();
+    let files = this.files(this.options);
 
     // if we've defined targetFiles, get file info on ones that match
     return (targetFiles && targetFiles.length > 0 && _.intersection(files, targetFiles)) || files;
@@ -765,7 +765,7 @@ let Blueprint = CoreObject.extend({
     @param {Object} templateVariables
   */
   processFilesForUninstall(intoDir, templateVariables) {
-    let fileInfos = this._getFileInfos(this.files(), intoDir, templateVariables);
+    let fileInfos = this._getFileInfos(this.files(this.options), intoDir, templateVariables);
 
     this._ignoreUpdateFiles();
 

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -40,6 +40,7 @@ class InstallBlueprintTask extends Task {
       dryRun: options.dryRun,
       targetFiles: options.targetFiles,
       rawArgs: options.rawArgs,
+      ciProvider: options.ciProvider,
     };
 
     installOptions = merge(installOptions, options || {});

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -20,6 +20,7 @@ const lintFix = require('../../lib/utilities/lint-fix');
 const chai = require('../chai');
 let expect = chai.expect;
 let dir = chai.dir;
+let file = chai.file;
 
 let defaultIgnoredFiles = Blueprint.ignoredFiles;
 
@@ -42,7 +43,8 @@ describe('Acceptance: ember init', function () {
 
   function confirmBlueprinted() {
     let blueprintPath = path.join(root, 'blueprints', 'app', 'files');
-    let expected = walkSync(blueprintPath).sort();
+    // ignore .github to avoid .github ci file in test
+    let expected = walkSync(blueprintPath, { ignore: ['.github'] }).sort();
     let actual = walkSync('.').sort();
 
     forEach(Blueprint.renamedFiles, function (destFile, srcFile) {
@@ -178,5 +180,16 @@ describe('Acceptance: ember init', function () {
     td.verify(lintFixStub(), { ignoreExtraArgs: true, times: 1 });
 
     confirmBlueprinted();
+  });
+
+  it('configurable CI option', async function () {
+    await ember(['init', '--ci-provider=github', '--skip-npm', '--skip-bower']);
+
+    let fixturePath = 'app/npm-github';
+
+    expect(file('.github/workflows/ci.yml')).to.equal(
+      file(path.join(__dirname, '../fixtures', fixturePath, '.github/workflows/ci.yml'))
+    );
+    expect(file('.travis.yml')).to.not.exist;
   });
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -598,6 +598,10 @@ describe('Acceptance: ember new', function () {
       );
       expect(file('.travis.yml')).to.not.exist;
 
+      if (isExperimentEnabled('EMBROIDER')) {
+        fixturePath = 'app/yarn-github-embroider';
+      }
+
       checkFileWithEmberCLIVersionReplacement(fixturePath, 'config/ember-cli-update.json');
     });
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -585,6 +585,10 @@ describe('Acceptance: ember new', function () {
       );
       expect(file('.travis.yml')).to.not.exist;
 
+      if (isExperimentEnabled('EMBROIDER')) {
+        fixturePath = 'app/npm-github-embroider';
+      }
+
       checkFileWithEmberCLIVersionReplacement(fixturePath, 'config/ember-cli-update.json');
     });
 

--- a/tests/fixtures/addon/defaults-github/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults-github/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Lint
+      run: npm run lint
+
+  floating:
+    name: "Floating dependencies"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        try-scenario: 
+          - ember-lts-3.20
+          - ember-lts-3.24
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-classic
+          - ember-default-with-jquery
+          - embroider-safe
+          - embroider-optimized
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Run Tests
+      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/tests/fixtures/addon/defaults-github/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults-github/.github/workflows/ci.yml
@@ -8,37 +8,48 @@ on:
   pull_request: {}
 
 jobs:
-
-  lint:
-    name: "Lint"
-    env:
-      CI: true
+  test:
+    name: "Tests"
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Lint
-      run: npm run lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Run Tests
+        run: npm run test:ember
 
   floating:
-    name: "Floating dependencies"
-    env:
-      CI: true
+    name: "Floating Dependencies"
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm install --no-shrinkwrap
+      - name: Run Tests
+        run: npm run test:ember
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: 'test'
+
     strategy:
       fail-fast: true
       matrix:
-        try-scenario: 
+        try-scenario:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-release
@@ -48,18 +59,15 @@ jobs:
           - ember-default-with-jquery
           - embroider-safe
           - embroider-optimized
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm ci
-    - name: Run Tests
-      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/tests/fixtures/addon/defaults-github/CONTRIBUTING.md
+++ b/tests/fixtures/addon/defaults-github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd foo`
+* `npm install`
+
+## Linting
+
+* `npm run lint`
+* `npm run lint:fix`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/tests/fixtures/addon/defaults-github/README.md
+++ b/tests/fixtures/addon/defaults-github/README.md
@@ -1,0 +1,38 @@
+foo
+==============================================================================
+
+[Short description of the addon.]
+
+
+Compatibility
+------------------------------------------------------------------------------
+
+* Ember.js v3.20 or above
+* Ember CLI v3.20 or above
+* Node.js v12 or above
+
+
+Installation
+------------------------------------------------------------------------------
+
+```
+ember install foo
+```
+
+
+Usage
+------------------------------------------------------------------------------
+
+[Longer description of how to use the addon in apps.]
+
+
+Contributing
+------------------------------------------------------------------------------
+
+See the [Contributing](CONTRIBUTING.md) guide for details.
+
+
+License
+------------------------------------------------------------------------------
+
+This project is licensed under the [MIT License](LICENSE.md).

--- a/tests/fixtures/addon/defaults-github/config/ember-try.js
+++ b/tests/fixtures/addon/defaults-github/config/ember-try.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
+
+module.exports = async function () {
+  return {
+    scenarios: [
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.3',
+          },
+        },
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
+          },
+        },
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta'),
+          },
+        },
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary'),
+          },
+        },
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true,
+          }),
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^1.1.0',
+          },
+        },
+      },
+      {
+        name: 'ember-classic',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'application-template-wrapper': true,
+            'default-async-observers': false,
+            'template-only-glimmer-components': false,
+          }),
+        },
+        npm: {
+          ember: {
+            edition: 'classic',
+          },
+        },
+      },
+      embroiderSafe(),
+      embroiderOptimized(),
+    ],
+  };
+};

--- a/tests/fixtures/addon/defaults-github/package.json
+++ b/tests/fixtures/addon/defaults-github/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "foo",
+  "version": "0.0.0",
+  "description": "The default blueprint for ember-cli addons.",
+  "keywords": [
+    "ember-addon"
+  ],
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build --environment=production",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
+    "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
+    "lint:hbs": "ember-template-lint .",
+    "lint:hbs:fix": "ember-template-lint . --fix",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
+    "start": "ember serve",
+    "test": "npm-run-all lint test:*",
+    "test:ember": "ember test",
+    "test:ember-compatibility": "ember try:each"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^7.26.6",
+    "ember-cli-htmlbars": "^5.7.1"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^2.0.0",
+    "@ember/test-helpers": "^2.2.5",
+    "@embroider/test-setup": "^0.41.0",
+    "@glimmer/component": "^1.0.4",
+    "@glimmer/tracking": "^1.0.4",
+    "babel-eslint": "^10.1.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.11.3",
+    "ember-cli": "~<%= emberCLIVersion %>",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-inject-live-reload": "^2.0.2",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-terser": "^4.0.2",
+    "ember-disable-prototype-extensions": "^1.1.3",
+    "ember-export-application-global": "^2.0.1",
+    "ember-load-initializers": "^2.1.2",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-page-title": "^6.2.2",
+    "ember-qunit": "^5.1.4",
+    "ember-resolver": "^8.0.2",
+    "ember-source": "~3.27.2",
+    "ember-source-channel-url": "^3.0.0",
+    "ember-template-lint": "^3.4.2",
+    "ember-try": "^1.4.0",
+    "eslint": "^7.27.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-ember": "^10.4.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-qunit": "^6.1.1",
+    "loader.js": "^4.7.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.3.0",
+    "qunit": "^2.15.0",
+    "qunit-dom": "^1.6.0"
+  },
+  "engines": {
+    "node": "12.* || 14.* || >= 16"
+  },
+  "ember": {
+    "edition": "octane"
+  },
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
+  }
+}

--- a/tests/fixtures/addon/defaults-github/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/defaults-github/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,5 @@
+{{page-title "Dummy"}}
+
+<h2 id="title">Welcome to Ember</h2>
+
+{{outlet}}

--- a/tests/fixtures/addon/defaults-github/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/defaults-github/tests/dummy/config/ember-cli-update.json
@@ -6,13 +6,12 @@
       "version": "<%= emberCLIVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "addon",
+          "outputRepo": "https://github.com/ember-cli/ember-addon-output",
+          "codemodsSource": "ember-addon-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [
-            "--yarn",
-            "--ci-provider=travis"
+            "--ci-provider=github"
           ]
         }
       ]

--- a/tests/fixtures/addon/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults/.github/workflows/ci.yml
@@ -11,34 +11,42 @@ jobs:
 
   lint:
     name: "Lint"
-    env:
-      CI: true
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
-
-    - uses: actions/cache@v2
-      with:
-        path: ~./npm
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Lint
-      run: npm run lint
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
 
   floating:
     name: "Floating dependencies"
-    env:
-      CI: true
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: install dependencies
+        run: npm install --no-shrinkwrap
+      - name: Test
+        run: npm run test:ember
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+
     strategy:
       fail-fast: true
       matrix:
-        try-scenario: 
+        try-scenario:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-release
@@ -48,18 +56,15 @@ jobs:
           - ember-default-with-jquery
           - embroider-safe
           - embroider-optimized
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - uses: actions/cache@v2
-      with:
-        path: ~./npm
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm ci
-    - name: Run Tests
-      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/tests/fixtures/addon/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: ~./npm
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Lint
+      run: npm run lint
+
+  floating:
+    name: "Floating dependencies"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        try-scenario: 
+          - ember-lts-3.20
+          - ember-lts-3.24
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-classic
+          - ember-default-with-jquery
+          - embroider-safe
+          - embroider-optimized
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - uses: actions/cache@v2
+      with:
+        path: ~./npm
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Run Tests
+      run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
@@ -10,7 +10,9 @@
           "outputRepo": "https://github.com/ember-cli/ember-addon-output",
           "codemodsSource": "ember-addon-codemods-manifest@1",
           "isBaseBlueprint": true,
-          "options": []
+          "options": [
+            "--ci-provider=travis"
+          ]
         }
       ]
     }

--- a/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
@@ -12,7 +12,8 @@
           "isBaseBlueprint": true,
           "options": [
             "--welcome",
-            "--yarn"
+            "--yarn",
+            "--ci-provider=travis"
           ]
         }
       ]

--- a/tests/fixtures/app/defaults/config/ember-cli-update.json
+++ b/tests/fixtures/app/defaults/config/ember-cli-update.json
@@ -10,7 +10,9 @@
           "outputRepo": "https://github.com/ember-cli/ember-new-output",
           "codemodsSource": "ember-app-codemods-manifest@1",
           "isBaseBlueprint": true,
-          "options": []
+          "options": [
+            "--ci-provider=travis"
+          ]
         }
       ]
     }

--- a/tests/fixtures/app/embroider-no-welcome/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-no-welcome/config/ember-cli-update.json
@@ -12,7 +12,8 @@
           "isBaseBlueprint": true,
           "options": [
             "--no-welcome",
-            "--embroider"
+            "--embroider",
+            "--ci-provider=travis"
           ]
         }
       ]

--- a/tests/fixtures/app/embroider-yarn/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-yarn/config/ember-cli-update.json
@@ -12,7 +12,8 @@
           "isBaseBlueprint": true,
           "options": [
             "--yarn",
-            "--embroider"
+            "--embroider",
+            "--ci-provider=travis"
           ]
         }
       ]

--- a/tests/fixtures/app/embroider/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider/config/ember-cli-update.json
@@ -11,7 +11,8 @@
           "codemodsSource": "ember-app-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [
-            "--embroider"
+            "--embroider",
+            "--ci-provider=travis"
           ]
         }
       ]

--- a/tests/fixtures/app/npm-github-embroider/config/ember-cli-update.json
+++ b/tests/fixtures/app/npm-github-embroider/config/ember-cli-update.json
@@ -11,7 +11,6 @@
           "codemodsSource": "ember-app-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [
-            "--yarn",
             "--embroider",
             "--ci-provider=github"
           ]

--- a/tests/fixtures/app/npm-github/.github/workflows/ci.yml
+++ b/tests/fixtures/app/npm-github/.github/workflows/ci.yml
@@ -8,53 +8,34 @@ on:
   pull_request: {}
 
 jobs:
-
   lint:
     name: "Lint"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get npm cache directory path
-      id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm config get cache)"
-    - uses: actions/cache@v2
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Lint
-      run: npm run lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
 
   test:
     name: "Test"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get npm cache directory path
-      id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm config get cache)"
-    - uses: actions/cache@v2
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Tests
-      run: npm test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: npm test

--- a/tests/fixtures/app/npm-github/.github/workflows/ci.yml
+++ b/tests/fixtures/app/npm-github/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get npm cache directory path
+      id: npm-cache-dir-path
+      run: echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Lint
+      run: npm run lint
+
+  test:
+    name: "Test"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get npm cache directory path
+      id: npm-cache-dir-path
+      run: echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Run Tests
+      run: npm test

--- a/tests/fixtures/app/npm-github/README.md
+++ b/tests/fixtures/app/npm-github/README.md
@@ -1,0 +1,56 @@
+# foo
+
+This README outlines the details of collaborating on this Ember application.
+A short introduction of this app could easily go here.
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](https://git-scm.com/)
+* [Node.js](https://nodejs.org/) (with npm)
+* [Ember CLI](https://ember-cli.com/)
+* [Google Chrome](https://google.com/chrome/)
+
+## Installation
+
+* `git clone <repository-url>` this repository
+* `cd foo`
+* `npm install`
+
+## Running / Development
+
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
+
+* `ember test`
+* `ember test --server`
+
+### Linting
+
+* `npm run lint`
+* `npm run lint:fix`
+
+### Building
+
+* `ember build` (development)
+* `ember build --environment production` (production)
+
+### Deploying
+
+Specify what it takes to deploy your app.
+
+## Further Reading / Useful Links
+
+* [ember.js](https://emberjs.com/)
+* [ember-cli](https://ember-cli.com/)
+* Development Browser Extensions
+  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)

--- a/tests/fixtures/app/npm-github/app/templates/application.hbs
+++ b/tests/fixtures/app/npm-github/app/templates/application.hbs
@@ -1,0 +1,5 @@
+{{page-title "Foo"}}
+
+<h2 id="title">Welcome to Ember</h2>
+
+{{outlet}}

--- a/tests/fixtures/app/npm-github/config/ember-cli-update.json
+++ b/tests/fixtures/app/npm-github/config/ember-cli-update.json
@@ -11,8 +11,7 @@
           "codemodsSource": "ember-app-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [
-            "--yarn",
-            "--ci-provider=travis"
+            "--ci-provider=github"
           ]
         }
       ]

--- a/tests/fixtures/app/npm-github/package.json
+++ b/tests/fixtures/app/npm-github/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "foo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Small description for foo goes here",
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build --environment=production",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
+    "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
+    "lint:hbs": "ember-template-lint .",
+    "lint:hbs:fix": "ember-template-lint . --fix",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
+    "start": "ember serve",
+    "test": "npm-run-all lint test:*",
+    "test:ember": "ember test"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^2.0.0",
+    "@ember/test-helpers": "^2.2.5",
+    "@glimmer/component": "^1.0.4",
+    "@glimmer/tracking": "^1.0.4",
+    "babel-eslint": "^10.1.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.11.3",
+    "ember-cli": "~<%= emberCLIVersion %>",
+    "ember-cli-app-version": "^5.0.0",
+    "ember-cli-babel": "^7.26.6",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-inject-live-reload": "^2.0.2",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-terser": "^4.0.2",
+    "ember-data": "~3.27.1",
+    "ember-export-application-global": "^2.0.1",
+    "ember-fetch": "^8.0.4",
+    "ember-load-initializers": "^2.1.2",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-page-title": "^6.2.2",
+    "ember-qunit": "^5.1.4",
+    "ember-resolver": "^8.0.2",
+    "ember-source": "~3.27.2",
+    "ember-template-lint": "^3.4.2",
+    "eslint": "^7.27.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-ember": "^10.4.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-qunit": "^6.1.1",
+    "loader.js": "^4.7.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.3.0",
+    "qunit": "^2.15.0",
+    "qunit-dom": "^1.6.0"
+  },
+  "engines": {
+    "node": "12.* || 14.* || >= 16"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/tests/fixtures/app/npm/config/ember-cli-update.json
+++ b/tests/fixtures/app/npm/config/ember-cli-update.json
@@ -11,7 +11,8 @@
           "codemodsSource": "ember-app-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [
-            "--no-welcome"
+            "--no-welcome",
+            "--ci-provider=travis"
           ]
         }
       ]

--- a/tests/fixtures/app/yarn-github-embroider/config/ember-cli-update.json
+++ b/tests/fixtures/app/yarn-github-embroider/config/ember-cli-update.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "1.0.0",
+  "packages": [
+    {
+      "name": "ember-cli",
+      "version": "<%= emberCLIVersion %>",
+      "blueprints": [
+        {
+          "name": "app",
+          "outputRepo": "https://github.com/ember-cli/ember-new-output",
+          "codemodsSource": "ember-app-codemods-manifest@1",
+          "isBaseBlueprint": true,
+          "options": [
+            "--yarn",
+            "--ci-provider=github",
+            "--embroider"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/app/yarn-github/.github/workflows/ci.yml
+++ b/tests/fixtures/app/yarn-github/.github/workflows/ci.yml
@@ -8,53 +8,34 @@ on:
   pull_request: {}
 
 jobs:
-
   lint:
     name: "Lint"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-    - uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-    - name: Install Dependencies
-      run: yarn install
-    - name: Lint
-      run: yarn lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint
+        run: yarn lint
 
   test:
     name: "Test"
-    env:
-      CI: true
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install node
-      uses: actions/setup-node@v2
-      with:
-        node-version: 12.x
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-    - uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-    - name: Install Dependencies
-      run: yarn install
-    - name: Run Tests
-      run: yarn test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        run: yarn test

--- a/tests/fixtures/app/yarn-github/.github/workflows/ci.yml
+++ b/tests/fixtures/app/yarn-github/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+jobs:
+
+  lint:
+    name: "Lint"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    - uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+    - name: Install Dependencies
+      run: yarn install
+    - name: Lint
+      run: yarn lint
+
+  test:
+    name: "Test"
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    - uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+    - name: Install Dependencies
+      run: yarn install
+    - name: Run Tests
+      run: yarn test

--- a/tests/fixtures/app/yarn-github/README.md
+++ b/tests/fixtures/app/yarn-github/README.md
@@ -1,0 +1,57 @@
+# foo
+
+This README outlines the details of collaborating on this Ember application.
+A short introduction of this app could easily go here.
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](https://git-scm.com/)
+* [Node.js](https://nodejs.org/)
+* [Yarn](https://yarnpkg.com/)
+* [Ember CLI](https://ember-cli.com/)
+* [Google Chrome](https://google.com/chrome/)
+
+## Installation
+
+* `git clone <repository-url>` this repository
+* `cd foo`
+* `yarn install`
+
+## Running / Development
+
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
+
+* `ember test`
+* `ember test --server`
+
+### Linting
+
+* `yarn lint`
+* `yarn lint:fix`
+
+### Building
+
+* `ember build` (development)
+* `ember build --environment production` (production)
+
+### Deploying
+
+Specify what it takes to deploy your app.
+
+## Further Reading / Useful Links
+
+* [ember.js](https://emberjs.com/)
+* [ember-cli](https://ember-cli.com/)
+* Development Browser Extensions
+  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)

--- a/tests/fixtures/app/yarn-github/app/templates/application.hbs
+++ b/tests/fixtures/app/yarn-github/app/templates/application.hbs
@@ -1,0 +1,7 @@
+{{page-title "Foo"}}
+
+{{!-- The following component displays Ember's default welcome message. --}}
+<WelcomePage />
+{{!-- Feel free to remove this! --}}
+
+{{outlet}}

--- a/tests/fixtures/app/yarn-github/config/ember-cli-update.json
+++ b/tests/fixtures/app/yarn-github/config/ember-cli-update.json
@@ -12,7 +12,7 @@
           "isBaseBlueprint": true,
           "options": [
             "--yarn",
-            "--ci-provider=travis"
+            "--ci-provider=github"
           ]
         }
       ]

--- a/tests/fixtures/app/yarn-github/package.json
+++ b/tests/fixtures/app/yarn-github/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "foo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Small description for foo goes here",
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build --environment=production",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
+    "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
+    "lint:hbs": "ember-template-lint .",
+    "lint:hbs:fix": "ember-template-lint . --fix",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
+    "start": "ember serve",
+    "test": "npm-run-all lint test:*",
+    "test:ember": "ember test"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^2.0.0",
+    "@ember/test-helpers": "^2.2.5",
+    "@glimmer/component": "^1.0.4",
+    "@glimmer/tracking": "^1.0.4",
+    "babel-eslint": "^10.1.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.11.3",
+    "ember-cli": "~<%= emberCLIVersion %>",
+    "ember-cli-app-version": "^5.0.0",
+    "ember-cli-babel": "^7.26.6",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-inject-live-reload": "^2.0.2",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-terser": "^4.0.2",
+    "ember-data": "~3.27.1",
+    "ember-export-application-global": "^2.0.1",
+    "ember-fetch": "^8.0.4",
+    "ember-load-initializers": "^2.1.2",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-page-title": "^6.2.2",
+    "ember-qunit": "^5.1.4",
+    "ember-resolver": "^8.0.2",
+    "ember-source": "~3.27.2",
+    "ember-template-lint": "^3.4.2",
+    "ember-welcome-page": "^4.0.0",
+    "eslint": "^7.27.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-ember": "^10.4.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-qunit": "^6.1.1",
+    "loader.js": "^4.7.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.3.0",
+    "qunit": "^2.15.0",
+    "qunit-dom": "^1.6.0"
+  },
+  "engines": {
+    "node": "12.* || 14.* || >= 16"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -100,6 +100,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
     [90maliases: -n <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--ci-provider[39m [36m(travis, github)[39m [36m(Default: travis)[39m Installs the default CI blueprint. Either Travis or Github Actions is supported.
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
   Installs an ember-cli addon from npm.
@@ -132,6 +133,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -dir <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--ci-provider[39m [36m(travis, github)[39m [36m(Default: travis)[39m Installs the default CI blueprint. Either Travis or Github Actions is supported.
 
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -446,7 +446,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false,
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -564,7 +572,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false,
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<app-name>']
     },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -100,6 +100,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
     [90maliases: -n <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--ci-provider[39m [36m(travis, github)[39m [36m(Default: travis)[39m Installs the default CI blueprint. Either Travis or Github Actions is supported.
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
   Installs an ember-cli addon from npm.
@@ -132,6 +133,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -dir <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--ci-provider[39m [36m(travis, github)[39m [36m(Default: travis)[39m Installs the default CI blueprint. Either Travis or Github Actions is supported.
 
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -478,7 +478,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -596,7 +604,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<app-name>']
     },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -446,7 +446,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -564,7 +572,15 @@ module.exports = {
           name: 'embroider',
           description: 'Enables the build system to use Embroider',
           required: false
-        }
+        },
+        {
+          name: 'ci-provider',
+          key: 'ciProvider',
+          type: ['travis', 'github'],
+          default: 'travis',
+          description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
+          required: false,
+        },
       ],
       anonymousOptions: ['<app-name>']
     },


### PR DESCRIPTION
* Add support for choosing GitHub Actions as a CI provider via the new
  `--ci-provider` option
* Implement GitHub Actions workflows for the app and addon blueprints

Reviews/requests welcomed!

ref https://github.com/emberjs/rfcs/pull/696
Closes https://github.com/ember-cli/ember-cli/pull/9569