### PR TITLE
use our fork of remove-types with config: false

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -529,7 +529,7 @@ let Blueprint = CoreObject.extend({
     @return {Promise}
   */
   async removeTypes(extension, code) {
-    const { removeTypes } = require('remove-types');
+    const { removeTypes } = require('babel-remove-types');
 
     if (extension === '.gts') {
       const { Preprocessor } = require('content-tag');

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "promise-map-series": "^0.3.0",
     "promise.hash.helper": "^1.0.8",
     "quick-temp": "^0.1.8",
-    "remove-types": "^1.0.0",
+    "babel-remove-types": "^1.0.0",
     "resolve": "^1.22.1",
     "resolve-package-path": "^4.0.3",
     "safe-stable-stringify": "^2.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@pnpm/find-workspace-dir':
         specifier: ^6.0.2
         version: 6.0.3
+      babel-remove-types:
+        specifier: ^1.0.0
+        version: 1.0.0
       broccoli:
         specifier: ^3.5.2
         version: 3.5.2
@@ -209,9 +212,6 @@ importers:
       quick-temp:
         specifier: ^0.1.8
         version: 0.1.8
-      remove-types:
-        specifier: ^1.0.0
-        version: 1.0.0
       resolve:
         specifier: ^1.22.1
         version: 1.22.8
@@ -1011,6 +1011,9 @@ packages:
 
   aws-sign2@0.5.0:
     resolution: {integrity: sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA==}
+
+  babel-remove-types@1.0.0:
+    resolution: {integrity: sha512-Kg+NZLwfe1E+LoGrkX9I9nFDM1FVBoiIdyW4bjNGGvrqWhvgcdauqijOFn5/WYkdoGXpUEDRWvU4X100ghVx4A==}
 
   backbone@1.6.0:
     resolution: {integrity: sha512-13PUjmsgw/49EowNcQvfG4gmczz1ximTMhUktj0Jfrjth0MVaTxehpU+qYYX4MxnuIuhmvBLC6/ayxuAGnOhbA==}
@@ -4297,9 +4300,6 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  remove-types@1.0.0:
-    resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
-
   repeat-element@1.1.4:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
     engines: {node: '>=0.10.0'}
@@ -6121,6 +6121,15 @@ snapshots:
 
   aws-sign2@0.5.0:
     optional: true
+
+  babel-remove-types@1.0.0:
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.9)
+      prettier: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
 
   backbone@1.6.0:
     dependencies:
@@ -9947,15 +9956,6 @@ snapshots:
       es6-error: 4.1.1
 
   remove-trailing-separator@1.1.0: {}
-
-  remove-types@1.0.0:
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.9)
-      prettier: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
 
   repeat-element@1.1.4: {}
 


### PR DESCRIPTION
The reason for this PR is because of the questionable default that any time you call transform with babel it looks for a local babel config file 😭 and in the new embroider/vite app blueprint we have an explicit user-owned babel config file that we need to make sure isn't picked up by the parts of the wider ecosystem when they call `transform()` from babel.

The `remove-types` dependency is used in generators and it makes the same mistake of not disabling the babel config lookup which means that generators currently fail in the embroider/vite blueprint: https://github.com/embroider-build/app-blueprint/pull/74

I opened a PR 4 months ago in `remove-types` but there has been no response 🙈 https://github.com/cafreeman/remove-types/pull/3 

I intend to fork remove-types into the ember-cli org to fix this issue but I'm opening this PR now to test the end-to-end and make sure the strategy works 👍 

Edit: I've tested it in https://github.com/embroider-build/app-blueprint/pull/75 and I'm sure this fixes the problem 👍 

Edit: this is now using our [fork of remove-types](https://github.com/ember-cli/babel-remove-types) that has been deployed to npm as [babel-remove-types](https://www.npmjs.com/package/babel-remove-types)