### PR TITLE
[BUGFIX] Do not try to wire up Testem unless a test framework is dete…

### DIFF
--- a/lib/broccoli/test-support-suffix.js
+++ b/lib/broccoli/test-support-suffix.js
@@ -1,6 +1,6 @@
 runningTests = true;
 
-if (window.Testem) {
+if (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {
   window.Testem.hookIntoTestFramework();
 }
 

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -21,6 +21,10 @@ const assertVersionLock = require('../helpers/assert-version-lock');
 
 let tmpDir = './tmp/new-test';
 
+let { stdout: nodeOut } = execa.sync('node', ['--version']);
+
+let isNode14 = semver.satisfies(nodeOut, '14.x');
+
 describe('Acceptance: ember new', function () {
   this.timeout(300000);
   let ORIGINAL_PROCESS_ENV_CI;
@@ -625,7 +629,10 @@ describe('Acceptance: ember new', function () {
       checkFileWithEmberCLIVersionReplacement(fixturePath, 'tests/dummy/config/ember-cli-update.json');
     });
 
-    it.skip('app + typescript', async function () {
+    it('app + typescript', async function () {
+      if (isNode14) {
+        this.skip();
+      }
       // This is a very slow test, as the blueprint installs ember-cli-typescript, which requires installing all dependencies,
       // regardless of --skip-npm
       this.timeout(600000);
@@ -660,7 +667,11 @@ describe('Acceptance: ember new', function () {
       expect(file('tsconfig.json')).to.exist;
     });
 
-    it.skip('addon + typescript', async function () {
+    it('addon + typescript', async function () {
+      if (isNode14) {
+        this.skip();
+      }
+
       this.timeout(600000);
 
       await ember(['addon', 'foo', '--typescript', '--skip-npm', '--skip-bower', '--skip-git', '--yarn']);

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -625,7 +625,7 @@ describe('Acceptance: ember new', function () {
       checkFileWithEmberCLIVersionReplacement(fixturePath, 'tests/dummy/config/ember-cli-update.json');
     });
 
-    it('app + typescript', async function () {
+    it.skip('app + typescript', async function () {
       // This is a very slow test, as the blueprint installs ember-cli-typescript, which requires installing all dependencies,
       // regardless of --skip-npm
       this.timeout(600000);
@@ -660,7 +660,7 @@ describe('Acceptance: ember new', function () {
       expect(file('tsconfig.json')).to.exist;
     });
 
-    it('addon + typescript', async function () {
+    it.skip('addon + typescript', async function () {
       this.timeout(600000);
 
       await ember(['addon', 'foo', '--typescript', '--skip-npm', '--skip-bower', '--skip-git', '--yarn']);

--- a/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
+++ b/tests/unit/broccoli/default-packager/ember-cli-internal-test.js
@@ -138,7 +138,7 @@ describe('Default Packager: Ember CLI Internal', function () {
     );
     expect(testSupportPrefixFileContent).to.equal('');
     expect(testSupportSuffixFileContent).to.contain(
-      'runningTests = true;\n\nif (window.Testem) {\n  window.Testem.hookIntoTestFramework();\n}'
+      `runningTests = true;\n\nif (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {\n  window.Testem.hookIntoTestFramework();\n}`
     );
 
     expect(vendorPrefixFileContent).to.contain(`window.EmberENV = (function(EmberENV, extra) {


### PR DESCRIPTION
…cted -- this is for legacy compat -- modern libraries, such as ember-qunit, call hookIntoTestFramework themselves, because it has better knowledge of when Testem needs to be configured

Update test to reflect changes to internal default-packager files

Backport of https://github.com/ember-cli/ember-cli/pull/10300