### PR TITLE
[ENHANCEMENT] Update NPM version constraints

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -26,7 +26,7 @@ class NpmTask extends Task {
     // The command to run: can be 'install' or 'uninstall'
     this.command = '';
 
-    this.versionConstraints = '3 || 4 || 5 || 6';
+    this.versionConstraints = '3 || 4 || 5 || 6 || 7 || 8';
   }
 
   get packageManagerOutputName() {

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -25,7 +25,7 @@ describe('NpmTask', function () {
     });
 
     it('resolves with warning when a newer version is found', async function () {
-      td.when(task.npm(['--version'])).thenResolve({ stdout: '7.0.0' });
+      td.when(task.npm(['--version'])).thenResolve({ stdout: '9.0.0' });
 
       await task.checkNpmVersion();
       expect(ui.output).to.contain('WARNING');


### PR DESCRIPTION
This should resolve the following warning for apps using an NPM version higher than v6:

```
WARNING: Ember CLI is using the global npm, but your npm version has not yet been verified to work with the current Ember CLI release.
```