### PR TITLE
[BUGFIX] Handle errors gracefully when proxy target is down

### DIFF
--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -26,9 +26,11 @@ class ProxyServerAddon {
         timeout: options.proxyInTimeout,
       });
 
-      proxy.on('error', (e) => {
+      proxy.on('error', (e, req, res) => {
         options.ui.writeLine(`Error proxying to ${options.proxy}`);
         options.ui.writeError(e);
+        res.status(502);
+        res.end();
       });
 
       const morgan = require('morgan');

--- a/lib/tasks/server/middleware/proxy-server/index.js
+++ b/lib/tasks/server/middleware/proxy-server/index.js
@@ -29,8 +29,10 @@ class ProxyServerAddon {
       proxy.on('error', (e, req, res) => {
         options.ui.writeLine(`Error proxying to ${options.proxy}`);
         options.ui.writeError(e);
-        res.status(502);
-        res.end();
+        if (typeof res.status === 'function') {
+          res.status(502);
+          res.end();
+        }
       });
 
       const morgan = require('morgan');

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -523,6 +523,16 @@ describe('express-server', function () {
             done();
           });
       });
+
+      it('handles websocket errors gracefully when proxy target is down', function (done) {
+        proxy.httpServer.close();
+
+        let client = new WebSocket('ws://localhost:1337/foo');
+        client.onerror = (error) => {
+          expect(error).to.be.ok;
+          done();
+        };
+      });
     });
 
     describe('proxy with subdomain', function () {

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -509,6 +509,20 @@ describe('express-server', function () {
             done();
           });
       });
+
+      it('handles errors gracefully when proxy target is down', function (done) {
+        proxy.httpServer.close();
+
+        request(subject.httpServer)
+          .get('/api/get')
+          .end(function (err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(res.status, 'proxied request fails gracefully').to.equal(502);
+            done();
+          });
+      });
     });
 
     describe('proxy with subdomain', function () {


### PR DESCRIPTION
If there is an error connecting to the proxy target, proxied http requests hang indefinitely. Now the proxy server will respond with a 502.
