### PR TITLE
Add the fixtures/addon/pnpm path to the update-blueprint-dependencies…

### DIFF
--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -54,6 +54,7 @@ const PACKAGE_FILES = [
   '../tests/fixtures/app/embroider-no-welcome/package.json',
   '../tests/fixtures/addon/defaults/package.json',
   '../tests/fixtures/addon/yarn/package.json',
+  '../tests/fixtures/addon/pnpm/package.json',
 ];
 
 let filter = {


### PR DESCRIPTION
This was missed in the pnpm implementation PR: https://github.com/ember-cli/ember-cli/pull/10287
Without this change, we are at risk of needed separate PRs that update fixtures, like here: https://github.com/ember-cli/ember-cli/pull/10297