### PR TITLE
Reload `_packageInfo` as part of `reloadPkg`

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -594,6 +594,11 @@ class Project {
 
     this.packageInfoCache.reloadProjects();
 
+    // update `_packageInfo` after reloading projects from the `PackageInfoCache` instance
+    // if we don't do this we get into a state where `_packageInfo` is referencing the old
+    // pkginfo object that hasn't been updated/reloaded
+    this._packageInfo = this.packageInfoCache.loadProject(this);
+
     if (PerBundleAddonCache.isEnabled()) {
       this.perBundleAddonCache = new PerBundleAddonCache(this);
     }

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -495,6 +495,7 @@ describe('models/project.js', function () {
 
   describe('reloadPkg', function () {
     let newProjectPath, oldPkg;
+
     beforeEach(function () {
       projectPath = path.resolve(__dirname, '../../fixtures/addon/simple');
       packageContents = require(path.join(projectPath, 'package.json'));
@@ -513,6 +514,14 @@ describe('models/project.js', function () {
       project.reloadPkg();
 
       expect(oldPkg).to.not.deep.equal(project.pkg);
+    });
+
+    it('reloads the pkginfo', function () {
+      let pkgInfo = project._packageInfo;
+
+      project.reloadPkg();
+
+      expect(pkgInfo).to.not.equal(project._packageInfo);
     });
   });
 


### PR DESCRIPTION
This PR resolves https://github.com/ember-cli/ember-cli/issues/9606.

Some context: the issue here is that `_packageInfo` is not properly reset as part of `reloadPkg`, so (without this fix) you get into a state using `ember install` where the package info cache itself is properly reset, but we're still referencing the old package info object on the project instance. In this case, the newly installed package won't exist as expected, which causes us to run into a failure case as part of install.