### PR TITLE
Show a file diff when files don't match in the acceptance/new tests

### DIFF
--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -428,11 +428,16 @@ describe('Acceptance: ember new', function () {
       expect(file('.eslintrc.js')).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, '.eslintrc.js')));
     }
 
+    /**
+     * chai-files does not appropriately diff json
+     * works great on everything else though.
+     * shows similar information as this diff / patch here.
+     */
     function showHumanReadableDiff(expectedString, fileName) {
       let actualString = fs.readFileSync(fileName, { encoding: 'utf-8' });
 
       if (expectedString !== actualString) {
-        let patch = diff.createPatch('package.json', actualString, expectedString);
+        let patch = diff.createPatch(fileName, actualString, expectedString);
 
         // When content doesn't match, output something that can be understood
         // especially helpful for large files (or repetitive ones, like package.json)

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -12,6 +12,7 @@ const EOL = require('os').EOL;
 const chalk = require('chalk');
 const hasGlobalYarn = require('../helpers/has-global-yarn');
 const { isExperimentEnabled } = require('../../lib/experiments');
+const diff = require('diff');
 
 const { expect } = require('chai');
 const { dir, file } = require('chai-files');
@@ -427,6 +428,18 @@ describe('Acceptance: ember new', function () {
       expect(file('.eslintrc.js')).to.equal(file(path.join(__dirname, '../fixtures', fixturePath, '.eslintrc.js')));
     }
 
+    function showHumanReadableDiff(expectedString, fileName) {
+      let actualString = fs.readFileSync(fileName, { encoding: 'utf-8' });
+
+      if (expectedString !== actualString) {
+        let patch = diff.createPatch('package.json', actualString, expectedString);
+
+        // When content doesn't match, output something that can be understood
+        // especially helpful for large files (or repetitive ones, like package.json)
+        console.error(patch);
+      }
+    }
+
     function checkFileWithEmberCLIVersionReplacement(fixtureName, fileName) {
       let currentVersion = require('../../package').version;
       let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
@@ -434,12 +447,17 @@ describe('Acceptance: ember new', function () {
         .readFileSync(fixturePath, { encoding: 'utf-8' })
         .replace('<%= emberCLIVersion %>', currentVersion);
 
+      showHumanReadableDiff(fixtureContents, fileName);
+
       expect(file(fileName)).to.equal(fixtureContents);
     }
 
     function checkEmberCLIBuild(fixtureName, fileName) {
       let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
       let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' });
+
+      showHumanReadableDiff(fixtureContents, fileName);
+
       expect(file(fileName)).to.equal(fixtureContents);
     }
 

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foo",
+  "name": " foo",
   "version": "0.0.0",
   "private": true,
   "description": "Small description for foo goes here",


### PR DESCRIPTION
Work extracted from: https://github.com/ember-cli/ember-cli/pull/10287
This is helpful when working with blueprints, because the files are kind of large, and all chai-files says is "expect file to have content <the full expected content>" -- this behavior from chai-files isn't helpful when we're looking for minor differences between package.jsons, for example.

Whenever there is an error comparing files,
**before**
![image](https://github.com/ember-cli/ember-cli/assets/199018/2c4fefe8-7280-43fe-9fc1-cc072add0ac4)


**after**



