### PR TITLE
Use `strictEqual` QUnit assertion instead of `equal` in blueprint tests

### DIFF
--- a/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/component-with-template/tests/acceptance/main-test.js
@@ -10,13 +10,13 @@ module('Acceptance', function(hooks) {
     await visit('/');
 
     var element = this.element.querySelector('.basic-thing');
-    assert.equal(element.textContent.trim(), 'WOOT!!');
+    assert.strictEqual(element.textContent.trim(), 'WOOT!!');
   });
 
   test('renders imported component', async function (assert) {
     await visit('/');
 
     var element = this.element.querySelector('.second-thing');
-    assert.equal(element.textContent.trim(), 'SECOND!!');
+    assert.strictEqual(element.textContent.trim(), 'SECOND!!');
   });
 });

--- a/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
+++ b/tests/fixtures/addon/kitchen-sink/tests/acceptance/main-test.js
@@ -10,7 +10,7 @@ module('Acceptance', function(hooks) {
     await visit('/');
 
     var element = this.element.querySelector('.basic-thing');
-    assert.equal(element.textContent.trim(), 'WOOT!!');
+    assert.strictEqual(element.textContent.trim(), 'WOOT!!');
     assert.ok(truthyHelper(), 'addon-test-support helper');
   });
 
@@ -18,6 +18,6 @@ module('Acceptance', function(hooks) {
     await visit('/');
 
     var element = this.element.querySelector('.second-thing');
-    assert.equal(element.textContent.trim(), 'SECOND!!');
+    assert.strictEqual(element.textContent.trim(), 'SECOND!!');
   });
 });

--- a/tests/fixtures/brocfile-tests/custom-environment-config/tests/unit/config-test.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/tests/unit/config-test.js
@@ -2,5 +2,5 @@ import { test } from 'qunit';
 import config from '../../config/environment';
 
 test('the correct config is used', function(assert) {
-  assert.equal(config.fileUsed, 'config/something-else.js');
+  assert.strictEqual(config.fileUsed, 'config/something-else.js');
 });

--- a/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string-test.js
+++ b/tests/fixtures/brocfile-tests/mu-unit-test-with-relative-import/src/utils/string-test.js
@@ -5,7 +5,7 @@ import stringFn from './string';
 module('Unit | Utility | string', function() {
 
   test('returns hola', function(assert) {
-    assert.equal(stringFn(), 'hola');
+    assert.strictEqual(stringFn(), 'hola');
   });
 
 });

--- a/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-templates/tests/integration/pods-template-test.js
@@ -11,6 +11,6 @@ module('pods based templates', function(hooks) {
     await visit('/');
 
     let actual = this.element.querySelector('#title').textContent
-    assert.equal(actual, 'ZOMG, PODS WORKS!!');
+    assert.strictEqual(actual, 'ZOMG, PODS WORKS!!');
   });
 });

--- a/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
+++ b/tests/fixtures/brocfile-tests/pods-with-prefix-templates/tests/integration/pods-template-test.js
@@ -11,6 +11,6 @@ module('pods based templates', function(hooks) {
     await visit('/');
 
     let actual = this.element.querySelector('#title').textContent
-    assert.equal(actual, 'ZOMG, PODS WORKS!!');
+    assert.strictEqual(actual, 'ZOMG, PODS WORKS!!');
   });
 });

--- a/tests/fixtures/generate/acceptance-test-expected.js
+++ b/tests/fixtures/generate/acceptance-test-expected.js
@@ -7,6 +7,6 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo');
+    assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/tests/fixtures/generate/addon-acceptance-test-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-expected.js
@@ -7,6 +7,6 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo');
+    assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
+++ b/tests/fixtures/generate/addon-acceptance-test-nested-expected.js
@@ -7,6 +7,6 @@ test('visiting /foo/bar', function(assert) {
   visit('/foo/bar');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo/bar');
+    assert.strictEqual(currentURL(), '/foo/bar');
   });
 });


### PR DESCRIPTION
[no-assert-equal](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md) is now a recommended rule in eslint-plugin-qunit v7 (#9667).

In JavaScript, we should generally use strict equality checks.

https://api.qunitjs.com/assert/strictEqual/

Targetted to `beta` branch so it can go in alongside the eslint-plugin-qunit v7 upgrade.