### PR TITLE
Serve app on root url without trailing slash

### DIFF
--- a/lib/tasks/server/middleware/history-support/index.js
+++ b/lib/tasks/server/middleware/history-support/index.js
@@ -87,8 +87,14 @@ class HistorySupportAddon {
       return false;
     }
     let rootURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL);
-    let rootURLRegexp = new RegExp(`^${rootURL}`);
-    return rootURLRegexp.test(req.path);
+    if (req.path.startsWith(rootURL)) {
+      return true;
+    }
+    // exactly match the rootURL without a trailing slash
+    if (req.path === rootURL.slice(0, -1)) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -752,6 +752,27 @@ describe('express-server', function () {
         });
       });
 
+      it('serves index.html when file not found (with rootURL) with auto/history location on root url without trailing slash', function (done) {
+        project._config = {
+          rootURL: '/foo',
+          locationType: 'history',
+        };
+
+        startServer('/foo').then(function () {
+          request(subject.app)
+            .get('/foo')
+            .set('accept', 'text/html')
+            .expect(200)
+            .expect('Content-Type', /html/)
+            .end(function (err) {
+              if (err) {
+                return done(err);
+              }
+              done();
+            });
+        });
+      });
+
       it('serves index.html when file not found (with rootURL) with custom history location', function (done) {
         project._config = {
           rootURL: '/',


### PR DESCRIPTION
Closes #10246.

I confirmed that my test fails without the middleware change and passes after the middleware change.

I also tried this out locally in an application that specifies `rootURL: "/example"`. Note that after the application boots up, Ember does a client-side route transition to normalize the URL to include the trailing slash.


https://user-images.githubusercontent.com/1151810/230454814-8f3d406b-af3b-4484-aaa4-7deeed3d3d03.mov