### PR TITLE
use patched github-changelog for properly rolling up beta changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,11 @@
     "yuidocjs": "0.10.2"
   },
   "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "overrides": {
+      "github-changelog": "github:embroider-build/github-changelog#ignore-pre-release"
+    }
+  },
   "engines": {
     "node": ">= 18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  github-changelog: github:embroider-build/github-changelog#ignore-pre-release
+
 importers:
 
   .:
@@ -2593,8 +2596,9 @@ packages:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
     engines: {node: '>= 4.0'}
 
-  github-changelog@2.0.0:
-    resolution: {integrity: sha512-JdAwddNCvHkZY/pTMqpoaLEfksaWiTc+beDjBkPEnr7iVlKfu8SeyCT8Sef+KsonRgIj6pl3SiWDPSefWmeicw==}
+  github-changelog@https://codeload.github.com/embroider-build/github-changelog/tar.gz/31b8203ea7f6f65cb3f63439792aa1649f649836:
+    resolution: {tarball: https://codeload.github.com/embroider-build/github-changelog/tar.gz/31b8203ea7f6f65cb3f63439792aa1649f649836}
+    version: 2.0.0
     engines: {node: 18.* || 20.* || >= 22}
     hasBin: true
 
@@ -4420,6 +4424,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -5589,7 +5598,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -7996,7 +8005,7 @@ snapshots:
 
   git-repo-info@2.1.1: {}
 
-  github-changelog@2.0.0:
+  github-changelog@https://codeload.github.com/embroider-build/github-changelog/tar.gz/31b8203ea7f6f65cb3f63439792aa1649f649836:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       chalk: 4.1.2
@@ -8006,6 +8015,7 @@ snapshots:
       make-fetch-happen: 9.1.0
       p-map: 3.0.0
       progress: 2.0.3
+      semver: 7.7.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - bluebird
@@ -9775,7 +9785,7 @@ snapshots:
       cli-highlight: 2.1.11
       execa: 9.5.3
       fs-extra: 11.3.0
-      github-changelog: 2.0.0
+      github-changelog: https://codeload.github.com/embroider-build/github-changelog/tar.gz/31b8203ea7f6f65cb3f63439792aa1649f649836
       js-yaml: 4.1.0
       latest-version: 9.0.0
       parse-github-repo-url: 1.4.1
@@ -9970,6 +9980,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  semver@7.7.2: {}
 
   send@0.19.0:
     dependencies:


### PR DESCRIPTION
As you can see by https://github.com/ember-cli/ember-cli/pull/10723 the changelog is not nearly as detailed as it needs to be. As it turns out this is an issue with the `github-changelog` tool we are using to list the releases (this used to be called lerna-changelog)

I have started a PR upstream to discuss the right behaviour https://github.com/embroider-build/github-changelog/pull/52 but for now I have verified that this is working for us here 👍 Here is the new changelog that this generates: 

```
## Release (2025-06-13)

* ember-cli 6.5.0 (minor)

#### :rocket: Enhancement
* `ember-cli`
  * [#10721](https://github.com/ember-cli/ember-cli/pull/10721) Prepare 6.5.0 release ([@mansona](https://github.com/mansona))
  * [#10705](https://github.com/ember-cli/ember-cli/pull/10705) add `--strict` flag for new app and addon generation ([@mansona](https://github.com/mansona))

#### :bug: Bug Fix
* `ember-cli`
  * [#10684](https://github.com/ember-cli/ember-cli/pull/10684) [BUGFIX] Remove deprecated `@types/eslint__js` dependency from `app` blueprint ([@gvdp](https://github.com/gvdp))

#### :house: Internal
* `ember-cli`
  * [#10722](https://github.com/ember-cli/ember-cli/pull/10722) prevent clashes between release-plan branches ([@mansona](https://github.com/mansona))
  * [#10719](https://github.com/ember-cli/ember-cli/pull/10719) [Backport release]: start using release-plan to release ember-cli ([@mansona](https://github.com/mansona))
  * [#10718](https://github.com/ember-cli/ember-cli/pull/10718) Prepare Beta Release v6.5.0-beta.2 ([@github-actions[bot]](https://github.com/apps/github-actions))
  * [#10717](https://github.com/ember-cli/ember-cli/pull/10717) pass --publish-branch to release-plan publish ([@mansona](https://github.com/mansona))
  * [#10716](https://github.com/ember-cli/ember-cli/pull/10716) Prepare Beta Release v6.5.0-beta.1 ([@github-actions[bot]](https://github.com/apps/github-actions))
  * [#10715](https://github.com/ember-cli/ember-cli/pull/10715) [Backport beta]: Set up release-plan ([@mansona](https://github.com/mansona))
  * [#10695](https://github.com/ember-cli/ember-cli/pull/10695) update beta deps ([@kellyselden](https://github.com/kellyselden))
  * [#10693](https://github.com/ember-cli/ember-cli/pull/10693) update stable deps ([@kellyselden](https://github.com/kellyselden))

#### Committers: 4
- Chris Manson ([@mansona](https://github.com/mansona))
- Kelly Selden ([@kellyselden](https://github.com/kellyselden))
- [@github-actions[bot]](https://github.com/apps/github-actions)
- [@gvdp](https://github.com/gvdp)
```

I'm pretty sure that covers all changes that we would expect to show up in the changelog 👍 