### PR TITLE
Bump ember-template-lint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -90,7 +90,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0<% if (welcome) { %>",
+    "ember-template-lint": "^6.0.0<% if (welcome) { %>",
     "ember-welcome-page": "^7.0.2<% } %>",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -55,7 +55,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-try": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/addon/pnpm/package.json
+++ b/tests/fixtures/addon/pnpm/package.json
@@ -55,7 +55,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-try": "^3.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -99,7 +99,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-try": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -55,7 +55,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-try": "^3.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -53,7 +53,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -54,7 +54,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^11.12.0",

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -54,7 +54,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -54,7 +54,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -54,7 +54,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -53,7 +53,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^11.12.0",

--- a/tests/fixtures/app/pnpm/package.json
+++ b/tests/fixtures/app/pnpm/package.json
@@ -53,7 +53,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -86,7 +86,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -85,7 +85,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -53,7 +53,7 @@
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.11.0-beta.1",
-    "ember-template-lint": "^5.13.0",
+    "ember-template-lint": "^6.0.0",
     "ember-welcome-page": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
Prior versions do not work with gjs/gts/`<template>`