### PR TITLE
Set resolution-mode to highest for apps using pnpm

### DIFF
--- a/blueprints/app/files/.npmrc
+++ b/blueprints/app/files/.npmrc
@@ -1,0 +1,9 @@
+# For more information: https://pnpm.io/npmrc
+#
+# The default is lowest-direct,
+# which is good for library authors as it ensures they continue
+# testing and developing against the bottom of their
+# supported semver range for retaining maximum compatibility.
+#
+# but for apps we always want the latest bugfixes
+resolution-mode=highest

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -77,6 +77,10 @@ module.exports = {
       files = files.filter((file) => file.indexOf('.github') < 0);
     }
 
+    if (!options.pnpm) {
+      files = files.filter((file) => !file.endsWith('.npmrc'));
+    }
+
     if (!options.typescript) {
       files = files.filter(
         (file) => !['tsconfig.json', 'app/config/', 'types/'].includes(file) && !file.endsWith('.d.ts')

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -49,7 +49,7 @@ describe('Acceptance: ember init', function () {
     let blueprintPath = path.join(root, 'blueprints', 'app', 'files');
     // ignore .travis.yml and TypeScript files
     let expected = walkSync(blueprintPath, {
-      ignore: ['.travis.yml', 'tsconfig.json', 'types', 'app/config'],
+      ignore: ['.travis.yml', 'tsconfig.json', 'types', 'app/config', '.npmrc'],
     })
       .map((name) => (typescript ? name : name.replace(/\.ts$/, '.js')))
       .sort();

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -43,7 +43,7 @@ describe('Acceptance: ember new', function () {
     let blueprintPath = path.join(root, blueprintDir, 'files');
     // ignore .travis.yml and TypeScript files
     let expected = walkSync(blueprintPath, {
-      ignore: ['.travis.yml', 'tsconfig.json', 'types', 'app/config'],
+      ignore: ['.travis.yml', 'tsconfig.json', 'types', 'app/config', '.npmrc'],
     }).map((name) => (typescript ? name : name.replace(/\.ts$/, '.js')));
 
     let actual = walkSync('.').sort();

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -562,7 +562,7 @@ describe('Acceptance: ember new', function () {
 
       let fixturePath = 'app/pnpm';
 
-      ['app/templates/application.hbs', '.github/workflows/ci.yml', 'README.md'].forEach((filePath) => {
+      ['app/templates/application.hbs', '.github/workflows/ci.yml', 'README.md', '.npmrc'].forEach((filePath) => {
         checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
       });
 

--- a/tests/fixtures/app/pnpm/.npmrc
+++ b/tests/fixtures/app/pnpm/.npmrc
@@ -1,0 +1,9 @@
+# For more information: https://pnpm.io/npmrc
+#
+# The default is lowest-direct,
+# which is good for library authors as it ensures they continue
+# testing and developing against the bottom of their
+# supported semver range for retaining maximum compatibility.
+#
+# but for apps we always want the latest bugfixes
+resolution-mode=highest


### PR DESCRIPTION
Discussion here: https://discord.com/channels/480462759797063690/480501885837770763/1122582845873983529

tl;dr: 
```
# For more information: https://pnpm.io/npmrc
#
# The default is lowest-direct,
# which is good for library authors as it ensures they continue
# testing and developing against the bottom of their
# supported semver range for retaining maximum compatibility.
#
# but for apps we always want the latest bugfixes
```
Addons have not changed the `resolution-mode`.

pnpm made the decision for doing lowest-direct, which is great for ensuring maximum compatibility. 

There is a ton to read up on if you want more context: https://github.com/pnpm/pnpm/issues/6463

_NOTE_: for addons/libraries which are using secret / intimate dependencies (`@glimmer/syntax`, vm, etc), due to the pre-1.0 nature of semver behavior, folks will want to make sure that the versions are carefully managed -- as each minor version is actually a major, per semver, and if folks have too-low a version set up in their package.json, they'll likely get something very old) 

-----------------

Additionally, v1 addons will inherently have broken behavior (though it probably will not be noticed by many) because their dummy app setups do not correctly simulate a fresh app install (this includes ember-try, regardless of using npm, yarn, etc)