### PR TITLE
[ENHANCEMENT] Deprecate Travis CI support

### DIFF
--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/blueprints/addon/files/.travis.yml
+++ b/blueprints/addon/files/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/blueprints/app/files/.travis.yml
+++ b/blueprints/app/files/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -9,6 +9,7 @@ const normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 const { isPnpmProject, isYarnProject } = require('../utilities/package-managers');
 const getLangArg = require('../../lib/utilities/get-lang-arg');
+const { deprecate } = require('../debug');
 
 module.exports = Command.extend({
   name: 'init',
@@ -118,6 +119,25 @@ module.exports = Command.extend({
     }
     const projectName = this.project.name();
     const prependEmoji = require('../../lib/utilities/prepend-emoji');
+
+    if (ciProvider === 'travis') {
+      this.ui.writeLine('');
+
+      deprecate(
+        'Support for generating a Travis CI config file is deprecated.\nYou can keep using Travis CI, or you could also consider switching to GitHub Actions instead.',
+        false,
+        {
+          for: 'ember-cli',
+          id: 'travis-ci-support',
+          since: {
+            available: '5.4.0',
+            enabled: '5.4.0',
+          },
+          until: '6.0.0',
+          url: 'https://deprecations.emberjs.com/ember-cli/v5.x#TODO',
+        }
+      );
+    }
 
     this.ui.writeLine('');
     this.ui.writeLine(prependEmoji('🎉', `Successfully created project ${chalk.yellow(projectName)}.`));

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -134,7 +134,7 @@ module.exports = Command.extend({
             enabled: '5.4.0',
           },
           until: '6.0.0',
-          url: 'https://deprecations.emberjs.com/ember-cli/v5.x#TODO',
+          url: 'https://deprecations.emberjs.com/id/travis-ci-support',
         }
       );
     }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -130,8 +130,8 @@ module.exports = Command.extend({
           for: 'ember-cli',
           id: 'travis-ci-support',
           since: {
-            available: '5.4.0',
-            enabled: '5.4.0',
+            available: '5.5.0',
+            enabled: '5.5.0',
           },
           until: '6.0.0',
           url: 'https://deprecations.emberjs.com/id/travis-ci-support',

--- a/lib/debug/deprecate.js
+++ b/lib/debug/deprecate.js
@@ -74,6 +74,7 @@ function deprecate(description, condition, options) {
   let message = formatMessage(description, options);
 
   warn(message);
+  warn('');
   warn(getStackTrace());
 
   // Return the message for testing purposes.
@@ -86,13 +87,21 @@ function isSemVer(version) {
 }
 
 function formatMessage(description, options) {
-  let message = [`DEPRECATION: ${description}`, `[ID: ${options.id}]`];
+  let message = [
+    chalk.inverse(' DEPRECATION '),
+    '\n\n',
+    description,
+    '\n\n',
+    `ID     ${options.id}`,
+    '\n',
+    `UNTIL  ${options.until}`,
+  ];
 
   if (options.url) {
-    message.push(`See ${options.url} for more details.`);
+    message.push('\n', `URL    ${options.url}`);
   }
 
-  return message.join(' ');
+  return message.join('');
 }
 
 function getStackTrace() {

--- a/tests/fixtures/addon/defaults-travis/.travis.yml
+++ b/tests/fixtures/addon/defaults-travis/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/tests/fixtures/addon/defaults-travis/.travis.yml
+++ b/tests/fixtures/addon/defaults-travis/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/tests/fixtures/addon/yarn/.travis.yml
+++ b/tests/fixtures/addon/yarn/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/tests/fixtures/app/npm-travis/.travis.yml
+++ b/tests/fixtures/app/npm-travis/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/tests/fixtures/app/npm-travis/.travis.yml
+++ b/tests/fixtures/app/npm-travis/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/tests/fixtures/app/yarn-travis/.travis.yml
+++ b/tests/fixtures/app/yarn-travis/.travis.yml
@@ -1,3 +1,14 @@
+# DEPRECATION:
+#
+# Support for generating a Travis CI config file is deprecated.
+# You can keep using Travis CI, or you could also consider switching to GitHub Actions instead.
+#
+# Feel free to remove this comment block if you want to continue using Travis CI.
+#
+# ID     travis-ci-support
+# UNTIL  6.0.0
+# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+
 ---
 language: node_js
 node_js:

--- a/tests/fixtures/app/yarn-travis/.travis.yml
+++ b/tests/fixtures/app/yarn-travis/.travis.yml
@@ -7,7 +7,7 @@
 #
 # ID     travis-ci-support
 # UNTIL  6.0.0
-# URL    https://deprecations.emberjs.com/ember-cli/v5.x#TODO
+# URL    https://deprecations.emberjs.com/id/travis-ci-support
 
 ---
 language: node_js

--- a/tests/unit/debug/deprecate-test.js
+++ b/tests/unit/debug/deprecate-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const stripAnsi = require('strip-ansi');
 const { deprecate } = require('../../../lib/debug');
 
 describe('deprecate', function () {
@@ -155,7 +156,11 @@ describe('deprecate', function () {
       until: '5.0.0',
     });
 
-    expect(message).to.be.equal('DEPRECATION: description [ID: foo]');
+    expect(stripAnsi(message)).to.be.equal(` DEPRECATION \n
+description
+
+ID     foo
+UNTIL  5.0.0`);
   });
 
   it('it includes the `url` option in the deprecation message when provided', function () {
@@ -170,6 +175,11 @@ describe('deprecate', function () {
       url: 'https://example.com',
     });
 
-    expect(message).to.be.equal('DEPRECATION: description [ID: foo] See https://example.com for more details.');
+    expect(stripAnsi(message)).to.be.equal(` DEPRECATION \n
+description
+
+ID     foo
+UNTIL  5.0.0
+URL    https://example.com`);
   });
 });


### PR DESCRIPTION
Implements https://github.com/emberjs/rfcs/pull/918.

The first commit isn't a necessity, but I think it makes deprecations more readable (a bit "heavier" though).

Example:

<img width="1512" alt="Screenshot 2023-08-21 at 16 48 46 (2)" src="https://github.com/ember-cli/ember-cli/assets/7403183/1da3865b-a647-4010-99b3-b211ab01d383">