### PR TITLE
[INTERNAL] Remove use of `rimraf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "nyc": "^15.1.0",
     "prettier": "2.8.7",
     "release-it": "^15.10.0",
-    "rimraf": "^3.0.2",
     "strip-ansi": "^6.0.0",
     "supertest": "^6.3.1",
     "testdouble": "^3.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,9 +330,6 @@ importers:
       release-it:
         specifier: ^15.10.0
         version: 15.11.0
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
       strip-ansi:
         specifier: ^6.0.0
         version: 6.0.1

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const BuildCommand = require('../../../lib/commands/build');
 const commandOptions = require('../../factories/command-options');
-const rimraf = require('rimraf');
 const fixturify = require('fixturify');
 const MockProject = require('../../helpers/mock-project');
 const mkTmpDirIn = require('../../../lib/utilities/mk-tmp-dir-in');
@@ -154,7 +153,7 @@ describe('models/builder.js', function () {
       delete process.env.BROCCOLI_VIZ;
       builder.project.ui.output = '';
       if (fs.existsSync(`${builder.project.root}/tmp`)) {
-        rimraf.sync(`${builder.project.root}/tmp`);
+        fs.removeSync(`${builder.project.root}/tmp`);
       }
     });
 
@@ -210,7 +209,7 @@ describe('models/builder.js', function () {
       let result = await builder.build();
       expect(fs.existsSync(result.directory)).to.be.true;
       expect(fs.existsSync(`${builder.project.root}/tmp`)).to.be.false;
-      rimraf.sync(result.directory);
+      fs.removeSync(result.directory);
     });
 
     it('produces the correct output', async function () {


### PR DESCRIPTION
As we can use `fsExtra.removeSync` (uses `fs.rmSync` internally) for these cases.