### PR TITLE
[CLEANUP] Remove `ie 11` from default targets

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -311,7 +311,7 @@ class Project {
     if (fs.existsSync(`${targetsPath}.js`)) {
       this._targets = this.require(targetsPath);
     } else {
-      this._targets = require('../utilities/default-targets');
+      this._targets = require('../../blueprints/app/files/config/targets');
     }
     return this._targets;
   }

--- a/lib/utilities/default-targets.js
+++ b/lib/utilities/default-targets.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  browsers: ['ie 11', 'last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'],
-};

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -282,7 +282,7 @@ describe('models/project.js', function () {
 
       it('returns the default targets', function () {
         expect(project.targets).to.deep.equal({
-          browsers: ['ie 11', 'last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'],
+          browsers: ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'],
         });
       });
     });


### PR DESCRIPTION
IE 11 was removed from the app's `targets` file here https://github.com/ember-cli/ember-cli/pull/9666.
So I'm guessing the default targets used should reflect that as well?

Closes #9884.