### PR TITLE
fix yuidoc generation on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "docs": "yuidoc",
     "lint": "eslint . --cache",
     "mocha": "pnpm exec mocha --require ./tests/bootstrap.js tests/**/*-test.js",
-    "prepack": "pnpm docs",
+    "prepack": "pnpm run docs",
     "test": "node --unhandled-rejections=strict tests/runner",
     "test:all": "node --unhandled-rejections=strict tests/runner all",
     "test:cover": "nyc --all --reporter=text --reporter=lcov node tests/runner all",


### PR DESCRIPTION
It looks like our first release-plan based release failed 😢 https://github.com/ember-cli/ember-cli/actions/runs/15588133049/job/43899725720 

the problem was that it runs `pnpm docs` during prepack, which I'm assuming is to try to build the yuidoc for ember-cli before releasing. The correct command should be `pnpm run docs`, otherwise it tries to open the docs for the current package in a browser 🙈 

I have confirmed that this works locally during a `pnpm pack` 👍 