### PR TITLE
[CLEANUP] Drop support for the `baseURL` environment option

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -58,7 +58,7 @@ module.exports = Command.extend({
     { name: 'watcher', type: String, default: 'events', aliases: ['w'] },
     { name: 'live-reload', type: Boolean, default: true, aliases: ['lr'] },
     { name: 'live-reload-host', type: String, aliases: ['lrh'], description: 'Defaults to host' },
-    { name: 'live-reload-base-url', type: String, aliases: ['lrbu'], description: 'Defaults to baseURL' },
+    { name: 'live-reload-base-url', type: String, aliases: ['lrbu'], description: 'Defaults to rootURL' },
     { name: 'live-reload-port', type: Number, aliases: ['lrp'], description: 'Defaults to same port as ember app' },
     { name: 'live-reload-prefix', type: String, default: '_lr', aliases: ['lrprefix'], description: 'Default to _lr' },
     {

--- a/lib/tasks/server/express-server.js
+++ b/lib/tasks/server/express-server.js
@@ -251,7 +251,6 @@ class ExpressServerTask extends Task {
     const config = this.project.config(options.environment);
     const middlewareOptions = Object.assign({}, options, {
       rootURL: config.rootURL,
-      baseURL: config.baseURL || '/',
     });
 
     await liveReloadServer.setupMiddleware(this.startOptions);

--- a/lib/tasks/server/middleware/broccoli-watcher/index.js
+++ b/lib/tasks/server/middleware/broccoli-watcher/index.js
@@ -27,20 +27,20 @@ class WatcherAddon {
       autoIndex: false, // disable directory listings
     });
 
-    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+    let rootURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL);
 
-    logger.info('serverMiddleware: baseURL: %s', baseURL);
+    logger.info('serverMiddleware: rootURL: %s', rootURL);
 
     app.use((req, res, next) => {
       let oldURL = req.url;
       let url = req.serveUrl || req.url;
       logger.info('serving: %s', url);
 
-      let actualPrefix = req.url.slice(0, baseURL.length - 1); // Don't care
-      let expectedPrefix = baseURL.slice(0, baseURL.length - 1); // about last slash
+      let actualPrefix = req.url.slice(0, rootURL.length - 1); // Don't care
+      let expectedPrefix = rootURL.slice(0, rootURL.length - 1); // about last slash
 
       if (actualPrefix === expectedPrefix) {
-        let urlToBeServed = url.slice(actualPrefix.length); // Remove baseURL prefix
+        let urlToBeServed = url.slice(actualPrefix.length); // Remove rootURL prefix
         req.url = urlToBeServed;
         logger.info('serving: (prefix stripped) %s, was: %s', urlToBeServed, url);
 

--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -44,8 +44,7 @@ class HistorySupportAddon {
     let app = config.app;
     let options = config.options;
     let watcher = options.watcher;
-
-    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+    let rootURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL);
 
     app.use(async (req, _, next) => {
       try {
@@ -60,7 +59,7 @@ class HistorySupportAddon {
         }
 
         if (this.shouldHandleRequest(req, options)) {
-          let assetPath = req.path.slice(baseURL.length);
+          let assetPath = req.path.slice(rootURL.length);
           let isFile = false;
 
           try {
@@ -69,7 +68,7 @@ class HistorySupportAddon {
             /* ignore */
           }
           if (!isFile) {
-            req.serveUrl = `${baseURL}index.html`;
+            req.serveUrl = `${rootURL}index.html`;
           }
         }
       } finally {
@@ -87,9 +86,9 @@ class HistorySupportAddon {
     if (!hasHTMLHeader) {
       return false;
     }
-    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
-    let baseURLRegexp = new RegExp(`^${baseURL}`);
-    return baseURLRegexp.test(req.path);
+    let rootURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL);
+    let rootURLRegexp = new RegExp(`^${rootURL}`);
+    return rootURLRegexp.test(req.path);
   }
 }
 

--- a/lib/tasks/server/middleware/testem-url-rewriter/index.js
+++ b/lib/tasks/server/middleware/testem-url-rewriter/index.js
@@ -16,16 +16,6 @@ class TestemUrlRewriterAddon {
     let config = this.project.config(env);
     logger.info('config.rootURL = %s', config.rootURL);
 
-    this.project.ui.writeDeprecateLine(
-      'Using the `baseURL` setting is deprecated, use `rootURL` instead.',
-      !(!('rootURL' in config) && config.baseURL)
-    );
-
-    this.project.ui.writeWarnLine(
-      'The `baseURL` and `rootURL` settings should not be used at the same time.',
-      !('rootURL' in config && config.baseURL)
-    );
-
     let rootURL = cleanBaseURL(config.rootURL) || '/';
     logger.info('rootURL = %s', rootURL);
 

--- a/lib/tasks/server/middleware/tests-server/index.js
+++ b/lib/tasks/server/middleware/tests-server/index.js
@@ -8,7 +8,7 @@ const logger = require('heimdalljs-logger')('ember-cli:test-server');
 module.exports = class TestsServerAddon {
   /**
    * This addon is used to serve the QUnit or Mocha test runner
-   * at `baseURL + '/tests'`.
+   * at `rootURL + '/tests'`.
    *
    * @class TestsServerAddon
    * @constructor
@@ -22,9 +22,8 @@ module.exports = class TestsServerAddon {
     let app = config.app;
     let options = config.options;
     let watcher = options.watcher;
-
-    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
-    let testsPath = `${baseURL}tests`;
+    let rootURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL);
+    let testsPath = `${rootURL}tests`;
 
     app.use(async (req, _, next) => {
       let results;
@@ -42,7 +41,7 @@ module.exports = class TestsServerAddon {
       }
 
       if (watcherSuccess) {
-        rewriteRequestUrlIfBasePageIsNeeded(req, testsPath, baseURL, results.directory);
+        rewriteRequestUrlIfBasePageIsNeeded(req, testsPath, rootURL, results.directory);
       }
 
       next();
@@ -54,7 +53,7 @@ module.exports = class TestsServerAddon {
   }
 };
 
-function rewriteRequestUrlIfBasePageIsNeeded(req, testsPath, baseURL, directory) {
+function rewriteRequestUrlIfBasePageIsNeeded(req, testsPath, rootURL, directory) {
   let acceptHeaders = req.headers.accept || [];
   let hasHTMLHeader = acceptHeaders.indexOf('text/html') !== -1;
   let hasWildcardHeader = acceptHeaders.indexOf('*/*') !== -1;
@@ -64,12 +63,12 @@ function rewriteRequestUrlIfBasePageIsNeeded(req, testsPath, baseURL, directory)
   logger.info('isForTests: %o', isForTests);
 
   if (isForTests && (hasHTMLHeader || hasWildcardHeader) && req.method === 'GET') {
-    let assetPath = req.path.slice(baseURL.length);
+    let assetPath = req.path.slice(rootURL.length);
     let filePath = path.join(directory, assetPath);
 
     if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-      // N.B., `baseURL` will end with a slash as it went through `cleanBaseURL`
-      let newURL = `${baseURL}tests/index.html`;
+      // N.B., `rootURL` will end with a slash as it went through `cleanBaseURL`
+      let newURL = `${rootURL}tests/index.html`;
       logger.info('url: %s resolved to path: %s which is not a file. Assuming %s instead', req.path, filePath, newURL);
       req.url = newURL;
     }

--- a/lib/utilities/ember-app-utils.js
+++ b/lib/utilities/ember-app-utils.js
@@ -35,24 +35,6 @@ function convertObjectToString(env) {
 }
 
 /**
- * Returns the <base> tag for index.html.
- *
- * @method calculateBaseTag
- * @param {String} baseURL
- * @param {String} locationType 'history', 'none' or 'hash'.
- * @return {String} Base tag or an empty string
- */
-function calculateBaseTag(baseURL, locationType) {
-  let normalizedBaseUrl = cleanBaseURL(baseURL);
-
-  if (locationType === 'hash') {
-    return '';
-  }
-
-  return normalizedBaseUrl ? `<base href="${normalizedBaseUrl}" />` : '';
-}
-
-/**
  * Returns the content for a specific type (section) for index.html.
  *
  * ```
@@ -90,8 +72,6 @@ function contentFor(config, match, type, options) {
 
   switch (type) {
     case 'head':
-      content.push(calculateBaseTag(config.baseURL, config.locationType));
-
       if (options.storeConfigInMeta) {
         content.push(
           `<meta name="${config.modulePrefix}/config/environment" content="${encodeURIComponent(
@@ -195,4 +175,4 @@ function configReplacePatterns(options) {
   ];
 }
 
-module.exports = { normalizeUrl, convertObjectToString, calculateBaseTag, contentFor, configReplacePatterns };
+module.exports = { normalizeUrl, convertObjectToString, contentFor, configReplacePatterns };

--- a/lib/utilities/get-serve-url.js
+++ b/lib/utilities/get-serve-url.js
@@ -4,7 +4,7 @@ const cleanBaseURL = require('clean-base-url');
 
 module.exports = function (options, project) {
   let config = project.config(options.environment);
+  let rootURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || '/');
 
-  let baseURL = config.rootURL === '' ? '/' : cleanBaseURL(config.rootURL || config.baseURL || '/');
-  return `http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
+  return `http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${rootURL}`;
 };

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -163,7 +163,7 @@ ember serve [36m<options...>[39m
     [90maliases: -lr[39m
   [36m--live-reload-host[39m [36m(String)[39m Defaults to host
     [90maliases: -lrh <value>[39m
-  [36m--live-reload-base-url[39m [36m(String)[39m Defaults to baseURL
+  [36m--live-reload-base-url[39m [36m(String)[39m Defaults to rootURL
     [90maliases: -lrbu <value>[39m
   [36m--live-reload-port[39m [36m(Number)[39m Defaults to same port as ember app
     [90maliases: -lrp <value>[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -691,7 +691,7 @@ module.exports = {
         },
         {
           aliases: ['lrbu'],
-          description: 'Defaults to baseURL',
+          description: 'Defaults to rootURL',
           key: 'liveReloadBaseUrl',
           name: 'live-reload-base-url',
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -163,7 +163,7 @@ ember serve [36m<options...>[39m
     [90maliases: -lr[39m
   [36m--live-reload-host[39m [36m(String)[39m Defaults to host
     [90maliases: -lrh <value>[39m
-  [36m--live-reload-base-url[39m [36m(String)[39m Defaults to baseURL
+  [36m--live-reload-base-url[39m [36m(String)[39m Defaults to rootURL
     [90maliases: -lrbu <value>[39m
   [36m--live-reload-port[39m [36m(Number)[39m Defaults to same port as ember app
     [90maliases: -lrp <value>[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -723,7 +723,7 @@ module.exports = {
         },
         {
           aliases: ['lrbu'],
-          description: 'Defaults to baseURL',
+          description: 'Defaults to rootURL',
           key: 'liveReloadBaseUrl',
           name: 'live-reload-base-url',
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -691,7 +691,7 @@ module.exports = {
         },
         {
           aliases: ['lrbu'],
-          description: 'Defaults to baseURL',
+          description: 'Defaults to rootURL',
           key: 'liveReloadBaseUrl',
           name: 'live-reload-base-url',
           required: false

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -38,7 +38,7 @@ class MockProject extends Project {
   config() {
     return (
       this._config || {
-        baseURL: '/',
+        rootURL: '/',
         locationType: 'history',
       }
     );

--- a/tests/unit/broccoli/default-packager/index-test.js
+++ b/tests/unit/broccoli/default-packager/index-test.js
@@ -26,7 +26,7 @@ describe('Default Packager: Index', function () {
   };
 
   let META_TAG =
-    '/best-url-ever/\n<meta name="the-best-app-ever/config/environment" content="{"rootURL":"/best-url-ever/","modulePrefix":"the-best-app-ever"}" />';
+    '/best-url-ever/<meta name="the-best-app-ever/config/environment" content="{"rootURL":"/best-url-ever/","modulePrefix":"the-best-app-ever"}" />';
 
   before(async function () {
     input = await createTempDir();

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -38,7 +38,7 @@ describe('models/project.js', function () {
       projectPath = 'tmp/test-app';
       return tmp.setup(projectPath).then(function () {
         touch(`${projectPath}/config/environment.js`, {
-          baseURL: '/foo/bar',
+          rootURL: '/foo/bar',
         });
 
         project = new Project(projectPath, {}, cli.ui, cli);
@@ -56,15 +56,15 @@ describe('models/project.js', function () {
       called = false;
       return tmp.setup(projectPath).then(function () {
         touch(`${projectPath}/config/environment.js`, {
-          baseURL: '/foo/bar',
+          rootURL: '/foo/bar',
         });
 
         touch(`${projectPath}/config/a.js`, {
-          baseURL: '/a',
+          rootURL: '/a',
         });
 
         touch(`${projectPath}/config/b.js`, {
-          baseURL: '/b',
+          rootURL: '/b',
         });
 
         makeProject();

--- a/tests/unit/models/watcher-test.js
+++ b/tests/unit/models/watcher-test.js
@@ -170,38 +170,6 @@ describe('Watcher', function () {
       expect(output[0]).to.equal(`${chalk.green('Build successful (12344ms)')} – Serving on https://localhost:1337/`);
     });
 
-    it('with baseURL', async function () {
-      let subject = (
-        await Watcher.build({
-          ui,
-          analytics,
-          builder,
-          watcher,
-          serving: true,
-          options: {
-            host: undefined,
-            port: '1337',
-            environment: 'development',
-            project: {
-              config() {
-                return {
-                  baseURL: '/foo',
-                };
-              },
-            },
-          },
-        })
-      ).watcher;
-
-      subject.didChange(mockResult);
-
-      let output = ui.output.trim().split(EOL);
-      expect(output[0]).to.equal(
-        `${chalk.green('Build successful (12344ms)')} – Serving on http://localhost:1337/foo/`
-      );
-      expect(output.length).to.equal(1, 'expected only one line of output');
-    });
-
     it('with rootURL', async function () {
       let subject = (
         await Watcher.build({

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -17,7 +17,7 @@ const WebSocket = require('websocket').w3cwebsocket;
 const FixturifyProject = require('../../../helpers/fixturify-project');
 
 function checkMiddlewareOptions(options) {
-  expect(options).to.satisfy((option) => option.baseURL || option.rootURL);
+  expect(options).to.satisfy((option) => option.rootURL);
 }
 
 function sleep(timeout) {
@@ -1012,8 +1012,7 @@ describe('express-server', function () {
 
       it('calls processAppMiddlewares upon start', function () {
         let realOptions = {
-          baseURL: '/',
-          rootURL: undefined,
+          rootURL: '/',
           host: undefined,
           port: '1337',
         };
@@ -1026,8 +1025,7 @@ describe('express-server', function () {
 
       it('calls processAppMiddlewares upon restart', function () {
         let realOptions = {
-          baseURL: '/',
-          rootURL: undefined,
+          rootURL: '/',
           host: undefined,
           port: '1337',
         };

--- a/tests/unit/tasks/server/middleware/tests-server-test.js
+++ b/tests/unit/tasks/server/middleware/tests-server-test.js
@@ -63,26 +63,6 @@ describe('TestServerAddon', function () {
       });
     });
 
-    it('allows baseURL containing `+` character', function (done) {
-      mockRequest.path = '/braden/+/tests/any-old-file';
-      mockRequest.headers.accept = ['*/*'];
-      addon.serverMiddleware({
-        app,
-        options: {
-          watcher: Promise.resolve({ directory: 'nothing' }),
-          baseURL: '/braden/+',
-        },
-        finally() {
-          try {
-            expect(mockRequest.url).to.equal('/braden/+/tests/index.html');
-            done();
-          } catch (e) {
-            done(e);
-          }
-        },
-      });
-    });
-
     it('allows rootURL containing `+` character', function (done) {
       mockRequest.path = '/grayson/+/tests/any-old-file';
       mockRequest.headers.accept = ['text/html'];

--- a/tests/unit/utilities/ember-app-utils-test.js
+++ b/tests/unit/utilities/ember-app-utils-test.js
@@ -9,7 +9,6 @@ const emberAppUtils = require('../../../lib/utilities/ember-app-utils');
 const contentFor = emberAppUtils.contentFor;
 const configReplacePatterns = emberAppUtils.configReplacePatterns;
 const normalizeUrl = emberAppUtils.normalizeUrl;
-const calculateBaseTag = emberAppUtils.calculateBaseTag;
 const convertObjectToString = emberAppUtils.convertObjectToString;
 
 describe('ember-app-utils', function () {
@@ -130,44 +129,6 @@ describe('ember-app-utils', function () {
 
         expect(output, '`<meta>` tag was not included').not.to.contain(expected);
       });
-
-      it('returns `<base>` tag if `locationType` is "auto"', function () {
-        config.locationType = 'auto';
-        config.baseURL = '/';
-
-        let expected = '<base href="/" />';
-        let output = contentFor(config, defaultMatch, 'head', defaultOptions);
-
-        expect(output, '`<base>` tag was included').to.contain(expected);
-      });
-
-      // this is required by testem
-      it('returns `<base>` tag if `locationType` is "none"', function () {
-        config.locationType = 'none';
-        config.baseURL = '/';
-
-        let output = contentFor(config, defaultMatch, 'head', defaultOptions);
-        let expected = '<base href="/" />';
-
-        expect(output, '`<base>` tag was included').to.contain(expected);
-      });
-
-      it('omits `<base>` tag if `locationType` is "hash"', function () {
-        config.locationType = 'hash';
-        config.baseURL = '/foo/bar';
-
-        let expected = '<base href="/foo/bar/" />';
-        let output = contentFor(config, defaultMatch, 'head', defaultOptions);
-
-        expect(output, '`<base>` tag was not included').to.not.contain(expected);
-      });
-
-      it('omits `<base>` tag if `baseURL` is `undefined`', function () {
-        let expected = '<base href=';
-        let output = contentFor(config, defaultMatch, 'head', defaultOptions);
-
-        expect(output, '`<base>` tag was not included').to.not.contain(expected);
-      });
     });
 
     describe('"config-module"', function () {
@@ -271,24 +232,6 @@ document.addEventListener('DOMContentLoaded', function() {
         let output = contentFor(config, defaultMatch, 'foo', options);
 
         expect(output).to.equal('blammo\nblahzorz');
-      });
-    });
-  });
-
-  describe(`calculateBaseTag`, function () {
-    ['auto', 'history'].forEach((locationType) => {
-      it(`generates a base tag correctly for location: ${locationType}`, function () {
-        expect(calculateBaseTag('/', locationType), `base tag was generated correctly`).to.equal('<base href="/" />');
-      });
-    });
-
-    it('returns an empty string if location is "hash"', function () {
-      expect(calculateBaseTag('/', 'hash'), `base tag was generated correctly`).to.equal('');
-    });
-
-    [null, undefined, ''].forEach((url) => {
-      it(`returns an empty string if the url is ${url === '' ? 'empty string' : url}`, function () {
-        expect(calculateBaseTag(url, 'hash')).to.equal('');
       });
     });
   });


### PR DESCRIPTION
`baseURL` was deprecated [a long time ago](https://github.com/ember-cli/ember-cli/pull/5792), but support for it was never cleaned up.

Closes #9877.