### PR TITLE
fix: properly set loglevel flag for npm

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -212,9 +212,9 @@ class NpmTask extends Task {
     }
 
     if (options.verbose) {
-      args.push('--loglevel verbose');
+      args.push('--loglevel', 'verbose');
     } else {
-      args.push('--loglevel error');
+      args.push('--loglevel', 'error');
     }
 
     if (options.packages) {


### PR DESCRIPTION
When spawning `npm` to run some command, the `loglevel` flag was not being passed correctly. Note the difference:

```
🗲 🗲 npm --loglevel silly whoami
npm verb cli [
npm verb cli   '/home/<user>/.nvm/versions/node/v14.16.0/bin/node',
npm verb cli   '/home/<user>/.nvm/versions/node/v14.16.0/bin/npm',
npm verb cli   '--loglevel',
npm verb cli   'silly',
npm verb cli   'whoami'
npm verb cli ]
npm info using npm@7.20.1
[ TONS OF LOGS OMITTED ]
npm timing npm:load:projectScope Completed in 1ms
npm timing npm:load Completed in 24ms
jrvidal
npm timing command:whoami Completed in 523ms
npm verb exit 0
npm timing npm Completed in 669ms

🗲 🗲 ✗ npm "--loglevel silly" whoami              
jrvidal
```

I tested with npm 7.2.0 and 6.14.4.