### PR TITLE
Update .eslintignore, so saving the doesn't run eslint on tests/fixtures

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,6 @@
 /coverage/
 /docs/build/
 /node_modules/
-/tests/fixtures/
 /tmp/
 
 /lib/broccoli/app-*.js
@@ -14,4 +13,4 @@
 
 !.*
 /.git/
-tests/fixtures/
+/tests/fixtures/

--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@
 
 !.*
 /.git/
+tests/fixtures/

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@
 /coverage/
 /docs/build/
 /node_modules/
+tests/fixtures/
 /tmp/
 
 /lib/broccoli/app-*.js
@@ -13,4 +14,3 @@
 
 !.*
 /.git/
-/tests/fixtures/


### PR DESCRIPTION
Extracted from https://github.com/ember-cli/ember-cli/pull/10287

Without this change, if anyone opens the fixtures files and saves, and happens to have their editor set up to format on save, these files get formatted.

Without this change, eslint running on the files results in a big diff:
![image](https://github.com/ember-cli/ember-cli/assets/199018/dafa6dc4-650a-4227-9614-c77cb9aedea1)

I do not know why removing the leading `/` fixes the problem, if anyone knows how to actually debug _why_ things happen with ignore files, that'd be immensely helpful.
I suppose I could node-debugger eslint -- but that's high effort for a little change.
