### PR TITLE
[CLEANUP] Drop support for including Ember builds via Bower

### DIFF
--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -9,6 +9,7 @@ const p = require('ember-cli-preprocess-registry/preprocessors');
 const chalk = require('chalk');
 const resolve = require('resolve');
 
+const assert = require('../debug/assert');
 const Project = require('../models/project');
 
 let preprocessJs = p.preprocessJs;
@@ -369,46 +370,26 @@ class EmberApp {
     @method _initVendorFiles
   */
   _initVendorFiles() {
-    let ember = this.project.findAddonByName('ember-source');
-    let developmentEmber;
-    let productionEmber;
-    let emberTesting;
+    let emberSource = this.project.findAddonByName('ember-source');
 
-    if (ember) {
-      developmentEmber = ember.paths.debug;
-      productionEmber = ember.paths.prod;
-      emberTesting = ember.paths.testing;
-    } else {
-      // in Ember 1.10 and higher `ember.js` is deprecated in favor of
-      // the more aptly named `ember.debug.js`.
-      productionEmber = `${this.bowerDirectory}/ember/ember.prod.js`;
-      developmentEmber = `${this.bowerDirectory}/ember/ember.debug.js`;
-      if (!fs.existsSync(this._resolveLocal(developmentEmber))) {
-        developmentEmber = `${this.bowerDirectory}/ember/ember.js`;
-      }
-      emberTesting = `${this.bowerDirectory}/ember/ember-testing.js`;
-    }
+    assert(
+      'Could not find `ember-source`. Please install `ember-source` by running `ember install ember-source`.',
+      emberSource
+    );
 
     this.vendorFiles = omitBy(
       merge(
         {
           'ember.js': {
-            development: developmentEmber,
-            production: productionEmber,
+            development: emberSource.paths.debug,
+            production: emberSource.paths.prod,
           },
-          'ember-testing.js': [emberTesting, { type: 'test' }],
+          'ember-testing.js': [emberSource.paths.testing, { type: 'test' }],
         },
         this.options.vendorFiles
       ),
       isNull
     );
-
-    // If ember-testing.js is coming from Bower (not ember-source) and it does not
-    // exist, then we remove it from vendor files. This is needed to support versions
-    // of Ember older than 1.8.0 (when ember-testing.js was incldued in ember.js itself)
-    if (!ember && this.vendorFiles['ember-testing.js'] && !fs.existsSync(this.vendorFiles['ember-testing.js'][0])) {
-      delete this.vendorFiles['ember-testing.js'];
-    }
   }
 
   /**

--- a/tests/unit/broccoli/ember-addon-test.js
+++ b/tests/unit/broccoli/ember-addon-test.js
@@ -7,6 +7,18 @@ const EmberApp = require('../../../lib/broccoli/ember-app');
 const { expect } = require('chai');
 const MockCLI = require('../../helpers/mock-cli');
 
+const EMBER_SOURCE_ADDON = {
+  name: 'ember-source',
+  paths: {
+    debug: 'vendor/ember/ember.js',
+    prod: 'vendor/ember/ember.js',
+    testing: 'vendor/ember/ember-testing.js',
+  },
+  pkg: {
+    name: 'ember-source',
+  },
+};
+
 describe('EmberAddon', function () {
   let project, emberAddon, projectPath;
 
@@ -19,7 +31,7 @@ describe('EmberAddon', function () {
       return function () {};
     };
     project.initializeAddons = function () {
-      this.addons = [];
+      this.addons = [EMBER_SOURCE_ADDON];
     };
 
     return project;

--- a/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
+++ b/tests/unit/broccoli/ember-app/app-and-dependencies-test.js
@@ -11,6 +11,18 @@ const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 const walkSync = require('walk-sync');
 
+const EMBER_SOURCE_ADDON = {
+  name: 'ember-source',
+  paths: {
+    debug: 'vendor/ember/ember.js',
+    prod: 'vendor/ember/ember.js',
+    testing: 'vendor/ember/ember-testing.js',
+  },
+  pkg: {
+    name: 'ember-source',
+  },
+};
+
 describe('EmberApp#appAndDependencies', function () {
   let input, output;
 
@@ -69,7 +81,17 @@ describe('EmberApp#appAndDependencies', function () {
     };
 
     let cli = new MockCLI();
-    let project = new Project(input.path(), pkg, cli.ui, cli);
+    let project = new (class extends Project {
+      initializeAddons() {
+        if (this._addonsInitialized) {
+          return;
+        }
+
+        super.initializeAddons();
+
+        this.addons.push(EMBER_SOURCE_ADDON);
+      }
+    })(input.path(), pkg, cli.ui, cli);
 
     return new EmberApp(
       {

--- a/tests/unit/broccoli/template-precompilation-test.js
+++ b/tests/unit/broccoli/template-precompilation-test.js
@@ -15,6 +15,18 @@ const EmberApp = require('../../../lib/broccoli/ember-app');
 const createBuilder = broccoliTestHelper.createBuilder;
 const createTempDir = broccoliTestHelper.createTempDir;
 
+const EMBER_SOURCE_ADDON = {
+  name: 'ember-source',
+  paths: {
+    debug: 'vendor/ember/ember.js',
+    prod: 'vendor/ember/ember.js',
+    testing: 'vendor/ember/ember-testing.js',
+  },
+  pkg: {
+    name: 'ember-source',
+  },
+};
+
 describe('template preprocessors', function () {
   let input, output, addon;
 
@@ -125,7 +137,17 @@ describe('template preprocessors', function () {
       input = await createTempDir();
       let cli = new MockCLI();
       let pkg = { name: 'fake-app-test', devDependencies: { 'ember-cli': '*' } };
-      project = new Project(input.path(), pkg, cli.ui, cli);
+      project = new (class extends Project {
+        initializeAddons() {
+          if (this._addonsInitialized) {
+            return;
+          }
+
+          super.initializeAddons();
+
+          this.addons.push(EMBER_SOURCE_ADDON);
+        }
+      })(input.path(), pkg, cli.ui, cli);
     });
 
     afterEach(async function () {


### PR DESCRIPTION
~~Still need to update the corresponding tests, but I'm going to wait until #10195 is merged, as that will make updating the tests easier.~~

I think after merging this, it should be easier to clean up the `ember-cli.building-bower-packages` deprecation.