### PR TITLE
[INTERNAL] Remove `BROCCOLI_WATCHER` from deprecated experiments

### DIFF
--- a/lib/experiments/index.js
+++ b/lib/experiments/index.js
@@ -3,7 +3,7 @@
 const chalk = require('chalk');
 const availableExperiments = Object.freeze(['PACKAGER', 'EMBROIDER', 'CLASSIC']);
 
-const deprecatedExperiments = Object.freeze(['BROCCOLI_WATCHER', 'PACKAGER']);
+const deprecatedExperiments = Object.freeze(['PACKAGER']);
 const enabledExperiments = Object.freeze([]);
 const deprecatedExperimentsDeprecationsIssued = [];
 


### PR DESCRIPTION
This experiment was enabled by default in https://github.com/ember-cli/ember-cli/pull/8906.
I don't think it was supposed to be added to `deprecatedExperiments`.