### PR TITLE
[BUGFIX] Don't invoke Testem.hookIntoTestFramework if there is no test framework (yet)

### DIFF
--- a/lib/broccoli/test-support-suffix.js
+++ b/lib/broccoli/test-support-suffix.js
@@ -1,6 +1,6 @@
 runningTests = true;
 
-if (window.Testem) {
+if (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {
   window.Testem.hookIntoTestFramework();
 }
 

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -138,7 +138,7 @@ describe('Default Packager: Ember CLI Internal', function () {
     );
     expect(testSupportPrefixFileContent).to.equal('');
     expect(testSupportSuffixFileContent).to.contain(
-      'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
+      `runningTests = true;\n\nif (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {\n  window.Testem.hookIntoTestFramework();\n}`
     );
 
     expect(vendorPrefixFileContent).to.contain(`window.EmberENV = (function(EmberENV, extra) {


### PR DESCRIPTION
**Note**:
- I would like to backport this througout the LTS versions as far back as what ember-qunit supports (v4)

**Goal**:
- do not throw an error if we don't have a test-framework when test-support-suffix's code is executed
  (testem does this by default if `hookIntoTestFramework` is called and there isn't a supported test framework available)

**What**:

I believe this change to be pretty safe, because if anyone happens to rely on this old behavior, it should keep working.
From the newer side of things, if, somehow, QUnit is defined before test-support-suffix, `hookIntoTestFramework` is idempotent, so calling it multiple times is safe.

Long term, if folks want to provide a test adapter for Testem, they need to call testem themselves.

For example, ember-qunit has had this line in its own code for ages: 
- (v2 addon beta) https://github.com/emberjs/ember-qunit/blob/master/addon/src/index.js#L11
- v7.0.0 https://github.com/emberjs/ember-qunit/blob/v7.0.0/addon-test-support/index.js#L9
- v6.0.0 https://github.com/emberjs/ember-qunit/blob/v6.0.0/addon-test-support/index.js#L9
- v5.0.0 https://github.com/emberjs/ember-qunit/blob/v5.0.0/addon-test-support/index.js#L9


-----------------------------

<details><summary>Original Description</summary>

(kept for historical reasons)

Note this is still a Draft -- I'm still trying to figure out what the best course of action will be for support v2 addons as test-support dependencies. Right now, as I write this, ~~I'm sort of leaning towards solving this~~ in ember-auto-import/embroider, but it would mean _more_ code to maintain -- where as the code in this ember-cli PR would result in _less_ code to maintain -- we could drop support for test-support-suffix in ember-cli v6 for example (waiting until a major as a courtesy -- I couldn't find evidence of this being public API)

Here are all known usages in the ecosystem: https://emberobserver.com/code-search?codeQuery=test-support-suffix
(internal stuff)

-----------------


</details>

This change is part of investigations into: https://github.com/emberjs/ember-qunit/issues/1100

the tl;dr: is that ember-cli is arbitrarily trying to setup Testem, before the test-framework adapter is ready (ember-qunit).

Previously, this worked because `test-support-suffix` is at the tail-end of the `test-support.js` file, where `ember-qunit` gets inserted into when used as a v1 addon (v7.0.0 and earlier).

The `ember-qunit` v7.1.0-0 (beta) release is a v2 addon, which means that ember-qunit is brought in via ember-auto-import and therefor inserted in the index.html _after_ `test-support.js`, which means `ember-cli` has already invoked `Testem.hookIntoTestFramework()`, which fails, due to ember-qunit not being loaded yet, and then reports an error to the CLI.

I propose this change because this is _private_ behavior -- I could not find `test-support-suffix` formally supported / declared public anywhere.
- https://github.com/search?q=repo%3Aemberjs%2Frfcs%20test-support-suffix&type=code
- https://github.com/search?q=org%3Aemberjs+test-support-suffix&type=code
- https://github.com/search?q=org%3Aember-cli+test-support-suffix&type=issues
  - there have been previous efforts to try to remove this "prefix" / "suffix" behavior for "app" - https://github.com/ember-cli/ember-cli/issues/5240 
  - a mention here, but it's just supporting node 8 / dropping node 6 https://github.com/ember-cli/ember-cli/issues/8511
  - these hooks were added in Feb 2015: https://github.com/ember-cli/ember-cli-changelog/commit/1a0ebea966226aefd0ce99506e04240227f6562f / https://github.com/ember-cli/ember-cli/commit/1a0ebea966226aefd0ce99506e04240227f6562f
  - none of this is documented: https://ember-cli.com/api/classes/defaultpackager


I am willing to backport this to a good few ember-cli versions

An alternative approach could be to solve this in ember-auto-import, and insert known test-focused dependencies before test-support.js -- https://github.com/embroider-build/ember-auto-import/blob/b9abf2923220293278d8129046e98f3f3e9a5e0c/packages/ember-auto-import/ts/inserter.ts#L137

---

How I tested locally that booting up an app's tests still works:

```bash
node ../NullVoxPopuli/ember-cli/bin/ember new suffixless --skip-git --skip-npm
cd suffixless
pnpm i
pnpm ember test
pnpm ember test --serve --no-launch --test-port 7000
# visit localhost:7000
```