### PR TITLE
fix GitHub Action floating deps scenario for PNPM

### DIFF
--- a/blueprints/addon/files/.github/workflows/ci.yml
+++ b/blueprints/addon/files/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: wyvox/action-setup-pnpm@v2
         with:
           node-version: 18
-          no-lockfile: true<% } else { %>
+          args: '--no-lockfile'<% } else { %>
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/tests/fixtures/addon/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/addon/pnpm/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: wyvox/action-setup-pnpm@v2
         with:
           node-version: 18
-          no-lockfile: true
+          args: '--no-lockfile'
       - name: Run Tests
         run: pnpm test:ember
 


### PR DESCRIPTION
The _Floating Dependencies_ scenario is broken for a newly created Ember addon using PNPM. This change fixes it.

It seems that `wyvox/action-setup-pnpm`'s `no-lockfile` option is not working as expected. It throws the following error:

> Error: Dependencies lock file is not found in /home/runner/work/test-ember-addon-with-pnpm/test-ember-addon-with-pnpm. Supported file patterns: pnpm-lock.yaml

The option has been removed in `wyvox/action-setup-pnpm@v3`. So upgrading is not an option. But using `--no-lockfile` flag of PNPM is the recommended upgrade path anyways: https://github.com/wyvox/action-setup-pnpm/pull/3

Please find a demonstration of the bug here: https://github.com/jelhan/test-ember-addon-with-pnpm/actions/runs/7453402485/job/20278700434

A demonstration that the fix work could be found here: https://github.com/jelhan/test-ember-addon-with-pnpm/pull/1

@NullVoxPopuli would be great if you could review. I think you are the expert here as you implemented the PNPM support in Ember CLI _and_ maintain `wyvox/action-setup-pnpm`.