### PR TITLE
chore: remove git.io

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -155,7 +155,7 @@ class CLI {
       let platform = new PlatformChecker(process.version);
       let recommendation =
         ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
-        ' See https://git.io/v7S5n for details.';
+        ' See https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md for details.';
 
       if (!this.testing) {
         if (platform.isDeprecated) {

--- a/lib/tasks/server/livereload-server.js
+++ b/lib/tasks/server/livereload-server.js
@@ -133,7 +133,7 @@ module.exports = class LiveReloadServer {
 
     // this is required to prevent tiny-lr from triggering an error
     // when checking this.server._handle during its close handler
-    // here: https://git.io/fA7Tr
+    // here: https://github.com/mklabs/tiny-lr/blob/d68d983eaf80b5bae78b2dba259a1ad5e3b03a63/lib/server.js#L209
     lrServer.server = this.httpServer;
 
     return lrServer;


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/