### PR TITLE
[INTERNAL] Fix internal `sequence` util

### DIFF
--- a/lib/utilities/sequence.js
+++ b/lib/utilities/sequence.js
@@ -27,14 +27,16 @@
  * @return Promise<Array>
  *
  */
-module.exports = function sequence(tasks) {
+module.exports = async function sequence(tasks) {
   let length = tasks.length;
-  let current = Promise.resolve();
-  let results = new Array(length);
+  let results = [];
 
   for (let i = 0; i < length; ++i) {
-    current = results[i] = current.then(tasks[i]);
+    let task = tasks[i];
+    let prevResult = results[i - 1];
+
+    results.push(typeof task === 'function' ? await task(prevResult) : await task);
   }
 
-  return Promise.all(results);
+  return results;
 };

--- a/tests/unit/utilities/sequence-test.js
+++ b/tests/unit/utilities/sequence-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { expect } = require('chai');
+const sequence = require('../../../lib/utilities/sequence');
+
+describe('sequence', function () {
+  it('it works', async function () {
+    let results = await sequence([
+      Promise.resolve(1),
+      () => Promise.resolve(2),
+      3,
+      () => new Promise((resolve) => setTimeout(() => resolve(4), 100)),
+      (prevResult) => prevResult + 1,
+    ]);
+
+    expect(results).to.deep.equal([1, 2, 3, 4, 5]);
+  });
+});


### PR DESCRIPTION
Noticed this util wasn't working as documented.
Mainly the returned `results` array was incorrect.

Closes #9862.