### PR TITLE
Make tests easier to run, closes #10520

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const ciInfo = require('ci-info');
+let reporter = process.env.MOCHA_REPORTER || (ciInfo.isCI ? 'tap' : 'spec');
+const chaiJestSnapshot = require('chai-jest-snapshot');
+
+module.exports = {
+  timeout: 5000,
+  reporter,
+  retries: 2,
+  rootHooks: {
+    beforeEach() {
+      chaiJestSnapshot.resetSnapshotRegistry();
+      chaiJestSnapshot.configureUsingMochaContext(this);
+    },
+  },
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,16 +37,28 @@ for more information.
 ## Run the test suite
 
 ```
-npm test
+pnpm test
 ```
 
 will run ESLint and the "fast" subset of the test suite. Run
-`npm run test:all` for the full test suite which will currently take quite a
+`pnpm run test:all` for the full test suite which will currently take quite a
 few minutes due to heavy IO and network usage.
+
+To run a single test 
+```
+pnpm mocha --fgrep "ember new adds ember-welcome-page by default"
+```
+
+To get help with mocha, run
+```
+pnpm mocha --help
+```
 
 ember-cli is using [Mocha](https://mochajs.org/) for its internal tests. If
 you want to run a specific subset of tests have a look at their
 [documentation](https://mochajs.org/#exclusive-tests).
+
+
 
 ## Update fixtures
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docs": "yuidoc",
     "lint": "eslint . --cache",
     "prepack": "pnpm docs",
+    "mocha": "pnpm exec mocha --require ./tests/bootstrap.js tests/**/*-test.js",
     "test": "node --unhandled-rejections=strict tests/runner",
     "test:all": "node --unhandled-rejections=strict tests/runner all",
     "test:cover": "nyc --all --reporter=text --reporter=lcov node tests/runner all",

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const Mocha = require('mocha');
 
 const chaiAsPromised = require('chai-as-promised');
 const chaiFiles = require('chai-files');

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const chai = require('chai');
+const Mocha = require('mocha');
+
+const chaiAsPromised = require('chai-as-promised');
+const chaiFiles = require('chai-files');
+const chaiJestSnapshot = require('chai-jest-snapshot');
+
+chai.use(chaiFiles);
+chai.use(chaiAsPromised);
+chai.use(chaiJestSnapshot);
+
+module.exports = { chai };

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,14 +1,16 @@
 'use strict';
 
+const path = require('path');
 const captureExit = require('capture-exit');
 captureExit.captureExit();
 
 const glob = require('glob');
 const Mocha = require('mocha');
+const mochaConfig = require(path.join(__dirname, '../.mocharc'));
 
 const { chai } = require('./bootstrap');
 
-const mocha = new Mocha();
+const mocha = new Mocha(mochaConfig);
 
 let root = 'tests/{unit,integration,acceptance}';
 let optionOrFile = process.argv[2];
@@ -42,7 +44,7 @@ function runMocha() {
 
   // ensure that at the end of every test, we are in the correct current
   // working directory
-  mocha.suite.afterEach(function () {
+  mocha.suite.afterEach(function() {
     chai.expect(process.cwd()).to.equal(ROOT);
   });
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -44,7 +44,7 @@ function runMocha() {
 
   // ensure that at the end of every test, we are in the correct current
   // working directory
-  mocha.suite.afterEach(function() {
+  mocha.suite.afterEach(function () {
     chai.expect(process.cwd()).to.equal(ROOT);
   });
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -3,33 +3,16 @@
 const captureExit = require('capture-exit');
 captureExit.captureExit();
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
-const chaiFiles = require('chai-files');
-const chaiJestSnapshot = require('chai-jest-snapshot');
-const ciInfo = require('ci-info');
 const glob = require('glob');
 const Mocha = require('mocha');
 
-chai.use(chaiFiles);
-chai.use(chaiAsPromised);
-chai.use(chaiJestSnapshot);
+const { chai } = require('./bootstrap');
+
+const mocha = new Mocha();
 
 let root = 'tests/{unit,integration,acceptance}';
 let optionOrFile = process.argv[2];
 // default to `tap` reporter in CI otherwise default to `spec`
-let reporter = process.env.MOCHA_REPORTER || (ciInfo.isCI ? 'tap' : 'spec');
-let mocha = new Mocha({
-  timeout: 5000,
-  reporter,
-  retries: 2,
-  rootHooks: {
-    beforeEach() {
-      chaiJestSnapshot.resetSnapshotRegistry();
-      chaiJestSnapshot.configureUsingMochaContext(this);
-    },
-  },
-});
 let testFiles = glob.sync(`${root}/**/*-test.js`);
 let docsLintPosition = testFiles.indexOf('tests/unit/docs-lint-test.js');
 let docsLint = testFiles.splice(docsLintPosition, 1);


### PR DESCRIPTION
Closes #10520 

Found that this was needed while I was exploring https://github.com/ember-cli/ember-cli/pull/10516

Can now do:

```bash
pnpm mocha --fgrep "name of test"
```

Examples:

```bash
pnpm mocha --fgrep "Acceptance: ember init"
```
or
```bash
pnpm mocha --fgrep "Acceptance: ember new"
```