### PR TITLE
Update `glob` to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "fs-tree-diff": "^2.0.1",
     "get-caller-file": "^2.0.5",
     "git-repo-info": "^2.1.1",
-    "glob": "^7.2.0",
+    "glob": "^8.0.3",
     "heimdalljs": "^0.2.6",
     "heimdalljs-fs-monitor": "^1.1.1",
     "heimdalljs-graph": "^1.0.0",

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -92,7 +92,7 @@ describe('Acceptance: ember init', function () {
 
   function pickSync(filePath, pattern) {
     return glob
-      .sync(path.join('**', pattern), {
+      .sync(`**/${pattern}`, {
         cwd: filePath,
         dot: true,
         mark: true,

--- a/tests/integration/models/blueprint-test.js
+++ b/tests/integration/models/blueprint-test.js
@@ -392,7 +392,7 @@ describe('Blueprint', function () {
       await blueprint.install(options);
       let actualFiles = walkSync(tmpdir).sort();
       let globFiles = glob
-        .sync(path.join('**', '*.txt'), {
+        .sync('**/*.txt', {
           cwd: tmpdir,
           dot: true,
           mark: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4185,7 +4185,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@7.2.0, glob@^7.0.0, glob@^7.0.4, glob@^7.1.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@7.2.0, glob@^7.0.0, glob@^7.0.4, glob@^7.1.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -4207,6 +4207,17 @@ glob@^5.0.10:
     minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 global-dirs@^3.0.0:
   version "3.0.0"
@@ -6108,7 +6119,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^5.1.0:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==


### PR DESCRIPTION
Using forward slashes in glob patterns is now required.
More info here: https://github.com/isaacs/minimatch#windows.