### PR TITLE
Allow app property to pass through addon proxy to addon instance

### DIFF
--- a/lib/models/per-bundle-addon-cache/addon-proxy.js
+++ b/lib/models/per-bundle-addon-cache/addon-proxy.js
@@ -41,10 +41,7 @@ function validateCacheKey(realAddonInstance, treeType, newCacheKey) {
 
 /**
  * Returns a proxy to a target with specific handling for the
- * `parent` property, as well has to handle the `app` property;
- * that is, the proxy should maintain correct local state in
- * closure scope for the `app` property if it happens to be set
- * by `ember-cli`. Other than `parent` & `app`, this function also
+ * `parent` property. Other than `parent`, this function also
  * proxies _almost_ everything to `target[TARGET_INSTANCE] with a few
  * exceptions: we trap & return `[]` for `addons`, and we don't return
  * the original `included` (it's already called on the "real" addon
@@ -62,8 +59,6 @@ function validateCacheKey(realAddonInstance, treeType, newCacheKey) {
  * @return Proxy
  */
 function getAddonProxy(targetCacheEntry, parent) {
-  let _app;
-
   // handle `preprocessJs` separately for Embroider
   //
   // some context here:
@@ -80,10 +75,6 @@ function getAddonProxy(targetCacheEntry, parent) {
     get(targetCacheEntry, property) {
       if (property === 'parent') {
         return parent;
-      }
-
-      if (property === 'app') {
-        return _app;
       }
 
       // only return `_preprocessJs` here if it was previously set to a patched version
@@ -136,11 +127,6 @@ function getAddonProxy(targetCacheEntry, parent) {
       return Reflect.get(targetCacheEntry, property);
     },
     set(targetCacheEntry, property, value) {
-      if (property === 'app') {
-        _app = value;
-        return true;
-      }
-
       if (property === 'preprocessJs') {
         _preprocessJs = value;
         return true;


### PR DESCRIPTION
When the EmberApp constructor runs, the presence of nested addon dependencies can result in the `project.addons` list containing a mixture of addon instances and addon proxy objects. For the addon proxy objects, the EmberApp setting their `app` property would prevent the addon *instance* from having it set, which goes against the expectation described in the models/addon.js app property comment: 

https://github.com/ember-cli/ember-cli/blob/ee6d372df2e16384a92f06800329eeb23c83a7d1/lib/broccoli/ember-app.js#L132

https://github.com/ember-cli/ember-cli/blob/ee6d372df2e16384a92f06800329eeb23c83a7d1/lib/models/addon.js#L188-L193

Later on, when an addon attempts to read `this.app` it will be undefined if the addon was a Proxy by the time the EmberApp constructor method attempted to set it. This seems like a bug.

The comment explaining the proxy holding the app claims that ember-cli might set that app property, but I'm not sure what situation it is referring to. I didn't see any test coverage of this behavior. Simply removing this fixes the issue where addons in my project that expect to be able to read `this.app` in their index.js functions were erroring.