### PR TITLE
Bump ember-page-title from v6.2.2 to v7.0.0

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -45,7 +45,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/addon/defaults-travis/package.json
+++ b/tests/fixtures/addon/defaults-travis/package.json
@@ -47,7 +47,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.27.2",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -46,7 +46,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -46,7 +46,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -45,7 +45,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -45,7 +45,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -45,7 +45,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.1",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.27.0-beta.3",

--- a/tests/fixtures/app/npm-travis/package.json
+++ b/tests/fixtures/app/npm-travis/package.json
@@ -43,7 +43,7 @@
     "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.27.2",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.1",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.2",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.26.0-beta.2",

--- a/tests/fixtures/app/yarn-travis/package.json
+++ b/tests/fixtures/app/yarn-travis/package.json
@@ -43,7 +43,7 @@
     "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.27.2",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.0.0-beta.4",


### PR DESCRIPTION
In preparation for Ember v4.0, we need to bump ember-page-title to v7.x for [Ember.assign](https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign) deprecation fix.

v7.x also dropped Node 10 support - https://github.com/ember-cli/ember-page-title/releases/tag/v7.0.0

Currently this PR is targeting canary but it probably should land in beta already. Should I change the base branch to beta?