### PR TITLE
[ENHANCEMENT] Remove reference to `ember-mocha` in `app` blueprint

### DIFF
--- a/blueprints/app/files/tests/helpers/index.ts
+++ b/blueprints/app/files/tests/helpers/index.ts
@@ -5,7 +5,7 @@ import {
   SetupTestOptions,
 } from 'ember-qunit';
 
-// This file exists to provide wrappers around ember-qunit's / ember-mocha's
+// This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -596,7 +596,7 @@ class Project {
     Generate test file contents.
 
     This method is supposed to be overwritten by test framework addons
-    like `ember-qunit` and `ember-mocha`.
+    like `ember-qunit`.
 
     @public
     @method generateTestFile

--- a/tests/fixtures/addon/typescript/tests/helpers/index.ts
+++ b/tests/fixtures/addon/typescript/tests/helpers/index.ts
@@ -5,7 +5,7 @@ import {
   SetupTestOptions,
 } from 'ember-qunit';
 
-// This file exists to provide wrappers around ember-qunit's / ember-mocha's
+// This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 

--- a/tests/fixtures/app/defaults/tests/helpers/index.js
+++ b/tests/fixtures/app/defaults/tests/helpers/index.js
@@ -4,7 +4,7 @@ import {
   setupTest as upstreamSetupTest,
 } from 'ember-qunit';
 
-// This file exists to provide wrappers around ember-qunit's / ember-mocha's
+// This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 

--- a/tests/fixtures/app/typescript-embroider/tests/helpers/index.ts
+++ b/tests/fixtures/app/typescript-embroider/tests/helpers/index.ts
@@ -5,7 +5,7 @@ import {
   SetupTestOptions,
 } from 'ember-qunit';
 
-// This file exists to provide wrappers around ember-qunit's / ember-mocha's
+// This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 

--- a/tests/fixtures/app/typescript/tests/helpers/index.ts
+++ b/tests/fixtures/app/typescript/tests/helpers/index.ts
@@ -5,7 +5,7 @@ import {
   SetupTestOptions,
 } from 'ember-qunit';
 
-// This file exists to provide wrappers around ember-qunit's / ember-mocha's
+// This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 


### PR DESCRIPTION
As `ember-mocha` is officially deprecated.