### PR TITLE
[ENHANCEMENT] Update `ember-welcome-page` to v7 in `app` blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -58,7 +58,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2<% if (welcome) { %>",
-    "ember-welcome-page": "^7.0.0<% } %>",
+    "ember-welcome-page": "^7.0.1<% } %>",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -58,7 +58,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2<% if (welcome) { %>",
-    "ember-welcome-page": "^6.2.0<% } %>",
+    "ember-welcome-page": "^7.0.0<% } %>",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -56,7 +56,7 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.3.2",
     "ember-try": "^2.0.0",
-    "ember-welcome-page": "^6.2.0",
+    "ember-welcome-page": "^7.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -56,7 +56,7 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.3.2",
     "ember-try": "^2.0.0",
-    "ember-welcome-page": "^7.0.0",
+    "ember-welcome-page": "^7.0.1",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^6.2.0",
+    "ember-welcome-page": "^7.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^7.0.0",
+    "ember-welcome-page": "^7.0.1",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -54,7 +54,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^7.0.0",
+    "ember-welcome-page": "^7.0.1",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -54,7 +54,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^6.2.0",
+    "ember-welcome-page": "^7.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -54,7 +54,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^7.0.0",
+    "ember-welcome-page": "^7.0.1",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -54,7 +54,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^6.2.0",
+    "ember-welcome-page": "^7.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^6.2.0",
+    "ember-welcome-page": "^7.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.11.0-beta.1",
     "ember-template-lint": "^5.3.2",
-    "ember-welcome-page": "^7.0.0",
+    "ember-welcome-page": "^7.0.1",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-ember": "^11.4.3",


### PR DESCRIPTION
## Description

Just [released `ember-welcome-page@v7.0.0`](https://github.com/ember-cli/ember-welcome-page/blob/v7.0.0/CHANGELOG.md#v700-2023-02-13) (a major version because support for Node 12 and Ember 3.24 had been dropped). Let's see if we can include the new version to the blueprint.