### PR TITLE
[INTERNAL] Don't run basic tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu, macOS, windows]
+        os: [ubuntu, macOS]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `basic-tests` job runs all basic/faster tests. The `tests` job runs all basic/faster tests, _plus all slow tests_. This separation probably exists to provide quicker feedback for PRs, but it does slow down the entire run, as `basic-tests` on Windows already takes +10 minutes. This change speeds up the entire run, while keeping the same coverage.
This is just a quick fix/win. The entire CI setup could be improved I think.