### PR TITLE
Add .lint-todo to prettier ignore

### DIFF
--- a/blueprints/app/files/.prettierignore
+++ b/blueprints/app/files/.prettierignore
@@ -14,6 +14,7 @@
 /coverage/
 !.*
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
The ember-template-lint todo files are not intended to be human-readable, and they can create a lot of churn if prettier gets run against them, particularly if people decide to enable linting against staged files in their project. Since ember-template-lint and prettier both ship by default in the Ember blueprint, we should proactively ignore this directory from being run against prettier.