### PR TITLE
Fix sync output repos

### DIFF
--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -77,6 +77,10 @@ jobs:
     name: "Push to addon/app output repos"
     runs-on: ubuntu-latest
     needs: [verify-inputs]
+    strategy:
+      fail-fast: false
+      matrix:
+        blueprint: ["addon", "app"]
 
     steps:
       - uses: actions/checkout@v3
@@ -93,6 +97,7 @@ jobs:
       - run: node ./dev/update-output-repos.js ${{ needs.verify-inputs.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          BLUEPRINT: ${{ matrix.blueprint }}
 
   push-editors:
     name: "Push to editor output repos (${{ matrix.variant }})"

--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -74,7 +74,7 @@ jobs:
 
 
   push-addon-app:
-    name: "Push to addon/app output repos"
+    name: "Push to ${{ matrix.blueprint }} output repo"
     runs-on: ubuntu-latest
     needs: [verify-inputs]
     strategy:

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -9,14 +9,17 @@ const { cloneBranch, clearRepo, generateOutputFiles } = require('./output-repo-h
 tmp.setGracefulCleanup();
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const BLUEPRINT = process.env.BLUEPRINT;
 const APP_REPO = 'ember-cli/ember-new-output';
 const ADDON_REPO = 'ember-cli/ember-addon-output';
 const [, , version] = process.argv;
 
 assert(GITHUB_TOKEN, 'GITHUB_TOKEN must be set');
 assert(version, 'a version must be provided as the first argument to this script.');
+assert(BLUEPRINT, 'BLUEPRINT must be set to either `app` or `addon`');
 
-async function updateRepo(repoName, version) {
+async function updateRepo(version) {
+  let repoName = BLUEPRINT === 'addon' ? ADDON_REPO : APP_REPO;
   let tag = `v${version}`;
   let latestEC = await latestVersion('ember-cli');
   let latestECBeta = await latestVersion('ember-cli', { version: 'beta' });
@@ -63,9 +66,4 @@ async function updateRepo(repoName, version) {
   }
 }
 
-async function main(version) {
-  await updateRepo(APP_REPO, version);
-  await updateRepo(ADDON_REPO, version);
-}
-
-main(version);
+updateRepo(version);

--- a/dev/update-output-repos.js
+++ b/dev/update-output-repos.js
@@ -19,7 +19,16 @@ assert(version, 'a version must be provided as the first argument to this script
 assert(BLUEPRINT, 'BLUEPRINT must be set to either `app` or `addon`');
 
 async function updateRepo(version) {
-  let repoName = BLUEPRINT === 'addon' ? ADDON_REPO : APP_REPO;
+  let repoName = APP_REPO;
+  let command = 'new';
+  let name = 'my-app';
+
+  if (BLUEPRINT === 'addon') {
+    repoName = ADDON_REPO;
+    command = 'addon';
+    name = 'my-addon';
+  }
+
   let tag = `v${version}`;
   let latestEC = await latestVersion('ember-cli');
   let latestECBeta = await latestVersion('ember-cli', { version: 'beta' });
@@ -27,8 +36,6 @@ async function updateRepo(version) {
   let isLatest = version === latestEC;
   let isLatestBeta = version === latestECBeta;
 
-  let command = repoName === 'ember-new-output' ? 'new' : 'addon';
-  let name = repoName === 'ember-new-output' ? 'my-app' : 'my-addon';
   let isStable = !tag.includes('-beta');
 
   let outputRepoBranch = isStable ? 'stable' : 'master';


### PR DESCRIPTION
Here: https://github.com/NullVoxPopuli/ember-cli/actions/runs/5160247411/jobs/9296112544
we can see that the addon matrix part has invoked `ember addon`
and that the app matrix part has invoked `ember new`

Previously, only `ember addon` was invoked