### PR TITLE
[CLEANUP] Clean up old `heimdalljs` deprecation

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -222,8 +222,6 @@ class Builder extends CoreObject {
         Object.assign({}, buildResults, { outputChanges, directory: this.outputPath })
       );
 
-      this.checkForPostBuildEnvironmentIssues();
-
       return buildResults;
     } catch (error) {
       await this.processAddonBuildSteps('buildError', error);
@@ -271,26 +269,6 @@ class Builder extends CoreObject {
         node.stop();
       }
     }
-  }
-
-  /**
-   * Checks for issues in the environment that can't easily be detected until
-   * after a build and issues any necessary deprecation warnings.
-   *
-   * - check for old (pre 0.1.4) versions of heimdalljs
-   *
-   * @private
-   * @method checkForPostBuildEnvironmentIssues
-   */
-  checkForPostBuildEnvironmentIssues(value) {
-    // 0.1.3 and prior used a global heimdall instance to share sessions
-    // newer versions keep the session itself on process
-    this.project.ui.writeDeprecateLine(
-      'Heimdalljs < 0.1.4 found.  Please remove old versions of heimdalljs and reinstall (you can find them with `npm ls heimdalljs` as long as you have nothing `npm link`d).  Performance instrumentation data will be incomplete until then.',
-      !process._heimdall
-    );
-
-    return value;
   }
 
   throwFormattedBroccoliError(err) {

--- a/tests/unit/models/builder-test.js
+++ b/tests/unit/models/builder-test.js
@@ -174,24 +174,6 @@ describe('models/builder.js', function () {
       );
     });
 
-    it('prints a deprecation warning if it discovers a < v0.1.4 version of heimdalljs', async function () {
-      process._heimdall = {};
-
-      await builder.build();
-
-      let output = builder.project.ui.output;
-      expect(output).to.include('Heimdalljs < 0.1.4 found.  Please remove old versions');
-    });
-
-    it('does not print a deprecation warning if it does not discover a < v0.1.4 version of heimdalljs', async function () {
-      expect(process._heimdall).to.equal(undefined);
-
-      await builder.build();
-
-      let output = builder.project.ui.output;
-      expect(output).to.not.include('Heimdalljs < 0.1.4 found.  Please remove old versions');
-    });
-
     it('writes temp files to Broccoli temp dir', async function () {
       const project = new MockProject();
       project.root += '/tests/fixtures/build/simple';


### PR DESCRIPTION
This "deprecation" is [8 years old](https://github.com/ember-cli/ember-cli/pull/6086).