### PR TITLE
Add workflow_dispatch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'release-*'
       - 'lts-*'
   pull_request:
+  workflow_dispatch:
   merge_group:
   schedule:
     - cron:  '0 3 * * *' # daily, at 3am


### PR DESCRIPTION
This allows manual running of C.I. in the GH Actions tab.

I wasn't expecting https://github.com/ember-cli/ember-cli/pull/10355 to fail, so I wanted a way to check that the `master` tests were currently green.