### PR TITLE
[BUGFIX release] Correctly instantiate `Watcher` instance when running `ember test --serve`

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -182,13 +182,15 @@ module.exports = Command.extend({
         session = this.runTask('TestServer', testOptions);
       } else {
         let builder = new this.Builder(testOptions);
-        testOptions.watcher = new this.Watcher(
-          Object.assign(this._env(), {
-            builder,
-            verbose: false,
-            options: commandOptions,
-          })
-        );
+        testOptions.watcher = (
+          await this.Watcher.build(
+            Object.assign(this._env(), {
+              builder,
+              verbose: false,
+              options: commandOptions,
+            })
+          )
+        ).watcher;
         session = this.runTask('TestServer', testOptions).finally(() => builder.cleanup());
       }
     } else if (hasBuild) {

--- a/tests/unit/commands/test-test.js
+++ b/tests/unit/commands/test-test.js
@@ -188,7 +188,11 @@ describe('test command', function () {
           buildCleanupWasCalled = true;
         },
       });
-      options.Watcher = CoreObject.extend();
+      options.Watcher = class Watcher extends CoreObject {
+        static build() {
+          return { watcher: new this(...arguments) };
+        }
+      };
 
       buildCommand();
     });


### PR DESCRIPTION
Closes #10100.