### PR TITLE
[INTERNAL] Remove `greenkeeper` entry from `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,9 +173,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "greenkeeper": {
-    "ignore": []
-  },
   "release-it": {
     "hooks": {
       "after:release": "node ./dev/update-output-repos.js"


### PR DESCRIPTION
Not used anymore.