### PR TITLE
[ENHANCEMENT] Add `declarations` folder to `.eslintignore` file in `app` blueprint

### DIFF
--- a/blueprints/app/files/.eslintignore
+++ b/blueprints/app/files/.eslintignore
@@ -2,6 +2,7 @@
 /blueprints/*/files/
 
 # compiled output
+/declarations/
 /dist/
 
 # misc


### PR DESCRIPTION
Otherwise, running the `lint` script after the `prepack` script might result in ESLint errors.