### PR TITLE
pass --publish-branch to release-plan publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
-        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --github-prerelease
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --github-prerelease --publish-branch=beta
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This is needed because release-plan (and maybe pnpm) has checks that confirms if you want to continue publishing if you're not on main or master. When publishing on a branch that is not main or master you need to pass a `--publish-branch` 