### PR TITLE
[Bugfix release]: Fix eslint parser for js when using --typescript

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.7",
     "@babel/eslint-parser": "^7.26.5",
-    "@babel/plugin-proposal-decorators": "^7.25.9<% if (typescript && emberData) { %>",
+    "@babel/plugin-proposal-decorators": "^7.25.9<% if (typescript) { %>",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",

--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -26,9 +26,9 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.7<% if (!typescript) { %>",
+    "@babel/core": "^7.26.7",
     "@babel/eslint-parser": "^7.26.5",
-    "@babel/plugin-proposal-decorators": "^7.25.9<% } %><% if (typescript) { %>",
+    "@babel/plugin-proposal-decorators": "^7.25.9<% if (typescript && emberData) { %>",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -52,6 +52,8 @@
     "ember-template-imports": "^4.3.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "^4.0.5",
     "@embroider/test-setup": "^4.0.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -27,6 +27,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -27,6 +27,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/adapter": "~5.3.10",
     "@ember-data/graph": "~5.3.10",
     "@ember-data/json-api": "~5.3.10",


### PR DESCRIPTION
backport of https://github.com/ember-cli/ember-cli/pull/10641