### PR TITLE
[ENHANCEMENT] Update ESLint parser `ecmaVersion` to `latest` in `app` blueprint

### DIFF
--- a/blueprints/app/files/.eslintrc.js
+++ b/blueprints/app/files/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '<%= typescript ? '@typescript-eslint/parser' : '@babel/eslint-parser' %>',
   parserOptions: {
-    ecmaVersion: 2018,<% if (!typescript) { %>
+    ecmaVersion: 'latest',<% if (!typescript) { %>
     sourceType: 'module',
     requireConfigFile: false,
     babelOptions: {

--- a/tests/fixtures/addon/.eslintrc.js
+++ b/tests/fixtures/addon/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
     sourceType: 'module',
     requireConfigFile: false,
     babelOptions: {

--- a/tests/fixtures/addon/typescript/.eslintrc.js
+++ b/tests/fixtures/addon/typescript/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [

--- a/tests/fixtures/app/.eslintrc.js
+++ b/tests/fixtures/app/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
     sourceType: 'module',
     requireConfigFile: false,
     babelOptions: {

--- a/tests/fixtures/app/typescript-embroider/.eslintrc.js
+++ b/tests/fixtures/app/typescript-embroider/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [

--- a/tests/fixtures/app/typescript/.eslintrc.js
+++ b/tests/fixtures/app/typescript/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
   },
   plugins: ['ember', '@typescript-eslint'],
   extends: [

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.eslintrc.js
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
     sourceType: 'module',
     requireConfigFile: false,
     babelOptions: {


### PR DESCRIPTION
There's no particular reason we should still be using the 2018 version of the parser. This should be forward-compatible, and we certainly would want new application to run against the latest parser.