### PR TITLE
Filter out tsconfig.declarations.json correctly

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -218,7 +218,7 @@ module.exports = {
     }
 
     if (!options.typescript) {
-      addonFiles = addonFiles.filter((file) => file !== 'tsconfig.json' && !file.endsWith('.d.ts'));
+      addonFiles = addonFiles.filter((file) => !file.startsWith('tsconfig.') && !file.endsWith('.d.ts'));
     }
 
     return uniq(appFiles.concat(addonFiles));

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -473,6 +473,7 @@ describe('Acceptance: ember new', function () {
       // no TypeScript files
       [
         'tsconfig.json',
+        'tsconfig.declarations.json',
         'app/config/environment.d.ts',
         'types/global.d.ts',
         'types/foo/index.d.ts',
@@ -511,7 +512,12 @@ describe('Acceptance: ember new', function () {
       expect(file('tests/dummy/app/index.html')).to.contain('<html>');
 
       // no TypeScript files
-      ['tsconfig.json', 'tests/dummy/app/config/environment.d.ts', 'types/global.d.ts'].forEach((filePath) => {
+      [
+        'tsconfig.json',
+        'tsconfig.declarations.json',
+        'tests/dummy/app/config/environment.d.ts',
+        'types/global.d.ts',
+      ].forEach((filePath) => {
         expect(file(filePath)).to.not.exist;
       });
     });


### PR DESCRIPTION
Don't include tsconfig.declarations.json when running the addon blueprint without typescript enabled