### PR TITLE
Cancel stale workflows when starting a new one.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron:  '0 3 * * *' # daily, at 3am
 
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 jobs:
   linting:
     name: Linting


### PR DESCRIPTION
With this change, we will cancel any pending and in-progress CI jobs when a new one is pushed. This will help a bit with the CI queue by preventing tons and tons of queued up CI jobs when pushing new commits to a pull request.

This pulls the general changes from #9697 into our own workflow file. Thanks to @runspired for suggesting.
