### PR TITLE
[INTERNAL] Remove workaround for old Windows related issue

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -187,21 +187,9 @@ class CLI {
           resultOrExitCode = await this.callHelp(helpOptions);
         }
 
-        let exitCode = resultOrExitCode;
+        loggerTesting.info(`cli: command run complete. exitCode: ${resultOrExitCode}`);
 
-        loggerTesting.info(`cli: command run complete. exitCode: ${exitCode}`);
-        // TODO: fix this
-        // Possibly this issue: https://github.com/joyent/node/issues/8329
-        // Wait to resolve promise when running on windows.
-        // This ensures that stdout is flushed so acceptance tests get full output
-
-        if (process.platform === 'win32') {
-          return new Promise((resolve) => {
-            setTimeout(resolve, 250, exitCode);
-          });
-        } else {
-          return exitCode;
-        }
+        return resultOrExitCode;
       });
 
       onCommandInterrupt = async () => {


### PR DESCRIPTION
Let's see if this is still relevant for acceptance tests on Windows.
I assume this might also have a positive effect on CI time (probably only slightly).