### PR TITLE
Deprecate `vendor-shim` blueprint

### DIFF
--- a/blueprints/vendor-shim/index.js
+++ b/blueprints/vendor-shim/index.js
@@ -1,9 +1,22 @@
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');
+const { deprecate } = require('../../lib/debug');
 
 module.exports = {
   description: 'Generates an ES6 module shim for global libraries.',
+
+  beforeInstall() {
+    deprecate('The `vendor-shim` blueprint is deprecated. Please use `ember-auto-import` instead.', false, {
+      for: 'ember-cli',
+      id: 'ember-cli.vendor-shim-blueprint',
+      since: {
+        available: '4.6.0',
+        enabled: '4.6.0',
+      },
+      until: '5.0.0',
+    });
+  },
 
   locals(options) {
     let entity = options.entity;

--- a/tests/unit/blueprints/vendor-shim-test.js
+++ b/tests/unit/blueprints/vendor-shim-test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { expect, file } = require('ember-cli-blueprint-test-helpers/chai');
+const { emberGenerate, emberNew, setupTestHooks } = require('ember-cli-blueprint-test-helpers/helpers');
+const path = require('path');
+
+describe('Acceptance: ember generate and destroy vendor-shim', function () {
+  setupTestHooks(this, {
+    cliPath: path.resolve(`${__dirname}/../../..`),
+  });
+
+  it('it works', async function () {
+    await emberNew();
+    await emberGenerate(['vendor-shim', 'foo']);
+
+    expect(file('vendor/shims/foo.js')).to.equal(`(function() {
+  function vendorModule() {
+    'use strict';
+
+    return {
+      'default': self['foo'],
+      __esModule: true,
+    };
+  }
+
+  define('foo', [], vendorModule);
+})();
+`);
+  });
+});


### PR DESCRIPTION
Also added a test, to make sure I didn't break anything.

Closes #9883.