### PR TITLE
Add failing test for `sequence` util

### DIFF
--- a/tests/unit/utilities/sequence-test.js
+++ b/tests/unit/utilities/sequence-test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { expect } = require('chai');
+const sequence = require('../../../lib/utilities/sequence');
+
+describe('sequence', function () {
+  it('it works', async function () {
+    let results = await sequence([
+      () => Promise.resolve(1),
+      2,
+      () => new Promise((resolve) => setTimeout(() => resolve(3), 1000)),
+    ]);
+
+    expect(results).to.deep.equal([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
According to the docs of the `sequence` util, the return value [should be `[1, 2, 3]`](https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/sequence.js#L17-L21), but actually seems to be `[1, 1, 3]`.
This failing test should illustrate that.

At the moment, the util is [used only once](https://github.com/ember-cli/ember-cli/blob/177f52340dcaa59cf27402ed77fda5e55860fd35/lib/models/blueprint.js#L1773), and the actual return value isn't used, so I don't think it's causing any real issues.

Do we fix the util, or do we replace the use of it with an async for loop?