### PR TITLE
[ENHANCEMENT] feat: add skip-install alias to skip-npm

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -11,7 +11,7 @@ module.exports = NewCommand.extend({
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'blueprint', type: String, default: 'addon', aliases: ['b'] },
-    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn', 'skip-install', 'si'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
     {
       name: 'package-manager',

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -20,7 +20,7 @@ module.exports = Command.extend({
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'blueprint', type: String, aliases: ['b'] },
-    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn', 'skip-install', 'si'] },
     { name: 'lint-fix', type: Boolean, default: true },
     {
       name: 'welcome',

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -17,7 +17,7 @@ module.exports = Command.extend({
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'blueprint', type: String, default: 'app', aliases: ['b'] },
-    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn'] },
+    { name: 'skip-npm', type: Boolean, default: false, aliases: ['sn', 'skip-install', 'si'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] },
     {
       name: 'welcome',

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -126,7 +126,7 @@ let Command = CoreObject.extend({
      *   { name: 'dry-run',    type: Boolean, default: false, aliases: ['d'] },
      *   { name: 'verbose',    type: Boolean, default: false, aliases: ['v'] },
      *   { name: 'blueprint',  type: String,  default: 'app', aliases: ['b'] },
-     *   { name: 'skip-npm',   type: Boolean, default: false, aliases: ['sn'] },
+     *   { name: 'skip-npm',   type: Boolean, default: false, aliases: ['sn', 'skip-install', 'si'] },
      *   { name: 'skip-git',   type: Boolean, default: false, aliases: ['sg'] },
      *   { name: 'directory',  type: String ,                 aliases: ['dir'] }
      * ],

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -11,7 +11,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m [36m(Default: addon)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--skip-git[39m [36m(Boolean)[39m [36m(Default: false)[39m
     [90maliases: -sg[39m
   [36m--package-manager[39m [36m(npm, pnpm, yarn)[39m
@@ -95,7 +95,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--welcome[39m [36m(Boolean)[39m [36m(Default: true)[39m Installs and uses {{ember-welcome-page}}. Use --no-welcome to skip it.
   [36m--package-manager[39m [36m(npm, pnpm, yarn)[39m
@@ -128,7 +128,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m [36m(Default: app)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--skip-git[39m [36m(Boolean)[39m [36m(Default: false)[39m
     [90maliases: -sg[39m
   [36m--welcome[39m [36m(Boolean)[39m [36m(Default: true)[39m Installs and uses {{ember-welcome-page}}. Use --no-welcome to skip it.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -41,7 +41,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -415,7 +415,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -546,7 +546,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -11,7 +11,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m [36m(Default: addon)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--skip-git[39m [36m(Boolean)[39m [36m(Default: false)[39m
     [90maliases: -sg[39m
   [36m--package-manager[39m [36m(npm, pnpm, yarn)[39m
@@ -95,7 +95,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--welcome[39m [36m(Boolean)[39m [36m(Default: true)[39m Installs and uses {{ember-welcome-page}}. Use --no-welcome to skip it.
   [36m--package-manager[39m [36m(npm, pnpm, yarn)[39m
@@ -128,7 +128,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--blueprint[39m [36m(String)[39m [36m(Default: app)[39m
     [90maliases: -b <value>[39m
   [36m--skip-npm[39m [36m(Boolean)[39m [36m(Default: false)[39m
-    [90maliases: -sn[39m
+    [90maliases: -sn, --skip-install, -si[39m
   [36m--skip-git[39m [36m(Boolean)[39m [36m(Default: false)[39m
     [90maliases: -sg[39m
   [36m--welcome[39m [36m(Boolean)[39m [36m(Default: true)[39m Installs and uses {{ember-welcome-page}}. Use --no-welcome to skip it.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -41,7 +41,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -447,7 +447,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -578,7 +578,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -41,7 +41,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -415,7 +415,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },
@@ -546,7 +546,7 @@ module.exports = {
         {
           name: 'skip-npm',
           default: false,
-          aliases: ['sn'],
+          aliases: ['sn', 'skip-install', 'si'],
           key: 'skipNpm',
           required: false
         },


### PR DESCRIPTION
The `--skip-npm` flag seems rather confusing now that three package managers are supported.

e.g. a valid way to generate an Ember app with pnpm today is:

```sh
ember new example-app --pnpm --skip-npm
```

With this alias it could be written as follows:

```sh
ember new example-app --pnpm --skip-install
```

I don't have a lot of context about the impact of this change, so please let me know if it isn't as simple as just adding an alias 😄 