### PR TITLE
[ENHANCEMENT] Remove `app.import` comment in `app` blueprint

### DIFF
--- a/blueprints/app/files/ember-cli-build.js
+++ b/blueprints/app/files/ember-cli-build.js
@@ -7,19 +7,6 @@ module.exports = function (defaults) {
     // Add options here
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   <% if (embroider) { %>const { Webpack } = require('@embroider/webpack');
   return require('@embroider/compat').compatBuild(app, Webpack, {
     skipBabel: [

--- a/tests/fixtures/app/defaults/ember-cli-build.js
+++ b/tests/fixtures/app/defaults/ember-cli-build.js
@@ -7,18 +7,5 @@ module.exports = function (defaults) {
     // Add options here
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   return app.toTree();
 };

--- a/tests/fixtures/app/embroider/ember-cli-build.js
+++ b/tests/fixtures/app/embroider/ember-cli-build.js
@@ -7,19 +7,6 @@ module.exports = function (defaults) {
     // Add options here
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   const { Webpack } = require('@embroider/webpack');
   return require('@embroider/compat').compatBuild(app, Webpack, {
     skipBabel: [

--- a/tests/fixtures/app/nested-project/actual-project/ember-cli-build.js
+++ b/tests/fixtures/app/nested-project/actual-project/ember-cli-build.js
@@ -7,18 +7,5 @@ module.exports = function (defaults) {
     // Add options here
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   return app.toTree();
 };

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/ember-cli-build.js
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/ember-cli-build.js
@@ -7,18 +7,5 @@ module.exports = function (defaults) {
     // Add options here
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   return app.toTree();
 };


### PR DESCRIPTION
Seems like something we should not include / recommend anymore.
Do we want / need to include something else instead?