### PR TITLE
Add lint:fix to `ember addon`

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -12,6 +12,7 @@ module.exports = NewCommand.extend({
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'blueprint', type: String, default: 'addon', aliases: ['b'] },
     { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'lint-fix', type: Boolean, default: true },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
     { name: 'yarn', type: Boolean }, // no default means use yarn if the blueprint has a yarn.lock
     { name: 'pnpm', type: Boolean, default: false },


### PR DESCRIPTION
`ember new` has `lint:fix` by default, but `ember addon` does not.
This makes both things behave the same, post-blueprint installation.

The app blueprint recently was shipped with some lint errors, which the app blueprint doesn't observe, because it has `lint:fix`. the v2 addon blueprint noticed the lint errors, and CI started failing because `addon` does not `lint:fix`

Gotta add some tests

Guidance here: https://discord.com/channels/480462759797063690/1138509045112786944/1138520128754045108