### PR TITLE
Trap unhandled failures

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -42,4 +42,7 @@ cli({
 
   logger.info('Quitting "ember-cli" with exit code: %j', exitCode);
   exit(exitCode);
+}, function(err) {
+  console.log(err);
+  process.exit(-1);
 });


### PR DESCRIPTION
If an exception escapes from the main `cli()` function, we don't handle it. On Node < 16 that results in a successful process exit code even though the process has crashed.

On Node >= 16 this was not a bug because of the stricter handling of unhandled promise rejections.

You can demonstrate the bug by putting a string in `ember-addon.paths` in your app's package.json file. (It's supposed to be an array, and will cause a crash.)