### PR TITLE
[ENHANCEMENT] Remove NPM version checking

### DIFF
--- a/lib/tasks/npm-task.js
+++ b/lib/tasks/npm-task.js
@@ -25,8 +25,6 @@ class NpmTask extends Task {
 
     // The command to run: can be 'install' or 'uninstall'
     this.command = '';
-
-    this.versionConstraints = '3 || 4 || 5 || 6 || 7 || 8';
   }
 
   get packageManagerOutputName() {
@@ -114,24 +112,6 @@ class NpmTask extends Task {
       let result = await this.npm(['--version']);
       let version = result.stdout;
       logger.info('npm --version: %s', version);
-
-      let ok = semver.satisfies(version, this.versionConstraints);
-      if (!ok) {
-        logger.warn('npm --version is outside of version constraint: %s', this.versionConstraints);
-
-        let below = semver.ltr(version, this.versionConstraints);
-        if (below) {
-          throw new SilentError(
-            'Ember CLI is now using the global npm, but your npm version is outdated.\n' +
-              'Please update your global npm version by running: npm install -g npm'
-          );
-        }
-
-        this.ui.writeWarnLine(
-          'Ember CLI is using the global npm, but your npm version has not yet been ' +
-            'verified to work with the current Ember CLI release.'
-        );
-      }
 
       return { name: 'npm', version };
     } catch (error) {

--- a/tests/unit/tasks/npm-task-test.js
+++ b/tests/unit/tasks/npm-task-test.js
@@ -24,22 +24,6 @@ describe('NpmTask', function () {
       expect(ui.errors).to.be.empty;
     });
 
-    it('resolves with warning when a newer version is found', async function () {
-      td.when(task.npm(['--version'])).thenResolve({ stdout: '9.0.0' });
-
-      await task.checkNpmVersion();
-      expect(ui.output).to.contain('WARNING');
-      expect(ui.errors).to.be.empty;
-    });
-
-    it('rejects when an older version is found', async function () {
-      td.when(task.npm(['--version'])).thenResolve({ stdout: '2.9.9' });
-
-      await expect(task.checkNpmVersion()).to.be.rejectedWith(SilentError, /npm install -g npm/);
-      expect(ui.output).to.be.empty;
-      expect(ui.errors).to.be.empty;
-    });
-
     it('rejects when npm is not found', async function () {
       let error = new Error('npm not found');
       error.code = 'ENOENT';
@@ -50,14 +34,6 @@ describe('NpmTask', function () {
         SilentError,
         /instructions at https:\/\/github.com\/npm\/npm/
       );
-      expect(ui.output).to.be.empty;
-      expect(ui.errors).to.be.empty;
-    });
-
-    it('rejects when npm returns an unreadable version', async function () {
-      td.when(task.npm(['--version'])).thenResolve({ stdout: '5' });
-
-      await expect(task.checkNpmVersion()).to.be.rejectedWith(TypeError, /Invalid Version/);
       expect(ui.output).to.be.empty;
       expect(ui.errors).to.be.empty;
     });


### PR DESCRIPTION
Resolves:

```
WARNING: Ember CLI is using the global npm, but your npm version has not yet been verified to work with the current Ember CLI release.
```

for all future majors.