### PR TITLE
Make output repo scripts re runnable

### DIFF
--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -12,6 +12,13 @@
 name: Sync Output Repos
 
 on:
+  # Manual run
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: 'Specify the released version of ember-cli to use to generate / update the output repos. Should be full semver version, and without a leading "v"'
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
   push:
@@ -31,9 +38,45 @@ env:
   GIT_EMAIL: 'github-actions+bot@users.noreply.github.com'
 
 jobs:
+  verify-inputs:
+    name: "Verify Inputs"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.determine.outputs.version }}
+      tag: ${{ steps.determine.outputs.tag }}
+
+    steps:
+      - id: determine
+        run: |
+          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
+            TAG="v${{ github.event.inputs.version }}"
+            VERSION="${{ github.event.inputs.version }}"
+          elif [[ "${{ github.ref_name }}" != "" ]]; then
+            TAG="${{github.ref_name}}"
+            _version="${{github.ref_name}}"
+            VERSION="${_version/v/''}"
+          else
+            echo "Could not determine tag / version"
+            echo ""
+            echo "github.ref_name = ${{ github.ref_name }}"
+            echo "event.inputs.version = ${{ github.event.inputs.version }}"
+            exit 1;
+          fi
+
+          if [[ "$VERSION" == v* ]]; then
+            echo "version, $VERSION, may not start with a 'v' character"
+            exit 1;
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+
+
   push-addon-app:
     name: "Push to addon/app output repos"
     runs-on: ubuntu-latest
+    needs: [verify-inputs]
 
     steps:
       - uses: actions/checkout@v3
@@ -47,13 +90,14 @@ jobs:
         run: |
           git config --global user.name "${{ env.GIT_NAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
