### PR TITLE
[ENHANCEMENT] Remove warning when encountering a `.js` file when generating a TS blueprint

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -481,21 +481,6 @@ let Blueprint = CoreObject.extend({
 
     // If the blueprint isn't a TS file to begin with, there's nothing to convert.
     if (!isTypeScriptFile(fileInfo.outputPath)) {
-      // If the user wants TypeScript output but there is no TypeScript blueprint available, we want
-      // to warn them that they're not going to get what they're expecting while still at least giving
-      // them the JS output. We check for this *after* checking `shouldTranformTypeScript` because
-      // it's possible for people to set `{typescript: true}` in their `.ember-cli` file, which would
-      // then erroneously trigger this message every time they generate a JS blueprint even though
-      // they didn't pass the flag.
-      if (options.typescript === true && isJavaScriptFile(fileInfo.outputPath)) {
-        this.ui.writeLine(
-          chalk.yellow(
-            "You passed the '--typescript' flag but there is no TypeScript blueprint available. " +
-              'A JavaScript blueprint will be generated instead.'
-          )
-        );
-      }
-
       return false;
     }
 
@@ -1765,10 +1750,6 @@ function replaceTypeScriptExtension(filePath) {
 
 function isTypeScriptFile(filePath) {
   return path.extname(filePath) === '.ts' || path.extname(filePath) === '.gts';
-}
-
-function isJavaScriptFile(filePath) {
-  return path.extname(filePath) === '.js' || path.extname(filePath) === '.gjs';
 }
 
 /**

--- a/tests/acceptance/typescript-generate-test.js
+++ b/tests/acceptance/typescript-generate-test.js
@@ -210,14 +210,11 @@ describe('Acceptance: ember generate with typescript blueprints', function () {
       }`
     );
 
-    const result = await ember(['generate', 'foo', 'bar', '--typescript']);
-    const output = result.outputStream.map((v) => v.toString());
+    await ember(['generate', 'foo', 'bar', '--typescript']);
+
     const generated = file('app/foos/bar.js');
 
     expect(generated).to.contain('export default function bar(a, b) {');
-    expect(output.join('\n')).to.contain(
-      "You passed the '--typescript' flag but there is no TypeScript blueprint available."
-    );
   });
 
   it('does not generate typescript when the `--no-typescript` flag, even if a typescript blueprint exists', async function () {


### PR DESCRIPTION
Closes #10420.