### PR TITLE
Update the `--no-ember-data` fixtures

### DIFF
--- a/tests/fixtures/app/embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/embroider-no-ember-data/package.json
@@ -53,7 +53,7 @@
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
-    "ember-page-title": "^8.2.3",
+    "ember-page-title": "^9.0.1",
     "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-source": "~6.3.0-beta.1",

--- a/tests/fixtures/app/no-ember-data/package.json
+++ b/tests/fixtures/app/no-ember-data/package.json
@@ -52,7 +52,7 @@
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
-    "ember-page-title": "^8.2.3",
+    "ember-page-title": "^9.0.1",
     "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-source": "~6.3.0-beta.1",

--- a/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "^5.1.0",
     "@embroider/compat": "^3.8.0",
@@ -59,7 +61,7 @@
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
-    "ember-page-title": "^8.2.3",
+    "ember-page-title": "^9.0.1",
     "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-source": "~6.3.0-beta.1",

--- a/tests/fixtures/app/typescript-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-no-ember-data/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
+    "@babel/eslint-parser": "^7.26.5",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "^5.1.0",
     "@embroider/macros": "^1.16.10",
@@ -58,7 +60,7 @@
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
-    "ember-page-title": "^8.2.3",
+    "ember-page-title": "^9.0.1",
     "ember-qunit": "^9.0.1",
     "ember-resolver": "^13.1.0",
     "ember-source": "~6.3.0-beta.1",


### PR DESCRIPTION
It seems the [PR](https://github.com/ember-cli/ember-cli/pull/10644) that added these fixtures was behind the beta branch when it got merged which caused [CI to fail](https://github.com/ember-cli/ember-cli/actions/runs/13926725778) due to some missing fixture updates.