### PR TITLE
[BUGFIX release] Fix contents of addon `.gitignore` file

### DIFF
--- a/blueprints/addon/files/gitignore
+++ b/blueprints/addon/files/gitignore
@@ -1,2 +1,0 @@
-# broccoli-debug
-/DEBUG/


### PR DESCRIPTION
Reverts part of https://github.com/ember-cli/ember-cli/pull/9680.
Closes #9849.