### PR TITLE
Update Node compatibility warning

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -151,20 +151,22 @@ class CLI {
 
       let platformCheckerToken = heimdall.start('platform-checker');
 
+      const emberCLIVersion = require('../../package.json').version;
       const PlatformChecker = require('../utilities/platform-checker');
       let platform = new PlatformChecker(process.version);
       let recommendation =
-        ' We recommend that you use the most-recent "Active LTS" version of Node.js.' +
-        ' See https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md for details.';
+        ' See "https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md" to find out which version of Node is best to use.';
 
       if (!this.testing) {
         if (platform.isDeprecated) {
-          this.ui.writeDeprecateLine(`Node ${process.version} is no longer supported by Ember CLI.${recommendation}`);
+          this.ui.writeDeprecateLine(
+            `Node ${process.version} is no longer supported by Ember CLI v${emberCLIVersion}.${recommendation}`
+          );
         }
 
         if (!platform.isTested) {
           this.ui.writeWarnLine(
-            `Node ${process.version} is not tested against Ember CLI on your platform.${recommendation}`
+            `Ember CLI v${emberCLIVersion} is not tested against Node ${process.version}.${recommendation}`
           );
         }
       }


### PR DESCRIPTION
New warning:

```
WARNING: Ember CLI v3.21.2 is not tested against Node v16.15.0. See "https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md" to find out which version of Node is best to use.
```

Closes #9783.