### PR TITLE
Add ability to skip printing files based on user provided regex

### DIFF
--- a/lib/commands/asset-sizes.js
+++ b/lib/commands/asset-sizes.js
@@ -9,6 +9,7 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'output-path', type: 'Path', default: 'dist/', aliases: ['o'] },
     { name: 'json', type: Boolean, default: false },
+    { name: 'asset-sizes-skip-file-regex', type: String, default: null },
   ],
 
   run(commandOptions) {

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -20,6 +20,7 @@ module.exports = Command.extend({
     { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
     { name: 'watcher', type: String },
     { name: 'suppress-sizes', type: Boolean, default: false },
+    { name: 'asset-sizes-skip-file-regex', type: String, default: null },
   ],
 
   async run(commandOptions) {
@@ -32,6 +33,7 @@ module.exports = Command.extend({
     if (!commandOptions.suppressSizes && isProduction) {
       return this.runTask('ShowAssetSizes', {
         outputPath: commandOptions.outputPath,
+        assetSizesSkipFileRegex: commandOptions.assetSizesSkipFileRegex,
       });
     }
   },

--- a/lib/models/asset-size-printer.js
+++ b/lib/models/asset-size-printer.js
@@ -51,15 +51,25 @@ module.exports = class AssetPrinterSize {
     let files = this.findFiles();
     let testFileRegex = /(test-(loader|support))|(testem)/i;
 
+    let skipFilesRegex;
+    if (this.skipFilesRegex) {
+      skipFilesRegex = new RegExp(this.skipFilesRegex);
+    }
+
     // create a dedicated worker
     const pool = workerpool.pool(`${__dirname}/worker.js`);
 
     try {
       let assets = files
-        // Skip test files
+        // Skip test files and file based on user preference.
         .filter((file) => {
           let filename = path.basename(file);
-          return !testFileRegex.test(filename);
+          let shouldKeepFile = true;
+          shouldKeepFile = !testFileRegex.test(filename);
+          if (skipFilesRegex) {
+            shouldKeepFile = !skipFilesRegex.test(filename);
+          }
+          return shouldKeepFile;
         })
         // Print human-readable file sizes (including gzipped)
         .map((file) => {

--- a/lib/tasks/show-asset-sizes.js
+++ b/lib/tasks/show-asset-sizes.js
@@ -8,6 +8,7 @@ class ShowAssetSizesTask extends Task {
     let sizePrinter = new AssetSizePrinter({
       ui: this.ui,
       outputPath: options.outputPath,
+      skipFilesRegex: this.settings.assetSizesSkipFileRegex,
     });
 
     if (options.json) {

--- a/lib/tasks/show-asset-sizes.js
+++ b/lib/tasks/show-asset-sizes.js
@@ -8,7 +8,7 @@ class ShowAssetSizesTask extends Task {
     let sizePrinter = new AssetSizePrinter({
       ui: this.ui,
       outputPath: options.outputPath,
-      skipFilesRegex: this.settings.assetSizesSkipFileRegex,
+      skipFilesRegex: options.assetSizesSkipFileRegex,
     });
 
     if (options.json) {


### PR DESCRIPTION
This can be configured using the `.ember-cli` file. I chose this because neither `ember-cli-build.js` or `config/environment.js` seemed appropriate. I'm not 100% sure if this also means that this can be passed as a flag to `ember build` and `ember asset-sizes`.

I saw there aren't any tests for reading these options yet: https://github.com/ember-cli/ember-cli/blob/60d55de1a3cfb2eb751e4e76ac46b722464884a9/tests/unit/commands/show-asset-sizes-test.js#L56-L58. Happy to try to add some if we want them!

Closes #9763.