### PR TITLE
[ENHANCEMENT] Disable prototype extensions by default in `app` blueprint

### DIFF
--- a/blueprints/addon/additional-package.json
+++ b/blueprints/addon/additional-package.json
@@ -7,7 +7,6 @@
   },
   "devDependencies": {
     "@embroider/test-setup": "^1.8.3",
-    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^2.0.0"
   },

--- a/blueprints/app/files/config/environment.js
+++ b/blueprints/app/files/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function (environment) {
     rootURL: '/',
     locationType: 'history',
     EmberENV: {
+      EXTEND_PROTOTYPES: false,
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true

--- a/tests/fixtures/addon/defaults-travis/package.json
+++ b/tests/fixtures/addon/defaults-travis/package.json
@@ -44,7 +44,6 @@
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^7.0.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -44,7 +44,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -44,7 +44,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",

--- a/tests/unit/blueprints/addon-test.js
+++ b/tests/unit/blueprints/addon-test.js
@@ -124,19 +124,6 @@ describe('blueprint - addon', function () {
         expect(json.keywords).to.deep.equal(['ember-addon']);
       });
 
-      it('overwrites any version of `ember-disable-prototype-extensions`', function () {
-        let output = blueprint.updatePackageJson(
-          JSON.stringify({
-            devDependencies: {
-              'ember-disable-prototype-extensions': '1.1.2',
-            },
-          })
-        );
-
-        let json = JSON.parse(output);
-        expect(json.devDependencies['ember-disable-prototype-extensions']).to.equal('^1.1.3');
-      });
-
       it('adds `scripts.test:all`', function () {
         let output = blueprint.updatePackageJson(
           JSON.stringify({
@@ -176,7 +163,6 @@ describe('blueprint - addon', function () {
         );
 
         let json = JSON.parse(output);
-        delete json.devDependencies['ember-disable-prototype-extensions'];
         delete json.devDependencies['eslint-plugin-node'];
         delete json.devDependencies['ember-try'];
         delete json.devDependencies['ember-source-channel-url'];


### PR DESCRIPTION
According to [RFC 848](https://github.com/emberjs/rfcs/pull/848).