### PR TITLE
[INTERNAL] Avoid output for `deprecate` tests

### DIFF
--- a/lib/debug/deprecate.js
+++ b/lib/debug/deprecate.js
@@ -81,10 +81,6 @@ function deprecate(description, condition, options) {
   let message = formatMessage(description, options);
 
   warn(`${message}\n\n${getStackTrace()}`);
-
-  // Return the message for testing purposes.
-  // This can be removed once we can register deprecation handlers.
-  return message;
 }
 
 function isSemVer(version) {


### PR DESCRIPTION
Makes the test output more readable.