### PR TITLE
Improve dx when WelcomePage is present

### DIFF
--- a/blueprints/app/files/app/templates/application.hbs
+++ b/blueprints/app/files/app/templates/application.hbs
@@ -1,8 +1,10 @@
 {{page-title "<%= namespace %>"}}
-
-<% if (welcome) { %>{{! The following component displays Ember's default welcome message. }}
-<WelcomePage />
-{{! Feel free to remove this! }}
-<% } else { %><h2 id="title">Welcome to Ember</h2>
-<% } %>
+<% if (welcome) { %>
 {{outlet}}
+
+{{! The following component displays Ember's default welcome message. }}
+<WelcomePage />
+{{! Feel free to remove this! }}<% } else { %>
+<h2 id="title">Welcome to Ember</h2>
+
+{{outlet}}<% } %>

--- a/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "Dummy"}}
 
+{{outlet}}
+
 {{! The following component displays Ember's default welcome message. }}
 <WelcomePage />
 {{! Feel free to remove this! }}
-
-{{outlet}}

--- a/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "Dummy"}}
 
+{{outlet}}
+
 {{! The following component displays Ember's default welcome message. }}
 <WelcomePage />
 {{! Feel free to remove this! }}
-
-{{outlet}}

--- a/tests/fixtures/app/defaults/app/templates/application.hbs
+++ b/tests/fixtures/app/defaults/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "Foo"}}
 
+{{outlet}}
+
 {{! The following component displays Ember's default welcome message. }}
 <WelcomePage />
 {{! Feel free to remove this! }}
-
-{{outlet}}

--- a/tests/fixtures/app/pnpm/app/templates/application.hbs
+++ b/tests/fixtures/app/pnpm/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "Foo"}}
 
+{{outlet}}
+
 {{! The following component displays Ember's default welcome message. }}
 <WelcomePage />
 {{! Feel free to remove this! }}
-
-{{outlet}}

--- a/tests/fixtures/app/yarn/app/templates/application.hbs
+++ b/tests/fixtures/app/yarn/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "Foo"}}
 
+{{outlet}}
+
 {{! The following component displays Ember's default welcome message. }}
 <WelcomePage />
 {{! Feel free to remove this! }}
-
-{{outlet}}


### PR DESCRIPTION
This moves the `{{outlet}}` to before the `<WelcomePage/>`. In the out-of-the-box case, it doesn't look any different because there's no content in the index route. But if you try to put content in the index route without first editing application.hbs, this ensures your content will be on screen, above the WelcomePage, rather than hidden off the bottom scroll, which can result in confusion and make you think your change had no effect.