### PR TITLE
add a repository for each of the packages

### DIFF
--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
   "version": "6.7.0-alpha.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-cli/ember-cli.git",
+    "directory": "packages/addon-blueprint"
+  },
   "dependencies": {
     "@ember-tooling/blueprint-model": "workspace:*",
     "chalk": "^4.1.2",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.2",
     "ember-auto-import": "^2.10.0",
-    "ember-cli": "~6.7.0-alpha.1",
+    "ember-cli": "~6.7.0-alpha.2",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
   "version": "6.7.0-alpha.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-cli/ember-cli.git",
+    "directory": "packages/app-blueprint"
+  },
   "dependencies": {
     "@ember-tooling/blueprint-model": "workspace:*",
     "chalk": "^4.1.2",

--- a/packages/blueprint-blueprint/package.json
+++ b/packages/blueprint-blueprint/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@ember-tooling/blueprint-blueprint",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-cli/ember-cli.git",
+    "directory": "packages/blueprint-blueprint"
+  }
 }

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ember-tooling/blueprint-model",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-cli/ember-cli.git",
+    "directory": "packages/blueprint-model"
+  },
   "dependencies": {
     "chalk": "^4.1.2",
     "diff": "^7.0.0",


### PR DESCRIPTION
The initial release failed because we are using provenance, we need to make sure that the `repository.url` is set properly for deploying: 

https://github.com/ember-cli/ember-cli/actions/runs/15978524290/job/45067126791#step:6:164