### PR TITLE
Remove support for `ember-cli-inject-live-reload` < v1.10.0

### DIFF
--- a/lib/utilities/is-live-reload-request.js
+++ b/lib/utilities/is-live-reload-request.js
@@ -1,17 +1,7 @@
 'use strict';
 
 const cleanBaseUrl = require('clean-base-url');
-const deprecate = require('./deprecate');
 
 module.exports = function isLiveReloadRequest(url, liveReloadPrefix) {
-  let regex = /\/livereload$/gi;
-  if (url === `${cleanBaseUrl(liveReloadPrefix)}livereload`) {
-    return true;
-  } else if (regex.test(url)) {
-    //version needs to be updated according to the this PR (https://github.com/ember-cli/ember-cli-inject-live-reload/pull/55)
-    //in master of ember-cli-inject-live-reload.
-    deprecate(`Upgrade ember-cli-inject-live-reload version to 1.10.0 or above`, true);
-    return true;
-  }
-  return false;
+  return url === `${cleanBaseUrl(liveReloadPrefix)}livereload`;
 };

--- a/tests/unit/tasks/server/middleware/proxy-server-test.js
+++ b/tests/unit/tasks/server/middleware/proxy-server-test.js
@@ -17,7 +17,7 @@ describe('proxy-server', function () {
       liveReloadPrefix: 'test/',
     };
     let req = {
-      url: 'test/livereload',
+      url: '/test/livereload',
     };
     expect(proxyServer.handleProxiedRequest({ req, options })).to.undefined;
   });

--- a/tests/unit/utilities/is-live-reload-request-test.js
+++ b/tests/unit/utilities/is-live-reload-request-test.js
@@ -8,10 +8,10 @@ describe('isLiveReloadRequest()', function () {
     expect(isLiveReloadRequest('/livereload', '/')).to.be.true;
   });
   it('path/livereload', function () {
-    expect(isLiveReloadRequest('path/livereload', 'path/')).to.be.true;
+    expect(isLiveReloadRequest('/path/livereload', 'path/')).to.be.true;
   });
   it('path/path/livereload', function () {
-    expect(isLiveReloadRequest('path/path/livereload', 'path/path/')).to.be.true;
+    expect(isLiveReloadRequest('/path/path/livereload', 'path/path/')).to.be.true;
   });
   it('livereload', function () {
     expect(isLiveReloadRequest('livereload', '/')).to.be.false;


### PR DESCRIPTION
Support for versions older than v1.10.0 was deprecated in https://github.com/ember-cli/ember-cli/pull/8096 and released in [v3.5.1](https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#v351).

Closes #9796.
Closes #9887.