### PR TITLE
Remove support for finding an addon by its unscoped name

### DIFF
--- a/lib/utilities/find-addon-by-name.js
+++ b/lib/utilities/find-addon-by-name.js
@@ -1,34 +1,14 @@
 'use strict';
 
-function unscope(name) {
-  if (name[0] !== '@') {
-    return name;
-  }
-
-  return name.slice(name.indexOf('/') + 1);
-}
-
 let HAS_FOUND_ADDON_BY_NAME = Object.create(null);
-let HAS_FOUND_ADDON_BY_UNSCOPED_NAME = Object.create(null);
+
 /*
-  Finds an addon given a specific name. Due to older versions of ember-cli
-  not properly supporting scoped packages it was (at one point) common practice
-  to have `package.json` include a scoped name but `index.js` having an unscoped
-  name.
+  Finds an addon given a specific name.
 
-  Changes to the blueprints and addon model (in ~ 3.4+) have made it much clearer
-  that both `package.json` and `index.js` `name`'s should match. At some point
-  this will be "forced" and no longer optional.
-
-  This function is attempting to prioritize matching across all of the combinations
-  (in this priority order):
-
-  - package.json name matches requested name exactly
-  - index.js name matches requested name exactly
-  - unscoped (leaf portion) index.js name matches unscoped requested name
+  The `name` value in an addon's `package.json` file takes priority over the
+  `name` value in an addon's `index.js` file.
 */
 module.exports = function findAddonByName(addons, name) {
-  let unscopedName = unscope(name);
   let exactMatchFromPkg = addons.find((addon) => addon.pkg && addon.pkg.name === name);
 
   if (exactMatchFromPkg) {
@@ -51,22 +31,9 @@ module.exports = function findAddonByName(addons, name) {
     return exactMatchFromIndex;
   }
 
-  let unscopedMatchFromIndex = addons.find((addon) => addon.name && unscope(addon.name) === unscopedName);
-  if (unscopedMatchFromIndex) {
-    if (HAS_FOUND_ADDON_BY_UNSCOPED_NAME[name] !== true) {
-      HAS_FOUND_ADDON_BY_UNSCOPED_NAME[name] = true;
-      console.trace(
-        `Finding a scoped addon via its unscoped name is deprecated. You searched for \`${name}\` which we found as \`${unscopedMatchFromIndex.name}\` in '${unscopedMatchFromIndex.root}'`
-      );
-    }
-
-    return unscopedMatchFromIndex;
-  }
-
   return null;
 };
 
 module.exports._clearCaches = function () {
   HAS_FOUND_ADDON_BY_NAME = Object.create(null);
-  HAS_FOUND_ADDON_BY_UNSCOPED_NAME = Object.create(null);
 };

--- a/tests/unit/utilities/find-addon-by-name-test.js
+++ b/tests/unit/utilities/find-addon-by-name-test.js
@@ -93,41 +93,6 @@ describe('findAddonByName', function () {
     expect(consoleOutput).to.deep.equal([]);
   });
 
-  it('matches unscoped name of scoped package when no exact match is found with logging', function () {
-    let addon = findAddonByName(addons, 'other');
-    expect(addon.pkg.name).to.equal('@scoped/other');
-    expect(consoleOutput).to.deep.equal([
-      [
-        'trace',
-        "Finding a scoped addon via its unscoped name is deprecated. You searched for `other` which we found as `@scoped/other` in 'node_modules/@scoped/other'",
-      ],
-    ]);
-  });
-
-  it('matches unscoped name of scoped package repeatedly when no exact match is found with logging', function () {
-    let addon = findAddonByName(addons, 'other');
-    expect(addon.pkg.name).to.equal('@scoped/other');
-
-    addon = findAddonByName(addons, 'other');
-    expect(addon.pkg.name).to.equal('@scoped/other');
-
-    addon = findAddonByName(addons, 'other');
-    expect(addon.pkg.name).to.equal('@scoped/other');
-
-    expect(consoleOutput).to.deep.equal([
-      [
-        'trace',
-        "Finding a scoped addon via its unscoped name is deprecated. You searched for `other` which we found as `@scoped/other` in 'node_modules/@scoped/other'",
-      ],
-    ]);
-  });
-
-  it('if exact match is found, it "wins" over unscoped matches', function () {
-    let addon = findAddonByName(addons, 'foo-bar');
-    expect(addon.pkg.name).to.equal('foo-bar');
-    expect(consoleOutput).to.deep.equal([]);
-  });
-
   it('if exact match by addon name is found, it "wins" with a warning', function () {
     let addon = findAddonByName(addons, 'thing');
     expect(addon.pkg.name).to.equal('@scope/thing');


### PR DESCRIPTION
Closes #9878.