### PR TITLE
make sure we release alpha with release-plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,13 +163,13 @@
     "yuidoc-ember-cli-theme": "^1.0.4",
     "yuidocjs": "0.10.2"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.12.1",
   "engines": {
     "node": ">= 18"
   },
   "volta": {
     "node": "18.12.0",
-    "pnpm": "9.15.0"
+    "pnpm": "10.12.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.5.0-beta.0",
+  "version": "6.6.0-alpha.0",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",
@@ -36,6 +36,14 @@
     "test:cover": "nyc --all --reporter=text --reporter=lcov node tests/runner all",
     "test:debug": "node --unhandled-rejections=strict debug tests/runner",
     "test:slow": "node --unhandled-rejections=strict tests/runner slow"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
   },
   "dependencies": {
     "@pnpm/find-workspace-dir": "^1000.1.0",

--- a/tests/acceptance/new-test-slow.js
+++ b/tests/acceptance/new-test-slow.js
@@ -2,9 +2,10 @@
 
 const tmp = require('tmp-promise');
 const execa = require('execa');
-const { join } = require('node:path');
+const { join, resolve } = require('node:path');
 const ember = require('../helpers/ember');
 
+const emberCliRoot = resolve(join(__dirname, '../..'));
 const root = process.cwd();
 let tmpDir;
 
@@ -23,24 +24,32 @@ describe('Acceptance: ember new | ember addon', function () {
 
   describe('ember new', function () {
     it('generates a new app with no linting errors', async function () {
-      await ember(['new', 'foo-app', '--pnpm']);
+      await ember(['new', 'foo-app', '--pnpm', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
       await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-app') });
     });
 
     it('generates a new TS app with no linting errors', async function () {
-      await ember(['new', 'foo-app', '--pnpm', '--typescript']);
+      await ember(['new', 'foo-app', '--pnpm', '--typescript', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
       await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-app') });
     });
   });
 
   describe('ember addon', function () {
     it('generates a new addon with no linting errors', async function () {
-      await ember(['addon', 'foo-addon', '--pnpm']);
+      await ember(['addon', 'foo-addon', '--pnpm', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
       await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
     });
 
     it('generates a new TS addon with no linting errors', async function () {
-      await ember(['addon', 'foo-addon', '--pnpm', '--typescript']);
+      await ember(['addon', 'foo-addon', '--pnpm', '--typescript', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
       await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
     });
   });


### PR DESCRIPTION
Our first release-plan PR has been opened 🎉 https://github.com/ember-cli/ember-cli/pull/10709

but as you can see from the description, the version it is going to release is wrong. This PR fixes that 👍 I checked this locally and it will release as `ember-cli 6.6.0-alpha.1 (minor)`
