### PR TITLE
Automate output repos

### DIFF
--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -29,6 +29,10 @@ on:
 #  GITHUB_REF_NAME - github.ref_name - <tag-name>
 #  GITHUB_REF_TYPE - github.ref_type - branch or tag
 
+env:
+  GIT_NAME: 'github-actions[bot]'
+  GIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+
 jobs:
   push-addon-app:
     name: "Push to addon/app output repos"
@@ -43,6 +47,11 @@ jobs:
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
+      - name: "Configure Git"
+        run: |
+          git config --unset-all http.https://github.com/.extraheader
+          git config user.name ${{ env.GIT_NAME }}
+          git config user.email ${{ env.GIT_EMAIL }}
       - run: node ./dev/update-output-repos.js
 
   push-editors:
@@ -58,4 +67,9 @@ jobs:
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
+      - name: "Configure Git"
+        run: |
+          git config --unset-all http.https://github.com/.extraheader
+          git config user.name ${{ env.GIT_NAME }}
+          git config user.email ${{ env.GIT_EMAIL }}
       - run: node ./dev/update-editor-output-repos.js

--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -1,0 +1,61 @@
+# This Workflow requires a GITHUB_AUTH token that can push to the editor output repos
+# - https://github.com/ember-cli/ember-addon-output
+# - https://github.com/ember-cli/ember-new-output
+# - https://github.com/ember-cli/editor-output
+#
+# NOTE:
+#   ember-addon-output and ember-new-output have tags for each release, as well as branches
+#   for each lts, master (beta), and stable (release)
+#
+#   editor-output has a branch per-editor / scenario.
+#   so branches form the pattern ${service}-{addon|app}-output{-typescript ?}
+name: Sync Output Repos
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  push:
+    # for addon and new output
+    tags:
+      - 'v*'
+    # for editor output
+    branches:
+      - 'release-*'
+
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+# https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+#
+#  GITHUB_REF      - github.ref      - refs/tags/<tag-name>
+#  GITHUB_REF_NAME - github.ref_name - <tag-name>
+#  GITHUB_REF_TYPE - github.ref_type - branch or tag
+
+jobs:
+  push-addon-app:
+    name: "Push to addon/app output repos"
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: node ./dev/update-output-repos.js
+
+  push-editors:
+    name: "Push to editor output repos"
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: node ./dev/update-editor-output-repos.js

--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -60,6 +60,7 @@ jobs:
     if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         variant: ["javascript", "typescript"]
 

--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -56,9 +56,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   push-editors:
-    name: "Push to editor output repos"
+    name: "Push to editor output repos (${{ matrix.variant }})"
     if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: ["javascript", "typescript"]
+
 
     steps:
       - uses: actions/checkout@v3
@@ -72,13 +76,8 @@ jobs:
         run: |
           git config --global user.name "${{ env.GIT_NAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
-      - name: Publish JavaScript branches
+      - name: Publish ${{ matrix.variant }} branches
         run: node ./dev/update-editor-output-repos.js
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          VARIANT: javascript
-      - name: Publish TypeScript branches
-        run: node ./dev/update-editor-output-repos.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          VARIANT: typescript
+          VARIANT: ${{ matrix.variant }}

--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   GIT_NAME: 'github-actions[bot]'
-  GIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+  GIT_EMAIL: 'github-actions+bot@users.noreply.github.com'
 
 jobs:
   push-addon-app:
@@ -43,16 +43,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
       - name: "Configure Git"
         run: |
-          git config --unset-all http.https://github.com/.extraheader
-          git config user.name ${{ env.GIT_NAME }}
-          git config user.email ${{ env.GIT_EMAIL }}
+          git config --global user.name "${{ env.GIT_NAME }}"
+          git config --global user.email "${{ env.GIT_EMAIL }}"
       - run: node ./dev/update-output-repos.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   push-editors:
     name: "Push to editor output repos"
