### PR TITLE
[WIP] Default workspace settings for Visual Studio Code

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -130,7 +130,7 @@ module.exports = {
     let addonName = stringUtil.dasherize(addonRawName);
     let addonNamespace = stringUtil.classify(addonRawName);
 
-    let hasOptions = options.welcome || options.yarn || options.ciProvider;
+    let hasOptions = options.welcome || options.yarn || options.ciProvider || options.codeEditor;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -142,6 +142,7 @@ module.exports = {
           options.welcome && '"--welcome"',
           options.yarn && '"--yarn"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
+          options.codeEditor && `"--code-editor=${options.codeEditor}"`,
         ]
           .filter(Boolean)
           .join(',\n            ') +
@@ -164,6 +165,7 @@ module.exports = {
       embroider: false,
       lang: options.lang,
       ciProvider: options.ciProvider,
+      codeEditor: options.codeEditor,
     };
   },
 
@@ -172,7 +174,7 @@ module.exports = {
     let addonFilesPath = this.filesPath(this.options);
     let ignoredCITemplate = this.options.ciProvider !== 'travis' ? '.travis.yml' : '.github';
 
-    let addonFiles = walkSync(addonFilesPath, { ignore: [ignoredCITemplate] });
+    let addonFiles = walkSync(addonFilesPath, { ignore: [ignoredCITemplate, '.vscode'] });
 
     return uniq(appFiles.concat(addonFiles));
   },

--- a/blueprints/app/files/.vscode/extensions.json
+++ b/blueprints/app/files/.vscode/extensions.json
@@ -1,10 +1,18 @@
 {
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"lifeart.vscode-ember-unstable",
-		"EditorConfig.EditorConfig",
-		"lifeart.vscode-glimmer-syntax",
-		"chiragpat.vscode-glimmer",
+    "EditorConfig.EditorConfig",
 		"esbenp.prettier-vscode",
 		"dbaeumer.vscode-eslint",
+		"lifeart.vscode-ember-unstable",
+		"lifeart.vscode-glimmer-syntax",
+		"chiragpat.vscode-glimmer",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
 	]
 }

--- a/blueprints/app/files/.vscode/extensions.json
+++ b/blueprints/app/files/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+	"recommendations": [
+		"lifeart.vscode-ember-unstable",
+		"EditorConfig.EditorConfig",
+		"lifeart.vscode-glimmer-syntax",
+		"chiragpat.vscode-glimmer",
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	]
+}

--- a/blueprints/app/files/.vscode/launch.json
+++ b/blueprints/app/files/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "type": "chrome",
+      "request": "launch",
+      "preLaunchTask": "Ember serve",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "test-app/*": "${workspaceRoot}/app/*",
+        "test-app/tests/*": "${workspaceFolder}/tests/*",
+      },
+    },
+    {
+      "name": "Launch Edge",
+      "request": "launch",
+      "type": "msedge",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "test-app/*": "${workspaceRoot}/app/*",
+        "test-app/tests/*": "${workspaceFolder}/tests/*",
+      }
+    },
+  ]
+}

--- a/blueprints/app/files/.vscode/launch.json
+++ b/blueprints/app/files/.vscode/launch.json
@@ -12,8 +12,8 @@
       "url": "http://localhost:4200",
       "webRoot": "${workspaceFolder}",
       "sourceMapPathOverrides": {
-        "test-app/*": "${workspaceRoot}/app/*",
-        "test-app/tests/*": "${workspaceFolder}/tests/*",
+        "<%= name %>/*": "${workspaceRoot}/app/*",
+        "<%= name %>/tests/*": "${workspaceFolder}/tests/*",
       },
     },
     {
@@ -23,8 +23,8 @@
       "url": "http://localhost:4200",
       "webRoot": "${workspaceFolder}",
       "sourceMapPathOverrides": {
-        "test-app/*": "${workspaceRoot}/app/*",
-        "test-app/tests/*": "${workspaceFolder}/tests/*",
+        "<%= name %>/*": "${workspaceRoot}/app/*",
+        "<%= name %>/tests/*": "${workspaceFolder}/tests/*",
       }
     },
   ]

--- a/blueprints/app/files/.vscode/settings.json
+++ b/blueprints/app/files/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "search.exclude": {
+    "dist": true
+  }
+}

--- a/blueprints/app/files/.vscode/tasks.json
+++ b/blueprints/app/files/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Ember serve",
+      "type": "npm",
+      "script": "start",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+    },
+  ]
+}

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -24,7 +24,7 @@ module.exports = {
     let namespace = stringUtil.classify(rawName);
     let embroider = isExperimentEnabled('EMBROIDER') || options.embroider;
 
-    let hasOptions = !options.welcome || options.yarn || embroider || options.ciProvider;
+    let hasOptions = !options.welcome || options.yarn || embroider || options.ciProvider || options.codeEditor;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -37,6 +37,7 @@ module.exports = {
           options.yarn && '"--yarn"',
           embroider && '"--embroider"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
+          options.codeEditor && `"--code-editor=${options.codeEditor}"`,
         ]
           .filter(Boolean)
           .join(',\n            ') +
@@ -56,6 +57,7 @@ module.exports = {
       embroider,
       lang: options.lang,
       ciProvider: options.ciProvider,
+      codeEditor: options.codeEditor,
     };
   },
 
@@ -69,6 +71,10 @@ module.exports = {
       this._files = files.filter((file) => file !== '.travis.yml');
     } else {
       this._files = files.filter((file) => file.indexOf('.github') < 0);
+    }
+
+    if (options.codeEditor !== 'vscode') {
+      this._files = files.filter((file) => file.indexOf('.vscode') < 0);
     }
 
     return this._files;

