### PR TITLE
Add broccoli-plugin to the test fixture so that it uses the correct

### DIFF
--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -146,6 +146,14 @@ describe('Acceptance: brocfile-smoke-test', function () {
       packageJson.devDependencies['ember-test-addon'] = 'latest';
       fs.writeJsonSync(packageJsonPath, packageJson);
 
+      // we need to copy broccoli-plugin into the addon's node_modules to make up for the fact
+      // that the mock 'ember-test-addon' does not have a dependency install step
+      fs.mkdirSync(path.join(appRoot, 'node_modules', 'ember-test-addon', 'node_modules'));
+      await fs.copy(
+        path.join('..', '..', 'node_modules', 'broccoli-plugin'),
+        path.join(appRoot, 'node_modules', 'ember-test-addon', 'node_modules', 'broccoli-plugin')
+      );
+
       await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
       let checker = new DistChecker(path.join(appRoot, 'dist'));

--- a/tests/fixtures/brocfile-tests/app-test-import/node_modules/ember-test-addon/package.json
+++ b/tests/fixtures/brocfile-tests/app-test-import/node_modules/ember-test-addon/package.json
@@ -4,5 +4,8 @@
   "version": "0.0.0",
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "dependencies": {
+    "broccoli-plugin": "^4.0.7"
+  }
 }


### PR DESCRIPTION
version -- there is no install step for the fixtures

(cherry picked from commit 389beb16da7307ac5fea51ef619e3e577c36dacc)