### PR TITLE
Fixes for eslint 9 / flat config

### DIFF
--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -36,8 +36,8 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
-  ember.base,
-  ember.gjs,
+  ember.configs.base,
+  ember.configs.gjs,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore

--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -43,14 +43,10 @@ export default [
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
-      parserOptions: esmParserOptions,
-      globals: {
-        ...globals.browser,
-      },
     },
   },
   {
-    files: ['**/*.gjs'],
+    files: ['**/*.{js,gjs}'],
     languageOptions: {
       parserOptions: esmParserOptions,
       globals: {

--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -1,15 +1,11 @@
 import globals from 'globals';
 import js from '@eslint/js';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-
+import ember from 'eslint-plugin-ember/recommended'
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -26,8 +22,18 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
+  ember.gjs,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
   {
     ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
@@ -42,28 +48,19 @@ export default [
       },
     },
     plugins: {
-      ember,
+      ember: ember.plugin,
     },
     rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
+      ...ember.base,
     },
   },
   {
     files: ['**/*.gjs'],
     languageOptions: {
-      parser: emberParser,
       parserOptions: esmParserOptions,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {

--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -90,7 +90,7 @@ export default [
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },

--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -1,3 +1,17 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 

--- a/blueprints/app/files/_js_eslint.config.mjs
+++ b/blueprints/app/files/_js_eslint.config.mjs
@@ -1,7 +1,7 @@
 import globals from 'globals';
 import js from '@eslint/js';
 
-import ember from 'eslint-plugin-ember/recommended'
+import ember from 'eslint-plugin-ember/recommended';
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
@@ -22,6 +22,7 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
+  ember.base,
   ember.gjs,
   /**
    * Ignores must be in their own object
@@ -46,12 +47,6 @@ export default [
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember: ember.plugin,
-    },
-    rules: {
-      ...ember.base,
     },
   },
   {

--- a/blueprints/app/files/_ts_eslint.config.mjs
+++ b/blueprints/app/files/_ts_eslint.config.mjs
@@ -36,8 +36,8 @@ const parserOptions = {
 export default ts.config(
   js.configs.recommended,
   prettier,
-  gjs,
-  gts,
+  ember.gjs,
+  ember.gts,
   {
     files: ['**/*.js'],
     languageOptions: {

--- a/blueprints/app/files/_ts_eslint.config.mjs
+++ b/blueprints/app/files/_ts_eslint.config.mjs
@@ -3,16 +3,12 @@ import js from '@eslint/js';
 
 import ts from 'typescript-eslint';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-import gtsRecommended from 'eslint-plugin-ember/configs/recommended-gts';
+import ember from 'eslint-plugin-ember/recommended'
 
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const parserOptions = {
@@ -40,6 +36,8 @@ const parserOptions = {
 export default ts.config(
   js.configs.recommended,
   prettier,
+  gjs,
+  gts,
   {
     files: ['**/*.js'],
     languageOptions: {
@@ -50,51 +48,42 @@ export default ts.config(
       },
     },
     plugins: {
-      ember,
+      ember: ember.plugin,
     },
     rules: {
-      ...emberRecommended.rules,
+      ...ember.base.rules,
     },
   },
   {
     files: ['**/*.ts'],
-    plugins: { ember },
+    plugins: { ember: ember.plugin },
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.strictTypeChecked, ...emberRecommended],
+    extends: [...ts.configs.strictTypeChecked, ...ember.base],
   },
   {
     files: ['**/*.gjs'],
     languageOptions: {
-      parser: emberParser,
       parserOptions: parserOptions.esm.js,
       globals: {
         ...globals.browser,
       },
     },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
-    },
   },
   {
     files: ['**/*.gts'],
-    plugins: { ember },
+    plugins: { ember: ember.plugin },
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
     extends: [
       ...ts.configs.strictTypeChecked,
-      ...emberRecommended,
-      ...gtsRecommended,
+      ...ember.gts,,
     ],
   },
   {
-    files: ['tests/**/*-test.{js,gjs}'],
+    files: ['tests/**/*-test.{js,gjs,ts,gts}'],
     plugins: {
       qunit,
     },
@@ -147,9 +136,11 @@ export default ts.config(
    * Settings
    */
   {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
-  }
+  },
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
 );

--- a/blueprints/app/files/_ts_eslint.config.mjs
+++ b/blueprints/app/files/_ts_eslint.config.mjs
@@ -1,3 +1,17 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
@@ -35,10 +49,10 @@ const parserOptions = {
 
 export default ts.config(
   js.configs.recommended,
+  ember.configs.base,
+  ember.configs.gjs,
+  ember.configs.gts,
   prettier,
-  ember.base,
-  ember.gjs,
-  ember.gts,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore
@@ -70,11 +84,19 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.{ts,gts}'],
+    files: ['**/*.ts'],
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.strictTypeChecked],
+    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
+  },
+  {
+    files: ['**/*.gts'],
+    languageOptions: {
+      parser: ember.parser,
+      parserOptions: parserOptions.esm.ts,
+    },
+    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
   },
   {
     files: ['tests/**/*-test.{js,gjs,ts,gts}'],

--- a/blueprints/app/files/_ts_eslint.config.mjs
+++ b/blueprints/app/files/_ts_eslint.config.mjs
@@ -3,7 +3,7 @@ import js from '@eslint/js';
 
 import ts from 'typescript-eslint';
 
-import ember from 'eslint-plugin-ember/recommended'
+import ember from 'eslint-plugin-ember/recommended';
 
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
@@ -36,34 +36,32 @@ const parserOptions = {
 export default ts.config(
   js.configs.recommended,
   prettier,
+  ember.base,
   ember.gjs,
   ember.gts,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember: ember.plugin,
-    },
-    rules: {
-      ...ember.base.rules,
     },
   },
   {
-    files: ['**/*.ts'],
-    plugins: { ember: ember.plugin },
-    languageOptions: {
-      parserOptions: parserOptions.esm.ts,
-    },
-    extends: [...ts.configs.strictTypeChecked, ...ember.base],
-  },
-  {
-    files: ['**/*.gjs'],
+    files: ['**/*.{js,gjs}'],
     languageOptions: {
       parserOptions: parserOptions.esm.js,
       globals: {
@@ -72,15 +70,11 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.gts'],
-    plugins: { ember: ember.plugin },
+    files: ['**/*.{ts,gts}'],
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [
-      ...ts.configs.strictTypeChecked,
-      ...ember.gts,,
-    ],
+    extends: [...ts.configs.strictTypeChecked],
   },
   {
     files: ['tests/**/*-test.{js,gjs,ts,gts}'],
@@ -118,7 +112,7 @@ export default ts.config(
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },
@@ -131,16 +125,5 @@ export default ts.config(
         ...globals.node,
       },
     },
-  },
-  /**
-   * Settings
-   */
-  {
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
-  },
-  {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
   },
 );

--- a/tests/fixtures/addon/eslint.config.mjs
+++ b/tests/fixtures/addon/eslint.config.mjs
@@ -36,8 +36,8 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
-  ember.base,
-  ember.gjs,
+  ember.configs.base,
+  ember.configs.gjs,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore

--- a/tests/fixtures/addon/eslint.config.mjs
+++ b/tests/fixtures/addon/eslint.config.mjs
@@ -1,15 +1,25 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-
+import ember from 'eslint-plugin-ember/recommended';
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -26,8 +36,19 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
+  ember.base,
+  ember.gjs,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
   {
     ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
@@ -36,34 +57,15 @@ export default [
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
-      parserOptions: esmParserOptions,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
-    files: ['**/*.gjs'],
+    files: ['**/*.{js,gjs}'],
     languageOptions: {
-      parser: emberParser,
       parserOptions: esmParserOptions,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
@@ -102,7 +104,7 @@ export default [
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },

--- a/tests/fixtures/addon/typescript/eslint.config.mjs
+++ b/tests/fixtures/addon/typescript/eslint.config.mjs
@@ -1,18 +1,28 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
 import ts from 'typescript-eslint';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-import gtsRecommended from 'eslint-plugin-ember/configs/recommended-gts';
+import ember from 'eslint-plugin-ember/recommended';
 
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const parserOptions = {
@@ -39,62 +49,57 @@ const parserOptions = {
 
 export default ts.config(
   js.configs.recommended,
+  ember.configs.base,
+  ember.configs.gjs,
+  ember.configs.gts,
   prettier,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
+    },
+  },
+  {
+    files: ['**/*.{js,gjs}'],
+    languageOptions: {
       parserOptions: parserOptions.esm.js,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
     },
   },
   {
     files: ['**/*.ts'],
-    plugins: { ember },
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.strictTypeChecked, ...emberRecommended],
-  },
-  {
-    files: ['**/*.gjs'],
-    languageOptions: {
-      parser: emberParser,
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
-    },
+    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
   },
   {
     files: ['**/*.gts'],
-    plugins: { ember },
     languageOptions: {
+      parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [
-      ...ts.configs.strictTypeChecked,
-      ...emberRecommended,
-      ...gtsRecommended,
-    ],
+    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
   },
   {
-    files: ['tests/**/*-test.{js,gjs}'],
+    files: ['tests/**/*-test.{js,gjs,ts,gts}'],
     plugins: {
       qunit,
     },
@@ -129,7 +134,7 @@ export default ts.config(
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },
@@ -143,13 +148,4 @@ export default ts.config(
       },
     },
   },
-  /**
-   * Settings
-   */
-  {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
-  }
 );

--- a/tests/fixtures/app/eslint.config.mjs
+++ b/tests/fixtures/app/eslint.config.mjs
@@ -36,8 +36,8 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
-  ember.base,
-  ember.gjs,
+  ember.configs.base,
+  ember.configs.gjs,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore

--- a/tests/fixtures/app/eslint.config.mjs
+++ b/tests/fixtures/app/eslint.config.mjs
@@ -1,15 +1,25 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-
+import ember from 'eslint-plugin-ember/recommended';
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -26,8 +36,19 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
+  ember.base,
+  ember.gjs,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
   {
     ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
@@ -36,34 +57,15 @@ export default [
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
-      parserOptions: esmParserOptions,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
-    files: ['**/*.gjs'],
+    files: ['**/*.{js,gjs}'],
     languageOptions: {
-      parser: emberParser,
       parserOptions: esmParserOptions,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
@@ -102,7 +104,7 @@ export default [
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },

--- a/tests/fixtures/app/typescript-embroider/eslint.config.mjs
+++ b/tests/fixtures/app/typescript-embroider/eslint.config.mjs
@@ -1,18 +1,28 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
 import ts from 'typescript-eslint';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-import gtsRecommended from 'eslint-plugin-ember/configs/recommended-gts';
+import ember from 'eslint-plugin-ember/recommended';
 
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const parserOptions = {
@@ -39,62 +49,57 @@ const parserOptions = {
 
 export default ts.config(
   js.configs.recommended,
+  ember.configs.base,
+  ember.configs.gjs,
+  ember.configs.gts,
   prettier,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
+    },
+  },
+  {
+    files: ['**/*.{js,gjs}'],
+    languageOptions: {
       parserOptions: parserOptions.esm.js,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
     },
   },
   {
     files: ['**/*.ts'],
-    plugins: { ember },
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.strictTypeChecked, ...emberRecommended],
-  },
-  {
-    files: ['**/*.gjs'],
-    languageOptions: {
-      parser: emberParser,
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
-    },
+    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
   },
   {
     files: ['**/*.gts'],
-    plugins: { ember },
     languageOptions: {
+      parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [
-      ...ts.configs.strictTypeChecked,
-      ...emberRecommended,
-      ...gtsRecommended,
-    ],
+    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
   },
   {
-    files: ['tests/**/*-test.{js,gjs}'],
+    files: ['tests/**/*-test.{js,gjs,ts,gts}'],
     plugins: {
       qunit,
     },
@@ -129,7 +134,7 @@ export default ts.config(
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },
@@ -143,13 +148,4 @@ export default ts.config(
       },
     },
   },
-  /**
-   * Settings
-   */
-  {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
-  }
 );

--- a/tests/fixtures/app/typescript/eslint.config.mjs
+++ b/tests/fixtures/app/typescript/eslint.config.mjs
@@ -1,18 +1,28 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
 import ts from 'typescript-eslint';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-import gtsRecommended from 'eslint-plugin-ember/configs/recommended-gts';
+import ember from 'eslint-plugin-ember/recommended';
 
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const parserOptions = {
@@ -39,62 +49,57 @@ const parserOptions = {
 
 export default ts.config(
   js.configs.recommended,
+  ember.configs.base,
+  ember.configs.gjs,
+  ember.configs.gts,
   prettier,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
+    },
+  },
+  {
+    files: ['**/*.{js,gjs}'],
+    languageOptions: {
       parserOptions: parserOptions.esm.js,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
     },
   },
   {
     files: ['**/*.ts'],
-    plugins: { ember },
     languageOptions: {
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.strictTypeChecked, ...emberRecommended],
-  },
-  {
-    files: ['**/*.gjs'],
-    languageOptions: {
-      parser: emberParser,
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
-    },
+    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
   },
   {
     files: ['**/*.gts'],
-    plugins: { ember },
     languageOptions: {
+      parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [
-      ...ts.configs.strictTypeChecked,
-      ...emberRecommended,
-      ...gtsRecommended,
-    ],
+    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
   },
   {
-    files: ['tests/**/*-test.{js,gjs}'],
+    files: ['tests/**/*-test.{js,gjs,ts,gts}'],
     plugins: {
       qunit,
     },
@@ -129,7 +134,7 @@ export default ts.config(
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },
@@ -143,13 +148,4 @@ export default ts.config(
       },
     },
   },
-  /**
-   * Settings
-   */
-  {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
-  }
 );

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/eslint.config.mjs
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/eslint.config.mjs
@@ -36,8 +36,8 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
-  ember.base,
-  ember.gjs,
+  ember.configs.base,
+  ember.configs.gjs,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/eslint.config.mjs
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/eslint.config.mjs
@@ -1,15 +1,25 @@
+/**
+ * Debugging:
+ *   https://eslint.org/docs/latest/use/configure/debug
+ *  ----------------------------------------------------
+ *
+ *   Print a file's calculated configuration
+ *
+ *     npx eslint --print-config path/to/file.js
+ *
+ *   Inspecting the config
+ *
+ *     npx eslint --inspect-config
+ *
+ */
 import globals from 'globals';
 import js from '@eslint/js';
 
-import ember from 'eslint-plugin-ember';
-import emberRecommended from 'eslint-plugin-ember/configs/recommended';
-import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
-
+import ember from 'eslint-plugin-ember/recommended';
 import prettier from 'eslint-plugin-prettier/recommended';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
-import emberParser from 'ember-eslint-parser';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -26,8 +36,19 @@ const esmParserOptions = {
 export default [
   js.configs.recommended,
   prettier,
+  ember.base,
+  ember.gjs,
+  /**
+   * Ignores must be in their own object
+   * https://eslint.org/docs/latest/use/configure/ignore
+   */
   {
     ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  /**
+   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+   */
+  {
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
@@ -36,34 +57,15 @@ export default [
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
-      parserOptions: esmParserOptions,
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
-    files: ['**/*.gjs'],
+    files: ['**/*.{js,gjs}'],
     languageOptions: {
-      parser: emberParser,
       parserOptions: esmParserOptions,
       globals: {
         ...globals.browser,
       },
-    },
-    plugins: {
-      ember,
-    },
-    rules: {
-      ...emberRecommended.rules,
-      ...gjsRecommended.rules,
     },
   },
   {
@@ -102,7 +104,7 @@ export default [
    * ESM node files
    */
   {
-    files: ['*.mjs'],
+    files: ['**/*.mjs'],
     plugins: {
       n,
     },


### PR DESCRIPTION
Companion PR: https://github.com/ember-cli/eslint-plugin-ember/issues/2171


Also: https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files

we can do `includeIgnoreFile(path.resolve(import.meta.dirname, '.gitignore'))` for a one liner
