### PR TITLE
[BUGFIX] Remove `auto` as a possible value for `locationType` in `config` declaration

### DIFF
--- a/blueprints/app/files/app/config/environment.d.ts
+++ b/blueprints/app/files/app/config/environment.d.ts
@@ -6,7 +6,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: 'history' | 'hash' | 'none' | 'auto';
+  locationType: 'history' | 'hash' | 'none';
   rootURL: string;
   APP: Record<string, unknown>;
 };

--- a/tests/fixtures/addon/typescript/tests/dummy/app/config/environment.d.ts
+++ b/tests/fixtures/addon/typescript/tests/dummy/app/config/environment.d.ts
@@ -6,7 +6,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: 'history' | 'hash' | 'none' | 'auto';
+  locationType: 'history' | 'hash' | 'none';
   rootURL: string;
   APP: Record<string, unknown>;
 };

--- a/tests/fixtures/app/typescript-embroider/app/config/environment.d.ts
+++ b/tests/fixtures/app/typescript-embroider/app/config/environment.d.ts
@@ -6,7 +6,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: 'history' | 'hash' | 'none' | 'auto';
+  locationType: 'history' | 'hash' | 'none';
   rootURL: string;
   APP: Record<string, unknown>;
 };

--- a/tests/fixtures/app/typescript/app/config/environment.d.ts
+++ b/tests/fixtures/app/typescript/app/config/environment.d.ts
@@ -6,7 +6,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: 'history' | 'hash' | 'none' | 'auto';
+  locationType: 'history' | 'hash' | 'none';
   rootURL: string;
   APP: Record<string, unknown>;
 };


### PR DESCRIPTION
The `auto` location was removed in `ember-source` v5.