### PR TITLE
[BUGFIX release]: tsconfig.json referenced paths to types instead of imports

### DIFF
--- a/blueprints/app/files/tsconfig.json
+++ b/blueprints/app/files/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/ember/tsconfig.json",
+  "extends": "@tsconfig/ember",
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]
   },
@@ -14,20 +14,19 @@
       "*": ["types/*"]
     },
     "types": [
-      <% if (emberData) { %>"./node_modules/ember-source/types/stable",
-      "./node_modules/ember-data/unstable-preview-types",
-      "./node_modules/@ember-data/store/unstable-preview-types",
-      "./node_modules/@ember-data/adapter/unstable-preview-types",
-      "./node_modules/@ember-data/graph/unstable-preview-types",
-      "./node_modules/@ember-data/json-api/unstable-preview-types",
-      "./node_modules/@ember-data/legacy-compat/unstable-preview-types",
-      "./node_modules/@ember-data/request/unstable-preview-types",
-      "./node_modules/@ember-data/request-utils/unstable-preview-types",
-      "./node_modules/@ember-data/model/unstable-preview-types",
-      "./node_modules/@ember-data/serializer/unstable-preview-types",
-      "./node_modules/@ember-data/tracking/unstable-preview-types",
-      "./node_modules/@warp-drive/core-types/unstable-preview-types"<% } else { %>
-      "ember-source/types"<% } %>
+      "ember-source/types<% if (emberData) { %>",
+      "ember-data/unstable-preview-types",
+      "@ember-data/store/unstable-preview-types",
+      "@ember-data/adapter/unstable-preview-types",
+      "@ember-data/graph/unstable-preview-types",
+      "@ember-data/json-api/unstable-preview-types",
+      "@ember-data/legacy-compat/unstable-preview-types",
+      "@ember-data/request/unstable-preview-types",
+      "@ember-data/request-utils/unstable-preview-types",
+      "@ember-data/model/unstable-preview-types",
+      "@ember-data/serializer/unstable-preview-types",
+      "@ember-data/tracking/unstable-preview-types",
+      "@warp-drive/core-types/unstable-preview-types <% } %>"
     ]
   }
 }

--- a/blueprints/app/files/tsconfig.json
+++ b/blueprints/app/files/tsconfig.json
@@ -26,7 +26,7 @@
       "@ember-data/model/unstable-preview-types",
       "@ember-data/serializer/unstable-preview-types",
       "@ember-data/tracking/unstable-preview-types",
-      "@warp-drive/core-types/unstable-preview-types <% } %>"
+      "@warp-drive/core-types/unstable-preview-types<% } %>"
     ]
   }
 }

--- a/tests/fixtures/app/typescript-embroider/tsconfig.json
+++ b/tests/fixtures/app/typescript-embroider/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/ember/tsconfig.json",
+  "extends": "@tsconfig/ember",
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]
   },
@@ -14,19 +14,19 @@
       "*": ["types/*"]
     },
     "types": [
-      "./node_modules/ember-source/types/stable",
-      "./node_modules/ember-data/unstable-preview-types",
-      "./node_modules/@ember-data/store/unstable-preview-types",
-      "./node_modules/@ember-data/adapter/unstable-preview-types",
-      "./node_modules/@ember-data/graph/unstable-preview-types",
-      "./node_modules/@ember-data/json-api/unstable-preview-types",
-      "./node_modules/@ember-data/legacy-compat/unstable-preview-types",
-      "./node_modules/@ember-data/request/unstable-preview-types",
-      "./node_modules/@ember-data/request-utils/unstable-preview-types",
-      "./node_modules/@ember-data/model/unstable-preview-types",
-      "./node_modules/@ember-data/serializer/unstable-preview-types",
-      "./node_modules/@ember-data/tracking/unstable-preview-types",
-      "./node_modules/@warp-drive/core-types/unstable-preview-types"
+      "ember-source/types",
+      "ember-data/unstable-preview-types",
+      "@ember-data/store/unstable-preview-types",
+      "@ember-data/adapter/unstable-preview-types",
+      "@ember-data/graph/unstable-preview-types",
+      "@ember-data/json-api/unstable-preview-types",
+      "@ember-data/legacy-compat/unstable-preview-types",
+      "@ember-data/request/unstable-preview-types",
+      "@ember-data/request-utils/unstable-preview-types",
+      "@ember-data/model/unstable-preview-types",
+      "@ember-data/serializer/unstable-preview-types",
+      "@ember-data/tracking/unstable-preview-types",
+      "@warp-drive/core-types/unstable-preview-types"
     ]
   }
 }

--- a/tests/fixtures/app/typescript/tsconfig.json
+++ b/tests/fixtures/app/typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/ember/tsconfig.json",
+  "extends": "@tsconfig/ember",
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]
   },
@@ -14,19 +14,19 @@
       "*": ["types/*"]
     },
     "types": [
-      "./node_modules/ember-source/types/stable",
-      "./node_modules/ember-data/unstable-preview-types",
-      "./node_modules/@ember-data/store/unstable-preview-types",
-      "./node_modules/@ember-data/adapter/unstable-preview-types",
-      "./node_modules/@ember-data/graph/unstable-preview-types",
-      "./node_modules/@ember-data/json-api/unstable-preview-types",
-      "./node_modules/@ember-data/legacy-compat/unstable-preview-types",
-      "./node_modules/@ember-data/request/unstable-preview-types",
-      "./node_modules/@ember-data/request-utils/unstable-preview-types",
-      "./node_modules/@ember-data/model/unstable-preview-types",
-      "./node_modules/@ember-data/serializer/unstable-preview-types",
-      "./node_modules/@ember-data/tracking/unstable-preview-types",
-      "./node_modules/@warp-drive/core-types/unstable-preview-types"
+      "ember-source/types",
+      "ember-data/unstable-preview-types",
+      "@ember-data/store/unstable-preview-types",
+      "@ember-data/adapter/unstable-preview-types",
+      "@ember-data/graph/unstable-preview-types",
+      "@ember-data/json-api/unstable-preview-types",
+      "@ember-data/legacy-compat/unstable-preview-types",
+      "@ember-data/request/unstable-preview-types",
+      "@ember-data/request-utils/unstable-preview-types",
+      "@ember-data/model/unstable-preview-types",
+      "@ember-data/serializer/unstable-preview-types",
+      "@ember-data/tracking/unstable-preview-types",
+      "@warp-drive/core-types/unstable-preview-types"
     ]
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/ember-cli/ember-cli/issues/10611

<details><summary>former blockers</summary>

Blocked: Requires new release of ember-data (& friends)

Blocked on: https://github.com/emberjs/data/pull/9633 


</details>


Fixing this on 6.1 would also require ember-data upgrades, I think