### PR TITLE
Add required dependencies for beta/canary try scenarios

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -36,6 +36,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },
@@ -44,6 +46,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },

--- a/tests/fixtures/addon/defaults-travis/config/ember-try.js
+++ b/tests/fixtures/addon/defaults-travis/config/ember-try.js
@@ -35,6 +35,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },
@@ -43,6 +45,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },

--- a/tests/fixtures/addon/defaults/config/ember-try.js
+++ b/tests/fixtures/addon/defaults/config/ember-try.js
@@ -35,6 +35,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },
@@ -43,6 +45,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },

--- a/tests/fixtures/addon/yarn/config/ember-try.js
+++ b/tests/fixtures/addon/yarn/config/ember-try.js
@@ -36,6 +36,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },
@@ -44,6 +46,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-auto-import': '^2.0.0',
+            webpack: '^5.0.0',
           },
         },
       },


### PR DESCRIPTION
ember-source beta currently requires ember-auto-import v2, without this
no addon ember-beta test scenarios will run. As far as I can figure
adding these as requirements for the scenarios will actually enhance
addon compatibility as real errors in Webpack config will be surfaced
instead of a dependency warning.