### PR TITLE
Modify test so it no longer causes some subsequent tests to fail

### DIFF
--- a/tests/acceptance/addon-smoke-test-slow.js
+++ b/tests/acceptance/addon-smoke-test-slow.js
@@ -7,7 +7,6 @@ const execa = require('execa');
 const chalk = require('chalk');
 
 const runCommand = require('../helpers/run-command');
-const ember = require('../helpers/ember');
 const copyFixtureFiles = require('../helpers/copy-fixture-files');
 const acceptance = require('../helpers/acceptance');
 let createTestTargets = acceptance.createTestTargets;
@@ -59,8 +58,9 @@ describe('Acceptance: addon-smoke-test', function () {
     expect(packageContents['ember-addon']).to.deep.equal({ configPath: 'tests/dummy/config' });
   });
 
-  it('ember addon foo, clean from scratch', function () {
-    return ember(['test']);
+  it('ember addon foo, clean from scratch', async function () {
+    let result = await runCommand('node_modules/ember-cli/bin/ember', 'test');
+    expect(result.code).to.eql(0);
   });
 
   it('works in most common scenarios for an example addon', async function () {


### PR DESCRIPTION
The test `ember addon foo, clean from scratch` when run before 5 tests in `smoke-test-slow` causes those tests to fail, but only when it uses the `ember` helper. This switch to use `runCommand` allows the test suite to pass.

Fixes #10112 