### PR TITLE
[DOC] Add bower note

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1130,7 +1130,11 @@ let Blueprint = CoreObject.extend({
   },
 
   /**
-    Used to add a package to the projects `bower.json`.
+    Used to add a Bower package to the projects `bower.json`.
+    
+    Bower is a package manager that is no longer recommended 
+    for new projects, but you may find this hook used in older
+    addons.
 
     Generally, this would be done from the `afterInstall` hook, to
     ensure that a package that is required by a given blueprint is
@@ -1180,6 +1184,10 @@ let Blueprint = CoreObject.extend({
 
   /**
     Used to add an array of packages to the projects `bower.json`.
+    
+    Bower is a package manager that is no longer recommended 
+    for new projects, but you may find this hook used in older
+    addons.
 
     Generally, this would be done from the `afterInstall` hook, to
     ensure that a package that is required by a given blueprint is


### PR DESCRIPTION
In the CLI guides, we removed references to Bower given the status of the Bower project. Is this guidance useful to include in the API docs? Please close if not.