### PR TITLE
fix: ember-default-with-jquery not passing in new addons

### DIFF
--- a/blueprints/addon/files/addon-config/ember-try.js
+++ b/blueprints/addon/files/addon-config/ember-try.js
@@ -56,6 +56,7 @@ module.exports = async function () {
         },
         npm: {
           devDependencies: {
+            'ember-source': '~3.24.3',
             '@ember/jquery': '^1.1.0',
           },
         },


### PR DESCRIPTION
Previously it ran against default which was < v4 and so it worked, but now the default is v4 and this test fails.