### PR TITLE
Upgrade broccoli-merge-trees

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -20,9 +20,9 @@ const concat = require('broccoli-concat');
 const BroccoliDebug = require('broccoli-debug');
 const AmdFunnel = require('broccoli-amd-funnel');
 const mergeTrees = require('./merge-trees');
+const broccoliMergeTrees = require('broccoli-merge-trees');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
-const BroccoliMergeTrees = require('broccoli-merge-trees');
 
 const merge = require('ember-cli-lodash-subset').merge;
 const defaultsDeep = require('ember-cli-lodash-subset').defaultsDeep;
@@ -1727,7 +1727,7 @@ class EmberApp {
     }
 
     let trees = [].concat(packagedTree, additionalTrees).filter(Boolean);
-    let combinedPackageTree = new BroccoliMergeTrees(trees);
+    let combinedPackageTree = broccoliMergeTrees(trees);
 
     return this.addonPostprocessTree('all', combinedPackageTree);
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.8",
     "broccoli-funnel-reducer": "^1.0.0",
-    "broccoli-merge-trees": "^3.0.2",
+    "broccoli-merge-trees": "^4.2.0",
     "broccoli-middleware": "^2.1.1",
     "broccoli-slow-trees": "^3.1.0",
     "broccoli-source": "^3.0.1",

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -14,7 +14,7 @@ const createTempDir = broccoliTestHelper.createTempDir;
 const MockCLI = require('../../helpers/mock-cli');
 const { isExperimentEnabled } = require('../../../lib/experiments');
 const mergeTrees = require('../../../lib/broccoli/merge-trees');
-const BroccoliMergeTrees = require('broccoli-merge-trees');
+const BroccoliMergeTrees = require('broccoli-merge-trees').MergeTrees;
 
 let EmberApp = require('../../../lib/broccoli/ember-app');
 const Addon = require('../../../lib/models/addon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,6 +1393,14 @@ broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^3.0.2:
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
+broccoli-merge-trees@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz#692d3c163ecea08c5714a9434d664e628919f47c"
+  integrity sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==
+  dependencies:
+    broccoli-plugin "^4.0.2"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-2.1.1.tgz#183635bbef4dc1241533ee001a162f013d776cb9"


### PR DESCRIPTION
In `ember-app.js` there was a substitution of `broccoli-merge-trees` with the project's `merge-trees` utility:

```
-    let combinedPackageTree = new BroccoliMergeTrees(trees);
+    let combinedPackageTree = mergeTrees(trees);
```

This was making tests fail so I brought it back to the original code. If the tests should have actually passed then I suggest we open an issue and follow up separately.