### PR TITLE
update blueprint version of ember-cli as part of release plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -80,6 +80,14 @@ jobs:
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 
+      # this is needed because our fixtures are highly dependent on the exact version of ember-cli in the monorepo
+      # and release-plan updates the version during the plan phase
+      - name: "Update blueprint to use new ember-cli version"
+        # if you're planning to test this locally and you're on a mac then you should use `gsed` because bsd sed has different
+        # arguments. You can install gsed with `brew install gnu-sed`
+        run: |
+          sed -i 's/"ember-cli".*/"ember-cli": "~'$(jq -r .version package.json)'",/' packages/app-blueprint/files/package.json
+
       - uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "Prepare Alpha Release ${{ steps.explanation.outputs.new_version}} using 'release-plan'"


### PR DESCRIPTION
This is to fix an issue that was hidden and only became apparent **after** the last release. We have enabled CI on release-plan PRs to make sure we catch this issue before it becomes a problem. You can see the CI is failing here: https://github.com/ember-cli/ember-cli/pull/10746

This PR adds a step to update the ember-cli version in the app blueprint during release-plan planning. After this is merged release-plan PRs will be green again and CI won't be broken directly after release any more 👍 