### PR TITLE
[ENHANCEMENT] Simplify Prettier config in blueprints

### DIFF
--- a/blueprints/app/files/.prettierrc.js
+++ b/blueprints/app/files/.prettierrc.js
@@ -7,12 +7,6 @@ module.exports = {
       files: '*.{js,gjs,ts,gts,mjs,mts,cjs,cts}',
       options: {
         singleQuote: true,
-      },
-    },
-    {
-      files: '*.{gjs,gts}',
-      options: {
-        singleQuote: true,
         templateSingleQuote: false,
       },
     },


### PR DESCRIPTION
Simplify to just one rule -- the `templateSingleQuote` option will just be ignored for file types other than `gjs` and `gts`