### PR TITLE
Remove unused CLI error class

### DIFF
--- a/lib/errors/cli.js
+++ b/lib/errors/cli.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = class BuildError extends Error {};


### PR DESCRIPTION
Noticed this while doing https://github.com/ember-cli/ember-cli/pull/9899.
This file was originally added here https://github.com/ember-cli/ember-cli/pull/7798, but later on, the sole use of it was removed here https://github.com/ember-cli/ember-cli/pull/8470.