### PR TITLE
remove all template tags

### DIFF
--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -145,7 +145,9 @@ function removeTemplateExpression(dependency) {
     return dependency;
   }
 
-  return dependency.replace(dependency.substring(dependency.indexOf('<'), dependency.indexOf('>') + 1), '');
+  let semverRange = dependency.replace(dependency.substring(dependency.indexOf('<'), dependency.indexOf('>') + 1), '');
+
+  return semverRange;
 }
 
 async function main() {

--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -145,7 +145,10 @@ function removeTemplateExpression(dependency) {
     return dependency;
   }
 
-  let semverRange = dependency.replace(dependency.substring(dependency.indexOf('<'), dependency.indexOf('>') + 1), '');
+  let semverRange = dependency.replace(
+    dependency.substring(dependency.indexOf('<'), dependency.lastIndexOf('>') + 1),
+    ''
+  );
 
   return semverRange;
 }


### PR DESCRIPTION
Converts `^7.24.7<% } %><% if (typescript) { %>` to `^7.24.7`, instead of the error:

```
VersionNotFoundError: Version `^7.24.7<% if (typescript) { %>` for package `@babel/plugin-proposal-decorators` could not be found
```