### PR TITLE
Change blueprint to generate apps using 'history' location

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: '<%= modulePrefix %>',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
@@ -3,6 +3,6 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/environment.js',
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
   };
 };

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
@@ -3,7 +3,7 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/something-else.js',
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     APP: {
       autoboot: false
     }

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -41,7 +41,7 @@ class MockProject extends Project {
     return (
       this._config || {
         baseURL: '/',
-        locationType: 'auto',
+        locationType: 'history',
       }
     );
   }


### PR DESCRIPTION
as 'auto' location has been deprecated

- Update some test blueprints that do not care about location type