-      - run: node ./dev/update-output-repos.js
+      - run: node ./dev/update-output-repos.js ${{ needs.verify-inputs.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   push-editors:
     name: "Push to editor output repos (${{ matrix.variant }})"
     runs-on: ubuntu-latest
+    needs: [verify-inputs]
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +117,7 @@ jobs:
           git config --global user.name "${{ env.GIT_NAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
       - name: Publish ${{ matrix.variant }} branches
-        run: node ./dev/update-editor-output-repos.js
+        run: node ./dev/update-editor-output-repos.js ${{ needs.verify-inputs.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           VARIANT: ${{ matrix.variant }}

--- a/dev/output-repo-helpers.js
+++ b/dev/output-repo-helpers.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const tmp = require('tmp');
+const path = require('path');
+const execa = require('execa');
+
+async function clearRepo(repoPath) {
+  console.log(`clearing repo content in ${repoPath}`);
+  await execa(`git`, [`rm`, `-rf`, `.`], {
+    cwd: repoPath,
+  });
+}
+
+async function cloneBranch(containingPath, { repo, branch }) {
+  let outputName = 'output-repo';
+  let outputRepoPath = path.join(containingPath, outputName);
+
+  console.log(`cloning ${repo} in to ${containingPath}`);
+
+  try {
+    await execa.command(`git clone ${repo} --branch=${branch} ${outputName}`, { cwd: containingPath });
+  } catch (e) {
+    console.log(`Branch does not exist -- creating fresh (local) repo.`);
+
+    await execa.command(`git clone ${repo} ${outputName}`, { cwd: containingPath });
+    await execa.command(`git switch -C ${branch}`, { cwd: outputRepoPath });
+  }
+
+  return outputRepoPath;
+}
+
+let cliOutputCache = {};
+/**
+ * We can re-use generated projects
+ */
+async function generateOutputFiles({ name, variant, isTypeScript, tag, command }) {
+  console.log(Object.keys(cliOutputCache));
+  let cacheKey = `${command}-${variant}`;
+
+  if (cliOutputCache[cacheKey]) {
+    return cliOutputCache[cacheKey];
+  }
+
+  let updatedOutputTmpDir = tmp.dirSync();
+  console.log(`Running npx ember-cli@${tag} ${command} ${name}`);
+
+  await execa(
+    'npx',
+    [`ember-cli@${tag}`, command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
+    {
+      cwd: updatedOutputTmpDir.name,
+      env: {
+        /**
+         * using --typescript triggers npm's peer resolution features,
+         * and since we don't know if the npm package has been released yet,
+         * (and therefor) generate the project using the local ember-cli,
+         * the ember-cli version may not exist yet.
+         *
+         * We need to tell npm to ignore peers and just "let things be".
+         * Especially since we don't actually care about npm running,
+         * and just want the typescript files to generate.
+         *
+         * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
+         */
+        // eslint-disable-next-line camelcase
+        npm_config_legacy_peer_deps: 'true',
+      },
+    }
+  );
+
+  // node_modules is .gitignored, but since we already need to remove package-lock.json due to #10045,
+  // we may as well remove node_modules as while we're at it, just in case.
+  await execa('rm', ['-rf', 'node_modules', 'package-lock.json'], { cwd: updatedOutputTmpDir.name });
+
+  let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
+
+  cliOutputCache[cacheKey] = generatedOutputPath;
+
+  return generatedOutputPath;
+}
+
+module.exports = { cloneBranch, clearRepo, generateOutputFiles };

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -81,7 +81,7 @@ async function updateOnlineEditorRepos(tag) {
     console.log(`Running ember ${command} ${name} (for ${VARIANT})`);
     await execa(
       'npx',
-      ['ember-cli', command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
+      [`ember-cli@${tag}`, command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
       {
         cwd: updatedOutputTmpDir.name,
         env: {

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -14,10 +14,15 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const VARIANT = process.env.VARIANT;
 const VALID_VARIANT = ['javascript', 'typescript'];
 const EDITORS = ['stackblitz'];
+const [, , version] = process.argv;
 
-if (!GITHUB_TOKEN) {
-  throw new Error('GITHUB_TOKEN must be set');
-}
+assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');
+assert(
+  VALID_VARIANT.includes(VARIANT),
+  `Invalid VARIANT env var specified: ${VARIANT}. Must be one of ${VALID_VARIANT}`
+);
+
+assert(version, 'a version must be provided as the first argument to this script.');
 
 /**
  * The editor output repos differ from the output repos in that
@@ -218,8 +223,4 @@ async function updateOnlineEditorRepos(tag) {
   }
 }
 
-const [, , tag] = process.argv;
-
-assert(tag, 'a tag must be provided as the first argument to this script.');
-
-updateOnlineEditorRepos(tag);
+updateOnlineEditorRepos(version);

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -1,14 +1,13 @@
 'use strict';
 
+const assert = require('assert');
 const fs = require('fs-extra');
 const path = require('path');
 const execa = require('execa');
 const tmp = require('tmp');
+const latestVersion = require('latest-version');
 tmp.setGracefulCleanup();
 
-const currentVersion = require('../package').version;
-const EMBER_PATH = require.resolve('../bin/ember');
-const isStable = !currentVersion.includes('-beta');
 const ONLINE_EDITOR_FILES = path.join(__dirname, 'online-editors');
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -19,11 +18,33 @@ if (!GITHUB_TOKEN) {
   throw new Error('GITHUB_TOKEN must be set');
 }
 
-async function updateOnlineEditorRepos() {
-  if (!isStable) {
-    console.log(`Current version is ${currentVersion}, which is not considered stable.`);
-    return;
-  }
+/**
+ * The editor output repos differ from the output repos in that
+ * the editor output repos use branches for their convention of differentiating between
+ * editors and tags/versions/etc.
+ *
+ * The convention is (for the branch names):
+ *  - {onlineEditor}-{projectType}-output{-VARIANT?}{-tag?}
+ *
+ *    Examples:
+ *      stackblitz-addon-output-typescript
+ *      stackblitz-app-output-typescript-v4.10.0
+ *      codesandbox-app-output-v4.10.0
+ *
+ * For every tag, we generate
+ *  - 2 variants (js and ts)
+ *    * 2 project types (app and addon)
+ *      * # of supported editors with custom configurations
+ *   (4 at the time of writing)
+ *
+ *
+ *   TODO: flatten the triple-nested for loop into
+ *    - a function that returns a list of objects containing the information
+ *    - have a single loop that iterates over that doing all the git stuff
+ */
+async function updateOnlineEditorRepos(tag) {
+  let latestEC = await latestVersion('ember-cli');
+  let isLatest = tag === `v${latestEC}`;
 
   if (!VALID_VARIANT.includes(VARIANT)) {
     throw new Error(`Invalid VARIANT specified: ${VARIANT}`);
@@ -35,6 +56,21 @@ async function updateOnlineEditorRepos() {
   for (let command of ['new', 'addon']) {
     let isTypeScript = VARIANT === 'typescript';
     let branchSuffix = isTypeScript ? '-typescript' : '';
+
+    /**
+     * If we're working with the latest tag, we want to update the default
+     * branch for an editor as well as the tagged version.
+     */
+    let getBranches = (onlineEditor, projectType) => {
+      let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
+
+      if (isLatest) {
+        return [editorBranch, `${editorBranch}-${tag}`];
+      }
+
+      return [`${editorBranch}-${tag}`];
+    };
+
     let tmpdir = tmp.dirSync();
     await fs.mkdirp(tmpdir.name);
 
@@ -43,25 +79,29 @@ async function updateOnlineEditorRepos() {
 
     let updatedOutputTmpDir = tmp.dirSync();
     console.log(`Running ember ${command} ${name} (for ${VARIANT})`);
-    await execa(EMBER_PATH, [command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])], {
-      cwd: updatedOutputTmpDir.name,
-      env: {
-        /**
-         * using --typescript triggers npm's peer resolution features,
-         * and since we don't know if the npm package has been released yet,
-         * (and therefor) generate the project using the local ember-cli,
-         * the ember-cli version may not exist yet.
-         *
-         * We need to tell npm to ignore peers and just "let things be".
-         * Especially since we don't actually care about npm running,
-         * and just want the typescript files to generate.
-         *
-         * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
-         */
-        // eslint-disable-next-line camelcase
-        npm_config_legacy_peer_deps: 'true',
-      },
-    });
+    await execa(
+      'npx',
+      ['ember-cli', command, name, `--skip-npm`, `--skip-git`, ...(isTypeScript ? ['--typescript'] : [])],
+      {
+        cwd: updatedOutputTmpDir.name,
+        env: {
+          /**
+           * using --typescript triggers npm's peer resolution features,
+           * and since we don't know if the npm package has been released yet,
+           * (and therefor) generate the project using the local ember-cli,
+           * the ember-cli version may not exist yet.
+           *
+           * We need to tell npm to ignore peers and just "let things be".
+           * Especially since we don't actually care about npm running,
+           * and just want the typescript files to generate.
+           *
+           * See this related issue: https://github.com/ember-cli/ember-cli/issues/10045
+           */
+          // eslint-disable-next-line camelcase
+          npm_config_legacy_peer_deps: 'true',
+        },
+      }
+    );
 
     // node_modules is .gitignored, but since we already need to remove package-lock.json due to #10045,
     // we may as well remove node_modules as while we're at it, just in case.
@@ -70,52 +110,55 @@ async function updateOnlineEditorRepos() {
     let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
 
     for (let onlineEditor of onlineEditors) {
-      let editorBranch = `${onlineEditor}-${projectType}-output${branchSuffix}`;
-      let outputRepoPath = path.join(tmpdir.name, 'editor-output');
+      let branches = getBranches(onlineEditor, projectType);
 
-      console.log(`cloning ${repo} in to ${tmpdir.name}`);
-      try {
-        await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
-          cwd: tmpdir.name,
+      for (let editorBranch of branches) {
+        let outputRepoPath = path.join(tmpdir.name, 'editor-output');
+
+        console.log(`cloning ${repo} in to ${tmpdir.name}`);
+        try {
+          await execa('git', ['clone', repo, `--branch=${editorBranch}`], {
+            cwd: tmpdir.name,
+          });
+        } catch (e) {
+          // branch may not exist yet
+          await execa('git', ['clone', repo], {
+            cwd: tmpdir.name,
+          });
+        }
+
+        console.log('preparing updates for online editors');
+        await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
+
+        console.log(`clearing ${repo} in ${outputRepoPath}`);
+        await execa(`git`, [`rm`, `-rf`, `.`], {
+          cwd: outputRepoPath,
         });
-      } catch (e) {
-        // branch may not exist yet
-        await execa('git', ['clone', repo], {
-          cwd: tmpdir.name,
-        });
-      }
 
-      console.log('preparing updates for online editors');
-      await execa('git', ['switch', '-C', editorBranch], { cwd: outputRepoPath });
+        console.log('copying generated contents to output repo');
+        await fs.copy(generatedOutputPath, outputRepoPath);
 
-      console.log(`clearing ${repo} in ${outputRepoPath}`);
-      await execa(`git`, [`rm`, `-rf`, `.`], {
-        cwd: outputRepoPath,
-      });
+        console.log('copying online editor files');
+        await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
 
-      console.log('copying generated contents to output repo');
-      await fs.copy(generatedOutputPath, outputRepoPath);
+        console.log('commiting updates');
+        await execa('git', ['add', '--all'], { cwd: outputRepoPath });
+        await execa('git', ['commit', '-m', tag], { cwd: outputRepoPath });
 
-      console.log('copying online editor files');
-      await fs.copy(path.join(ONLINE_EDITOR_FILES, onlineEditor), outputRepoPath);
-
-      console.log('commiting updates');
-      await execa('git', ['add', '--all'], { cwd: outputRepoPath });
-      await execa('git', ['commit', '-m', currentVersion], { cwd: outputRepoPath });
-
-      console.log('pushing commit');
-      try {
-        await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
-      } catch (e) {
-        // branch may not exist yet
-        await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
+        console.log('pushing commit');
+        try {
+          await execa('git', ['push', '--force', 'origin', editorBranch], { cwd: outputRepoPath });
+        } catch (e) {
+          // branch may not exist yet
+          await execa('git', ['push', '-u', 'origin', editorBranch], { cwd: outputRepoPath });
+        }
       }
     }
   }
 }
 
-async function main() {
-  await updateOnlineEditorRepos();
-}
+const [, , tag] = process.argv;
 
-main();
+assert(tag, 'a tag must be provided as the first argument to this script.');
+
+updateOnlineEditorRepos(tag);

--- a/dev/update-editor-output-repos.js
+++ b/dev/update-editor-output-repos.js
@@ -14,6 +14,7 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const VARIANT = process.env.VARIANT;
 const VALID_VARIANT = ['javascript', 'typescript'];
 const EDITORS = ['stackblitz'];
+const REPO = 'ember-cli/editor-output';
 const [, , version] = process.argv;
 
 assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -11,10 +11,10 @@ tmp.setGracefulCleanup();
 let tmpdir = tmp.dirSync();
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const [, , version] = process.argv;
 
-if (!GITHUB_TOKEN) {
-  throw new Error('GITHUB_TOKEN must be set');
-}
+assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');
+assert(version, 'a version must be provided as the first argument to this script.');
 
 async function updateRepo(repoName, tag) {
   let latestEC = await latestVersion('ember-cli');
@@ -75,13 +75,9 @@ async function updateRepo(repoName, tag) {
   }
 }
 
-async function main(tag) {
-  await updateRepo('ember-new-output', tag);
-  await updateRepo('ember-addon-output', tag);
+async function main(version) {
+  await updateRepo('ember-new-output', version);
+  await updateRepo('ember-addon-output', version);
 }
 
-const [, , tag] = process.argv;
-
-assert(tag, 'a tag must be provided as the first argument to this script.');
-
-main(tag);
+main(version);

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -11,6 +11,8 @@ tmp.setGracefulCleanup();
 let tmpdir = tmp.dirSync();
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const APP_REPO = 'ember-cli/ember-new-output';
+const ADDON_REPO = 'ember-cli/ember-addon-output';
 const [, , version] = process.argv;
 
 assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');
@@ -33,13 +35,9 @@ async function updateRepo(repoName, tag) {
   let branchToClone = shouldUpdateMasterFromStable ? 'stable' : outputRepoBranch;
 
   console.log(`cloning ${repoName}`);
-  await execa(
-    'git',
-    ['clone', `https://${GITHUB_TOKEN}@github.com/ember-cli/${repoName}.git`, `--branch=${branchToClone}`],
-    {
-      cwd: tmpdir.name,
-    }
-  );
+  await execa('git', ['clone', `https://${GITHUB_TOKEN}@github.com/${repoName}.git`, `--branch=${branchToClone}`], {
+    cwd: tmpdir.name,
+  });
 
   console.log(`clearing ${repoName}`);
   await execa(`git`, [`rm`, `-rf`, `.`], {
@@ -76,8 +74,8 @@ async function updateRepo(repoName, tag) {
 }
 
 async function main(version) {
-  await updateRepo('ember-new-output', version);
-  await updateRepo('ember-addon-output', version);
+  await updateRepo(APP_REPO, version);
+  await updateRepo(ADDON_REPO, version);
 }
 
 main(version);

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -2,13 +2,11 @@
 
 const assert = require('assert');
 const fs = require('fs-extra');
-const path = require('path');
 const execa = require('execa');
 const tmp = require('tmp');
 const latestVersion = require('latest-version');
+const { cloneBranch, clearRepo, generateOutputFiles } = require('./output-repo-helpers');
 tmp.setGracefulCleanup();
-
-let tmpdir = tmp.dirSync();
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const APP_REPO = 'ember-cli/ember-new-output';
@@ -18,39 +16,31 @@ const [, , version] = process.argv;
 assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');
 assert(version, 'a version must be provided as the first argument to this script.');
 
-async function updateRepo(repoName, tag) {
+async function updateRepo(repoName, version) {
+  let tag = `v${version}`;
   let latestEC = await latestVersion('ember-cli');
   let latestECBeta = await latestVersion('ember-cli', { version: 'beta' });
 
-  let isLatest = tag === `v${latestEC}`;
-  let isLatestBeta = tag === `v${latestECBeta}`;
+  let isLatest = version === latestEC;
+  let isLatestBeta = version === latestECBeta;
 
   let command = repoName === 'ember-new-output' ? 'new' : 'addon';
   let name = repoName === 'ember-new-output' ? 'my-app' : 'my-addon';
-  let outputRepoPath = path.join(tmpdir.name, repoName);
   let isStable = !tag.includes('-beta');
 
   let outputRepoBranch = isStable ? 'stable' : 'master';
   let shouldUpdateMasterFromStable = tag.endsWith('-beta.1');
   let branchToClone = shouldUpdateMasterFromStable ? 'stable' : outputRepoBranch;
+  let tmpdir = tmp.dirSync();
 
-  console.log(`cloning ${repoName}`);
-  await execa('git', ['clone', `https://${GITHUB_TOKEN}@github.com/${repoName}.git`, `--branch=${branchToClone}`], {
-    cwd: tmpdir.name,
+  let outputRepoPath = await cloneBranch(tmpdir.name, {
+    repo: `https://github-actions:${GITHUB_TOKEN}@github.com/${repoName}.git`,
+    branch: branchToClone,
   });
 
-  console.log(`clearing ${repoName}`);
-  await execa(`git`, [`rm`, `-rf`, `.`], {
-    cwd: path.join(tmpdir.name, repoName),
-  });
+  await clearRepo(outputRepoPath);
 
-  let updatedOutputTmpDir = tmp.dirSync();
-  console.log(`Running ember ${command} ${name}`);
-  await execa('npx', [`ember-cli@${tag}`, command, name, `--skip-npm`, `--skip-git`], {
-    cwd: updatedOutputTmpDir.name,
-  });
-
-  let generatedOutputPath = path.join(updatedOutputTmpDir.name, name);
+  let generatedOutputPath = await generateOutputFiles({ tag, name, command, variant: 'javascript' });
 
   console.log('copying generated contents to output repo');
   await fs.copy(generatedOutputPath, outputRepoPath);
@@ -62,10 +52,10 @@ async function updateRepo(repoName, tag) {
   console.log('commiting updates');
   await execa('git', ['add', '--all'], { cwd: outputRepoPath });
   await execa('git', ['commit', '-m', tag], { cwd: outputRepoPath });
-  await execa('git', ['tag', `${tag}`], { cwd: outputRepoPath });
+  await execa('git', ['tag', `-f`, `${tag}`], { cwd: outputRepoPath });
 
   console.log('pushing commit & tag');
-  await execa('git', ['push', 'origin', `${tag}`], { cwd: outputRepoPath });
+  await execa('git', ['push', 'origin', `${tag}`, '--force'], { cwd: outputRepoPath });
 
   // Only push thihs branch if we are using an up-to-date tag
   if ((isStable && isLatest) || (!isStable && isLatestBeta)) {


### PR DESCRIPTION
Due to how these are currently implemented, you'll want this setting:
![image](https://user-images.githubusercontent.com/199018/230701105-d88cfa8a-311f-4a2f-872e-920e739e12f0.png)

You'll also want to review per-commit, otherwise it's hard to see how things have changed.
Instead of small PRs, this work was done in small commits, because:
 - this sort of code can't be merged in a non-working state (we need CI to not have errors)
 - the code is not worth keeping working each step of the way, given the needed changes
 - we also needed increased readability (in the end result), because of how complicated parameterization has made the editor-output script, so a refactor is included (also as separate commits)

## Demo

If any reviewers want to play around with these test repos, lemme know, and I'll add you

"ember-cli": https://github.com/NullVoxPopuli/automation-test-a/actions/workflows/sync-output-repos.yml
 - manual run
   - old version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682586083
     - editor repo: updated branches (force / replace)
     - app repo: updated tags (force / replace)
     - addon repo: updated tags (force / replace)
   - current version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682529637
     - editor repo: created branches
     - app repo: created tags, updated branches
     - addon repo: created tags, updated branches
   - beta version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682666298 
     - this run told me I needed to guard against improper version checking: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682762377/jobs/8297014298 (done here)
 - from tag: 
   - old version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682618693
   - new version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682655147
   - beta version: https://github.com/NullVoxPopuli/automation-test-a/actions/runs/4682659422
 
"app output repo": https://github.com/NullVoxPopuli/automation-test-c 
 - https://github.com/NullVoxPopuli/automation-test-c/branches/all
 - https://github.com/NullVoxPopuli/automation-test-c/tags
 
"addon output repo":  https://github.com/NullVoxPopuli/automation-test-d
 - https://github.com/NullVoxPopuli/automation-test-d/branches/all
 - https://github.com/NullVoxPopuli/automation-test-d/tags
 
"editor output repo": https://github.com/NullVoxPopuli/automation-test-b/branches/all


## Requirements of the GH_PAT:

I used a fine-grained PAT with _only_ access to the required repositories (3: app output, addon output, editor output)

 - Repository permissions
   - Read access to metadata
   - Read and Write access to code and workflows
   
![image](https://user-images.githubusercontent.com/199018/231567895-3526ffa9-c8ed-4546-bb15-3cfb0763b088.png)
