### PR TITLE
ENHANCEMENT: Add .DS_Store file in gitignore

### DIFF
--- a/blueprints/app/files/gitignore
+++ b/blueprints/app/files/gitignore
@@ -19,6 +19,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+.DS_Store
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
The `.gitignore` file inside the project that the CLI generates does not contain `.DS_Store` file. The file is automatically generated in macOS and pollutes the repo if it is accidentally committed.

So the PR is adding the `.DS_Store` file in the gitignore file created in the Ember project using the CLI.