### PR TITLE
Update to deploy to the master branch and also correct a comment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
       version:
         required: true
         type: string
-        description: 'Specify the released version of ember-cli to use to generate and deploy documentation. Should be full semver version, and without a leading "v"'
+        description: 'Specify the released version of ember-cli to use to generate and deploy documentation. Should be full tag name, including the leading "v"'
 
 env:
   GIT_NAME: 'github-actions[bot]'
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: 'ember-learn/ember-cli.github.io'
           ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
-          branch: test-deploy-docs
+          branch: master
       - name: Download docs artifact
         uses: actions/download-artifact@v3
         with:
@@ -68,5 +68,5 @@ jobs:
             git commit --allow-empty -m "$COMMIT_MESSAGE"
       - name: Push
         run: |
-          git push -f origin HEAD:refs/heads/test-deploy-docs
+          git push -f origin HEAD:refs/heads/master
 


### PR DESCRIPTION
This updates the docs script to deploy directly to the `master` branch of `ember-learn/ember-cli.github.io` when an ember-cli version is tagged. This has been tested by deploying to `test-docs-deploy` in that same repo 

https://github.com/ember-cli/ember-cli/actions/runs/6829056476

https://github.com/ember-learn/ember-cli.github.io/tree/test-deploy-docs

This script has a slight problem at the moment in that if we tag a point release for an older version, it will clobber the newer docs. For now, I am satisfied that that is very rare and we can always fix it by manually triggering the workflow for the newer semver version.

cc @mansona 