### PR TITLE
Remove deprecated `addonJsFiles` method on `addon` model

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1270,23 +1270,6 @@ let addonProto = {
   },
 
   /**
-    Returns a tree containing the addon's js files
-
-    @private
-    @deprecated
-    @method addonJsFiles
-    @return {Tree} The filtered addon js files
-  */
-  addonJsFiles(tree) {
-    this._warn(`Addon.prototype.addonJsFiles is deprecated`);
-
-    return new Funnel(tree, {
-      destDir: this.moduleName(),
-      annotation: 'Funnel: Addon JS',
-    });
-  },
-
-  /**
     Preprocesses a javascript tree.
 
     @private


### PR DESCRIPTION
This method was deprecated in https://github.com/ember-cli/ember-cli/pull/8834 and the deprecation was released in [v3.13.0](https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#v3130).

Closes #9873.