### PR TITLE
[ENHANCEMENT] Conditionally apply eslint parserOptions

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -4,11 +4,11 @@ module.exports = {
   root: true,
   parser: '<%= typescript ? '@typescript-eslint/parser' : 'babel-eslint' %>',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2018,<% if (!typescript) { %>
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,
-    },
+    },<% } %>
   },
   plugins: ['ember'<% if (typescript) { %>, '@typescript-eslint'<% } %>],
   extends: [
@@ -45,10 +45,10 @@ module.exports = {
         './server/**/*.js',<% } else { %>
         './tests/dummy/config/**/*.js',<% } %>
       ],
-      parserOptions: {
+<% if (!typescript) { %>      parserOptions: {
         sourceType: 'script',
       },
-      env: {
+<% } %>      env: {
         browser: false,
         node: true,
       },

--- a/tests/fixtures/addon/typescript/.eslintrc.js
+++ b/tests/fixtures/addon/typescript/.eslintrc.js
@@ -5,10 +5,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      legacyDecorators: true,
-    },
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [
@@ -43,9 +39,6 @@ module.exports = {
         './config/**/*.js',
         './tests/dummy/config/**/*.js',
       ],
-      parserOptions: {
-        sourceType: 'script',
-      },
       env: {
         browser: false,
         node: true,

--- a/tests/fixtures/app/typescript-embroider/.eslintrc.js
+++ b/tests/fixtures/app/typescript-embroider/.eslintrc.js
@@ -5,10 +5,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      legacyDecorators: true,
-    },
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [
@@ -43,9 +39,6 @@ module.exports = {
         './lib/*/index.js',
         './server/**/*.js',
       ],
-      parserOptions: {
-        sourceType: 'script',
-      },
       env: {
         browser: false,
         node: true,

--- a/tests/fixtures/app/typescript/.eslintrc.js
+++ b/tests/fixtures/app/typescript/.eslintrc.js
@@ -5,10 +5,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      legacyDecorators: true,
-    },
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [
@@ -43,9 +39,6 @@ module.exports = {
         './lib/*/index.js',
         './server/**/*.js',
       ],
-      parserOptions: {
-        sourceType: 'script',
-      },
       env: {
         browser: false,
         node: true,


### PR DESCRIPTION
This removes the `parserOptions` options that are not relevant for the `@typescript-eslint/parser' parser.

More information about the available options: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#configuration

Fixes #10046 