### PR TITLE
[INTERNAL] Remove `@babel/core` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "test:slow": "node --unhandled-rejections=strict tests/runner slow"
   },
   "dependencies": {
-    "@babel/core": "^7.22.10",
     "@pnpm/find-workspace-dir": "^6.0.2",
     "broccoli": "^3.5.2",
     "broccoli-builder": "^0.18.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,7 +28,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
   integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
 
-"@babel/core@^7.16.10", "@babel/core@^7.22.10", "@babel/core@^7.7.5":
+"@babel/core@^7.16.10", "@babel/core@^7.7.5":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.10.tgz#aad442c7bcd1582252cb4576747ace35bc122f35"
   integrity sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==


### PR DESCRIPTION
Was added in https://github.com/ember-cli/ember-cli/pull/8427, to satisfy `@babel/plugin-transform-modules-amd`, but `@babel/plugin-transform-modules-amd` was removed in https://github.com/ember-cli/ember-cli/pull/10232, which means we can remove `@babel/core` again.