### PR TITLE
Ignore default folder name used by broccoli-debug

### DIFF
--- a/blueprints/addon/files/gitignore
+++ b/blueprints/addon/files/gitignore
@@ -1,0 +1,2 @@
+# broccoli-debug
+/DEBUG/

--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -27,3 +27,6 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/


### PR DESCRIPTION
https://cli.emberjs.com/release/advanced-use/debugging/#logging talks about how debugging is ready to be used and only an environment variable needs to be set to use it.  When a user does so though a `/DEBUG` folder is created, which they then need to ensure does not get checked into their repo.

Keeping this from being checked in can certainly fall within the realm of the end-application's responsibility, as a user should know how to a manage such resources, etc, but I am of the opinion that this folder falls in the same category as other files and paths already being ignored via the _.gitignore_ file, as they are by-products of running commands provided by the Ember CLI ecosystem and not something the user is necessarily aware they are opting into to when running the command.