### PR TITLE
[BUGFIX] Fix looking up the default blueprint for scoped addons

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1508,28 +1508,20 @@ let Blueprint = CoreObject.extend({
 Blueprint.lookup = function (name, options) {
   options = options || {};
 
-  if (name.includes(path.sep)) {
-    let blueprintPath = path.resolve(name);
-    let isNameAPath = Boolean(blueprintPath);
-
-    if (isNameAPath) {
-      if (Blueprint._existsSync(blueprintPath)) {
-        return Blueprint.load(blueprintPath, options.blueprintOptions);
-      }
-
-      if (!options.ignoreMissing) {
-        throw new SilentError(`Unknown blueprint: ${name}`);
-      }
-
-      return;
-    }
-  }
-
   let lookupPaths = generateLookupPaths(options.paths);
 
   let lookupPath;
   for (let i = 0; (lookupPath = lookupPaths[i]); i++) {
     let blueprintPath = path.resolve(lookupPath, name);
+
+    if (Blueprint._existsSync(blueprintPath)) {
+      return Blueprint.load(blueprintPath, options.blueprintOptions);
+    }
+  }
+
+  // Check if `name` itself is a path to a blueprint:
+  if (name.includes(path.sep)) {
+    let blueprintPath = path.resolve(name);
 
     if (Blueprint._existsSync(blueprintPath)) {
       return Blueprint.load(blueprintPath, options.blueprintOptions);

--- a/tests/acceptance/addon-generate-test.js
+++ b/tests/acceptance/addon-generate-test.js
@@ -143,4 +143,17 @@ describe('Acceptance: ember generate in-addon', function () {
     await generateInAddon(['server']);
     expect(file('server/index.js')).to.exist;
   });
+
+  it('successfully generates the default blueprint for scoped addons', async function () {
+    await initAddon('@foo/bar');
+    await ember(['g', 'blueprint', '@foo/bar']);
+    await fs.outputFile('blueprints/@foo/bar/files/__name__.js', '');
+    await ember(['g', '@foo/bar', 'baz']);
+
+    expect(file('baz.js')).to.exist;
+  });
+
+  it(`throws the unknown blueprint error when \`name\` matches a folder's name, but doesn't include the \`${path.sep}\` char`, async function () {
+    await expect(generateInAddon(['tests'])).to.be.rejectedWith('Unknown blueprint: tests');
+  });
 });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -234,4 +234,17 @@ describe('Acceptance: ember generate', function () {
 
     td.verify(lintFixStub(), { ignoreExtraArgs: true, times: 1 });
   });
+
+  it('successfully generates a blueprint with a scoped name', async function () {
+    await initApp();
+    await ember(['g', 'blueprint', '@foo/bar']);
+    await outputFile('blueprints/@foo/bar/files/__name__.js', '');
+    await ember(['g', '@foo/bar', 'baz']);
+
+    expect(file('baz.js')).to.exist;
+  });
+
+  it(`throws the unknown blueprint error when \`name\` matches a folder's name, but doesn't include the \`${path.sep}\` char`, async function () {
+    await expect(generate(['tests'])).to.be.rejectedWith('Unknown blueprint: tests');
+  });
 });


### PR DESCRIPTION
Fixes #10090 by checking if addon name starts with '@'