### PR TITLE
[INTERNAL] Bump `content-tag` to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "compression": "^1.7.4",
     "configstore": "^5.0.1",
     "console-ui": "^3.1.2",
-    "content-tag": "^2.0.1",
+    "content-tag": "^3.1.0",
     "core-object": "^3.1.5",
     "dag-map": "^2.0.2",
     "diff": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
       content-tag:
-        specifier: ^2.0.1
-        version: 2.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
       core-object:
         specifier: ^3.1.5
         version: 3.1.5
@@ -1638,8 +1638,8 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
-  content-tag@2.0.3:
-    resolution: {integrity: sha512-htLIdtfhhKW2fHlFLnZH7GFzHSdSpHhDLrWVswkNiiPMZ5uXq5JfrGboQKFhNQuAAFF8VNB2EYUj3MsdJrKKpg==}
+  content-tag@3.1.0:
+    resolution: {integrity: sha512-gSESx+fia81/vKjorui0V6wY7IBpuitd84LcQnaPVF9Xe9ctLAf4saHwbUi3SAhYfi9kxs5ODfAVnm5MmjojCQ==}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -6902,7 +6902,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-tag@2.0.3: {}
+  content-tag@3.1.0: {}
 
   content-type@1.0.5: {}
 


### PR DESCRIPTION
Updates `content-tag` to v3.

Changelog https://github.com/embroider-build/content-tag/releases/tag/v3.0.0-content-tag