### PR TITLE
[CLEANUP] Drop support for the `EMBER_CLI_ERROR_ON_INVALID_ADDON` env flag

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -412,11 +412,7 @@ class PackageInfo {
         });
       }
 
-      if (process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON) {
-        throw msg;
-      } else {
-        this.cache.ui.writeWarnLine(msg);
-      }
+      throw msg;
     }
   }
 

--- a/tests/fixtures/addon/with-app-styles/package.json
+++ b/tests/fixtures/addon/with-app-styles/package.json
@@ -4,10 +4,7 @@
   "dependencies": {
     "something-else": "latest"
   },
-  "ember-addon": {
-    "paths": ["./lib/ember-super-button"]
-  },
-    "devDependencies": {
+  "devDependencies": {
     "ember-resolver": "^7.0.0",
     "ember-cli": "latest",
     "ember-random-addon": "latest",

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -259,18 +259,9 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
 
       afterEach(function () {
         fixturifyProject.dispose();
-        delete process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON;
       });
 
-      it('shows a warning with invalid ember-addon#path', function () {
-        project.discoverAddons();
-        expect(project.cli.ui.output).to.include(
-          `specifies an invalid, malformed or missing addon at relative path 'lib${path.sep}no-such-path'`
-        );
-      });
-
-      it('throws an error with flag on', function () {
-        process.env.EMBER_CLI_ERROR_ON_INVALID_ADDON = 'true';
+      it('throws an error', function () {
         expect(() => project.discoverAddons()).to.throw(
           /specifies an invalid, malformed or missing addon at relative path 'lib[\\/]no-such-path'/
         );


### PR DESCRIPTION
Having an invalid addon path in `ember-addon.paths` will now always throw an error instead of a warning.