### PR TITLE
Set default CI config blueprints to run all builds

### DIFF
--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     needs: 'test'
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         try-scenario:
           - ember-lts-3.20

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -29,7 +29,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fast_finish: true
+  fast_finish: false
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/tests/fixtures/addon/defaults-travis/.travis.yml
+++ b/tests/fixtures/addon/defaults-travis/.travis.yml
@@ -26,7 +26,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fast_finish: true
+  fast_finish: false
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/tests/fixtures/addon/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     needs: 'test'
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         try-scenario:
           - ember-lts-3.20

--- a/tests/fixtures/addon/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/yarn/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     needs: 'test'
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         try-scenario:
           - ember-lts-3.20


### PR DESCRIPTION
The existing configs use `fail-fast` or `fast_finish` to abort builds once one scenario has failed. However, because addon projects will often support multiple versions of Ember as well as use forward-looking testing for beta/canary versions to catch issues, we want to ensure that all scenarios get run even if one of them fail. This is especially important for the GitHub Actions workflow, which doesn't have a concept of "allowed failures". As such, it's quite common that a build such as ember-canary might fail but still be ok to merge, if all other scenarios pass. By setting this config to true, we could hit scenarios where an expected failure occurred and all other builds were automatically aborted, thus preventing maintainers from knowing if the other scenarios would pass.