### PR TITLE
Reduce confusion when wanting to run tests

### DIFF
--- a/blueprints/app/files/README.md
+++ b/blueprints/app/files/README.md
@@ -32,8 +32,9 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Running Tests
 
-* `ember test`
-* `ember test --server`
+* `ember serve` and visit `/tests` in your browser
+* `ember test` for CI
+* `ember test --server` for debugging CI
 
 ### Linting
 


### PR DESCRIPTION
For folks new to ember and who "just want to run tests", I don't think we should not be recommending `ember test` -- because it's headless.

`ember test --server` is also buggy, because testem is buggy, and kind of unmaintained.