### PR TITLE
FEATURE: Enable Ember's stable types

### DIFF
--- a/blueprints/addon/files/local-types/index.ts
+++ b/blueprints/addon/files/local-types/index.ts
@@ -1,0 +1,12 @@
+<% if (typescript) { %>
+// This "side-effect"-type import provides auto-complete, go-to-def, etc. for
+// Ember's internals throughout your application, so don't remove it!
+import 'ember-source/types';
+<% } else { %>
+// This "type definition" import comment provides auto-complete, go-to-def, etc.
+// for Ember's internals throughout your application, so don't remove it, even
+// if you do not use TypeScript at all.
+/**
+  @typedef {import('ember-source/types')} Types
+*/
+<% } %>

--- a/blueprints/app/files/app/app.ts
+++ b/blueprints/app/files/app/app.ts
@@ -10,3 +10,15 @@ export default class App extends Application {
 }
 
 loadInitializers(App, config.modulePrefix);
+
+<% if (typescript) { %>
+// This "side-effect"-type import provides auto-complete, go-to-def, etc. for
+// Ember's internals throughout your application, so don't remove it!
+import 'ember-source/types';
+<% } else { %>
+// This "type definition" import comment provides auto-complete, go-to-def, etc.
+// for Ember's internals throughout your application, so don't remove it!
+/**
+  @typedef {import('ember-source/types')} Types
+*/
+<% } %>


### PR DESCRIPTION
- In TS, add an `import 'ember-source/types'` statement.
- In JS, add a `/** @typedef {import('ember-source/types')} */` comment.

This is sufficient to make the types shipped in Ember itself as of emberjs/ember.js#20449 "enabled" for end users out of the box. It should be coordinated with an `ember-cli-typescript` release which *removes* the `@types/ember` packages from its own blueprint so that users do not get those installed needlessly.

(Maintainers: what's the best spot to test this?)

---

> **Note**: this is currently a Draft while we discuss how best to roll it out, given that Ember Data's types (`@types/ember-data` etc.) are not currently compatible with these types.