### PR TITLE
[Bugfix] Fix typed eslint support

### DIFF
--- a/blueprints/app/files/_ts_eslint.config.mjs
+++ b/blueprints/app/files/_ts_eslint.config.mjs
@@ -84,14 +84,7 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: parserOptions.esm.ts,
-    },
-    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
-  },
-  {
-    files: ['**/*.gts'],
+    files: ['**/*.{ts,gts}'],
     languageOptions: {
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,

--- a/tests/fixtures/addon/typescript/eslint.config.mjs
+++ b/tests/fixtures/addon/typescript/eslint.config.mjs
@@ -84,14 +84,7 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: parserOptions.esm.ts,
-    },
-    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
-  },
-  {
-    files: ['**/*.gts'],
+    files: ['**/*.{ts,gts}'],
     languageOptions: {
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,

--- a/tests/fixtures/app/typescript-embroider/eslint.config.mjs
+++ b/tests/fixtures/app/typescript-embroider/eslint.config.mjs
@@ -84,14 +84,7 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: parserOptions.esm.ts,
-    },
-    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
-  },
-  {
-    files: ['**/*.gts'],
+    files: ['**/*.{ts,gts}'],
     languageOptions: {
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,

--- a/tests/fixtures/app/typescript/eslint.config.mjs
+++ b/tests/fixtures/app/typescript/eslint.config.mjs
@@ -84,14 +84,7 @@ export default ts.config(
     },
   },
   {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: parserOptions.esm.ts,
-    },
-    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
-  },
-  {
-    files: ['**/*.gts'],
+    files: ['**/*.{ts,gts}'],
     languageOptions: {
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,


### PR DESCRIPTION
When linting ts, and that ts file imports a gts, we _must_ use ember-eslint-parser, rather than the default ts parser. This means it makes 0  sense to  have separate config override entries for ts and gts file extensions.