### PR TITLE
[BUGFIX] Fix including `ember-source` types for v1 addons

### DIFF
--- a/blueprints/addon/files/tsconfig.json
+++ b/blueprints/addon/files/tsconfig.json
@@ -16,9 +16,9 @@
       "<%= addonName %>/test-support": ["addon-test-support"],
       "<%= addonName %>/test-support/*": ["addon-test-support/*"],
       "*": ["types/*"]
-    }
-  },
-  "types": [
-    "ember-source/types"
-  ]
+    },
+    "types": [
+      "ember-source/types"
+    ]
+  }
 }

--- a/tests/fixtures/addon/typescript/tsconfig.json
+++ b/tests/fixtures/addon/typescript/tsconfig.json
@@ -16,9 +16,9 @@
       "foo/test-support": ["addon-test-support"],
       "foo/test-support/*": ["addon-test-support/*"],
       "*": ["types/*"]
-    }
-  },
-  "types": [
-    "ember-source/types"
-  ]
+    },
+    "types": [
+      "ember-source/types"
+    ]
+  }
 }


### PR DESCRIPTION
`types` must be defined under `compilerOptions`.

See #10586.