### PR TITLE
[CLEANUP] Drop support for using `usePods: true` and the `--pod` flag simultaneously

### DIFF
--- a/lib/commands/destroy.js
+++ b/lib/commands/destroy.js
@@ -68,7 +68,7 @@ module.exports = Command.extend({
     };
 
     if (this.settings && this.settings.usePods && !commandOptions.classic) {
-      commandOptions.pod = !commandOptions.pod;
+      commandOptions.pod = true;
     }
 
     if (commandOptions.in) {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -58,16 +58,8 @@ module.exports = Command.extend({
       args: rawArgs,
     };
 
-    if (this.settings && this.settings.usePods) {
-      if (commandOptions.pod) {
-        let warning = 'Using both .ember-cli usePods settings and --pod flag ';
-        warning += 'together has been deprecated.';
-        this.ui.writeDeprecateLine(warning);
-      }
-
-      if (!commandOptions.classic) {
-        commandOptions.pod = !commandOptions.pod;
-      }
+    if (this.settings && this.settings.usePods && !commandOptions.classic) {
+      commandOptions.pod = true;
     }
 
     if (commandOptions.in) {


### PR DESCRIPTION
This was deprecated [a long time ago](https://github.com/ember-cli/ember-cli/pull/7164), because using `usePods: true` + the `--pod` flag simultaneously, resulted in generating files the classic way, which ended up being confusing for several users. Doing this now will just generate pod files.

The corresponding test for this was already removed [here](https://github.com/ember-cli/ember-cli/commit/b507fab882253b943e02837c7f04dbfb48304957#diff-279ea62c941faa9ef35bea30675f342dabc198f7036911772058269d9fb29e2fL98-L103).

Closes #9875.