### PR TITLE
Drop support for Node v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         os: [ubuntu, windows]
 
     steps:
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - run: yarn install --frozen-lockfile --non-interactive
 

--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --no-lockfile' : 'npm install --no-shrinkwrap' %>
@@ -71,7 +71,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/blueprints/addon/files/README.md
+++ b/blueprints/addon/files/README.md
@@ -7,7 +7,7 @@
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 ## Installation

--- a/blueprints/app/files/.github/workflows/ci.yml
+++ b/blueprints/app/files/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -64,7 +64,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -14,7 +14,7 @@
 | 9.x              | 2.16.2 - 3.2.x               |
 | 10.x             | 3.1.3 - 3.28.0               |
 | 11.x             | 3.9.0 - 3.13.0               |
-| 12.x             | 3.10.0 - Current             |
+| 12.x             | 3.10.0 - 4.6.0               |
 | 13.x             | 3.15.0 - 3.20.0              |
 | 14.x             | 3.19.0 - Current             |
 | 16.x             | 3.28.0 - Current             |
@@ -30,8 +30,6 @@ Node.js](https://github.com/nodejs/LTS#lts_schedule).
 
 ## Current support:
 
-* v12: Released as stable version then converted to LTS.
-  * Supported by ember-cli/ember-cli#master until: 2022-04-30.
 * v14: Released as stable version then converted to LTS.
   * Supported by ember-cli/ember-cli#master until: 2023-04-30.
 * v16: Released as stable version then converted to LTS.

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "yuidocjs": "0.10.2"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/tests/fixtures/addon/defaults-travis/.travis.yml
+++ b/tests/fixtures/addon/defaults-travis/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/tests/fixtures/addon/defaults-travis/README.md
+++ b/tests/fixtures/addon/defaults-travis/README.md
@@ -9,7 +9,7 @@ Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 Installation

--- a/tests/fixtures/addon/defaults-travis/package.json
+++ b/tests/fixtures/addon/defaults-travis/package.json
@@ -66,7 +66,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/defaults/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm install --no-shrinkwrap
@@ -71,7 +71,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/tests/fixtures/addon/defaults/README.md
+++ b/tests/fixtures/addon/defaults/README.md
@@ -7,7 +7,7 @@
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 ## Installation

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -66,7 +66,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/yarn/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -71,7 +71,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/tests/fixtures/addon/yarn/README.md
+++ b/tests/fixtures/addon/yarn/README.md
@@ -7,7 +7,7 @@
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 ## Installation

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -67,7 +67,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/defaults/.github/workflows/ci.yml
+++ b/tests/fixtures/app/defaults/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -61,7 +61,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -63,7 +63,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -64,7 +64,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -64,7 +64,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -60,7 +60,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/npm-travis/.travis.yml
+++ b/tests/fixtures/app/npm-travis/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/tests/fixtures/app/npm-travis/package.json
+++ b/tests/fixtures/app/npm-travis/package.json
@@ -60,7 +60,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/npm/.github/workflows/ci.yml
+++ b/tests/fixtures/app/npm/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -60,7 +60,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -59,7 +59,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/yarn-travis/.travis.yml
+++ b/tests/fixtures/app/yarn-travis/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "12"
+  - "14"
 
 dist: xenial
 

--- a/tests/fixtures/app/yarn-travis/package.json
+++ b/tests/fixtures/app/yarn-travis/package.json
@@ -61,7 +61,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/app/yarn/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -61,7 +61,7 @@
     "webpack": "^5.72.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/unit/utilities/platform-checker-test.js
+++ b/tests/unit/utilities/platform-checker-test.js
@@ -16,10 +16,11 @@ describe('platform-checker', function () {
 
     check('v8.0.0', { isTested: false, isDeprecated: true, isValid: false });
     check('v10.0.0', { isTested: false, isDeprecated: true, isValid: false });
-    check('v12.0.0', { isTested: true, isDeprecated: false, isValid: true });
-    check('v13.0.0', { isTested: false, isDeprecated: false, isValid: true });
+    check('v12.0.0', { isTested: false, isDeprecated: true, isValid: false });
+    check('v13.0.0', { isTested: false, isDeprecated: true, isValid: false });
     check('v14.0.0', { isTested: true, isDeprecated: false, isValid: true });
     check('v15.0.0', { isTested: false, isDeprecated: false, isValid: true });
+    check('v16.0.0', { isTested: true, isDeprecated: false, isValid: true });
   });
 
   it('checkIsDeprecated', function () {


### PR DESCRIPTION
Node v12 is EOL since 2022-04-30, which means we can drop support following [our Node support doc](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md).

Closes #9893.