### PR TITLE
[BUGFIX] fixes `--ssl=false` when using `ember test`

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -65,8 +65,8 @@ class TestTask extends Task {
       /* eslint-enable camelcase */
     };
 
-    transformed.key = options.ssl ? options.sslKey : null;
-    transformed.cert = options.ssl ? options.sslCert : null;
+    transformed.key = options.ssl ? options.sslKey : undefined;
+    transformed.cert = options.ssl ? options.sslCert : undefined;
 
     return transformed;
   }

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -65,10 +65,9 @@ class TestTask extends Task {
       /* eslint-enable camelcase */
     };
 
-    if (options.ssl) {
-      transformed.key = options.sslKey;
-      transformed.cert = options.sslCert;
-    }
+    transformed.key = options.ssl ? options.sslKey : null;
+    transformed.cert = options.ssl ? options.sslCert : null;
+
     return transformed;
   }
 

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -116,8 +116,8 @@ describe('test task test', function () {
         expect(options.ssl).to.equal(false);
 
         let testemOptions = this.transformOptions(options);
-        expect(testemOptions.key).to.equal('ssl/server.key');
-        expect(testemOptions.cert).to.equal('ssl/server.cert');
+        expect(testemOptions.key).to.be.undefined;
+        expect(testemOptions.cert).to.be.undefined;
       },
     });
 
@@ -130,8 +130,8 @@ describe('test task test', function () {
       testPage: 'http://my/test/page',
       configFile: 'custom-testem-config.json',
       ssl: false,
-      sslKey: null,
-      sslCert: null,
+      sslKey: 'ssl/server.key',
+      sslCert: 'ssl/server.cert',
     });
   });
 });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -129,7 +129,7 @@ describe('test task test', function () {
       testemDebug: 'testem.log',
       testPage: 'http://my/test/page',
       configFile: 'custom-testem-config.json',
-      ssl: true,
+      ssl: false,
       sslKey: null,
       sslCert: null,
     });

--- a/tests/unit/tasks/test-test.js
+++ b/tests/unit/tasks/test-test.js
@@ -107,4 +107,31 @@ describe('test task test', function () {
       sslCert: 'ssl/server.cert',
     });
   });
+
+  it('supports disabling SSL and nullifying related keys', function () {
+    subject = new TestTask({
+      project: new MockProject(),
+
+      invokeTestem(options) {
+        expect(options.ssl).to.equal(false);
+
+        let testemOptions = this.transformOptions(options);
+        expect(testemOptions.key).to.equal('ssl/server.key');
+        expect(testemOptions.cert).to.equal('ssl/server.cert');
+      },
+    });
+
+    subject.run({
+      host: 'greatwebsite.com',
+      port: 123324,
+      reporter: 'xunit',
+      outputPath: 'blerpy-derpy',
+      testemDebug: 'testem.log',
+      testPage: 'http://my/test/page',
+      configFile: 'custom-testem-config.json',
+      ssl: true,
+      sslKey: null,
+      sslCert: null,
+    });
+  });
 });


### PR DESCRIPTION
At the moment when you have the ssl keys defined in `.ember-cli` such as:
```
{
 ...
  "ssl": true,
  "ssl-key": "ssl/server.key.pem",
  "ssl-cert": "ssl/server.crt.pem"
}
```

And you run `ember test --ssl=false` then the key values are still passed through, causing testem to enable SSL - which in turn fails in CI as it looks for the ssl certs

Original change made here: https://github.com/ember-cli/ember-cli/pull/8171
Related issue here: https://github.com/ember-cli/ember-cli/issues/5029#issuecomment-154475311