@@ -63,13 +64,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --non-interactive
       - name: "Configure Git"
         run: |
-          git config --unset-all http.https://github.com/.extraheader
-          git config user.name ${{ env.GIT_NAME }}
-          git config user.email ${{ env.GIT_EMAIL }}
-      - run: node ./dev/update-editor-output-repos.js
+          git config --global user.name "${{ env.GIT_NAME }}"
+          git config --global user.email "${{ env.GIT_EMAIL }}"
+      - name: Publish JavaScript branches
+        run: node ./dev/update-editor-output-repos.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          VARIANT: javascript
+      - name: Publish TypeScript branches
+        run: node ./dev/update-editor-output-repos.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          VARIANT: typescript

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -12,6 +12,8 @@ const isStable = !currentVersion.includes('-beta');
 const ONLINE_EDITOR_FILES = path.join(__dirname, 'online-editors');
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const VARIANT = process.env.VARIANT;
+const VALID_VARIANT = ['javascript', 'typescript'];
 
 if (!GITHUB_TOKEN) {
   throw new Error('GITHUB_TOKEN must be set');
@@ -23,73 +25,94 @@ async function updateOnlineEditorRepos() {
     return;
   }
 
-  let repo = `https://${GITHUB_TOKEN}@github.com:ember-cli/editor-output.git`;
+  if (!VALID_VARIANT.includes(VARIANT)) {
+    throw new Error(`Invalid VARIANT specified: ${VARIANT}`);
+  }
+
+  let repo = `https://${GITHUB_TOKEN}@github.com/ember-cli/editor-output.git`;
   let onlineEditors = ['stackblitz'];
-  let variants = ['javascript', 'typescript'];
 
   for (let command of ['new', 'addon']) {
-    for (let variant of variants) {
-      let isTypeScript = variant === 'typescript';
-      let branchSuffix = isTypeScript ? '-typescript' : '';
-      let tmpdir = tmp.dirSync();
-      await fs.mkdirp(tmpdir.name);
+    let isTypeScript = VARIANT === 'typescript';
+    let branchSuffix = isTypeScript ? '-typescript' : '';
+    let tmpdir = tmp.dirSync();
+    await fs.mkdirp(tmpdir.name);
 
-      let name = command === 'new' ? 'my-app' : 'my-addon';
-      let projectType = command === 'new' ? 'app' : 'addon';
+    let name = command === 'new' ? 'my-app' : 'my-addon';
+    let projectType = command === 'new' ? 'app' : 'addon';
 
-      let updatedOutputTmpDir = tmp.dirSync();
-      console.log(`Running ember ${command} ${name} (for ${variant})`);
-      await execa(
-        EMBER_PATH,
-        [command, name, `--skip-bower`, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
-        {
-          cwd: updatedOutputTmpDir.name,
-        }
-      );
+    let updatedOutputTmpDir = tmp.dirSync();
+    console.log(`Running ember ${command} ${name} (for ${VARIANT})`);
+    await execa(
+      EMBER_PATH,
+      [command, name, `--skip-bower`, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
+      {
+        cwd: updatedOutputTmpDir.name,
+        env: {
+          /**
+           * using --typescript triggers npm's peer resolution features,
+           * and since we don't know if the npm package has been released yet,
+           * (and therefor) generate the project using the local ember-cli,
+           * the ember-cli version may not exist yet.
+           *
+           * We need to tell npm to ignore peers and just "let things be".
+           * Especially since we don't actually care about npm running,
+           * and just want the typescript files to generate.
+           *
+           * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
+           */
+          // eslint-disable-next-line camelcase
+          npm_config_legacy_peer_deps: 'true',
+        },
+      }
+    );
 
-      let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
+    // node_modules is .gitignored, but since we already need to remove package-lock.json due to #10045,
+    // we may as well remove node_modules as while we're at it, just in case.
+    await execa('rm', ['-rf', 'node_modules', 'package-lock.json'], { cwd: updatedOutputTmpDir.name });
 
-      for (let onlineEditor of onlineEditors) {
-        let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
-        let outputRepoPath = path.join(tmpdir.name, 'editor-output');
+    let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
 
-        console.log(`cloning ${repo} in to ${tmpdir.name}`);
-        try {
-          await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
-            cwd: tmpdir.name,
-          });
-        } catch (e) {
-          // branch may not exist yet
-          await execa('git', ['clone', repo], {
-            cwd: tmpdir.name,
-          });
-        }
+    for (let onlineEditor of onlineEditors) {
+      let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
+      let outputRepoPath = path.join(tmpdir.name, 'editor-output');
 
-        console.log('preparing updates for online editors');
-        await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
-
-        console.log(`clearing ${repo} in ${outputRepoPath}`);
-        await execa(`git`, [`rm`, `-rf`, `.`], {
-          cwd: outputRepoPath,
+      console.log(`cloning ${repo} in to ${tmpdir.name}`);
+      try {
+        await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
+          cwd: tmpdir.name,
         });
+      } catch (e) {
+        // branch may not exist yet
+        await execa('git', ['clone', repo], {
+          cwd: tmpdir.name,
+        });
+      }
 
-        console.log('copying generated contents to output repo');
-        await fs.copy(generatedOutputPath, outputRepoPath);
+      console.log('preparing updates for online editors');
+      await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
 
-        console.log('copying online editor files');
-        await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
+      console.log(`clearing ${repo} in ${outputRepoPath}`);
+      await execa(`git`, [`rm`, `-rf`, `.`], {
+        cwd: outputRepoPath,
+      });
 
-        console.log('commiting updates');
-        await execa('git', ['add', '--all'], { cwd: outputRepoPath });
-        await execa('git', ['commit', '-m', currentVersion], { cwd: outputRepoPath });
+      console.log('copying generated contents to output repo');
+      await fs.copy(generatedOutputPath, outputRepoPath);
 
-        console.log('pushing commit');
-        try {
-          await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
-        } catch (e) {
-          // branch may not exist yet
-          await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
-        }
+      console.log('copying online editor files');
+      await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
+
+      console.log('commiting updates');
+      await execa('git', ['add', '--all'], { cwd: outputRepoPath });
+      await execa('git', ['commit', '-m', currentVersion], { cwd: outputRepoPath });
+
+      console.log('pushing commit');
+      try {
+        await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
+      } catch (e) {
+        // branch may not exist yet
+        await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
       }
     }
   }

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -90,11 +90,7 @@ async function updateOnlineEditorRepos() {
 }
 
 async function main() {
-  try {
-    await updateOnlineEditorRepos();
-  } catch (error) {
-    console.log(error);
-  }
+  await updateOnlineEditorRepos();
 }
 
 main();

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+const execa = require('execa');
+const tmp = require('tmp');
+tmp.setGracefulCleanup();
+
+const currentVersion = require('../package').version;
+const EMBER_PATH = require.resolve('../bin/ember');
+const isStable = !currentVersion.includes('-beta');
+const ONLINE_EDITOR_FILES = path.join(__dirname, 'online-editors');
+
+async function updateOnlineEditorRepos() {
+  if (!isStable) {
+    console.log(`Current version is ${currentVersion}, which is not considered stable.`);
+    return;
+  }
+
+  let repo = 'git@github.com:ember-cli/editor-output.git';
+  let onlineEditors = ['stackblitz'];
+  let variants = ['javascript', 'typescript'];
+
+  for (let command of ['new', 'addon']) {
+    for (let variant of variants) {
+      let isTypeScript = variant === 'typescript';
+      let branchSuffix = isTypeScript ? '-typescript' : '';
+      let tmpdir = tmp.dirSync();
+      await fs.mkdirp(tmpdir.name);
+
+      let name = command === 'new' ? 'my-app' : 'my-addon';
+      let projectType = command === 'new' ? 'app' : 'addon';
+
+      let updatedOutputTmpDir = tmp.dirSync();
+      console.log(`Running ember ${command} ${name} (for ${variant})`);
+      await execa(
+        EMBER_PATH,
+        [command, name, `--skip-bower`, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
+        {
+          cwd: updatedOutputTmpDir.name,
+        }
+      );
+
+      let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
+
+      for (let onlineEditor of onlineEditors) {
+        let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
+        let outputRepoPath = path.join(tmpdir.name, 'editor-output');
+
+        console.log(`cloning ${repo} in to ${tmpdir.name}`);
+        try {
+          await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
+            cwd: tmpdir.name,
+          });
+        } catch (e) {
+          // branch may not exist yet
+          await execa('git', ['clone', repo], {
+            cwd: tmpdir.name,
+          });
+        }
+
+        console.log('preparing updates for online editors');
+        await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
+
+        console.log(`clearing ${repo} in ${outputRepoPath}`);
+        await execa(`git`, [`rm`, `-rf`, `.`], {
+          cwd: outputRepoPath,
+        });
+
+        console.log('copying generated contents to output repo');
+        await fs.copy(generatedOutputPath, outputRepoPath);
+
+        console.log('copying online editor files');
+        await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
+
+        console.log('commiting updates');
+        await execa('git', ['add', '--all'], { cwd: outputRepoPath });
+        await execa('git', ['commit', '-m', currentVersion], { cwd: outputRepoPath });
+
+        console.log('pushing commit');
+        try {
+          await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
+        } catch (e) {
+          // branch may not exist yet
+          await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
+        }
+      }
+    }
+  }
+}
+
+async function main() {
+  try {
+    await updateOnlineEditorRepos();
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+main();

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -11,13 +11,19 @@ const EMBER_PATH = require.resolve('../bin/ember');
 const isStable = !currentVersion.includes('-beta');
 const ONLINE_EDITOR_FILES = path.join(__dirname, 'online-editors');
 
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!GITHUB_TOKEN) {
+  throw new Error('GITHUB_TOKEN must be set');
+}
+
 async function updateOnlineEditorRepos() {
   if (!isStable) {
     console.log(`Current version is ${currentVersion}, which is not considered stable.`);
     return;
   }
 
-  let repo = 'git@github.com:ember-cli/editor-output.git';
+  let repo = `https://${GITHUB_TOKEN}@github.com:ember-cli/editor-output.git`;
   let onlineEditors = ['stackblitz'];
   let variants = ['javascript', 'typescript'];
 

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -43,29 +43,25 @@ async function updateOnlineEditorRepos() {
 
     let updatedOutputTmpDir = tmp.dirSync();
     console.log(`Running ember ${command} ${name} (for ${VARIANT})`);
-    await execa(
-      EMBER_PATH,
-      [command, name, `--skip-bower`, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
-      {
-        cwd: updatedOutputTmpDir.name,
-        env: {
-          /**
-           * using --typescript triggers npm's peer resolution features,
-           * and since we don't know if the npm package has been released yet,
-           * (and therefor) generate the project using the local ember-cli,
-           * the ember-cli version may not exist yet.
-           *
-           * We need to tell npm to ignore peers and just "let things be".
-           * Especially since we don't actually care about npm running,
-           * and just want the typescript files to generate.
-           *
-           * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
-           */
-          // eslint-disable-next-line camelcase
-          npm_config_legacy_peer_deps: 'true',
-        },
-      }
-    );
+    await execa(EMBER_PATH, [command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])], {
+      cwd: updatedOutputTmpDir.name,
+      env: {
+        /**
+         * using --typescript triggers npm's peer resolution features,
+         * and since we don't know if the npm package has been released yet,
+         * (and therefor) generate the project using the local ember-cli,
+         * the ember-cli version may not exist yet.
+         *
+         * We need to tell npm to ignore peers and just "let things be".
+         * Especially since we don't actually care about npm running,
+         * and just want the typescript files to generate.
+         *
+         * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
+         */
+        // eslint-disable-next-line camelcase
+        npm_config_legacy_peer_deps: 'true',
+      },
+    });
 
     // node_modules is .gitignored, but since we already need to remove package-lock.json due to #10045,
     // we may as well remove node_modules as while we're at it, just in case.

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -57,12 +57,8 @@ async function updateRepo(repoName) {
 }
 
 async function main() {
-  try {
-    await updateRepo('ember-new-output');
-    await updateRepo('ember-addon-output');
-  } catch (error) {
-    console.log(error);
-  }
+  await updateRepo('ember-new-output');
+  await updateRepo('ember-addon-output');
 }
 
 main();

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -9,82 +9,8 @@ tmp.setGracefulCleanup();
 const currentVersion = require('../package').version;
 const EMBER_PATH = require.resolve('../bin/ember');
 const isStable = !currentVersion.includes('-beta');
-const ONLINE_EDITOR_FILES = path.join(__dirname, 'online-editors');
 
 let tmpdir = tmp.dirSync();
-
-async function updateOnlineEditorRepos() {
-  if (!isStable) {
-    return;
-  }
-
-  let repo = 'git@github.com:ember-cli/editor-output.git';
-  let onlineEditors = ['stackblitz'];
-  let variants = ['javascript', 'typescript'];
-
-  for (let command of ['new', 'addon']) {
-    for (let variant of variants) {
-      let isTypeScript = variant === 'typescript';
-      let branchSuffix = isTypeScript ? '-typescript' : '';
-      let tmpdir = tmp.dirSync();
-      await fs.mkdirp(tmpdir.name);
-
-      let name = command === 'new' ? 'my-app' : 'my-addon';
-      let projectType = command === 'new' ? 'app' : 'addon';
-
-      let updatedOutputTmpDir = tmp.dirSync();
-      console.log(`Running ember ${command} ${name} (for ${variant})`);
-      await execa(EMBER_PATH, [command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])], {
-        cwd: updatedOutputTmpDir.name,
-      });
-
-      let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
-
-      for (let onlineEditor of onlineEditors) {
-        let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
-        let outputRepoPath = path.join(tmpdir.name, 'editor-output');
-
-        console.log(`cloning ${repo} in to ${tmpdir.name}`);
-        try {
-          await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
-            cwd: tmpdir.name,
-          });
-        } catch (e) {
-          // branch may not exist yet
-          await execa('git', ['clone', repo], {
-            cwd: tmpdir.name,
-          });
-        }
-
-        console.log('preparing updates for online editors');
-        await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
-
-        console.log(`clearing ${repo} in ${outputRepoPath}`);
-        await execa(`git`, [`rm`, `-rf`, `.`], {
-          cwd: outputRepoPath,
-        });
-
-        console.log('copying generated contents to output repo');
-        await fs.copy(generatedOutputPath, outputRepoPath);
-
-        console.log('copying online editor files');
-        await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
-
-        console.log('commiting updates');
-        await execa('git', ['add', '--all'], { cwd: outputRepoPath });
-        await execa('git', ['commit', '-m', currentVersion], { cwd: outputRepoPath });
-
-        console.log('pushing commit');
-        try {
-          await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
-        } catch (e) {
-          // branch may not exist yet
-          await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
-        }
-      }
-    }
-  }
-}
 
 async function updateRepo(repoName) {
   let command = repoName === 'ember-new-output' ? 'new' : 'addon';
@@ -134,7 +60,6 @@ async function main() {
   try {
     await updateRepo('ember-new-output');
     await updateRepo('ember-addon-output');
-    await updateOnlineEditorRepos();
   } catch (error) {
     console.log(error);
   }

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -12,6 +12,12 @@ const isStable = !currentVersion.includes('-beta');
 
 let tmpdir = tmp.dirSync();
 
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!GITHUB_TOKEN) {
+  throw new Error('GITHUB_TOKEN must be set');
+}
+
 async function updateRepo(repoName) {
   let command = repoName === 'ember-new-output' ? 'new' : 'addon';
   let name = repoName === 'ember-new-output' ? 'my-app' : 'my-addon';
@@ -22,9 +28,13 @@ async function updateRepo(repoName) {
   let branchToClone = shouldUpdateMasterFromStable ? 'stable' : outputRepoBranch;
 
   console.log(`cloning ${repoName}`);
-  await execa('git', ['clone', `git@github.com:ember-cli/${repoName}.git`, `--branch=${branchToClone}`], {
-    cwd: tmpdir.name,
-  });
+  await execa(
+    'git',
+    ['clone', `https://${GITHUB_TOKEN}@github.com:ember-cli/${repoName}.git`, `--branch=${branchToClone}`],
+    {
+      cwd: tmpdir.name,
+    }
+  );
 
   console.log(`clearing ${repoName}`);
   await execa(`git`, [`rm`, `-rf`, `.`], {

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -30,7 +30,7 @@ async function updateRepo(repoName) {
   console.log(`cloning ${repoName}`);
   await execa(
     'git',
-    ['clone', `https://${GITHUB_TOKEN}@github.com:ember-cli/${repoName}.git`, `--branch=${branchToClone}`],
+    ['clone', `https://${GITHUB_TOKEN}@github.com/ember-cli/${repoName}.git`, `--branch=${branchToClone}`],
     {
       cwd: tmpdir.name,
     }

--- a/package.json
+++ b/package.json
@@ -165,9 +165,6 @@
     "registry": "https://registry.npmjs.org"
   },
   "release-it": {
-    "hooks": {
-      "after:release": "node ./dev/update-output-repos.js"
-    },
     "git": {
       "tagName": "v${version}"
     },


### PR DESCRIPTION
To help reduce human involvement with updating the output repos, I've moved the running of the output repo scripts from release-it to run based on github actions triggers.

Comments are in the new workflow which describe what happens when.

The workflow is configured to use a `GH_PAT` token that has access to each of the repos.
For testing, I used a "Classic" token, but a "fine grained" one could be used as well.       

-------------------------


Additionally, due to the varying circumstances in which the two styles of output repos need to be updated, the code for updating the editor-output repo has been extracted to its own script. 
Notable changes in the editor-output scripts:
 - extra log at the top when the script runs, but is not applicable (hopefully shouldn't happen because the workflow only runs when release-branches are pushed)
 - JS/TS generation was extracted to an env variable so that we can run JS/TS output in separate jobs and they can error separately. This will help with debugging.


I've tested this change on my fork of [ember-cli here, using v4.10.0](https://github.com/NullVoxPopuli/ember-cli/actions/runs/4308484790)
 - C.I. logs:
   - when a tag is pushed: 
     - https://github.com/NullVoxPopuli/ember-cli/actions/runs/4308079722/jobs/7513916182
       - errorred, because my GH_PAT does not have push permissions to ember-cli (good)
   - when a release branch is pushed (previously, there was risk of these branches getting over-written by patch-releases older LTS versions): 
     - https://github.com/NullVoxPopuli/ember-cli/actions/runs/4305578543
       - successfully early exited as editor-output repo does not currently care about pre-releases
     - Successful publish for existing release v4.10.0:
       - well, JS errored, because it's already published: https://github.com/NullVoxPopuli/ember-cli/actions/runs/4308484790/jobs/7514815116
       - TS succeeded because it wasn't previously published: https://github.com/NullVoxPopuli/ember-cli/actions/runs/4308484790/jobs/7514815267
     - Branches on editor-output: https://github.com/ember-cli/editor-output/branches

