### PR TITLE
[ENHANCEMENT] Update the Prettier config in the blueprints

### DIFF
--- a/blueprints/app/files/.prettierrc.js
+++ b/blueprints/app/files/.prettierrc.js
@@ -1,5 +1,12 @@
 'use strict';
 
 module.exports = {
-  singleQuote: true,
+  overrides: [
+    {
+      files: '*.{js,ts}',
+      options: {
+        singleQuote: true,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
This updates the `.prettierrc.js` file so that it only applies the singleQuote config to `.js` (and `.ts`) files. This has the benefit that other file types will still use the default Prettier settings and apps no longer have to add config overrides to ensure that.

Closes #10061 