### PR TITLE
[ENHANCEMENT] Remove the `config/environment.js` file from the `addon` blueprint

### DIFF
--- a/blueprints/addon/files/addon-config/environment.js
+++ b/blueprints/addon/files/addon-config/environment.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = function (/* environment, appConfig */) {
-  return {};
-};

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -189,7 +189,6 @@ module.exports = {
     '^config.*': 'tests/dummy/:path',
     '^public.*': 'tests/dummy/:path',
 
-    '^addon-config/environment.js': 'config/environment.js',
     '^addon-config/ember-try.js': 'config/ember-try.js',
 
     '^npmignore': '.npmignore',

--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -146,7 +146,7 @@ describe('Acceptance: addon-smoke-test', function () {
       return handleError(error, 'tar');
     }
 
-    let necessaryFiles = ['package.json', 'index.js', 'LICENSE.md', 'README.md', 'config/environment.js'];
+    let necessaryFiles = ['package.json', 'index.js', 'LICENSE.md', 'README.md'];
 
     let unnecessaryFiles = [
       '.gitkeep',


### PR DESCRIPTION
Motivation:

- Most addons (that I know of) don't use or need this
- Since apps also have a `config/environment.js` file, it sometimes happens that addon authors mistakingly use this file to configure the dummy app - an unwanted side effect of this is that, the configuration also ends up in the consuming app

This doesn't mean that the file is not supported anymore of course, it's just not included by default.

Resolves part of https://github.com/ember-cli/ember-cli/issues/7486#issuecomment-811095821.