### PR TITLE
[ENHANCEMENT] Update `ember-cli-babel` to v8 in `app` and `addon` blueprints

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -56,6 +56,11 @@ module.exports = {
     contents.dependencies['ember-cli-babel'] = contents.devDependencies['ember-cli-babel'];
     delete contents.devDependencies['ember-cli-babel'];
 
+    // Addons must bring in their own version of `@babel/core`
+    // when using `ember-cli-babel` >= v8.
+    contents.dependencies['@babel/core'] = contents.devDependencies['@babel/core'];
+    delete contents.devDependencies['@babel/core'];
+
     // Move ember-cli-htmlbars into the dependencies of the addon blueprint by default
     // to prevent error:
     // `Addon templates were detected but there are no template compilers registered for (addon-name)`

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,6 +26,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "<% if (!typescript) { %>@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "<% } %>@ember/optional-features": "^2.0.0",
@@ -74,7 +75,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -28,7 +28,8 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.11",
+    "@babel/core": "^7.22.10",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-htmlbars": "^6.2.0"
   },
   "devDependencies": {

--- a/tests/fixtures/addon/pnpm/package.json
+++ b/tests/fixtures/addon/pnpm/package.json
@@ -28,7 +28,8 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.11",
+    "@babel/core": "^7.22.10",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-htmlbars": "^6.2.0"
   },
   "devDependencies": {

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -46,7 +46,8 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.11",
+    "@babel/core": "^7.22.10",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-htmlbars": "^6.2.0"
   },
   "devDependencies": {

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -28,7 +28,8 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.11",
+    "@babel/core": "^7.22.10",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-htmlbars": "^6.2.0"
   },
   "devDependencies": {

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -37,7 +38,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -40,7 +41,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -40,7 +41,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -40,7 +41,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -40,7 +41,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -37,7 +38,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/pnpm/package.json
+++ b/tests/fixtures/app/pnpm/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -37,7 +38,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -26,6 +26,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.2.0",
@@ -72,7 +73,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -26,6 +26,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.2.0",
@@ -69,7 +70,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -25,6 +25,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.10",
     "@babel/eslint-parser": "^7.22.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
     "@ember/optional-features": "^2.0.0",
@@ -37,7 +38,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli": "~<%= emberCLIVersion %>",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-babel": "^7.26.11",
+    "ember-cli-babel": "^8.0.0",
     "ember-cli-clean-css": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.2.0",


### PR DESCRIPTION
Mainly opening to see how CI will respond.

Closes https://github.com/ember-cli/ember-cli/issues/9933.
Closes https://github.com/ember-cli/ember-cli/pull/9934.
~~Closes https://github.com/babel/ember-cli-babel/issues/453.~~