### PR TITLE
[Bugfix release]: pin ember-cli-dependency-checker

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -36,7 +36,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/addon/defaults-travis/package.json
+++ b/tests/fixtures/addon/defaults-travis/package.json
@@ -39,7 +39,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.11.3",
     "ember-cli": "~<%= emberCLIVersion %>",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -39,7 +39,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.1",
     "ember-cli": "~<%= emberCLIVersion %>",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -39,7 +39,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.1",
     "ember-cli": "~<%= emberCLIVersion %>",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -36,7 +36,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -36,7 +36,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -36,7 +36,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.3",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/npm-travis/package.json
+++ b/tests/fixtures/app/npm-travis/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^4.0.0",
     "ember-cli-babel": "^7.23.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^5.3.2",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/yarn-travis/package.json
+++ b/tests/fixtures/app/yarn-travis/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/helpers/default-packager.js
+++ b/tests/helpers/default-packager.js
@@ -122,7 +122,7 @@ const DEFAULT_SOURCE = {
       'ember-cli': '~3.0.0-beta.1',
       'ember-cli-app-version': '^3.0.0',
       'ember-cli-babel': '^6.6.0',
-      'ember-cli-dependency-checker': '^3.1.0',
+      'ember-cli-dependency-checker': '3.2.0',
       'ember-cli-eslint': '^4.2.1',
       'ember-cli-htmlbars': '^3.0.0',
       'ember-cli-htmlbars-inline-precompile': '^1.0.0',


### PR DESCRIPTION
Summary
npx ember-cli new my-app breaks on npm install step, due to peerDep issues with https://github.com/quaertym/ember-cli-dependency-checker/pull/133
Issue
https://github.com/quaertym/ember-cli-dependency-checker/issues/132