### PR TITLE
Addon blue prints should depend on on ember-source

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -49,6 +49,9 @@ module.exports = {
     contents.dependencies = contents.dependencies || {};
     contents.devDependencies = contents.devDependencies || {};
 
+		// addon should depend on the ember-source that matches ember-cli
+    contents.dependencies['ember-source'] = contents.devDependencies['ember-cli'];
+
     // npm doesn't like it when we have something in both deps and devDeps
     // and dummy app still uses it when in deps
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -184,6 +184,19 @@ describe('blueprint - addon', function () {
         expect(json.dependencies).to.deep.equal({ a: '1', b: '1' });
         expect(json.devDependencies).to.deep.equal({ a: '1', b: '1' });
       });
+
+			it('copies ember-source into dependencies', function () {
+        let output = blueprint.updatePackageJson(
+          JSON.stringify({
+            devDependencies: {
+              'ember-source': '4.0.0',
+            },
+          })
+        );
+
+        let json = JSON.parse(output);
+        expect(json.dependencies['ember-source']).to.equal('4.0.0');
+      });
     });
   });
 });


### PR DESCRIPTION
Because ember has started to remove some deprecations, if you generate and addon without the correct ember-source then your addon won't work.

This happened to me when I was using ember-cli v3.24 to generate an addon. @ember/component was not available because the addon was using the latest version of ember and not the ember-cli version that was used to generate it.

By having the addon generate with the same ember-source as the ember-cli that created it, this is avoided.