### PR TITLE
[ENHANCEMENT] Use `content-tag` to parse GTS in blueprints

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -556,7 +556,7 @@ let Blueprint = CoreObject.extend({
       let strippedCode = code;
       for (let i = 0; i < templateTagMatches.length; i++) {
         const match = templateTagMatches[i];
-        const templateTag = code.substring(match.range.start, match.range.end);
+        const templateTag = substringBytes(code, match.range.start, match.range.end);
         strippedCode = strippedCode.replace(templateTag, templateTagIdentifier(i));
       }
 
@@ -567,7 +567,7 @@ let Blueprint = CoreObject.extend({
       let transformedWithTemplateTag = transformed;
       for (let i = 0; i < templateTagMatches.length; i++) {
         const match = templateTagMatches[i];
-        const templateTag = code.substring(match.range.start, match.range.end);
+        const templateTag = substringBytes(code, match.range.start, match.range.end);
         transformedWithTemplateTag = transformedWithTemplateTag.replace(templateTagIdentifier(i), templateTag);
         transformedWithTemplateTag = transformedWithTemplateTag.replace(templateTagIdentifierBraces(i), templateTag);
       }
@@ -1769,6 +1769,20 @@ function isTypeScriptFile(filePath) {
 
 function isJavaScriptFile(filePath) {
   return path.extname(filePath) === '.js' || path.extname(filePath) === '.gjs';
+}
+
+/**
+ * Takes a substring of a string based on byte offsets.
+ * @private
+ * @method substringBytes
+ * @param {string} value : The input string.
+ * @param {number} start : The byte index of the substring start.
+ * @param {number} end : The byte index of the substring end.
+ * @returns {string} : The substring.
+ */
+function substringBytes(value, start, end) {
+  let buf = Buffer.from(value);
+  return buf.subarray(start, end).toString();
 }
 
 module.exports = Blueprint;

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1778,7 +1778,7 @@ function isJavaScriptFile(filePath) {
  * @param {string} value : The input string.
  * @param {number} start : The byte index of the substring start.
  * @param {number} end : The byte index of the substring end.
- * @returns {string} : The substring.
+ * @return {string} : The substring.
  */
 function substringBytes(value, start, end) {
   let buf = Buffer.from(value);

--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -547,16 +547,16 @@ let Blueprint = CoreObject.extend({
     const { removeTypes } = require('remove-types');
 
     if (extension === '.gts') {
-      const { parseTemplates } = require('ember-template-tag');
+      const { Preprocessor } = require('content-tag');
+      const preprocessor = new Preprocessor();
       // Strip template tags
       const templateTagIdentifier = (index) => `template = __TEMPLATE_TAG_${index}__;`;
       const templateTagIdentifierBraces = (index) => `(template = __TEMPLATE_TAG_${index}__);`;
-      const templateTagMatches = parseTemplates(code).filter((match) => match.type === 'template-tag');
+      const templateTagMatches = preprocessor.parse(code);
       let strippedCode = code;
       for (let i = 0; i < templateTagMatches.length; i++) {
         const match = templateTagMatches[i];
-        const [matchStart, matchEnd] = match.range;
-        const templateTag = code.substring(matchStart, matchEnd);
+        const templateTag = code.substring(match.range.start, match.range.end);
         strippedCode = strippedCode.replace(templateTag, templateTagIdentifier(i));
       }
 
@@ -567,8 +567,7 @@ let Blueprint = CoreObject.extend({
       let transformedWithTemplateTag = transformed;
       for (let i = 0; i < templateTagMatches.length; i++) {
         const match = templateTagMatches[i];
-        const [matchStart, matchEnd] = match.range;
-        const templateTag = code.substring(matchStart, matchEnd);
+        const templateTag = code.substring(match.range.start, match.range.end);
         transformedWithTemplateTag = transformedWithTemplateTag.replace(templateTagIdentifier(i), templateTag);
         transformedWithTemplateTag = transformedWithTemplateTag.replace(templateTagIdentifierBraces(i), templateTag);
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^5.0.1",
     "ember-cli-string-utils": "^1.1.0",
-    "ember-template-tag": "^2.3.8",
     "ensure-posix-path": "^1.1.1",
     "execa": "^5.1.1",
     "exit": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "compression": "^1.7.4",
     "configstore": "^5.0.1",
     "console-ui": "^3.1.2",
+    "content-tag": "^1.2.2",
     "core-object": "^3.1.5",
     "dag-map": "^2.0.2",
     "diff": "^5.1.0",

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -60,6 +60,14 @@ describe('Blueprint', function () {
         'const foo = 1;\nexport default class Bar extends Component {\n  <template>Hello {{foo}}</template>\n}\n'
       );
     });
+
+    it('can handle multi-byte characters', async function () {
+      const output = await Blueprint.prototype.removeTypes(
+        '.gts',
+        "const x: string = '💩';\n<template>Hello {{x}}!</template>\n"
+      );
+      expect(output).to.equal("const x = '💩';\n<template>Hello {{x}}!</template>\n");
+    });
   });
 
   describe('.mapFile', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,6 +2314,11 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
+content-tag@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-1.2.2.tgz#8cbc3cdb9957a81f7c425b138e334330dd6fd78d"
+  integrity sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,14 @@
     "@babel/highlight" "^7.22.10"
     chalk "^2.4.2"
 
+"@babel/code-frame@^7.18.6", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.22.13":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
+  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
+  dependencies:
+    "@babel/highlight" "^7.23.4"
+    chalk "^2.4.2"
+
 "@babel/compat-data@^7.22.9":
   version "7.22.9"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
@@ -48,6 +56,16 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.2.2"
     semver "^6.3.1"
+
+"@babel/generator@^7.21.4":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
+  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
+  dependencies:
+    "@babel/types" "^7.23.6"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
 
 "@babel/generator@^7.22.10":
   version "7.22.10"
@@ -108,6 +126,14 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
+"@babel/helper-function-name@^7.21.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz#1f9a3cdbd5b2698a670c30d2735f9af95ed52759"
+  integrity sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==
+  dependencies:
+    "@babel/template" "^7.22.15"
+    "@babel/types" "^7.23.0"
+
 "@babel/helper-function-name@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz#ede300828905bb15e582c037162f99d5183af1be"
@@ -116,7 +142,7 @@
     "@babel/template" "^7.22.5"
     "@babel/types" "^7.22.5"
 
-"@babel/helper-hoist-variables@^7.22.5":
+"@babel/helper-hoist-variables@^7.18.6", "@babel/helper-hoist-variables@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
   integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
@@ -192,10 +218,20 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-string-parser@^7.19.4", "@babel/helper-string-parser@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
+  integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
+
 "@babel/helper-string-parser@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
+"@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
 "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
@@ -224,6 +260,20 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     chalk "^2.4.2"
     js-tokens "^4.0.0"
+
+"@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.20.7", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
+  integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
 
 "@babel/parser@^7.22.10", "@babel/parser@^7.22.5":
   version "7.22.10"
@@ -260,11 +310,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/standalone@^7.22.10":
-  version "7.22.10"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.22.10.tgz#0a39a85488d61d301751cc074ea77c44aacb9d07"
-  integrity sha512-VmK2sWxUTfDDh9mPfCtFJPIehZToteqK+Zpwq8oJUjJ+WeeKIFTTQIrDzH7jEdom+cAaaguU7FI/FBsBWFkIeQ==
-
 "@babel/template@^7.18.10":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -273,6 +318,15 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
+
+"@babel/template@^7.22.15":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
+  integrity sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==
+  dependencies:
+    "@babel/code-frame" "^7.22.13"
+    "@babel/parser" "^7.22.15"
+    "@babel/types" "^7.22.15"
 
 "@babel/template@^7.22.5":
   version "7.22.5"
@@ -322,6 +376,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.7", "@babel/types@^7.21.4", "@babel/types@^7.22.15", "@babel/types@^7.23.0", "@babel/types@^7.23.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
+  integrity sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.22.10", "@babel/types@^7.22.5":
@@ -377,42 +440,6 @@
   version "8.44.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
   integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
-
-"@glimmer/env@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
-  integrity sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==
-
-"@glimmer/interfaces@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.84.3.tgz#629777a4abe373b0785656f6c8d08989f5784805"
-  integrity sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==
-  dependencies:
-    "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/syntax@^0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.84.3.tgz#4045a1708cef7fd810cff42fe6deeba40c7286d0"
-  integrity sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==
-  dependencies:
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@handlebars/parser" "~2.0.0"
-    simple-html-tokenizer "^0.5.11"
-
-"@glimmer/util@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.84.3.tgz#9ae0166982c0b48aa94b02d6ba8c2c81976ade4b"
-  integrity sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.84.3"
-    "@simple-dom/interface" "^1.4.0"
-
-"@handlebars/parser@~2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
-  integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
@@ -662,11 +689,6 @@
   dependencies:
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
-
-"@simple-dom/interface@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
-  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2805,18 +2827,6 @@ ember-cli-string-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz#39b677fc2805f55173735376fcef278eaa4452a1"
   integrity sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==
-
-ember-template-tag@^2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/ember-template-tag/-/ember-template-tag-2.3.8.tgz#79cbab5eff2b935f5e9a537358fd7937701f5d67"
-  integrity sha512-WLu1yVPgHiSgy0oacgh3sOjzNyKhudRqEAMxQZ3ZknxIIGFlx1l72wIU5yCM3RLe6yQgBSxqryYaupLcweKHYw==
-  dependencies:
-    "@babel/generator" "^7.22.10"
-    "@babel/parser" "^7.22.10"
-    "@babel/standalone" "^7.22.10"
-    "@babel/traverse" "^7.22.10"
-    "@babel/types" "^7.22.10"
-    "@glimmer/syntax" "^0.84.3"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -7652,11 +7662,6 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
   dependencies:
     debug "^2.2.0"
-
-simple-html-tokenizer@^0.5.11:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
-  integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In https://github.com/ember-cli/ember-cli/pull/10332 support was added to use `.gts` files as blueprint source. It used [ember-template-tag](https://github.com/patricklx/ember-template-tag) to parse the source as it was able to give match ranges.

As of [v1.1.0](https://github.com/embroider-build/content-tag/releases/tag/v1.1.0), content-tag now also provides functionality to return match ranges. This PR refactors to use that package instead as it's the official one.