### PR TITLE
[INTERNAL] Add support for the `@ember-data/*` packages in the update-blueprint-dependencies script

### DIFF
--- a/dev/update-blueprint-dependencies.js
+++ b/dev/update-blueprint-dependencies.js
@@ -100,6 +100,10 @@ async function latestVersion(packageName, semverRange) {
       version: semverRange,
     };
 
+    if (isEmberDataPackage(packageName) && OPTIONS['ember-data']) {
+      options.version = OPTIONS['ember-data'];
+    }
+
     if (OPTIONS[packageName]) {
       options.version = OPTIONS[packageName];
     }
@@ -187,6 +191,10 @@ if (module === require.main) {
     process.exitCode = 1;
     return;
   }
+}
+
+function isEmberDataPackage(packageName) {
+  return packageName.includes('ember-data');
 }
 
 module.exports = { PACKAGE_FILES, updateDependencies };


### PR DESCRIPTION
EmberData is no longer in a lockstep version cadence with the ember-source and ember-cli projects. As a result, it's possible that no new ember-data stable release is out when ember-cli bumps the stable deps. This means that the `@ember-data/*` package.json files of the blueprints are published with their `-beta.` versions (since the `latest-version` package doesn't "downgrade" to a previous stable version).

To clarify the problem:
At the moment the blueprints use `~5.4.0-beta.12` for the different ember-data packages. When you run `node ./dev/update-blueprint-dependencies.js --ember-source=latest --ember-data=latest` it will use the `latest` npm tag for ember-data, but still passes `~5.4.0-beta.12` to `latest-version` for the other packages. Since there is no `5.4.0` stable release, `latest-version` will update to the latest 5.4.0 beta release instead.

This updates the script so that it uses the same version we use for the main `ember-data` package (latest / beta).

Running `node ./dev/update-blueprint-dependencies.js --ember-source=latest --ember-data=latest` now updates the version to the last released stable version of the packages.

Related to #10633 