### PR TITLE
[ENHANCEMENT] Display info message when running the `lint:fix` script post blueprint generation

### DIFF
--- a/lib/tasks/generate-from-blueprint.js
+++ b/lib/tasks/generate-from-blueprint.js
@@ -17,7 +17,7 @@ class GenerateTask extends Task {
 
     if (options.lintFix) {
       try {
-        await lintFix.run(this.ui);
+        await lintFix.run(this.project);
       } catch (error) {
         logger.error('Lint fix failed: %o', error);
       }

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -51,7 +51,7 @@ class InstallBlueprintTask extends Task {
 
     if (options.lintFix) {
       try {
-        await lintFix.run(this.ui);
+        await lintFix.run(this.project);
       } catch (error) {
         logger.error('Lint fix failed: %o', error);
       }

--- a/lib/utilities/lint-fix.js
+++ b/lib/utilities/lint-fix.js
@@ -1,26 +1,27 @@
 'use strict';
 
-const fs = require('fs-extra');
 const execa = require('../utilities/execa');
+const isYarnProject = require('../utilities/is-yarn-project');
+const prependEmoji = require('../utilities/prepend-emoji');
 
-async function run(ui) {
+async function run(project) {
   let lintFixScriptName = 'lint:fix';
-  let cwd = process.cwd();
-  let packageJson = fs.readJsonSync('package.json');
-
-  let hasLintFixScript = !!packageJson.scripts[lintFixScriptName];
+  let hasLintFixScript = Boolean(project.pkg.scripts[lintFixScriptName]);
 
   if (!hasLintFixScript) {
-    ui.writeWarnLine(
-      'Lint fix skipped: "lint:fix" not found in package.json scripts. New files might not pass linting.'
+    project.ui.writeWarnLine(
+      `Lint fix skipped: "${lintFixScriptName}" script not found in "package.json". New files might not pass linting.`
     );
 
     return;
   }
 
-  let usingYarn = fs.existsSync('yarn.lock');
+  project.ui.writeLine('');
+  project.ui.writeLine(prependEmoji('✨', `Running "${lintFixScriptName}" script...`));
 
-  if (usingYarn) {
+  let cwd = process.cwd();
+
+  if (isYarnProject(project.root)) {
     await execa('yarn', [lintFixScriptName], { cwd });
   } else {
     await execa('npm', ['run', lintFixScriptName], { cwd });


### PR DESCRIPTION
This will make it clearer that something is still happening (and what) and should also improve the perceived speed when generating blueprints.

Motivation:
- https://github.com/ember-cli/ember-cli/pull/9995
- https://discord.com/channels/480462759797063690/480501885837770763/1025092185839894578

Result:
https://user-images.githubusercontent.com/7403183/193127543-b0f5ff56-c6d7-4212-ada0-63375fe33eaa.mov