### PR TITLE
BUGFIX pin `isbinaryfile` to 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "inflection": "^1.13.1",
     "is-git-url": "^1.0.0",
     "is-language-code": "^3.1.0",
-    "isbinaryfile": "^4.0.8",
+    "isbinaryfile": "4.0.8",
     "js-yaml": "^3.14.0",
     "leek": "0.0.24",
     "lodash.template": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4744,7 +4744,7 @@ isarray@1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^4.0.8:
+isbinaryfile@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
   integrity sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==


### PR DESCRIPTION
Because 4.0.9 drops node 12 which ember-cli still supports.

Fixes #9828