### PR TITLE
[BUGFIX release] Correctly instantiate server watcher

### DIFF
--- a/lib/models/server-watcher.js
+++ b/lib/models/server-watcher.js
@@ -3,11 +3,13 @@
 const Watcher = require('./watcher');
 
 module.exports = class ServerWatcher extends Watcher {
-  constructor(options, build) {
-    super(options, build);
+  static async build(options, build) {
+    let { watcher: instance } = await super.build(options, build);
 
-    this.watcher.on('add', this.didAdd.bind(this));
-    this.watcher.on('delete', this.didDelete.bind(this));
+    instance.watcher.on('add', instance.didAdd.bind(instance));
+    instance.watcher.on('delete', instance.didDelete.bind(instance));
+
+    return { watcher: instance };
   }
 
   constructBroccoliWatcher(options) {

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -69,12 +69,14 @@ class ServeTask extends Task {
     let serverRoot = './server';
     let serverWatcher = null;
     if (fs.existsSync(serverRoot)) {
-      serverWatcher = new ServerWatcher({
-        ui: this.ui,
-        analytics: this.analytics,
-        watchedDir: path.resolve(serverRoot),
-        options,
-      });
+      serverWatcher = (
+        await ServerWatcher.build({
+          ui: this.ui,
+          analytics: this.analytics,
+          watchedDir: path.resolve(serverRoot),
+          options,
+        })
+      ).watcher;
     }
 
     let expressServer =

--- a/tests/unit/models/server-watcher-test.js
+++ b/tests/unit/models/server-watcher-test.js
@@ -17,10 +17,17 @@ describe('Server Watcher', function () {
     analytics = new MockAnalytics();
     watcher = new MockServerWatcher();
 
-    await ServerWatcher.build({
+    class ServerWatcherMock extends ServerWatcher {
+      setupBroccoliWatcher() {
+        this.watcher = watcher;
+
+        return super.setupBroccoliWatcher(...arguments);
+      }
+    }
+
+    await ServerWatcherMock.build({
       ui,
       analytics,
-      watcher,
     });
   });
 


### PR DESCRIPTION
Fixes:

```
instantiate Watcher with (await Watcher.build()).watcher, not new Watcher()
```

when running:

```
ember s
```

in a project that has a `server` directory.

Similar to https://github.com/ember-cli/ember-cli/pull/10101.