### PR TITLE
Remove ESLint config file from `server` blueprint

### DIFF
--- a/blueprints/server/files/server/.eslintrc.js
+++ b/blueprints/server/files/server/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    node: true
-  }
-};

--- a/blueprints/server/index.js
+++ b/blueprints/server/index.js
@@ -29,7 +29,13 @@ module.exports = {
   },
 
   files() {
-    return ['server/index.js', this.hasJSHint() ? 'server/.jshintrc' : 'server/.eslintrc.js'];
+    let files = ['server/index.js'];
+
+    if (this.hasJSHint()) {
+      files.push('server/.jshintrc');
+    }
+
+    return files;
   },
 
   hasJSHint() {


### PR DESCRIPTION
Because we already have this covered [here](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/.eslintrc.js#L36).
The `.jshintrc` file will be removed once we've officially deprecated / removed support for `ember-cli-jshint`.

Closes #9881.