### PR TITLE
[BUGFIX] Remove deprecated `@types/eslint__js` dependency from `app` blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -54,7 +54,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9<% if (emberData) {%>",
     "@warp-drive/core-types": "~0.0.2<% }} %>",

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -67,7 +67,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
@@ -44,7 +44,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -54,7 +54,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
     "@warp-drive/core-types": "~0.0.2",

--- a/tests/fixtures/app/typescript-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-no-ember-data/package.json
@@ -41,7 +41,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -51,7 +51,6 @@
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.5.2",
     "@tsconfig/ember": "^3.0.10",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.9",
     "@warp-drive/core-types": "~0.0.2",


### PR DESCRIPTION
Fixes #10683 