### PR TITLE
[ENHANCEMENT] Remove `ember-fetch` from blueprints

### DIFF
--- a/blueprints/addon/index.js
+++ b/blueprints/addon/index.js
@@ -71,14 +71,13 @@ module.exports = {
     contents.dependencies['ember-template-imports'] = contents.devDependencies['ember-template-imports'];
     delete contents.devDependencies['ember-template-imports'];
 
-    // 95% of addons don't need ember-data or ember-fetch, make them opt-in instead
+    // 95% of addons don't need ember-data, make them opt-in instead
     let deps = Object.keys(contents.devDependencies);
     for (let depName of deps) {
       if (depName.includes('ember-data') || depName.includes('warp-drive')) {
         delete contents.devDependencies[depName];
       }
     }
-    delete contents.devDependencies['ember-fetch'];
 
     // Per RFC #811, addons should not have this dependency.
     // @see https://github.com/emberjs/rfcs/blob/master/text/0811-element-modifiers.md#detailed-design

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -68,7 +68,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2<% } %>",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/lib/broccoli/default-packager.js
+++ b/lib/broccoli/default-packager.js
@@ -996,7 +996,6 @@ module.exports = class DefaultPackager {
    * ```
    * public
    * ├── crossdomain.xml
-   * ├── ember-fetch
    * ├── favicon.ico
    * ├── images
    * └── robots.txt
@@ -1006,7 +1005,6 @@ module.exports = class DefaultPackager {
    *
    * ```
    * ├── crossdomain.xml
-   * ├── ember-fetch
    * ├── favicon.ico
    * ├── images
    * └── robots.txt

--- a/lib/broccoli/ember-app.js
+++ b/lib/broccoli/ember-app.js
@@ -996,7 +996,6 @@ class EmberApp {
    * And add-on tree:
    *
    * ```
-   * ember-fetch/
    * └── fastboot-fetch.js
    * ```
    *
@@ -1004,8 +1003,6 @@ class EmberApp {
    *
    * ```
    * ├── 500.html
-   * ├── ember-fetch
-   * │   └── fastboot-fetch.js
    * ├── images
    * ├── maintenance.html
    * └── robots.txt

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -46,7 +46,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -47,7 +47,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -47,7 +47,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -47,7 +47,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -47,7 +47,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -43,7 +43,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-data": "~3.27.0-beta.0",
-    "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -46,7 +46,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/pnpm/package.json
+++ b/tests/fixtures/app/pnpm/package.json
@@ -46,7 +46,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -64,7 +64,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -63,7 +63,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -43,7 +43,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-data": "~3.26.0-beta.0",
-    "ember-fetch": "^8.0.4",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^7.0.0",

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -46,7 +46,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~5.4.0-beta.12",
-    "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",

--- a/tests/unit/broccoli/default-packager/public-test.js
+++ b/tests/unit/broccoli/default-packager/public-test.js
@@ -13,9 +13,6 @@ describe('Default Packager: Public', function () {
   let PUBLIC = {
     public: {
       images: {},
-      'ember-fetch': {
-        'fastboot-fetch.js': '',
-      },
       'robots.txt': '',
       '500.html': '',
     },

--- a/tests/unit/broccoli/default-packager/vendor-test.js
+++ b/tests/unit/broccoli/default-packager/vendor-test.js
@@ -15,7 +15,6 @@ describe('Default Packager: Vendor', function () {
       'polyfill.js': 'polyfill',
       'polyfill.min.js': 'polyfill',
     },
-    'ember-fetch.js': 'ember fetch',
     'ember-weakmap-passthrough.js': 'ember weakmap',
     'ember-weakmap-polyfill.js': 'ember weakmap',
     'install-getowner-polyfill.js': 'install getowner',


### PR DESCRIPTION
Update: 

- Made RFC: https://github.com/emberjs/rfcs/pull/1065


--------------

We haven't needed this for a good few years now, but this will require a documentation RFC to help folks migrate (if they choose to -- those same folks could also choose to keep ember-fetch -- with some known constraints about it's usage in future modern build stuff)