### PR TITLE
Bump @embroider/* dependencies

### DIFF
--- a/blueprints/addon/additional-package.json
+++ b/blueprints/addon/additional-package.json
@@ -6,7 +6,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "devDependencies": {
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^3.0.0"
   },

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -34,7 +34,7 @@
     "@ember/test-helpers": "^3.3.0<% if (embroider) { %>",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3<% } %>",
+    "@embroider/webpack": "^4.0.4<% } %>",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2<% if (typescript) { %>",
     "@glint/environment-ember-loose": "^1.4.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^3.3.0",
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/addon/pnpm/package.json
+++ b/tests/fixtures/addon/pnpm/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^3.3.0",
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^3.3.0",
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/environment-ember-loose": "^1.4.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^3.3.0",
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^3.3.0",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3",
+    "@embroider/webpack": "^4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^3.3.0",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3",
+    "@embroider/webpack": "^4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^3.3.0",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3",
+    "@embroider/webpack": "^4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^3.3.0",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3",
+    "@embroider/webpack": "^4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -32,7 +32,7 @@
     "@ember/test-helpers": "^3.3.0",
     "@embroider/compat": "^3.5.6",
     "@embroider/core": "^3.4.14",
-    "@embroider/webpack": "^3.2.3",
+    "@embroider/webpack": "^4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/environment-ember-loose": "^1.4.0",


### PR DESCRIPTION
Resolves some deprecations that landed in 5.9