### PR TITLE
Set a breakpoint when the window is about to unload.

### DIFF
--- a/blueprints/app/files/tests/test-helper.ts
+++ b/blueprints/app/files/tests/test-helper.ts
@@ -5,6 +5,14 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
+window.addEventListener('beforeunload', function() {
+  console.error('Window is about to unload. This means some test or code has tried to either set window.location or submit a form without "event.preventDefault()". Please use a mock window, window service, preventDefault, or some other technique to prevent navigation during testing');
+
+	// eslint-disable-next-line no-debugger
+	debugger;
+});
+
+
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);


### PR DESCRIPTION
Any time the window is going to unload during tests, it's inanely hard and annoying to debug which test is being problematic.

Setting a debugger in code gives folks a stack that they can trace back to their test to see what was going wrong.