### PR TITLE
make sure alphas releases are set as prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # For every push to the primary branch with .release-plan.json modified,
 # runs release-plan.
 
-name: Publish Stable
+name: Publish Stable (Alpha)
 
 on:
   workflow_dispatch:
@@ -37,7 +37,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
-        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --github-prerelease
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "nock": "^13.5.5",
     "nyc": "^15.1.0",
     "prettier": "2.8.7",
-    "release-plan": "^0.16.0",
+    "release-plan": "^0.17.0",
     "strip-ansi": "^6.0.0",
     "supertest": "^7.1.0",
     "testdouble": "^3.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ importers:
         specifier: 2.8.7
         version: 2.8.7
       release-plan:
-        specifier: ^0.16.0
-        version: 0.16.0
+        specifier: ^0.17.0
+        version: 0.17.0
       strip-ansi:
         specifier: ^6.0.0
         version: 6.0.1
@@ -4257,8 +4257,8 @@ packages:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
     engines: {node: '>=12'}
 
-  release-plan@0.16.0:
-    resolution: {integrity: sha512-S2hrXACiy39LenrdvPAhSY7PcitS4A4fAxlzoPgYyCiS2OU6Ed+cUKvN4h9/uRyZ/B3AMGywZUIPtIhCUIjTng==}
+  release-plan@0.17.0:
+    resolution: {integrity: sha512-mE6ZKEC2FLl0bMeHcd0mKXTxM8rb+gaiaLaEyL6pUmo8zKLAtJxpj6dufaoLd7peKtiw4rDyKKB2IreoGJoqXQ==}
     hasBin: true
 
   release-zalgo@1.0.0:
@@ -9842,7 +9842,7 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  release-plan@0.16.0:
+  release-plan@0.17.0:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       '@npmcli/package-json': 6.1.1


### PR DESCRIPTION
before the latest release-plan version every single github release would be set as `latest` and there was no way to fix that.

As of https://github.com/embroider-build/release-plan/pull/184 we can pass `--github-prerelease` to stop that from happening 👍 