### PR TITLE
[BUGFIX beta] App blueprint may not have explicit-any in ember-data types

### DIFF
--- a/blueprints/app/files/types/ember-data/types/registries/model.d.ts
+++ b/blueprints/app/files/types/ember-data/types/registries/model.d.ts
@@ -2,5 +2,6 @@
  * Catch-all for ember-data.
  */
 export default interface ModelRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/tests/fixtures/app/typescript-embroider/types/ember-data/types/registries/model.d.ts
+++ b/tests/fixtures/app/typescript-embroider/types/ember-data/types/registries/model.d.ts
@@ -2,5 +2,6 @@
  * Catch-all for ember-data.
  */
 export default interface ModelRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/tests/fixtures/app/typescript/types/ember-data/types/registries/model.d.ts
+++ b/tests/fixtures/app/typescript/types/ember-data/types/registries/model.d.ts
@@ -2,5 +2,6 @@
  * Catch-all for ember-data.
  */
 export default interface ModelRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }


### PR DESCRIPTION
Discovered over here: https://github.com/embroider-build/addon-blueprint/actions/runs/5912329738/job/16035634804?pr=188

In `--typescript` projects, we use
```
      extends: [
        'plugin:@typescript-eslint/eslint-recommended',
        'plugin:@typescript-eslint/recommended',
      ],
```

which then immediately fails `lint` / `lint:fix` due to the above configs having `@typescript-eslint/no-explicit-any` so we need to disable the rule for ember-data's model registry.


Unblocks: https://github.com/embroider-build/addon-blueprint/pull/188