### PR TITLE
[BUGFIX] The `addon` command should throw when no addon name is provided

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const SilentError = require('silent-error');
 const NewCommand = require('./new');
 
 module.exports = NewCommand.extend({
@@ -30,4 +31,16 @@ module.exports = NewCommand.extend({
   ],
 
   anonymousOptions: ['<addon-name>'],
+
+  run(commandOptions, commandArguments) {
+    let addonName = commandArguments[0];
+
+    if (addonName) {
+      return this._super(commandOptions, commandArguments);
+    }
+
+    return Promise.reject(
+      new SilentError('The `ember addon` command requires a name to be specified. For more details, run `ember help`.')
+    );
+  },
 });

--- a/tests/unit/commands/addon-test.js
+++ b/tests/unit/commands/addon-test.js
@@ -78,6 +78,12 @@ describe('addon command', function () {
     });
   });
 
+  it('throws when no addon name is provided', async function () {
+    expect(command.validateAndRun([])).to.be.rejectedWith(
+      'The `ember addon` command requires a name to be specified. For more details, run `ember help`.'
+    );
+  });
+
   it('registers blueprint options in beforeRun', function () {
     td.replace(Blueprint, 'lookup', td.function());
 


### PR DESCRIPTION
At the moment, when you run the `addon` command _without_ providing an addon name, it triggers the interactive-new flow, because the `addon` command extends the `new` command. According to https://github.com/emberjs/rfcs/pull/638, the `addon` command should never trigger the interactive-new flow. This means we should error when no addon name is provided [like we used to](https://github.com/bertdeblock/ember-cli/blob/5c26dc268f7da33b9ee3519d3ac85c03771783ae/lib/commands/new.js#L56-L60).