### PR TITLE
Fix `prefer-const` lint violations in `app` and `addon` blueprints

### DIFF
--- a/blueprints/addon/files/ember-cli-build.js
+++ b/blueprints/addon/files/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
-  let app = new EmberAddon(defaults, {
+  const app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function (environment) {
-  let ENV = {
+  const ENV = {
     modulePrefix: '<%= modulePrefix %>',
     environment,
     rootURL: '/',

--- a/blueprints/app/files/ember-cli-build.js
+++ b/blueprints/app/files/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/tests/fixtures/app/defaults/ember-cli-build.js
+++ b/tests/fixtures/app/defaults/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/tests/fixtures/app/embroider/ember-cli-build.js
+++ b/tests/fixtures/app/embroider/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/tests/fixtures/app/nested-project/actual-project/ember-cli-build.js
+++ b/tests/fixtures/app/nested-project/actual-project/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/ember-cli-build.js
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
   });
 

--- a/tests/fixtures/brocfile-tests/additional-trees/ember-cli-build.js
+++ b/tests/fixtures/brocfile-tests/additional-trees/ember-cli-build.js
@@ -3,7 +3,7 @@ const Funnel = require('broccoli-funnel');
 const { isExperimentEnabled } = require('ember-cli/lib/experiments');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {});
+  const app = new EmberApp(defaults, {});
 
   let funnel = new Funnel('vendor', {
     srcDir: '/',


### PR DESCRIPTION
Many users use the [prefer-const](https://eslint.org/docs/latest/rules/prefer-const) ESLint lint rule. We can make a minor/trivial/harmless tweak to the blueprint so that there won't be any violations from this lint rule. There's no reason anyone should be reassigning the value of `ENV` or `app` anyway.