### PR TITLE
Add new flag for `new`: `--ember-data` (default), and `--no-ember-data`

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,6 +7,9 @@ const chaiJestSnapshot = require('chai-jest-snapshot');
 module.exports = {
   timeout: 5000,
   reporter,
+  reporterOption: {
+    maxDiffSize: Infinity,
+  },
   retries: 2,
   rootHooks: {
     beforeEach() {

--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -242,6 +242,7 @@ module.exports = {
       blueprintOptions,
       embroider: false,
       lang: options.lang,
+      emberData: options.emberData,
       ciProvider: options.ciProvider,
       typescript: options.typescript,
       packageManager: options.packageManager ?? 'npm',

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0<% if (!typescript) { %>",
     "@babel/eslint-parser": "^7.25.9",
-    "@babel/plugin-proposal-decorators": "^7.25.9<% } %><% if (typescript) { %>",
+    "@babel/plugin-proposal-decorators": "^7.25.9<% } %><% if (typescript && emberData) { %>",
     "@ember-data/adapter": "~5.4.0-beta.12",
     "@ember-data/graph": "~5.4.0-beta.12",
     "@ember-data/json-api": "~5.4.0-beta.12",
@@ -68,8 +68,8 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0<% if (!embroider) { %>",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-terser": "^4.0.2<% } %>",
-    "ember-data": "~5.4.0-beta.12",
+    "ember-cli-terser": "^4.0.2<% } %>",<% if (emberData) { %>
+    "ember-data": "~5.4.0-beta.12",<% } %>
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -68,8 +68,8 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0<% if (!embroider) { %>",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-terser": "^4.0.2<% } %>",<% if (emberData) { %>
-    "ember-data": "~5.4.0-beta.12",<% } %>
+    "ember-cli-terser": "^4.0.2<% } %><% if (emberData) { %>",
+    "ember-data": "~5.4.0-beta.12<% } %>",
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",

--- a/blueprints/app/files/tsconfig.json
+++ b/blueprints/app/files/tsconfig.json
@@ -14,7 +14,7 @@
       "*": ["types/*"]
     },
     "types": [
-      "./node_modules/ember-source/types/stable",
+      <% if (emberData) { %>"./node_modules/ember-source/types/stable",
       "./node_modules/ember-data/unstable-preview-types",
       "./node_modules/@ember-data/store/unstable-preview-types",
       "./node_modules/@ember-data/adapter/unstable-preview-types",
@@ -26,7 +26,8 @@
       "./node_modules/@ember-data/model/unstable-preview-types",
       "./node_modules/@ember-data/serializer/unstable-preview-types",
       "./node_modules/@ember-data/tracking/unstable-preview-types",
-      "./node_modules/@warp-drive/core-types/unstable-preview-types"
+      "./node_modules/@warp-drive/core-types/unstable-preview-types"<% } else { %>
+      "ember-source/types"<% } %>
     ]
   }
 }

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -100,6 +100,11 @@ module.exports = {
       );
     }
 
+    if (!options.emberData) {
+      files = files.filter((file) => !file.includes('models/'));
+      files = files.filter((file) => !file.includes('ember-data/'));
+    }
+
     this._files = files;
 
     return this._files;

--- a/blueprints/app/index.js
+++ b/blueprints/app/index.js
@@ -76,6 +76,7 @@ module.exports = {
       blueprintOptions,
       embroider,
       lang: options.lang,
+      emberData: options.emberData,
       ciProvider: options.ciProvider,
       typescript: options.typescript,
       packageManager: options.packageManager ?? 'npm',

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -45,6 +45,12 @@ module.exports = Command.extend({
       default: 'github',
       description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
     },
+    {
+      name: 'ember-data',
+      type: Boolean,
+      default: true,
+      description: 'Include ember-data dependencies and configuration',
+    },
     { name: 'typescript', type: Boolean, default: false, description: 'Set up the app to use TypeScript' },
   ],
 

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -44,6 +44,12 @@ module.exports = Command.extend({
       description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
     },
     {
+      name: 'ember-data',
+      type: Boolean,
+      default: true,
+      description: 'Include ember-data dependencies and configuration',
+    },
+    {
       name: 'interactive',
       type: Boolean,
       default: false,
@@ -71,6 +77,10 @@ module.exports = Command.extend({
       if (answers.name) {
         projectName = answers.name;
         commandOptions.name = answers.name;
+      }
+
+      if (answers.emberData) {
+        commandOptions.emberData = answers.emberData;
       }
 
       if (answers.lang) {

--- a/lib/tasks/interactive-new.js
+++ b/lib/tasks/interactive-new.js
@@ -125,7 +125,7 @@ class InteractiveNewTask extends Task {
         name: 'emberData',
         type: 'confirm',
         message: 'Do you want to include ember-data?',
-        when: !newCommandOptions.emberData,
+        when: undefined === newCommandOptions.emberData,
         choices: [
           {
             name: 'Include ember-data',

--- a/lib/tasks/interactive-new.js
+++ b/lib/tasks/interactive-new.js
@@ -123,7 +123,7 @@ class InteractiveNewTask extends Task {
       },
       {
         name: 'emberData',
-        type: 'list',
+        type: 'confirm',
         message: 'Do you want to include ember-data?',
         when: !newCommandOptions.emberData,
         choices: [

--- a/lib/tasks/interactive-new.js
+++ b/lib/tasks/interactive-new.js
@@ -121,6 +121,22 @@ class InteractiveNewTask extends Task {
           },
         ],
       },
+      {
+        name: 'emberData',
+        type: 'list',
+        message: 'Do you want to include ember-data?',
+        when: !newCommandOptions.emberData,
+        choices: [
+          {
+            name: 'Include ember-data',
+            value: true,
+          },
+          {
+            name: 'Do not include ember-data',
+            value: false,
+          },
+        ],
+      },
     ];
   }
 

--- a/tests/acceptance/help-test.js
+++ b/tests/acceptance/help-test.js
@@ -101,6 +101,11 @@ describe('Acceptance: ember help', function () {
     let output = options.ui.output;
 
     let fixturePath = path.join(__dirname, '..', 'fixtures', 'help', 'generate.txt');
+
+    // makes updating this fixture much much easier...
+    if (process.env.WRITE_HELP_FIXTURES) {
+      fs.writeFileSync(fixturePath, output, { encoding: 'utf-8' });
+    }
     let expected = loadTextFixture(fixturePath);
 
     expect(output).to.contain(expected);

--- a/tests/fixtures/help/generate.txt
+++ b/tests/fixtures/help/generate.txt
@@ -1,21 +1,44 @@
+Requested ember-cli commands:
+
+ember generate [33m<blueprint>[39m [36m<options...>[39m
+  Generates new code from blueprints.
+  [90maliases: g[39m
+  [36m--dry-run[39m [36m(Boolean)[39m [36m(Default: false)[39m
+    [90maliases: -d[39m
+  [36m--verbose[39m [36m(Boolean)[39m [36m(Default: false)[39m
+    [90maliases: -v[39m
+  [36m--pod[39m [36m(Boolean)[39m [36m(Default: false)[39m
+    [90maliases: -p, -pods[39m
+  [36m--classic[39m [36m(Boolean)[39m [36m(Default: false)[39m
+    [90maliases: -c[39m
+  [36m--dummy[39m [36m(Boolean)[39m [36m(Default: false)[39m
+    [90maliases: -dum, -id[39m
+  [36m--in-repo-addon[39m [36m(String)[39m [36m(Default: null)[39m
+    [90maliases: --in-repo <value>, -ir <value>[39m
+  [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
+  [36m--in[39m [36m(String)[39m [36m(Default: null)[39m Runs a blueprint against an in repo addon. A path is expected, relative to the root of the project.
+  [36m--typescript[39m [36m(Boolean)[39m Generates a version of the blueprint written in TypeScript (if available).
+    [90maliases: -ts[39m
+
 
   Available blueprints:
     ember-cli:
-      addon \u001b[33m<name>\u001b[39m
-        \u001b[90mThe default blueprint for ember-cli addons.\u001b[39m
-      addon-import \u001b[33m<name>\u001b[39m
-        \u001b[90mGenerates an import wrapper.\u001b[39m
-      app \u001b[33m<name>\u001b[39m
-        \u001b[90mThe default blueprint for ember-cli projects.\u001b[39m
-      blueprint \u001b[33m<name>\u001b[39m
-        \u001b[90mGenerates a blueprint and definition.\u001b[39m
-      http-mock \u001b[33m<endpoint-path>\u001b[39m
-        \u001b[90mGenerates a mock api endpoint in /api prefix.\u001b[39m
-      http-proxy \u001b[33m<local-path> <remote-url>\u001b[39m
-        \u001b[90mGenerates a relative proxy to another server.\u001b[39m
-      in-repo-addon \u001b[33m<name>\u001b[39m
-        \u001b[90mThe blueprint for addon in repo ember-cli addons.\u001b[39m
-      lib \u001b[33m<name>\u001b[39m
-        \u001b[90mGenerates a lib directory for in-repo addons.\u001b[39m
-      server \u001b[33m<name>\u001b[39m
-        \u001b[90mGenerates a server directory for mocks and proxies.\u001b[39m
+      addon [33m<name>[39m
+        [90mThe default blueprint for ember-cli addons.[39m
+      addon-import [33m<name>[39m
+        [90mGenerates an import wrapper.[39m
+      app [33m<name>[39m
+        [90mThe default blueprint for ember-cli projects.[39m
+      blueprint [33m<name>[39m
+        [90mGenerates a blueprint and definition.[39m
+      http-mock [33m<endpoint-path>[39m
+        [90mGenerates a mock api endpoint in /api prefix.[39m
+      http-proxy [33m<local-path> <remote-url>[39m
+        [90mGenerates a relative proxy to another server.[39m
+      in-repo-addon [33m<name>[39m
+        [90mThe blueprint for addon in repo ember-cli addons.[39m
+      lib [33m<name>[39m
+        [90mGenerates a lib directory for in-repo addons.[39m
+      server [33m<name>[39m
+        [90mGenerates a server directory for mocks and proxies.[39m
+

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -106,6 +106,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
+  [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
@@ -141,6 +142,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
+  [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -474,6 +474,13 @@ module.exports = {
           required: false,
         },
         {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
+        },
+        {
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -608,6 +615,13 @@ module.exports = {
           type: ['github', 'none'],
           description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
           required: false,
+        },
+        {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
         },
         {
           name: 'interactive',

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -106,6 +106,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
+  [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
@@ -141,6 +142,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
+  [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -506,6 +506,13 @@ module.exports = {
           required: false,
         },
         {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
+        },
+        {
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -640,6 +647,13 @@ module.exports = {
           type: ['github', 'none'],
           description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
           required: false,
+        },
+        {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
         },
         {
           name: 'interactive',

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -474,6 +474,13 @@ module.exports = {
           required: false,
         },
         {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
+        },
+        {
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -608,6 +615,13 @@ module.exports = {
           type: ['github', 'none'],
           description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
           required: false,
+        },
+        {
+          name: 'ember-data',
+          key: 'emberData',
+          description: 'Include ember-data dependencies and configuration',
+          required: false,
+          default: true
         },
         {
           name: 'interactive',

--- a/tests/unit/tasks/interactive-new-test.js
+++ b/tests/unit/tasks/interactive-new-test.js
@@ -22,6 +22,7 @@ describe('interactive new task', function () {
       langSelection: 'en-US',
       packageManager: 'yarn',
       ciProvider: 'github',
+      emberData: true,
     });
 
     expect(answers).to.deep.equal({
@@ -30,6 +31,28 @@ describe('interactive new task', function () {
       lang: 'en-US',
       packageManager: 'yarn',
       ciProvider: 'github',
+      emberData: true,
+    });
+  });
+
+  it('it can opt out of ember-data', async function () {
+    const newCommandOptions = {};
+    const answers = await interactiveNewTask.run(newCommandOptions, {
+      blueprint: 'app',
+      name: 'foo',
+      langSelection: 'en-US',
+      packageManager: 'pnpm',
+      ciProvider: 'github',
+      emberData: false,
+    });
+
+    expect(answers).to.deep.equal({
+      blueprint: 'app',
+      name: 'foo',
+      lang: 'en-US',
+      packageManager: 'pnpm',
+      ciProvider: 'github',
+      emberData: false,
     });
   });
 


### PR DESCRIPTION
> [!IMPORTANT]  
> ember-cli 6.1+ are broken for all monorepo projects (due to ember-data tsconfig.json paths)

----------------

This is, in part, because I want to be unblocked on the v2 addon blueprint:
- https://github.com/embroider-build/addon-blueprint/pull/320
 blocked by: 
  - https://github.com/ember-cli/ember-cli/issues/10611
    - https://github.com/ember-cli/ember-cli/pull/10612
    - Related: 
      - ~~https://github.com/emberjs/data/issues/9630~~
      - https://github.com/emberjs/data/pull/9633


And also in part, because I haven't used fetch or any remote data in a test-app for any of my addons, and ember-data is always the first thing I kick out (along with ember-fetch, and a few others, but those will have other PRs)

There is precedence for this in existing code here: https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/index.js#L74