### PR TITLE
[INTERNAL] Remove old `deprecate` utility

### DIFF
--- a/lib/utilities/deprecate.js
+++ b/lib/utilities/deprecate.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const chalk = require('chalk');
-
-module.exports = function (message, test) {
-  if (test) {
-    console.log(chalk.yellow(`DEPRECATION: ${message}`));
-  }
-};


### PR DESCRIPTION
This one isn't used/needed anymore.

Closes #9792.