### PR TITLE
[ENHANCEMENT] automatically select a port by default with `ember serve`

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,16 +1,12 @@
 'use strict';
 
 const Command = require('../models/command');
-const util = require('util');
 const SilentError = require('silent-error');
 const PortFinder = require('portfinder');
 const Win = require('../utilities/windows-admin');
 const EOL = require('os').EOL;
 
-PortFinder.basePort = 7020;
-
-let getPort = util.promisify(PortFinder.getPort);
-let defaultPort = process.env.PORT || 4200;
+const DEFAULT_PORT = 4200;
 
 module.exports = Command.extend({
   name: 'serve',
@@ -21,9 +17,11 @@ module.exports = Command.extend({
     {
       name: 'port',
       type: Number,
-      default: defaultPort,
+      default: process.env.PORT || DEFAULT_PORT,
       aliases: ['p'],
-      description: `To use a port different than ${defaultPort}. Pass 0 to automatically pick an available port.`,
+      description: `Overrides $PORT (currently ${
+        process.env.PORT || 'blank'
+      }). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.`,
     },
     { name: 'host', type: String, aliases: ['H'], description: 'Listens on all interfaces by default' },
     { name: 'proxy', type: String, aliases: ['pr', 'pxy'] },
@@ -93,7 +91,7 @@ module.exports = Command.extend({
   async run(commandOptions) {
     commandOptions.liveReloadHost = commandOptions.liveReloadHost || commandOptions.host;
 
-    let wrappedCommandOptions = await this._checkExpressPort(commandOptions);
+    let wrappedCommandOptions = await this._checkOrGetPort(commandOptions);
     if (wrappedCommandOptions.proxy) {
       if (!/^(http:|https:)/.test(wrappedCommandOptions.proxy)) {
         let message = `You need to include a protocol with the proxy URL.${EOL}Try --proxy http://${wrappedCommandOptions.proxy}`;
@@ -106,22 +104,22 @@ module.exports = Command.extend({
     await this.runTask('Serve', commandOptions);
   },
 
-  async _checkExpressPort(commandOptions) {
-    let portOptions = { port: commandOptions.port, host: commandOptions.host };
-    if (commandOptions.port !== 0) {
+  async _checkOrGetPort(commandOptions) {
+    let portOptions = { port: commandOptions.port || DEFAULT_PORT, host: commandOptions.host };
+    if (commandOptions.port !== 0 && commandOptions.port !== DEFAULT_PORT) {
+      // if a port was set, only check for that port
       portOptions.stopPort = commandOptions.port;
     }
     try {
-      let foundPort = await getPort(portOptions);
-      commandOptions.port = foundPort;
+      commandOptions.port = await PortFinder.getPortPromise(portOptions);
       commandOptions.liveReloadPort = commandOptions.liveReloadPort || commandOptions.port;
       return commandOptions;
     } catch (err) {
       let message;
-      if (commandOptions.port === 0) {
-        message = `No open port found above ${commandOptions.port}`;
+      if (portOptions.port === DEFAULT_PORT) {
+        message = `No open port found above ${portOptions.port}`;
       } else if (commandOptions.port < 1024) {
-        message = `Port ${commandOptions.port} is already in use or you do not have permissions to use this port.`;
+        message = `Port ${commandOptions.port} is already in use or you do not have permission to use this port.`;
       } else {
         message = `Port ${commandOptions.port} is already in use.`;
       }

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -146,7 +146,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.
   [90maliases: server, s[39m
-  [36m--port[39m [36m(Number)[39m [36m(Default: 4200)[39m To use a port different than 4200. Pass 0 to automatically pick an available port.
+  [36m--port[39m [36m(Number)[39m [36m(Default: 4200)[39m Overrides $PORT (currently blank). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.
     [90maliases: -p <value>[39m
   [36m--host[39m [36m(String)[39m Listens on all interfaces by default
     [90maliases: -H <value>[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -624,7 +624,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
-          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
+          description: 'Overrides $PORT (currently blank). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.',
           aliases: ['p'],
           key: 'port',
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -146,7 +146,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.
   [90maliases: server, s[39m
-  [36m--port[39m [36m(Number)[39m [36m(Default: 4200)[39m To use a port different than 4200. Pass 0 to automatically pick an available port.
+  [36m--port[39m [36m(Number)[39m [36m(Default: 4200)[39m Overrides $PORT (currently blank). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.
     [90maliases: -p <value>[39m
   [36m--host[39m [36m(String)[39m Listens on all interfaces by default
     [90maliases: -H <value>[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -656,7 +656,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
-          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
+          description: 'Overrides $PORT (currently blank). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.',
           aliases: ['p'],
           key: 'port',
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -624,7 +624,7 @@ module.exports = {
         {
           name: 'port',
           default: 4200,
-          description: 'To use a port different than 4200. Pass 0 to automatically pick an available port.',
+          description: 'Overrides $PORT (currently blank). If the port 0 or the default port 4200 is passed, ember will use any available port starting from 4200.',
           aliases: ['p'],
           key: 'port',
           required: false


### PR DESCRIPTION
Fixes #9512

`ember serve` will now automatically choose a port (starting with 4200), unless a port is explicitly set with the `--port` flag or the `$PORT` env variable.  

## Notes:
The base port has also been changed from 7020 (which seems to have been arbitrarily chosen in 43878e2) to 4200, the current default. The old value of 7020 also doesn't seem to do anything since it's overridden by the default 4200 anyways.

The `should throw error when -p PORT is taken` test block has been moved out of a legacy if statement referencing appveyor.