### PR TITLE
Ensure `ember-classic` ember-try scenario uses Ember 3.x

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -70,6 +70,9 @@ module.exports = async function () {
           }),
         },
         npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
           ember: {
             edition: 'classic',
           },

--- a/tests/fixtures/addon/defaults/config/ember-try.js
+++ b/tests/fixtures/addon/defaults/config/ember-try.js
@@ -69,6 +69,9 @@ module.exports = async function () {
           }),
         },
         npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
           ember: {
             edition: 'classic',
           },

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -70,6 +70,9 @@ module.exports = async function () {
           }),
         },
         npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
           ember: {
             edition: 'classic',
           },


### PR DESCRIPTION
As we approach Ember 4.0.0, we need to help addons ensure that they only test ember-classic's set of optional features when running under 3.x.

This updates the default ember-try config to hard code the `ember-classic` scenario to Ember 3.28 (the last 3.x Ember version).

Fixes https://github.com/ember-cli/ember-cli/issues/9658
