### PR TITLE
[ENHANCEMENT] Support Bun

### DIFF
--- a/lib/utilities/will-interrupt-process.js
+++ b/lib/utilities/will-interrupt-process.js
@@ -12,7 +12,6 @@
 // on `process.exit()` and control the final exit code.
 
 const captureExit = require('capture-exit');
-const EventEmitter = require('events');
 
 const handlers = [];
 
@@ -24,7 +23,7 @@ module.exports = {
       throw new Error(`process already captured at: \n\n${_processCapturedLocation.stack}`);
     }
 
-    if (outerProcess instanceof EventEmitter === false) {
+    if (isEventEmitterCompatible(outerProcess) === false) {
       throw new Error('attempt to capture bad process instance');
     }
 
@@ -193,4 +192,16 @@ function onMessage(message) {
   if (message.kill) {
     exit();
   }
+}
+
+function isEventEmitterCompatible(obj) {
+  return (
+    Boolean(obj) &&
+    typeof obj === 'object' &&
+    typeof obj.on === 'function' &&
+    typeof obj.emit === 'function' &&
+    typeof obj.removeListener === 'function' &&
+    typeof obj.setMaxListeners === 'function' &&
+    typeof obj.exit === 'function'
+  );
 }


### PR DESCRIPTION
When using Bun, the process (outerProcess) is not an instance of EventEmitter but an object with the same methods. So, to make it more compatible with other runtimes, we should duck type check the object.

Should fix #10371 and #10444.

```shell
% node bin/ember version
ember-cli: 6.5.0-beta.0-bun-support-e37f6d1f5d
node: 20.18.1
os: darwin arm64

% bun --bun bin/ember version
ember-cli: 6.5.0-beta.0-bun-support-e37f6d1f5d
node: 22.6.0
os: darwin arm64

% deno --unstable-detect-cjs bin/ember version
✅ Granted all sys access.
✅ Granted all env access.
✅ Granted all read access.
ember-cli: 6.5.0-beta.0-bun-support-e37f6d1f5d
node: 22.14.0
os: darwin arm64
```

### Tested on
Bun 1.2.12
Deno 2.3.1
Node 20.18.1
macOS 15.4.1
