### PR TITLE
[CLEANUP] Remove `@typescript-eslint/*` dependencies from `app` blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -54,8 +54,6 @@
     "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
-    "@typescript-eslint/eslint-plugin": "^8.14.0",
-    "@typescript-eslint/parser": "^8.14.0",
     "@warp-drive/core-types": "~0.0.0-beta.12<% } %>",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.0",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -65,8 +65,6 @@
     "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
-    "@typescript-eslint/eslint-plugin": "^8.14.0",
-    "@typescript-eslint/parser": "^8.14.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.0",
     "ember-auto-import": "^2.10.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -52,8 +52,6 @@
     "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
-    "@typescript-eslint/eslint-plugin": "^8.14.0",
-    "@typescript-eslint/parser": "^8.14.0",
     "@warp-drive/core-types": "~0.0.0-beta.12",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.0",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -49,8 +49,6 @@
     "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
-    "@typescript-eslint/eslint-plugin": "^8.14.0",
-    "@typescript-eslint/parser": "^8.14.0",
     "@warp-drive/core-types": "~0.0.0-beta.12",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.0",


### PR DESCRIPTION
I believe this is not needed as we import from `typescript-eslint` package in https://github.com/ember-cli/ember-cli/blob/v6.1.0-beta.0/blueprints/app/files/_ts_eslint.config.mjs#L18 and list it in `devDependencies`