### PR TITLE
[BUGFIX] Do not try to wire up Testem unless a test framework is dete…

### DIFF
--- a/lib/broccoli/test-support-suffix.js
+++ b/lib/broccoli/test-support-suffix.js
@@ -1,6 +1,6 @@
 runningTests = true;
 
-if (window.Testem) {
+if (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {
   window.Testem.hookIntoTestFramework();
 }
 

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -138,7 +138,7 @@ describe('Default Packager: Ember CLI Internal', function () {
     );
     expect(testSupportPrefixFileContent).to.equal('');
     expect(testSupportSuffixFileContent).to.contain(
-      'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
+      `runningTests = true;\n\nif (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {\n  window.Testem.hookIntoTestFramework();\n}`
     );
 
     expect(vendorPrefixFileContent).to.contain(`window.EmberENV = (function(EmberENV, extra) {


### PR DESCRIPTION
…cted -- this is for legacy compat -- modern libraries, such as ember-qunit, call hookIntoTestFramework themselves, because it has better knowledge of when Testem needs to be configured

Update test to reflect changes to internal default-packager files.


Backport of https://github.com/ember-cli/ember-cli/pull/10300