### PR TITLE
Specified the locale in setupIntl()

### DIFF
--- a/blueprints/app/files/tests/helpers/index.ts
+++ b/blueprints/app/files/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/fixtures/addon/typescript/tests/helpers/index.ts
+++ b/tests/fixtures/addon/typescript/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/fixtures/app/defaults/tests/helpers/index.js
+++ b/tests/fixtures/app/defaults/tests/helpers/index.js
@@ -23,7 +23,7 @@ function setupApplicationTest(hooks, options) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/fixtures/app/typescript-embroider/tests/helpers/index.ts
+++ b/tests/fixtures/app/typescript-embroider/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/fixtures/app/typescript/tests/helpers/index.ts
+++ b/tests/fixtures/app/typescript/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 


### PR DESCRIPTION
In `ember-intl@v7`, the test helper `setupIntl()` [requires end-developers to specify a locale](https://ember-intl.github.io/ember-intl/versions/v7.0.2/docs/migration/v7#required-locale-in-test-helpers). I updated the blueprint file for `tests/helpers/index.ts` to reflect this breaking change.

> [!NOTE]
>
> The change to `tests/helpers/index.ts` is backward-compatible, because specifying the locale is optional in earlier versions of `ember-intl`.

Two possible alternatives:

1. Remove the commented line from `setupApplicationTest()`, because the test helper `setupIntl()` is really meant to help end-developers write rendering and unit tests.
1. Move the commented line to `setupRenderingTest()`, in case an end-developer wants an example of calling a function (e.g. `setupIntl()`) in all or most rendering tests.