### PR TITLE
Failing test default blueprint

### DIFF
--- a/lib/tasks/addon-install.js
+++ b/lib/tasks/addon-install.js
@@ -4,6 +4,8 @@ const Task = require('../models/task');
 const SilentError = require('silent-error');
 const merge = require('ember-cli-lodash-subset').merge;
 const getPackageBaseName = require('../utilities/get-package-base-name');
+const fs = require('fs');
+const path = require('path');
 
 class AddonInstallTask extends Task {
   constructor(options) {
@@ -81,6 +83,15 @@ class AddonInstallTask extends Task {
 
   findDefaultBlueprintName(givenName) {
     let packageName = getPackageBaseName(givenName);
+
+    if (!packageName) {
+      let packagePath = path.join(givenName, 'package.json');
+      // check to see if it's a file path that was used to install addon
+      if (fs.existsSync(packagePath)) {
+        packageName = require(packagePath).name;
+      }
+    }
+
     if (!packageName) {
       return null;
     }

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -472,6 +472,15 @@ module.exports = function() {
     expect(file(filePath)).to.contain('generated component successfully');
   });
 
+  it('runs default blueprint on install', async function () {
+    await ember(['install', path.join(__dirname, '..', 'fixtures', 'addon', 'with-default-blueprint')]);
+
+    let filePath = 'author/chris.md';
+
+    // because we're overriding, the fileMapTokens is default, sans 'component'
+    expect(file(filePath)).to.contain('This is some **markdown** about Chris.');
+  });
+
   it('template linting works properly for pods and classic structured templates', async function () {
     await copyFixtureFiles('smoke-tests/with-template-failing-linting');
 

--- a/tests/fixtures/addon/with-default-blueprint/blueprints/with-default-blueprint/files/author/chris.md
+++ b/tests/fixtures/addon/with-default-blueprint/blueprints/with-default-blueprint/files/author/chris.md
@@ -1,0 +1,1 @@
+This is some **markdown** about Chris.

--- a/tests/fixtures/addon/with-default-blueprint/blueprints/with-default-blueprint/index.js
+++ b/tests/fixtures/addon/with-default-blueprint/blueprints/with-default-blueprint/index.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+
+module.exports = {
+  normalizeEntityName() {
+    // no-op
+  },
+};

--- a/tests/fixtures/addon/with-default-blueprint/index.js
+++ b/tests/fixtures/addon/with-default-blueprint/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  }
+};

--- a/tests/fixtures/addon/with-default-blueprint/package.json
+++ b/tests/fixtures/addon/with-default-blueprint/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "with-default-blueprint",
+  "version": "0.0.1",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
This adds a failing test for the default blueprint issue in #9606 

I needed to fix something else to be able to `ember install` from a folder and have it run the default blueprint but this is a valid test that recreates the issue 👍 

~I will open a new PR that targets the same test to the 3.27 branch to show that the test actually passes~

Edit: there isn't actually a branch for the 3.27 release so I can't open a PR but I can confirm that it works fine in 3.27 and you can run it manually if you clone my branch https://github.com/mansona/ember-cli/tree/check-backport