### PR TITLE
[INTERNAL] Fix tests related to generating blueprints using a path instead of a name

### DIFF
--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -101,9 +101,11 @@ describe('Acceptance: ember destroy', function () {
     return assertDestroyAfterGenerate(commandArgs, files);
   });
 
-  it('deletes files generated using blueprint paths', function () {
-    let commandArgs = [`${__dirname}/../../blueprints/http-proxy`, 'foo', 'bar'];
-    let files = ['server/proxies/foo.js'];
+  it('deletes files generated using blueprint paths', async function () {
+    await fs.outputFile('path/to/blueprints/foo/files/foo/__name__.js', "console.log('bar');\n");
+
+    let commandArgs = [path.join('path', 'to', 'blueprints', 'foo'), 'bar'];
+    let files = ['foo/bar.js'];
 
     return assertDestroyAfterGenerate(commandArgs, files);
   });

--- a/tests/acceptance/generate-test.js
+++ b/tests/acceptance/generate-test.js
@@ -145,13 +145,10 @@ describe('Acceptance: ember generate', function () {
   });
 
   it('allows a path to be specified to a blueprint', async function () {
-    await outputFile(
-      'blueprints/http-proxy/files/server/proxies/__name__.js',
-      "import Ember from 'ember';\n" + 'export default Ember.Object.extend({ foo: true });\n'
-    );
-    await generate([path.resolve(`${__dirname}/../../blueprints/http-proxy`), 'foo', 'http://localhost:5000']);
+    await outputFile('path/to/blueprints/foo/files/foo/__name__.js', "console.log('bar');\n");
+    await generate([path.join('path', 'to', 'blueprints', 'foo'), 'bar']);
 
-    expect(file('server/index.js')).to.not.contain('foo: true', 'the local blueprint is not used');
+    expect(file('foo/bar.js')).to.contain("console.log('bar');\n");
   });
 
   it('passes custom cli arguments to blueprint options', async function () {


### PR DESCRIPTION
These tests were added in #9387, but they actually pass _with_ and _without_ [the added code](https://github.com/ember-cli/ember-cli/pull/9387/files#diff-0be5f01e6d22431d64f3da013c8f82658807a994ab75b368a150da89220585d2R1321-R1336), which makes them unreliable and makes it hard to know if the added code actually does what it's supposed to.

This was uncovered when reviewing #10091.