### PR TITLE
[INTERNAL] Restructure CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,72 +14,106 @@ on:
   workflow_dispatch:
   merge_group:
   schedule:
-    - cron:  '0 3 * * *' # daily, at 3am
+    - cron: '0 3 * * *' # daily, at 3am
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:
-    name: Linting
     runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: 'yarn'
-
-      - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn lint
-
-  basic-tests:
-    name: "Basic Tests - ${{ matrix.os }}"
-    runs-on: "${{ matrix.os }}-latest"
-
-    strategy:
-      matrix:
-        os: [ubuntu, macOS]
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn lint
+
+  basic-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test
 
-  tests:
-    name: "Node ${{ matrix.node-version }} - ${{ matrix.os }} "
-    runs-on: "${{ matrix.os }}-latest"
-
-    needs: [linting, basic-tests]
+  basic-tests-matrix:
+    needs:
+      - linting
+      - basic-tests
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
-        os: [ubuntu, windows]
+        node-version:
+          - 18
+          - 20
+        os:
+          - ubuntu-latest
+        # Active LTS + different OS
+        include:
+          - node-version: 20
+            os: macos-latest
+          - node-version: 20
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+          cache: yarn
 
       - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn test:all
+      - run: yarn test
+
+  slow-tests:
+    needs:
+      - linting
+      - basic-tests
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18
+          - 20
+        os:
+          - ubuntu-latest
+        # Active LTS + different OS
+        include:
+          - node-version: 20
+            os: macos-latest
+          - node-version: 20
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn test:slow
 
   feature-flags:
-    name: "Feature: ${{ matrix.feature-flag }}"
+    needs:
+      - linting
+      - basic-tests
     runs-on: ubuntu-latest
-
-    needs: [linting, basic-tests]
 
     strategy:
       fail-fast: false
@@ -94,9 +128,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: yarn
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test:all
         env:
-          "EMBER_CLI_${{ matrix.feature-flag }}": true
+          'EMBER_CLI_${{ matrix.feature-flag }}': true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,9 @@ jobs:
           - 18
           - 20
         os:
+          - macos-latest
           - ubuntu-latest
-        # Active LTS + different OS
-        include:
-          - node-version: 20
-            os: macos-latest
-          - node-version: 20
-            os: windows-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -91,13 +87,16 @@ jobs:
           - 18
           - 20
         os:
+          - macos-latest
           - ubuntu-latest
-        # Active LTS + different OS
-        include:
-          - node-version: 20
-            os: macos-latest
-          - node-version: 20
-            os: windows-latest
+          - windows-latest
+        # manual sharding to make CI faster
+        test-file:
+          - addon-smoke
+          - brocfile-smoke
+          - nested-addons-smoke
+          - preprocessor-smoke
+          - smoke
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +106,7 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn test:slow
+      - run: yarn test tests/acceptance/${{ matrix.test-file }}-test-slow.js
 
   feature-flags:
     needs:


### PR DESCRIPTION
This will mainly run the basic tests and slow tests in parallel. This reduces CI time to about 25 - 30 minutes. Still slow, but way better than 40 - 45 minutes.

Example runs
- https://github.com/ember-cli/ember-cli/actions/runs/9905624209
- https://github.com/ember-cli/ember-cli/actions/runs/9905086757