### PR TITLE
Updated ember-welcome-page to v7.0.2

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -58,7 +58,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2<% if (welcome) { %>",
-    "ember-welcome-page": "^7.0.1<% } %>",
+    "ember-welcome-page": "^7.0.2<% } %>",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -56,7 +56,7 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.7.2",
     "ember-try": "^2.0.0",
-    "ember-welcome-page": "^7.0.1",
+    "ember-welcome-page": "^7.0.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2",
-    "ember-welcome-page": "^7.0.1",
+    "ember-welcome-page": "^7.0.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -53,7 +53,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2",
-    "ember-welcome-page": "^7.0.1",
+    "ember-welcome-page": "^7.0.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -53,7 +53,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2",
-    "ember-welcome-page": "^7.0.1",
+    "ember-welcome-page": "^7.0.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2",
-    "ember-welcome-page": "^7.0.1",
+    "ember-welcome-page": "^7.0.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",


### PR DESCRIPTION
## Background

`ember-welcome-page@7.0.1` didn't support Glint and `<template>`-tag components correctly. I fixed the bugs and released `7.0.2` today.

https://github.com/ember-cli/ember-welcome-page/releases/tag/v7.0.2