### PR TITLE
Remove `EXTEND_PROTOTYPES` object in the app's `config/environment.js` file

### DIFF
--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -11,10 +11,6 @@ module.exports = function (environment) {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
-      EXTEND_PROTOTYPES: {
-        // Prevent Ember Data from overriding Date.parse.
-        Date: false,
-      },
     },
 
     APP: {


### PR DESCRIPTION
Ember Data does not override `Date.parse` anymore.

Closes #9854.