### PR TITLE
remove unnecessary project override

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -1250,23 +1250,6 @@ let Blueprint = CoreObject.extend({
 
     let previousCwd;
     if (!this.project.isEmberCLIProject()) {
-      // our blueprint ran *outside* an ember-cli project. So the only way this
-      // makes sense if the blueprint generated a new project, which we're now
-      // ready to add some addons into. So we need to switch from "outside" mode
-      // to "inside" by reinitializing the Project.
-      //
-      // One might think the cache clear is unnecessary, because in theory the
-      // caches should be shareable, but in practice the new Project we create
-      // below will have the same root dir as the NullProject and that makes bad
-      // things happen.
-      this.project.packageInfoCache._clear();
-      const Project = require('../../lib/models/project');
-      this.project = taskOptions.blueprintOptions.project = Project.closestSync(
-        options.blueprintOptions.target,
-        this.project.ui,
-        this.project.cli
-      );
-
       // The install task adds dependencies based on the current working directory.
       // But in case we created the new project by calling the blueprint with a custom target directory (options.target),
       // the current directory will *not* be the one the project is created in, so we must adjust this here.


### PR DESCRIPTION
This simplifies the interaction between the Project and the Blueprint models. Now a blueprint only uses the project that is passed in 👍 