### PR TITLE
Update eslint-plugin-qunit to v7 in a few more files

### DIFF
--- a/tests/fixtures/addon/defaults-travis/package.json
+++ b/tests/fixtures/addon/defaults-travis/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-ember": "^10.4.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-qunit": "^6.1.1",
+    "eslint-plugin-qunit": "^7.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-qunit": "^6.0.0",
+    "eslint-plugin-qunit": "^7.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",

--- a/tests/fixtures/app/npm-travis/package.json
+++ b/tests/fixtures/app/npm-travis/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-ember": "^10.4.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-qunit": "^6.1.1",
+    "eslint-plugin-qunit": "^7.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",

--- a/tests/fixtures/app/yarn-travis/package.json
+++ b/tests/fixtures/app/yarn-travis/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-ember": "^10.4.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-qunit": "^6.1.1",
+    "eslint-plugin-qunit": "^7.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",


### PR DESCRIPTION
Follow-up to https://github.com/ember-cli/ember-cli/pull/9667.

It looks like we missed updating this dependency in some files in the `beta` branch.