### PR TITLE
[ENHANCEMENT] Support an `EMBER_CLI_ADDON_LOAD_TIME_LIMIT` env variable

### DIFF
--- a/lib/models/package-info-cache/package-info.js
+++ b/lib/models/package-info-cache/package-info.js
@@ -9,6 +9,9 @@ const isEngine = require('../../utilities/is-engine');
 const isLazyEngine = require('../../utilities/is-lazy-engine');
 const logger = require('heimdalljs-logger')('ember-cli:package-info-cache:package-info');
 const PerBundleAddonCache = require('../per-bundle-addon-cache');
+const chalk = require('chalk');
+const { cwd, env } = require('process');
+const assert = require('../../debug/assert');
 
 function lexicographically(a, b) {
   const aIsString = typeof a.name === 'string';
@@ -547,14 +550,30 @@ class PackageInfo {
    * @private
    */
   _getAddonEntryPoint() {
-    if (!this.addonMainPath) {
-      throw new Error(`${this.pkg.name} at ${this.realPath} is missing its addon main file`);
+    let addonName = `${this.pkg.name}@${this.pkg.version}`;
+    let addonPath = path.relative(cwd(), this.realPath);
+
+    assert(`Addon "${addonName}" must provide an addon main file (located at "${addonPath}").`, this.addonMainPath);
+
+    let addon;
+
+    if (env.EMBER_CLI_ADDON_LOAD_TIME_LIMIT) {
+      const loadTimeStart = Date.now();
+
+      addon = require(this.addonMainPath);
+
+      const loadTimeEnd = Date.now();
+      const loadTimeLimit = Number(env.EMBER_CLI_ADDON_LOAD_TIME_LIMIT);
+      const loadTime = loadTimeEnd - loadTimeStart;
+
+      if (loadTime > loadTimeLimit) {
+        console.warn(chalk.yellow(`Addon "${addonName}" took ${loadTime}ms to load (located at "${addonPath}").`));
+      }
+    } else {
+      addon = require(this.addonMainPath);
     }
 
-    // Load the addon.
-    // TODO: Future work - allow a time budget for loading each addon and warn
-    // or error for those that take too long.
-    return require(this.addonMainPath);
+    return addon;
   }
 }
 


### PR DESCRIPTION
`EMBER_CLI_ADDON_LOAD_TIME_LIMIT=50 ember s`, will show a warning if an addon takes longer than 50ms to load.

Example:

```
Addon "@ember/optional-features@2.1.0" took 109ms to load (located at "node_modules/.pnpm/@ember+optional-features@2.1.0/node_modules/@ember/optional-features").
Addon "ember-cli-babel@7.26.11" took 72ms to load (located at "node_modules/.pnpm/ember-cli-babel@7.26.11/node_modules/ember-cli-babel").
Addon "@ember/test-helpers@4.0.4" took 58ms to load (located at "node_modules/.pnpm/@ember+test-helpers@4.0.4_@babel+core@7.25.8_@glint+template@1.5.0_ember-source@4.12.4_@babel_3uxctsndahyfwfo5i3mmsb6utm/node_modules/@ember/test-helpers").
Addon "ember-auto-import@2.8.1" took 64ms to load (located at "node_modules/.pnpm/ember-auto-import@2.8.1_@glint+template@1.5.0_webpack@5.95.0/node_modules/ember-auto-import").
Addon "ember-auto-import@1.12.2" took 179ms to load (located at "node_modules/.pnpm/ember-auto-import@1.12.2/node_modules/ember-auto-import").
Addon "ember-cli-workbox@3.1.2" took 192ms to load (located at "node_modules/.pnpm/ember-cli-workbox@https+++codeload.github.com+getflights+ember-cli-workbox+tar.gz+4a0d11770fe_vwtntoosrymjqs5w2zduis7kye/node_modules/ember-cli-workbox").
```