### PR TITLE
Fix test that started failing with v2.17.0 of qunit

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -171,6 +171,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
+  // See https://github.com/ember-cli/ember-cli/issues/9615 if test begins to fail; qunit had a regression
   it('addon trees are not jshinted', async function () {
     await copyFixtureFiles('brocfile-tests/jshint-addon');
 
@@ -183,9 +184,8 @@ describe('Acceptance: brocfile-smoke-test', function () {
 
     let ember = path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember');
 
-    let error = await expect(runCommand(ember, 'test', '--filter=jshint')).to.eventually.be.rejected;
-
-    expect(error.output.join('')).to.include('Error: No tests matched the filter "jshint"');
+    let response = await expect(runCommand(ember, 'test', '--filter=jshint')).to.eventually.be.ok;
+    expect(response.output.join('')).to.include('tests 0');
   });
 
   it('multiple css files in styles/ are output when a preprocessor is not used', async function () {


### PR DESCRIPTION
Change test to look for output that asserts the same results, the
underlying behavior of qunit changed in version 2.17.0 and altered the
result.

