### PR TITLE
added mention of the addon that contains a command override to console output

### DIFF
--- a/lib/cli/lookup-command.js
+++ b/lib/cli/lookup-command.js
@@ -27,11 +27,15 @@ module.exports = function (commands, commandName, commandArgs, optionHash) {
   // Attempt to find command in ember-cli core commands
   let command = findCommand(commands, commandName);
 
+  let addonWithCommand;
   let addonCommand;
   // Attempt to find command within addons
   if (project && project.eachAddonCommand) {
     project.eachAddonCommand((addonName, commands) => {
       addonCommand = findCommand(commands, commandName);
+      if (addonCommand) {
+        addonWithCommand = addonName;
+      }
       return !addonCommand;
     });
   }
@@ -39,7 +43,7 @@ module.exports = function (commands, commandName, commandArgs, optionHash) {
   if (command && addonCommand) {
     if (addonCommand.overrideCore) {
       ui.writeWarnLine(
-        `An ember-addon has attempted to override the core command "${command.prototype.name}". ` +
+        `An ember-addon (${addonWithCommand}) has attempted to override the core command "${command.prototype.name}". ` +
           `The addon command will be used as the overridding was explicit.`
       );
 
@@ -47,7 +51,7 @@ module.exports = function (commands, commandName, commandArgs, optionHash) {
     }
 
     ui.writeWarnLine(
-      `An ember-addon has attempted to override the core command "${command.prototype.name}". ` +
+      `An ember-addon (${addonWithCommand}) has attempted to override the core command "${command.prototype.name}". ` +
         `The core command will be used.`
     );
     return command;


### PR DESCRIPTION
When CLI prints an error message saying that a particular addon tried to override a core command (e.g. 'test' is overridden by 'ember-exam'), added the name of the offending addon to the message so we know where to find it. Tested locally