### PR TITLE
Use `createBuilder` instead of deprecated `buildOutput` in test suite

### DIFF
--- a/tests/unit/broccoli/addon/linting-test.js
+++ b/tests/unit/broccoli/addon/linting-test.js
@@ -7,7 +7,7 @@ const MockCLI = require('../../../helpers/mock-cli');
 const Project = require('../../../../lib/models/project');
 const Addon = require('../../../../lib/models/addon');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Addon - linting', function () {
@@ -52,7 +52,8 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(1);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       app: {
@@ -71,7 +72,8 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(2);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       addon: {
@@ -81,7 +83,8 @@ describe('Addon - linting', function () {
 
     await output.dispose();
 
-    output = await buildOutput(lintTrees[1]);
+    output = createBuilder(lintTrees[1]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       addon: {
@@ -102,13 +105,15 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(2);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({});
 
     await output.dispose();
 
-    output = await buildOutput(lintTrees[1]);
+    output = createBuilder(lintTrees[1]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       addon: {
@@ -132,7 +137,8 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(2);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       addon: {
@@ -142,7 +148,8 @@ describe('Addon - linting', function () {
 
     await output.dispose();
 
-    output = await buildOutput(lintTrees[1]);
+    output = createBuilder(lintTrees[1]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       addon: {
@@ -163,7 +170,8 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(1);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       'addon-test-support': {
@@ -182,7 +190,8 @@ describe('Addon - linting', function () {
     addon.jshintAddonTree();
     expect(lintTrees.length).to.equal(1);
 
-    output = await buildOutput(lintTrees[0]);
+    output = createBuilder(lintTrees[0]);
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       'test-support': {
@@ -214,7 +223,9 @@ describe('Addon - linting', function () {
     };
     input.write(addonRootContents);
 
-    output = await buildOutput(addon.jshintAddonTree());
+    output = createBuilder(addon.jshintAddonTree());
+    await output.build();
+
     expect(output.read()).to.deep.equal({
       first: {
         tests: addonRootContents,

--- a/tests/unit/broccoli/addon/module-name-test.js
+++ b/tests/unit/broccoli/addon/module-name-test.js
@@ -8,7 +8,7 @@ const MockCLI = require('../../../helpers/mock-cli');
 const Project = require('../../../../lib/models/project');
 const Addon = require('../../../../lib/models/addon');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Addon - moduleName', function () {
@@ -56,7 +56,8 @@ describe('Addon - moduleName', function () {
       },
     });
 
-    output = await buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
+    output = createBuilder(addon.treeForAddon(path.join(addon.root, '/addon')));
+    await output.build();
 
     expect(output.read()).to.deep.equal({
       'totes-not-fake-addon': {

--- a/tests/unit/broccoli/default-packager/additional-assets-test.js
+++ b/tests/unit/broccoli/default-packager/additional-assets-test.js
@@ -6,7 +6,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -108,7 +108,8 @@ describe('Default Packager: Additional Assets', function () {
 
     expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
 
-    output = await buildOutput(defaultPackager.importAdditionalAssets(input.path()));
+    output = createBuilder(defaultPackager.importAdditionalAssets(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedProcessedAdditionalAssets).to.not.equal(null);
     expect(defaultPackager._cachedProcessedAdditionalAssets._annotation).to.equal(
@@ -152,7 +153,8 @@ describe('Default Packager: Additional Assets', function () {
 
     expect(defaultPackager._cachedProcessedAdditionalAssets).to.equal(null);
 
-    output = await buildOutput(defaultPackager.importAdditionalAssets(input.path()));
+    output = createBuilder(defaultPackager.importAdditionalAssets(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/bower-test.js
+++ b/tests/unit/broccoli/default-packager/bower-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Bower', function () {
@@ -43,7 +43,7 @@ describe('Default Packager: Bower', function () {
 
     expect(defaultPackager._cachedBower).to.equal(null);
 
-    await buildOutput(defaultPackager.packageBower(input.path()));
+    await createBuilder(defaultPackager.packageBower(input.path())).build();
 
     expect(defaultPackager._cachedBower).to.not.equal(null);
     expect(defaultPackager._cachedBower._annotation).to.equal('Packaged Bower');
@@ -52,7 +52,8 @@ describe('Default Packager: Bower', function () {
   it('packages bower files with default folder', async function () {
     let defaultPackager = new DefaultPackager();
 
-    let packagedBower = await buildOutput(defaultPackager.packageBower(input.path()));
+    let packagedBower = createBuilder(defaultPackager.packageBower(input.path()));
+    await packagedBower.build();
     let output = packagedBower.read();
 
     expect(output).to.deep.equal({
@@ -63,7 +64,8 @@ describe('Default Packager: Bower', function () {
   it('packages bower files with custom folder', async function () {
     let defaultPackager = new DefaultPackager();
 
-    let packagedBower = await buildOutput(defaultPackager.packageBower(input.path(), 'foobar'));
+    let packagedBower = createBuilder(defaultPackager.packageBower(input.path(), 'foobar'));
+    await packagedBower.build();
     let output = packagedBower.read();
 
     expect(output).to.deep.equal({

--- a/tests/unit/broccoli/default-packager/config-test.js
+++ b/tests/unit/broccoli/default-packager/config-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Config', function () {
@@ -50,7 +50,8 @@ describe('Default Packager: Config', function () {
 
     expect(defaultPackager._cachedConfig).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageConfig());
+    output = createBuilder(defaultPackager.packageConfig());
+    await output.build();
 
     expect(defaultPackager._cachedConfig).to.not.equal(null);
     expect(defaultPackager._cachedConfig._annotation).to.equal('Packaged Config');
@@ -64,7 +65,8 @@ describe('Default Packager: Config', function () {
       areTestsEnabled: false,
     });
 
-    output = await buildOutput(defaultPackager.packageConfig());
+    output = createBuilder(defaultPackager.packageConfig());
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -87,7 +89,8 @@ describe('Default Packager: Config', function () {
       areTestsEnabled: true,
     });
 
-    output = await buildOutput(defaultPackager.packageConfig());
+    output = createBuilder(defaultPackager.packageConfig());
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Ember CLI Internal', function () {
@@ -55,7 +55,8 @@ describe('Default Packager: Ember CLI Internal', function () {
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = createBuilder(defaultPackager.packageEmberCliInternalFiles());
+    await output.build();
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.not.equal(null);
     expect(defaultPackager._cachedEmberCliInternalTree._annotation).to.equal('Packaged Ember CLI Internal Files');
@@ -73,7 +74,8 @@ describe('Default Packager: Ember CLI Internal', function () {
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = createBuilder(defaultPackager.packageEmberCliInternalFiles());
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -105,7 +107,8 @@ describe('Default Packager: Ember CLI Internal', function () {
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = createBuilder(defaultPackager.packageEmberCliInternalFiles());
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -170,7 +173,8 @@ var runningTests = false;`);
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = createBuilder(defaultPackager.packageEmberCliInternalFiles());
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -220,7 +224,8 @@ var runningTests = false;`);
 
     expect(defaultPackager._cachedEmberCliInternalTree).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageEmberCliInternalFiles());
+    output = createBuilder(defaultPackager.packageEmberCliInternalFiles());
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/external-test.js
+++ b/tests/unit/broccoli/default-packager/external-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: External', function () {
@@ -66,7 +66,8 @@ describe('Default Packager: External', function () {
       customTransformsMap,
     });
 
-    output = await buildOutput(defaultPackager.applyCustomTransforms(input.path()));
+    output = createBuilder(defaultPackager.applyCustomTransforms(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/index-test.js
+++ b/tests/unit/broccoli/default-packager/index-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Index', function () {
@@ -77,7 +77,8 @@ describe('Default Packager: Index', function () {
 
     expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processIndex(input.path()));
+    output = createBuilder(defaultPackager.processIndex(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedProcessedIndex).to.not.equal(null);
   });
@@ -100,7 +101,8 @@ describe('Default Packager: Index', function () {
 
     expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processIndex(input.path()));
+    output = createBuilder(defaultPackager.processIndex(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
     let indexContent = decodeURIComponent(outputFiles.custom['index.html'].trim());
@@ -126,7 +128,8 @@ describe('Default Packager: Index', function () {
 
     expect(defaultPackager._cachedProcessedIndex).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processIndex(input.path()));
+    output = createBuilder(defaultPackager.processIndex(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
     let indexContent = decodeURIComponent(outputFiles['index.html'].trim());

--- a/tests/unit/broccoli/default-packager/javascript-test.js
+++ b/tests/unit/broccoli/default-packager/javascript-test.js
@@ -6,7 +6,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -142,7 +142,8 @@ describe('Default Packager: Javascript', function () {
 
     expect(defaultPackager._cachedJavascript).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageJavascript(input.path()));
+    output = createBuilder(defaultPackager.packageJavascript(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedJavascript).to.not.equal(null);
     expect(defaultPackager._cachedJavascript._annotation).to.equal('Packaged Javascript');
@@ -172,7 +173,8 @@ describe('Default Packager: Javascript', function () {
       project,
     });
 
-    output = await buildOutput(defaultPackager.packageJavascript(input.path()));
+    output = createBuilder(defaultPackager.packageJavascript(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -212,7 +214,8 @@ describe('Default Packager: Javascript', function () {
       project,
     });
 
-    output = await buildOutput(defaultPackager.packageJavascript(input.path()));
+    output = createBuilder(defaultPackager.packageJavascript(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -236,7 +239,8 @@ describe('Default Packager: Javascript', function () {
 
     expect(defaultPackager._cachedProcessedJavascript).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processJavascript(input.path()));
+    output = createBuilder(defaultPackager.processJavascript(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -287,7 +291,8 @@ describe('Default Packager: Javascript', function () {
 
     expect(defaultPackager._cachedProcessedJavascript).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processJavascript(input.path()));
+    output = createBuilder(defaultPackager.processJavascript(input.path()));
+    await output.build();
 
     expect(addonPreprocessTreeHookCalled).to.equal(true);
     expect(addonPostprocessTreeHookCalled).to.equal(true);

--- a/tests/unit/broccoli/default-packager/process-test.js
+++ b/tests/unit/broccoli/default-packager/process-test.js
@@ -6,7 +6,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -113,7 +113,8 @@ describe('Default Packager: Process Javascript', function () {
 
     expect(defaultPackager._cachedProcessedAppAndDependencies).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processAppAndDependencies(input.path()));
+    output = createBuilder(defaultPackager.processAppAndDependencies(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedProcessedAppAndDependencies).to.not.equal(null);
     expect(defaultPackager._cachedProcessedAppAndDependencies._annotation).to.equal(

--- a/tests/unit/broccoli/default-packager/public-test.js
+++ b/tests/unit/broccoli/default-packager/public-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Public', function () {
@@ -40,7 +40,8 @@ describe('Default Packager: Public', function () {
 
     expect(defaultPackager._cachedPublic).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packagePublic(input.path()));
+    output = createBuilder(defaultPackager.packagePublic(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedPublic).to.not.equal(null);
   });
@@ -48,7 +49,8 @@ describe('Default Packager: Public', function () {
   it('packages public files', async function () {
     let defaultPackager = new DefaultPackager();
 
-    output = await buildOutput(defaultPackager.packagePublic(input.path()));
+    output = createBuilder(defaultPackager.packagePublic(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/styles-test.js
+++ b/tests/unit/broccoli/default-packager/styles-test.js
@@ -6,7 +6,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -107,7 +107,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedProcessedStyles).to.not.equal(null);
     expect(defaultPackager._cachedProcessedStyles._annotation).to.equal('Packaged Styles');
@@ -142,7 +143,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -180,7 +182,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -226,7 +229,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -262,7 +266,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -320,7 +325,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     expect(addonPreprocessTreeHookCalled).to.equal(true);
     expect(addonPostprocessTreeHookCalled).to.equal(true);
@@ -363,7 +369,8 @@ describe('Default Packager: Styles', function () {
 
     expect(defaultPackager._cachedProcessedStyles).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageStyles(input.path()));
+    output = createBuilder(defaultPackager.packageStyles(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/templates-test.js
+++ b/tests/unit/broccoli/default-packager/templates-test.js
@@ -6,7 +6,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -59,7 +59,8 @@ describe('Default Packager: Templates', function () {
 
     expect(defaultPackager._cachedProcessedTemplates).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processTemplates(input.path()));
+    output = createBuilder(defaultPackager.processTemplates(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedProcessedTemplates).to.not.equal(null);
   });
@@ -81,7 +82,8 @@ describe('Default Packager: Templates', function () {
 
     expect(defaultPackager._cachedProcessedTemplates).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processTemplates(input.path()));
+    output = createBuilder(defaultPackager.processTemplates(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -135,7 +137,8 @@ describe('Default Packager: Templates', function () {
 
     expect(defaultPackager._cachedProcessedTemplates).to.equal(null);
 
-    output = await buildOutput(defaultPackager.processTemplates(input.path()));
+    output = createBuilder(defaultPackager.processTemplates(input.path()));
+    await output.build();
 
     expect(addonPreprocessTreeHookCalled).to.equal(true);
     expect(addonPostprocessTreeHookCalled).to.equal(true);

--- a/tests/unit/broccoli/default-packager/tests-test.js
+++ b/tests/unit/broccoli/default-packager/tests-test.js
@@ -7,7 +7,7 @@ const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const setupRegistryFor = defaultPackagerHelpers.setupRegistryFor;
 
@@ -154,7 +154,8 @@ describe('Default Packager: Tests', function () {
 
     expect(defaultPackager._cachedTests).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedTests).to.not.equal(null);
   });
@@ -183,7 +184,8 @@ describe('Default Packager: Tests', function () {
       registry: setupRegistryFor('js', (tree) => tree),
     });
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -231,7 +233,8 @@ describe('Default Packager: Tests', function () {
       registry: setupRegistryFor('js', (tree) => tree),
     });
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -279,7 +282,8 @@ describe('Default Packager: Tests', function () {
       }),
     });
 
-    output = await buildOutput(defaultPackager.processTests(input.path()));
+    output = createBuilder(defaultPackager.processTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -354,7 +358,8 @@ describe('Default Packager: Tests', function () {
       }),
     });
 
-    output = await buildOutput(defaultPackager.processTests(input.path()));
+    output = createBuilder(defaultPackager.processTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -474,7 +479,8 @@ describe('Default Packager: Tests', function () {
       registry: setupRegistryFor('js', (tree) => tree),
     });
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -516,7 +522,8 @@ describe('Default Packager: Tests', function () {
       registry: setupRegistryFor('js', (tree) => tree),
     });
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 
@@ -549,7 +556,8 @@ describe('Default Packager: Tests', function () {
       registry: setupRegistryFor('js', (tree) => tree),
     });
 
-    output = await buildOutput(defaultPackager.packageTests(input.path()));
+    output = createBuilder(defaultPackager.packageTests(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/default-packager/vendor-test.js
+++ b/tests/unit/broccoli/default-packager/vendor-test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const DefaultPackager = require('../../../../lib/broccoli/default-packager');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('Default Packager: Vendor', function () {
@@ -61,7 +61,8 @@ describe('Default Packager: Vendor', function () {
 
     expect(defaultPackager._cachedVendor).to.equal(null);
 
-    output = await buildOutput(defaultPackager.packageVendor(input.path()));
+    output = createBuilder(defaultPackager.packageVendor(input.path()));
+    await output.build();
 
     expect(defaultPackager._cachedVendor).to.not.equal(null);
     expect(defaultPackager._cachedVendor._annotation).to.equal('Packaged Vendor');
@@ -70,7 +71,8 @@ describe('Default Packager: Vendor', function () {
   it('packages vendor files', async function () {
     let defaultPackager = new DefaultPackager();
 
-    output = await buildOutput(defaultPackager.packageVendor(input.path()));
+    output = createBuilder(defaultPackager.packageVendor(input.path()));
+    await output.build();
 
     let outputFiles = output.read();
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -8,7 +8,7 @@ const td = require('testdouble');
 const broccoliTestHelper = require('broccoli-test-helper');
 const { WatchedDir, UnwatchedDir } = require('broccoli-source');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 const MockCLI = require('../../helpers/mock-cli');
@@ -125,7 +125,8 @@ describe('EmberApp', function () {
         });
         mockTemplateRegistry(app);
 
-        output = await buildOutput(app.toTree());
+        output = createBuilder(app.toTree());
+        await output.build();
 
         let outputFiles = output.read();
 
@@ -162,7 +163,8 @@ describe('EmberApp', function () {
 
         app.getAppJavascript = () => js.path();
 
-        output = await buildOutput(app.toTree());
+        output = createBuilder(app.toTree());
+        await output.build();
 
         let outputFiles = output.read();
 
@@ -217,7 +219,8 @@ describe('EmberApp', function () {
           packageTests: td.function(),
         };
 
-        output = await buildOutput(app.toTree());
+        output = createBuilder(app.toTree());
+        await output.build();
 
         td.verify(app.getAppJavascript(false));
         td.verify(app.getStyles());
@@ -250,7 +253,8 @@ describe('EmberApp', function () {
           },
         });
 
-        output = await buildOutput(app.toTree());
+        output = createBuilder(app.toTree());
+        await output.build();
 
         let outputFiles = output.read();
 
@@ -279,7 +283,8 @@ describe('EmberApp', function () {
 
       app.addonTreesFor = () => [];
 
-      let output = await buildOutput(app.getStyles());
+      let output = createBuilder(app.getStyles());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles).to.deep.equal({
@@ -306,7 +311,8 @@ describe('EmberApp', function () {
       let addonFoo = new AddonFoo(app, project);
       app.project.addons.push(addonFoo);
 
-      let output = await buildOutput(app.getStyles());
+      let output = createBuilder(app.getStyles());
+      await output.build();
       let outputFiles = output.read();
 
       let expectedOutput = {};
@@ -341,7 +347,8 @@ describe('EmberApp', function () {
       let addonFoo = new AddonFoo(app, project);
       app.project.addons.push(addonFoo);
 
-      let output = await buildOutput(app.getStyles());
+      let output = createBuilder(app.getStyles());
+      await output.build();
       let outputFiles = output.read();
 
       let expectedOutput = {
@@ -383,7 +390,8 @@ describe('EmberApp', function () {
         return [addonFooStyles.path(), addonBarStyles.path()];
       };
 
-      let output = await buildOutput(app.getStyles());
+      let output = createBuilder(app.getStyles());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles).to.deep.equal({
@@ -408,7 +416,8 @@ describe('EmberApp', function () {
       });
       app.addonTreesFor = () => [];
 
-      let output = await buildOutput(app.getStyles());
+      let output = createBuilder(app.getStyles());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles).to.deep.equal({});
@@ -443,7 +452,8 @@ describe('EmberApp', function () {
         return [addonFooPublic.path(), addonBarPublic.path()];
       };
 
-      let output = await buildOutput(app.getPublic());
+      let output = createBuilder(app.getPublic());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles).to.deep.equal({
@@ -487,7 +497,8 @@ describe('EmberApp', function () {
         return [addonFooPublic.path(), addonBarPublic.path()];
       };
 
-      let output = await buildOutput(app.getPublic());
+      let output = createBuilder(app.getPublic());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles).to.deep.equal({
@@ -527,7 +538,8 @@ describe('EmberApp', function () {
         return [addonFooTemplates.path(), addonBarTemplates.path()];
       };
 
-      let output = await buildOutput(app.getAddonTemplates());
+      let output = createBuilder(app.getAddonTemplates());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles['test-project'].templates).to.deep.equal({
@@ -585,7 +597,8 @@ describe('EmberApp', function () {
         return [];
       };
 
-      let output = await buildOutput(app.getTests());
+      let output = createBuilder(app.getTests());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles.tests).to.deep.equal({
@@ -640,7 +653,8 @@ describe('EmberApp', function () {
         return [];
       };
 
-      let output = await buildOutput(app.getTests());
+      let output = createBuilder(app.getTests());
+      await output.build();
       let outputFiles = output.read();
 
       expect(outputFiles.tests).to.deep.equal({

--- a/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
+++ b/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
@@ -7,7 +7,7 @@ const EmberApp = require('../../../../lib/broccoli/ember-app');
 const MockCLI = require('../../../helpers/mock-cli');
 const Project = require('../../../../lib/models/project');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const walkSync = require('walk-sync');
 
@@ -127,7 +127,8 @@ describe('EmberApp#appAndDependencies', function () {
       });
     };
 
-    output = await buildOutput(app.getExternalTree());
+    output = createBuilder(app.getExternalTree());
+    await output.build();
     let actualFiles = getFiles(output.path());
 
     expect(actualFiles).to.contain('addon-tree-output/modules/my-addon/index.js');

--- a/tests/unit/broccoli/ember-app/import-test.js
+++ b/tests/unit/broccoli/ember-app/import-test.js
@@ -7,7 +7,7 @@ const defaultPackagerHelpers = require('../../../helpers/default-packager');
 
 const EmberApp = require('../../../../lib/broccoli/ember-app');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 const getDefaultUnpackagedDist = defaultPackagerHelpers.getDefaultUnpackagedDist;
@@ -54,7 +54,8 @@ describe('EmberApp: Bower Dependencies', function () {
     let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
     // Then
-    output = await buildOutput(packagedApplicationJs);
+    output = createBuilder(packagedApplicationJs);
+    await output.build();
     let results = output.read();
 
     expect(() => {
@@ -82,7 +83,8 @@ describe('EmberApp: Bower Dependencies', function () {
     let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
     // Then
-    output = await buildOutput(packagedApplicationJs);
+    output = createBuilder(packagedApplicationJs);
+    await output.build();
     let results = output.read();
 
     expect(() => {
@@ -115,7 +117,8 @@ describe('EmberApp: Bower Dependencies', function () {
     let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
     // Then
-    output = await buildOutput(packagedApplicationJs);
+    output = createBuilder(packagedApplicationJs);
+    await output.build();
     let results = output.read();
 
     expect(() => {
@@ -144,7 +147,8 @@ describe('EmberApp: Bower Dependencies', function () {
     let packagedApplicationJs = applicationInstance._defaultPackager.packageJavascript(applicationDirectory.path());
 
     // Then
-    output = await buildOutput(packagedApplicationJs);
+    output = createBuilder(packagedApplicationJs);
+    await output.build();
     let results = output.read();
 
     expect(() => {

--- a/tests/unit/broccoli/template-precompilation-test.js
+++ b/tests/unit/broccoli/template-precompilation-test.js
@@ -12,7 +12,7 @@ const Project = require('../../../lib/models/project');
 const Addon = require('../../../lib/models/addon');
 const EmberApp = require('../../../lib/broccoli/ember-app');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('template preprocessors', function () {
@@ -105,7 +105,8 @@ describe('template preprocessors', function () {
         },
       });
 
-      output = await buildOutput(addon.treeForAddon(path.join(addon.root, '/addon')));
+      output = createBuilder(addon.treeForAddon(path.join(addon.root, '/addon')));
+      await output.build();
 
       expect(output.read()).to.deep.equal({
         'fake-addon': {
@@ -179,7 +180,8 @@ describe('template preprocessors', function () {
         },
       });
 
-      output = await buildOutput(app.toTree());
+      output = createBuilder(app.toTree());
+      await output.build();
 
       let expectedContent = `export default class {}\nexport const template = hbs\`<!-- flerpy -->\``;
       let actualContent = output.read().assets['fake-app-test.js'];

--- a/tests/unit/settings-file/leek-options-test.js
+++ b/tests/unit/settings-file/leek-options-test.js
@@ -6,7 +6,7 @@ const Yam = require('yam');
 const cliEntry = require('../../../lib/cli');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('.ember-cli leek options', function () {
@@ -30,7 +30,7 @@ describe('.ember-cli leek options', function () {
 
     let primaryPath = leekConfigFolder.path();
 
-    await buildOutput(primaryPath);
+    await createBuilder(primaryPath).build();
 
     let mockedYam = new Yam('ember-cli', {
       primary: primaryPath,

--- a/tests/unit/utilities/load-config-test.js
+++ b/tests/unit/utilities/load-config-test.js
@@ -5,7 +5,7 @@ const path = require('path');
 const loadConfig = require('../../../lib/utilities/load-config');
 const broccoliTestHelper = require('broccoli-test-helper');
 
-const buildOutput = broccoliTestHelper.buildOutput;
+const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
 describe('load-config', function () {
@@ -25,7 +25,7 @@ describe('load-config', function () {
       },
     });
 
-    await buildOutput(fixtureDirectoryPath);
+    await createBuilder(fixtureDirectoryPath).build();
   });
 
   after(async function () {


### PR DESCRIPTION
Let's avoid using the deprecated broccoli-test-helper function
`buildOutput(outputNode)`, instead preferring to use
`createBuilder(outputNode)` followed by `await output.build()` as
suggested by the JSdocs.

This closes issue #9793.