### PR TITLE
Fix console warnings for deprecated locationType='auto' in ember 4.x. #9765

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: '<%= modulePrefix %>',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/environment.js
@@ -3,6 +3,6 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/environment.js',
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
   };
 };

--- a/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
+++ b/tests/fixtures/brocfile-tests/custom-environment-config/config/something-else.js
@@ -3,7 +3,7 @@ module.exports = function() {
     modulePrefix: 'some-cool-app',
     fileUsed: 'config/something-else.js',
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     APP: {
       autoboot: false
     }

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -41,7 +41,7 @@ class MockProject extends Project {
     return (
       this._config || {
         baseURL: '/',
-        locationType: 'auto',
+        locationType: 'history',
       }
     );
   }

--- a/tests/unit/tasks/server/middleware/history-support-test.js
+++ b/tests/unit/tasks/server/middleware/history-support-test.js
@@ -5,18 +5,6 @@ const HistorySupportAddon = require('../../../../../lib/tasks/server/middleware/
 
 describe('HistorySupportAddon', function () {
   describe('.serverMiddleware', function () {
-    it('add middleware when locationType is auto', function () {
-      let addon = new HistorySupportAddon({
-        config() {
-          return {
-            locationType: 'auto',
-          };
-        },
-      });
-
-      expect(addon.shouldAddMiddleware()).to.true;
-    });
-
     it('add middleware when locationType is history', function () {
       let addon = new HistorySupportAddon({
         config() {

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -131,16 +131,6 @@ describe('ember-app-utils', function () {
         expect(output, '`<meta>` tag was not included').not.to.contain(expected);
       });
 
-      it('returns `<base>` tag if `locationType` is "auto"', function () {
-        config.locationType = 'auto';
-        config.baseURL = '/';
-
-        let expected = '<base href="/" />';
-        let output = contentFor(config, defaultMatch, 'head', defaultOptions);
-
-        expect(output, '`<base>` tag was included').to.contain(expected);
-      });
-
       // this is required by testem
       it('returns `<base>` tag if `locationType` is "none"', function () {
         config.locationType = 'none';
@@ -276,10 +266,8 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   describe(`calculateBaseTag`, function () {
-    ['auto', 'history'].forEach((locationType) => {
-      it(`generates a base tag correctly for location: ${locationType}`, function () {
-        expect(calculateBaseTag('/', locationType), `base tag was generated correctly`).to.equal('<base href="/" />');
-      });
+    it(`generates a base tag correctly if location is "history"`, function () {
+      expect(calculateBaseTag('/', 'history'), `base tag was generated correctly`).to.equal('<base href="/" />');
     });
 
     it('returns an empty string if location is "hash"', function () {


### PR DESCRIPTION
Fixes: #9765

**Why is it needed?**
As mentioned in **ember 4.x** deprecations list:

>Several years ago only some browsers supported the (then) new History Location API. Others could only serialize the router location into an url hash my/path#/ember/route. To handle this dynamically, Ember built an AutoLocation that would feature-detect and use either 'hash' or 'history' as the underlying mechanism. These days, virtually all browsers support the history API, so this is what 'auto' will resolve to in almost every case. Since 'auto' has served its purpose, it's being removed. 

**What it does do?**
- It complies with the suggested adaptations ember suggests for this deprecated feature.
- It replaces the location type from `auto` to `history` in both, the template app and in all tests.

>Set locationType in config/environment.js to 'history'. This is it, your app should work just like it used to (*)

_* from ember 4.x deprecations list._

**References:**
[ember-v4-deprecate-auto-location](https://deprecations.emberjs.com/v4.x/#toc_deprecate-auto-location)
