### PR TITLE
[CLEANUP] Drop support for the `EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH` env flag

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -404,16 +404,14 @@ let addonProto = {
         return true;
       }
 
-      // Addon names in index.js and package.json should be the same at all times whether they have scope or not.
+      // Addon names in index.js and package.json must be the same at all times whether they have scope or not.
       if (this.root === this.parent.root) {
-        if (parentName !== this.name && !process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH) {
+        if (parentName !== this.name) {
           let pathToDisplay = process.cwd() === this.root ? process.cwd() : path.relative(process.cwd(), this.root);
 
           throw new SilentError(
-            'ember-cli: Your names in package.json and index.js should match. ' +
-              `The addon in ${pathToDisplay} currently have '${parentName}' in package.json and '${this.name}' in index.js. ` +
-              'Until ember-cli v3.9, this error can be disabled by setting env variable EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH to "true". ' +
-              'For more information about this workaround, see: https://github.com/ember-cli/ember-cli/pull/7950.'
+            'ember-cli: Your names in package.json and index.js must match. ' +
+              `The addon in ${pathToDisplay} currently has '${parentName}' in package.json and '${this.name}' in index.js.`
           );
         }
 

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -305,8 +305,6 @@ describe('models/addon.js', function () {
         } else {
           process.env.EMBER_ADDON_ENV = originalEnvValue;
         }
-
-        delete process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH;
       });
 
       it('returns true when `EMBER_ADDON_ENV` is set to development', function () {
@@ -320,16 +318,7 @@ describe('models/addon.js', function () {
         project.root = 'foo';
         project.name = () => '@foo/my-addon';
         addon.name = 'my-addon';
-        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
-      });
-
-      it('does not throw for a mismatched addon name when process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH is set', function () {
-        process.env.EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH = 'true';
-        process.env.EMBER_ADDON_ENV = 'development';
-        project.root = 'foo';
-        project.name = () => '@foo/my-addon';
-        addon.name = 'my-addon';
-        expect(addon.isDevelopingAddon()).to.eql(true);
+        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js must match*/);
       });
 
       it('throws an error if addon name is different in package.json and index.js ', function () {
@@ -337,7 +326,7 @@ describe('models/addon.js', function () {
         project.root = 'foo';
         project.name = () => 'foo-my-addon';
         addon.name = 'my-addon';
-        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js should match*/);
+        expect(() => addon.isDevelopingAddon()).to.throw(/Your names in package.json and index.js must match*/);
       });
 
       it('returns false when `EMBER_ADDON_ENV` is not set', function () {


### PR DESCRIPTION
This means that addons must now _always_ use the same name in `package.json` and `index.js`.