### PR TITLE
[BUGFIX release] Make sure newly installed addons are discovered when running `ember install`

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -658,6 +658,7 @@ class Project {
   reloadAddons() {
     this.reloadPkg();
     this._addonsInitialized = false;
+    this._didDiscoverAddons = false;
     return this.initializeAddons();
   }
 


### PR DESCRIPTION
Running `ember install addon-name` currently throws the following error:

```
Install failed. Could not find addon with name: addon-name
```

This regression seems to have been introduced by #9890, even though the fix in that PR seems logical.