--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -26,6 +26,12 @@ module.exports = NewCommand.extend({
       default: 'github',
       description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
     },
+    {
+      name: 'code-editor',
+      type: ['vscode'],
+      default: false,
+      description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+    },
   ],
 
   anonymousOptions: ['<addon-name>'],

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -42,6 +42,12 @@ module.exports = Command.extend({
       default: 'github',
       description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
     },
+    {
+      name: 'code-editor',
+      type: ['vscode'],
+      default: false,
+      description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+    },
   ],
 
   anonymousOptions: ['<glob-pattern>'],
@@ -65,6 +71,7 @@ module.exports = Command.extend({
     let project = this.project;
     let packageName = (commandOptions.name !== '.' && commandOptions.name) || project.name();
     let ciProvider = commandOptions.ciProvider;
+    let codeEditor = commandOptions.codeEditor;
 
     if (!packageName) {
       let message =
@@ -91,6 +98,7 @@ module.exports = Command.extend({
       rawArgs: rawArgs.toString(),
       blueprint: normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint()),
       ciProvider,
+      codeEditor,
     });
 
     if (!isValidProjectName(packageName)) {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -41,6 +41,12 @@ module.exports = Command.extend({
       default: 'github',
       description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
     },
+    {
+      name: 'code-editor',
+      type: ['vscode'],
+      default: false,
+      description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+    },
   ],
 
   anonymousOptions: ['<app-name>'],

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -41,6 +41,7 @@ class InstallBlueprintTask extends Task {
       targetFiles: options.targetFiles,
       rawArgs: options.rawArgs,
       ciProvider: options.ciProvider,
+      codeEditor: options.codeEditor,
     };
 
     installOptions = merge(installOptions, options || {});

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -49,8 +49,8 @@ describe('Acceptance: ember init', function () {
 
   function confirmBlueprinted() {
     let blueprintPath = path.join(root, 'blueprints', 'app', 'files');
-    // ignore .travis.yml
-    let expected = walkSync(blueprintPath, { ignore: ['.travis.yml'] }).sort();
+    // ignore .travis.yml and .vscode
+    let expected = walkSync(blueprintPath, { ignore: ['.travis.yml', '.vscode'] }).sort();
     let actual = walkSync('.').sort();
 
     forEach(Blueprint.renamedFiles, function (destFile, srcFile) {
@@ -195,5 +195,17 @@ describe('Acceptance: ember init', function () {
 
     expect(file('.travis.yml')).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, '.travis.yml')));
     expect(file('.github/workflows/ci.yml')).to.not.exist;
+  });
+
+  it('should not create .vscode folder', async function () {
+    await ember(['init', '--skip-npm', '--skip-bower']);
+
+    expect(dir('.vscode')).to.not.exist;
+  });
+
+  it('should create .vscode folder', async function () {
+    await ember(['init', '--code-editor=vscode', '--skip-npm', '--skip-bower']);
+
+    expect(dir('.vscode')).to.exist;
   });
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -46,7 +46,7 @@ describe('Acceptance: ember new', function () {
   function confirmBlueprintedForDir(blueprintDir, expectedAppDir = 'foo') {
     let blueprintPath = path.join(root, blueprintDir, 'files');
     // ignore .travis.yml
-    let expected = walkSync(blueprintPath, { ignore: ['.travis.yml'] });
+    let expected = walkSync(blueprintPath, { ignore: ['.travis.yml', '.vscode'] });
     let actual = walkSync('.').sort();
     let directory = path.basename(process.cwd());
 
@@ -645,6 +645,18 @@ describe('Acceptance: ember new', function () {
       expect(file('.github/workflows/ci.yml')).to.not.exist;
 
       checkFileWithEmberCLIVersionReplacement(fixturePath, 'tests/dummy/config/ember-cli-update.json');
+    });
+
+    it('should not create .vscode folder', async function () {
+      await ember(['init', '--skip-npm', '--skip-bower']);
+
+      expect(dir('.vscode')).to.not.exist;
+    });
+
+    it('should create .vscode folder', async function () {
+      await ember(['init', '--code-editor=vscode', '--skip-npm', '--skip-bower']);
+
+      expect(dir('.vscode')).to.exist;
     });
   });
 

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -84,6 +84,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<addon-name>']
     },
@@ -477,6 +485,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -605,6 +621,14 @@ module.exports = {
           default: 'github',
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
+        },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
         },
       ],
       anonymousOptions: ['<app-name>']

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -84,6 +84,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<addon-name>']
     },
@@ -509,6 +517,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -637,6 +653,14 @@ module.exports = {
           default: 'github',
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
+        },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
         },
       ],
       anonymousOptions: ['<app-name>']

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -84,6 +84,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<addon-name>']
     },
@@ -477,6 +485,14 @@ module.exports = {
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
         },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
+        },
       ],
       anonymousOptions: ['<glob-pattern>']
     },
@@ -605,6 +621,14 @@ module.exports = {
           default: 'github',
           description: 'Installs the default CI blueprint. Either Travis or Github Actions is supported.',
           required: false,
+        },
+        {
+          name: 'code-editor',
+          key: 'codeEditor',
+          type: ['vscode'],
+          default: false,
+          description: 'Installs the default workspace settings. Only Visual Studio Code is supported.',
+          required: false
         },
       ],
       anonymousOptions: ['<app-name>']


### PR DESCRIPTION
This PR adds a new argument `--code-editor=vscode` to `init` and `new` commands. It adds the default workspace settings for Visual Studio Code.