### PR TITLE
Update `git.io` URLs

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -19,7 +19,7 @@ cache:
 <% } %>
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -17,7 +17,7 @@ cache:
 <% } %>
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -155,7 +155,7 @@ class CLI {
       let platform = new PlatformChecker(process.version);
       let recommendation =
         ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
-        ' See https://git.io/v7S5n for details.';
+        ' See https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md for details.';
 
       if (!this.testing) {
         if (platform.isDeprecated) {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -133,7 +133,7 @@ module.exports = class LiveReloadServer {
 
     // this is required to prevent tiny-lr from triggering an error
     // when checking this.server._handle during its close handler
-    // here: https://git.io/fA7Tr
+    // here: https://github.com/mklabs/tiny-lr/blob/d68d983eaf80b5bae78b2dba259a1ad5e3b03a63/lib/server.js#L209
     lrServer.server = this.httpServer;
 
     return lrServer;

--- a/tests/fixtures/addon/defaults-travis/.travis.yml
+++ b/tests/fixtures/addon/defaults-travis/.travis.yml
@@ -16,7 +16,7 @@ cache:
 
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -15,7 +15,7 @@ cache:
 
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/tests/fixtures/app/npm-travis/.travis.yml
+++ b/tests/fixtures/app/npm-travis/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:

--- a/tests/fixtures/app/yarn-travis/.travis.yml
+++ b/tests/fixtures/app/yarn-travis/.travis.yml
@@ -13,7 +13,7 @@ cache:
 
 env:
   global:
-    # See https://git.io/vdao3 for details.
+    # See https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md for details.
     - JOBS=1
 
 branches:


### PR DESCRIPTION
`git.io` does not accept new links anymore and will be deprecated soon, see:
- https://github.blog/changelog/2022-01-11-git-io-no-longer-accepts-new-urls/
- https://github.blog/changelog/2022-04-25-git-io-deprecation/