### PR TITLE
[BUGFIX] Only remove type imports when removing the types from `.gts` files in blueprints

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@pnpm/find-workspace-dir": "^7.0.2",
-    "babel-remove-types": "^1.0.0",
+    "babel-remove-types": "^1.0.1",
     "broccoli": "^3.5.2",
     "broccoli-concat": "^4.2.5",
     "broccoli-config-loader": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.3
       babel-remove-types:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       broccoli:
         specifier: ^3.5.2
         version: 3.5.2
@@ -983,8 +983,8 @@ packages:
   aws-sign2@0.5.0:
     resolution: {integrity: sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA==}
 
-  babel-remove-types@1.0.0:
-    resolution: {integrity: sha512-Kg+NZLwfe1E+LoGrkX9I9nFDM1FVBoiIdyW4bjNGGvrqWhvgcdauqijOFn5/WYkdoGXpUEDRWvU4X100ghVx4A==}
+  babel-remove-types@1.0.1:
+    resolution: {integrity: sha512-au+oEGwCCxqb8R0x8EwccTVtWCP4lFkNpHV5skNZnNCwvar3DBBkmGZbx2B1A3RaCHVLQrxF6qv6rR/ZDRPW+A==}
 
   backbone@1.6.0:
     resolution: {integrity: sha512-13PUjmsgw/49EowNcQvfG4gmczz1ximTMhUktj0Jfrjth0MVaTxehpU+qYYX4MxnuIuhmvBLC6/ayxuAGnOhbA==}
@@ -6194,7 +6194,7 @@ snapshots:
   aws-sign2@0.5.0:
     optional: true
 
-  babel-remove-types@1.0.0:
+  babel-remove-types@1.0.1:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.0)

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -33,6 +33,25 @@ describe('Blueprint', function () {
       expect(output).to.equal('const x = 1;\n<template>Hello {{x}}!</template>\n');
     });
 
+    it('keeps imports used in templates when converting gts', async function () {
+      const output = await Blueprint.prototype.removeTypes(
+        '.gts',
+        `import { foo } from 'foo';
+import type { Bar } from 'bar';
+
+const bar: Bar = 'bar';
+
+<template>{{foo}} {{bar}}</template>
+`
+      );
+      expect(output).to.equal(`import { foo } from 'foo';
+
+const bar = 'bar';
+
+<template>{{foo}} {{bar}}</template>
+`);
+    });
+
     it('can handle template-only gts', async function () {
       const output = await Blueprint.prototype.removeTypes('.gts', '<template>Hello!</template>\n');
       expect(output).to.equal('<template>Hello!</template>\n');


### PR DESCRIPTION
When implementing https://github.com/emberjs/ember.js/pull/20835#discussion_r1927321171 I ran into an issue when the types are removed from the .gts file. I tried reproducing the issue in a test.

It looks like the imports that are only used inside the template context are removed incorrectly. It also seems to generate an `export {}` sometimes, ~~but I'm not 100% sure what causes that~~ which also seems related to the removal of the imports (when there are no other imports or exports: https://www.typescriptlang.org/docs/handbook/2/modules.html#non-modules).

Edit: The underlying issue was fixed in babel-remove-types and released in v1.0.1