### PR TITLE
[ENHANCEMENT] Don't delete the newly-generated app directory when an error occurs

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs-extra');
 const chalk = require('chalk');
 const Command = require('../models/command');
 const Project = require('../models/project');
@@ -115,7 +114,7 @@ module.exports = Command.extend({
       project: Project.nullProject(this.ui, this.cli),
     });
 
-    let opts = await this.runTask('CreateAndStepIntoDirectory', {
+    await this.runTask('CreateAndStepIntoDirectory', {
       projectName,
       directoryName: commandOptions.directory,
       dryRun: commandOptions.dryRun,
@@ -123,17 +122,6 @@ module.exports = Command.extend({
 
     initCommand.project.root = process.cwd();
 
-    try {
-      let response = await initCommand.run(commandOptions, rawArgs);
-      return response;
-    } catch (err) {
-      let { initialDirectory, projectDirectory } = opts;
-
-      process.chdir(initialDirectory);
-      await fs.remove(projectDirectory);
-
-      console.log(chalk.red(`Error creating new application. Removing generated directory \`./${projectDirectory}\``));
-      throw err;
-    }
+    return await initCommand.run(commandOptions, rawArgs);
   },
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -346,15 +346,6 @@ describe('Acceptance: ember new', function () {
     expect(dir('.git')).to.exist;
   });
 
-  it('ember new cleans up after itself on error', async function () {
-    fs.mkdirsSync('my_blueprint');
-    fs.writeFileSync('my_blueprint/index.js', 'throw("this will break");');
-
-    await ember(['new', 'foo', '--skip-npm', '--skip-bower', '--skip-git', '--blueprint=./my_blueprint']);
-
-    expect(dir('foo')).to.not.exist;
-  });
-
   it('ember new with --dry-run does not create new directory', async function () {
     await ember(['new', 'foo', '--dry-run']);
 


### PR DESCRIPTION
If anything fails during app generation, the entire app gets deleted. This means you can't debug what went wrong.

It's especially painful when generating anything that has a typescript type-checking step in its postinstall (like the `@embroider/addon-blueprint`), because if any type errors leak in due to dependency drift you have no way to move forward without patching this `fm.remove` out of ember-cli.