### PR TITLE
Add missing package for TS eslint config

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,9 +26,9 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.0<% if (!typescript) { %>",
+    "@babel/core": "^7.26.0",
     "@babel/eslint-parser": "^7.25.9",
-    "@babel/plugin-proposal-decorators": "^7.25.9<% } %><% if (typescript) { %>",
+    "@babel/plugin-proposal-decorators": "^7.25.9<% if (typescript) { %>",
     "@ember-data/adapter": "~5.4.0-beta.12",
     "@ember-data/graph": "~5.4.0-beta.12",
     "@ember-data/json-api": "~5.4.0-beta.12",


### PR DESCRIPTION
In eslint config we use `@babel/eslint-parser` import and also `@babel/plugin-proposal-decorators` but packages were only added for javascript

https://github.com/ember-cli/ember-cli/blob/8912653d9f3aedc93406582270e3e78e3da76dce/blueprints/app/files/_ts_eslint.config.mjs#L24-L28

https://github.com/ember-cli/ember-cli/blob/8912653d9f3aedc93406582270e3e78e3da76dce/blueprints/app/files/_ts_eslint.config.mjs#L30-L42

fyi @NullVoxPopuli 