### PR TITLE
[Bugfix] Fix missing lint dependency for typescript projects

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,9 +28,9 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.7<% if (!typescript) { %>",
+    "@babel/core": "^7.26.7",
     "@babel/eslint-parser": "^7.26.5",
-    "@babel/plugin-proposal-decorators": "^7.25.9<% } %><% if (typescript && emberData) { %>",
+    "@babel/plugin-proposal-decorators": "^7.25.9<% if (typescript && emberData) { %>",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -54,6 +54,8 @@
     "ember-template-imports": "^4.3.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "^5.1.0",
     "@embroider/macros": "^1.16.10",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",


### PR DESCRIPTION
uh, I'm so bad at managing fixtures in this project.
something is different about my machine (too modern? lol) that won't make local match CI 