### PR TITLE
[CLEANUP] Remove default `minifyJS` options

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -67,7 +67,6 @@ class EmberApp {
    - autoRun, defaults to `true`
    - outputPaths, defaults to `{}`
    - minifyCSS, defaults to `{enabled: !!isProduction,options: { relativeTo: 'assets' }}
-   - minifyJS, defaults to `{enabled: !!isProduction}
    - sourcemaps, defaults to `{}`
    - trees, defaults to `{}`
    - vendorFiles, defaults to `{}`
@@ -274,23 +273,6 @@ class EmberApp {
       minifyCSS: {
         enabled: this.isProduction,
         options: { processImport: false },
-      },
-      // TODO: remove this with a deprecation (nothing in the default app/addon setup consumes it)
-      minifyJS: {
-        enabled: this.isProduction,
-        options: {
-          compress: {
-            // this is adversely affects heuristics for IIFE eval
-            // eslint-disable-next-line camelcase
-            negate_iife: false,
-            // limit sequences because of memory issues during parsing
-            sequences: 30,
-          },
-          output: {
-            // no difference in size and much easier to debug
-            semicolons: false,
-          },
-        },
       },
       outputPaths: {
         app: {

--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1346,7 +1346,6 @@ let addonProto = {
 
     - Modifying configuration options (see list of defaults [here](https://github.com/ember-cli/ember-cli/blob/v2.4.3/lib/broccoli/ember-app.js#L163))
       - For example
-        - `minifyJS`
         - `storeConfigInMeta`
         - et, al
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -547,27 +547,20 @@ describe('EmberApp', function () {
           project,
         },
         {
-          minifyJS: {
+          minifyCSS: {
             enabled: true,
             options: {
-              exclusions: ['hey', 'you'],
+              processImport: true,
             },
           },
         }
       );
 
-      expect(app.options.minifyJS).to.deep.equal({
+      expect(app.options.minifyCSS).to.deep.equal({
         enabled: true,
         options: {
-          exclusions: ['hey', 'you'],
-          compress: {
-            // eslint-disable-next-line camelcase
-            negate_iife: false,
-            sequences: 30,
-          },
-          output: {
-            semicolons: false,
-          },
+          processImport: true,
+          relativeTo: 'assets',
         },
       });
     });


### PR DESCRIPTION
These used to be used by, for example, `ember-cli-uglify` [a very long time ago](https://github.com/ember-cli/ember-cli-terser/blob/v1.2.0/index.js#L12-L13).
Use of the `minifyJS` options object was removed here: https://github.com/ember-cli/ember-cli-terser/pull/17.
At this point, it should be safe to just remove it. Users can still re-add it manually in their `ember-cli-build.js` file if really needed, but I doubt this will be needed for users updating to ember-cli v5?