### PR TITLE
Add @ember/string as a dependency of projects

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1<% if (embroider) { %>",
     "@embroider/compat": "^2.0.2",
     "@embroider/core": "^2.0.2",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -52,7 +52,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0<% if (welcome) { %>",
     "ember-welcome-page": "^6.2.0<% } %>",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^2.0.2",
     "@glimmer/component": "^1.1.2",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -48,7 +48,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.2.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^2.0.2",
     "@glimmer/component": "^1.1.2",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -48,7 +48,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.2.0",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -46,7 +46,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "ember-welcome-page": "^6.2.0",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -49,7 +49,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "eslint": "^7.32.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/compat": "^2.0.2",
     "@embroider/core": "^2.0.2",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -49,7 +49,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "ember-welcome-page": "^6.2.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/compat": "^2.0.2",
     "@embroider/core": "^2.0.2",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -49,7 +49,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "ember-welcome-page": "^6.2.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/compat": "^2.0.2",
     "@embroider/core": "^2.0.2",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -46,7 +46,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "eslint": "^7.32.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -46,7 +46,7 @@
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
-    "ember-resolver": "^8.0.3",
+    "ember-resolver": "^10.0.0",
     "ember-source": "~4.10.0-beta.2",
     "ember-template-lint": "^5.2.0",
     "ember-welcome-page": "^6.2.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
This is required as 4.10 of ember-source deprecates the included `@ember/string`, and so `@ember/string` has been added as a peer dependency of `ember-resolver`. 

See https://github.com/emberjs/rfcs/pull/892