### PR TITLE
[INTERNAL] Remove template expression when updating blueprint dependencies

### DIFF
--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -172,3 +172,5 @@ if (module === require.main) {
     return;
   }
 }
+
+module.exports = { updateDependencies };

--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -104,12 +104,14 @@ async function latestVersion(packageName) {
 }
 
 async function updateDependencies(dependencies) {
-  for (let dependency in dependencies) {
-    if (!shouldCheckDependency(dependency)) {
+  for (let dependencyKey in dependencies) {
+    let dependencyName = removeTemplateExpression(dependencyKey);
+
+    if (!shouldCheckDependency(dependencyName)) {
       continue;
     }
 
-    let previousValue = dependencies[dependency];
+    let previousValue = dependencies[dependencyKey];
 
     // grab the first char (~ or ^)
     let prefix = previousValue[0];
@@ -122,9 +124,17 @@ async function updateDependencies(dependencies) {
     let hasVersion = previousValue[1] !== '<';
 
     if (hasVersion && isValidPrefix) {
-      dependencies[dependency] = `${prefix}${await latestVersion(dependency)}${templateSuffix}`;
+      dependencies[dependencyKey] = `${prefix}${await latestVersion(dependencyName)}${templateSuffix}`;
     }
   }
+}
+
+function removeTemplateExpression(dependency) {
+  if (dependency.includes('<') === false) {
+    return dependency;
+  }
+
+  return dependency.replace(dependency.substring(dependency.indexOf('<'), dependency.indexOf('>') + 1), '');
 }
 
 async function main() {

--- a/tests/unit/dev/update-blueprint-dependencies-test.js
+++ b/tests/unit/dev/update-blueprint-dependencies-test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { expect } = require('chai');
+const { updateDependencies } = require('../../../dev/update-blueprint-dependencies');
+
+describe('updateDependencies', function () {
+  it('it works', async function () {
+    let dependenciesBeforeUpdate = {
+      // Template expression in key:
+      '<% if (foo) { %>@glimmer/component': '^1.1.0',
+
+      // Template expression in value:
+      '@glimmer/component': '^1.1.0<% if (foo) { %>',
+      'ember-cli': '~<%= emberCLIVersion %>',
+
+      // Template expression in key and value:
+      '<% } %>@glimmer/component': '^1.1.0<% if (foo) { %>',
+
+      // Without template expressions:
+      '@glimmer/tracking': '^1.1.0',
+    };
+
+    let dependenciesAfterUpdate = { ...dependenciesBeforeUpdate };
+
+    await updateDependencies(dependenciesAfterUpdate);
+
+    expect(Object.keys(dependenciesAfterUpdate)).to.deep.equal(Object.keys(dependenciesBeforeUpdate));
+
+    for (let dependency in dependenciesAfterUpdate) {
+      if (dependency === 'ember-cli') {
+        expect(dependenciesAfterUpdate[dependency]).to.equal(dependenciesBeforeUpdate[dependency]);
+      } else {
+        expect(dependenciesAfterUpdate[dependency]).to.not.equal(dependenciesBeforeUpdate[dependency]);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Resolves:

```
HTTPError: Response code 405 (Method Not Allowed)
    at EventEmitter.<anonymous> (/Users/bertdeblock/Code/open-source/forks/ember-cli/node_modules/package-json/node_modules/got/source/as-promise.js:74:19)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

when running the `dev/update-blueprint-dependencies` script.