### PR TITLE
run tests on the release-plan PR

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -78,7 +78,9 @@ jobs:
           echo "$release_plan_output" >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          # this doesn't use secrets.GITHUB_TOKEN because we want CI to run on the PR that it opens.
+          # See: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GITHUB_AUTH: ${{ secrets.RELEASE_PLAN_GH_PAT }}
 
       - uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
We have a bit of a timing issue with our tests at the moment. Because we have a lot of fixtures that are checking against exact versions in a package.json output, and that package.json output is often driven by the version that is in the ember-cli.version 

This means that, because the release-plan PRs actually bump versions we need to run our tests in the release-plan PR and also bump the fixture (we can do that automatically somehow) 