### PR TITLE
feat: cancel stale actions workflows

### DIFF
--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   test:
     name: "Tests"

--- a/blueprints/app/files/.github/workflows/ci.yml
+++ b/blueprints/app/files/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   lint:
     name: "Lint"

--- a/tests/fixtures/addon/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   test:
     name: "Tests"

--- a/tests/fixtures/addon/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/yarn/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   test:
     name: "Tests"

--- a/tests/fixtures/app/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/app/defaults/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   lint:
     name: "Lint"

--- a/tests/fixtures/app/npm/.github/workflows/ci.yml
+++ b/tests/fixtures/app/npm/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   lint:
     name: "Lint"

--- a/tests/fixtures/app/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/app/yarn/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request: {}
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   lint:
     name: "Lint"


### PR DESCRIPTION
This uses Github Action's [concurrency](docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) feature to kill the workflow runs of commits that are not the current
head commit of a PR.  `head_ref` is only set for PRs [source](docs.github.com/en/actions/learn-github-actions/contexts#github-context), which is why we fall back to `ref` (so push workflows will run one job for each branch for the most recent commit).