### PR TITLE
[INTERNAL] Remove npm version check in `ember new` test

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const execa = require('execa');
-const semver = require('semver');
 const fs = require('fs-extra');
 const ember = require('../helpers/ember');
 const walkSync = require('walk-sync');
@@ -261,13 +259,6 @@ describe('Acceptance: ember new', function () {
   });
 
   it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
-    // Temporarily skipped for npm versions <= v6.0.0.
-    // See https://github.com/npm/cli/issues/4896 for more info.
-    let { stdout: npmVersion } = await execa('npm', ['-v']);
-    if (semver.major(npmVersion) <= 6) {
-      this.skip();
-    }
-
     this.timeout(20000); // relies on GH network stuff
 
     await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=ember-cli/app-blueprint-test#named-ref']);


### PR DESCRIPTION
Should not be needed anymore now that we've stopped testing against Node.js v14 / npm v6.

Originally introduced in https://github.com/ember-cli/ember-cli/pull/9914.