### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,8 +2,8 @@
   "solution": {
     "@ember-tooling/classic-build-addon-blueprint": {
       "impact": "minor",
-      "oldVersion": "6.7.0-alpha.3",
-      "newVersion": "6.7.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.0",
+      "newVersion": "6.8.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
@@ -12,19 +12,15 @@
         },
         {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :memo: Documentation"
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
       "impact": "minor",
-      "oldVersion": "6.7.0-alpha.3",
-      "newVersion": "6.7.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.0",
+      "newVersion": "6.8.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
@@ -33,11 +29,7 @@
         },
         {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :memo: Documentation"
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/app-blueprint/package.json"
@@ -50,8 +42,8 @@
     },
     "ember-cli": {
       "impact": "patch",
-      "oldVersion": "6.7.0-alpha.3",
-      "newVersion": "6.7.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.0",
+      "newVersion": "6.8.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
@@ -66,5 +58,5 @@
       "pkgJSONPath": "./package.json"
     }
   },
-  "description": "## Release (2025-07-26)\n\n* @ember-tooling/classic-build-addon-blueprint 6.7.0-alpha.4 (minor)\n* @ember-tooling/classic-build-app-blueprint 6.7.0-alpha.4 (minor)\n* ember-cli 6.7.0-alpha.4 (patch)\n\n#### :rocket: Enhancement\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10742](https://github.com/ember-cli/ember-cli/pull/10742) Drop node 18, add node 24 ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :bug: Bug Fix\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10742](https://github.com/ember-cli/ember-cli/pull/10742) Drop node 18, add node 24 ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :memo: Documentation\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10742](https://github.com/ember-cli/ember-cli/pull/10742) Drop node 18, add node 24 ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :house: Internal\n* [#10748](https://github.com/ember-cli/ember-cli/pull/10748) update blueprint version of ember-cli as part of release plan ([@mansona](https://github.com/mansona))\n* [#10747](https://github.com/ember-cli/ember-cli/pull/10747) only use the PAT for the PR creation in release-plan ([@mansona](https://github.com/mansona))\n* [#10744](https://github.com/ember-cli/ember-cli/pull/10744) run tests on the release-plan PR ([@mansona](https://github.com/mansona))\n\n#### Committers: 2\n- Chris Manson ([@mansona](https://github.com/mansona))\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
+  "description": "## Release (2025-08-02)\n\n* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.1 (minor)\n* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.1 (minor)\n* ember-cli 6.8.0-alpha.1 (patch)\n\n#### :rocket: Enhancement\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10755](https://github.com/ember-cli/ember-cli/pull/10755) Prepare 6.7-beta ([@mansona](https://github.com/mansona))\n* Other\n  * [#10751](https://github.com/ember-cli/ember-cli/pull/10751) [BETA BACKPORT] Backport drop node 18 ([@mansona](https://github.com/mansona))\n\n#### :house: Internal\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10763](https://github.com/ember-cli/ember-cli/pull/10763) Prepare 6.8-alpha ([@mansona](https://github.com/mansona))\n  * [#10754](https://github.com/ember-cli/ember-cli/pull/10754) Prepare Beta Release ([@github-actions[bot]](https://github.com/apps/github-actions))\n* Other\n  * [#10761](https://github.com/ember-cli/ember-cli/pull/10761) update release-plan ([@mansona](https://github.com/mansona))\n\n#### Committers: 2\n- Chris Manson ([@mansona](https://github.com/mansona))\n- [@github-actions[bot]](https://github.com/apps/github-actions)\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # ember-cli Changelog
 
+## Release (2025-08-02)
+
+* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.1 (minor)
+* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.1 (minor)
+* ember-cli 6.8.0-alpha.1 (patch)
+
+#### :rocket: Enhancement
+* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
+  * [#10755](https://github.com/ember-cli/ember-cli/pull/10755) Prepare 6.7-beta ([@mansona](https://github.com/mansona))
+* Other
+  * [#10751](https://github.com/ember-cli/ember-cli/pull/10751) [BETA BACKPORT] Backport drop node 18 ([@mansona](https://github.com/mansona))
+
+#### :house: Internal
+* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
+  * [#10763](https://github.com/ember-cli/ember-cli/pull/10763) Prepare 6.8-alpha ([@mansona](https://github.com/mansona))
+  * [#10754](https://github.com/ember-cli/ember-cli/pull/10754) Prepare Beta Release ([@github-actions[bot]](https://github.com/apps/github-actions))
+* Other
+  * [#10761](https://github.com/ember-cli/ember-cli/pull/10761) update release-plan ([@mansona](https://github.com/mansona))
+
+#### Committers: 2
+- Chris Manson ([@mansona](https://github.com/mansona))
+- [@github-actions[bot]](https://github.com/apps/github-actions)
+
 ## Release (2025-07-26)
 
 * @ember-tooling/classic-build-addon-blueprint 6.7.0-alpha.4 (minor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.8.0-alpha.0",
+  "version": "6.8.0-alpha.1",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.8.0-alpha.0",
+  "version": "6.8.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.0",
     "ember-auto-import": "^2.10.0",
-    "ember-cli": "~6.8.0-alpha.0",
+    "ember-cli": "~6.8.0-alpha.1",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.8.0-alpha.0",
+  "version": "6.8.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2025-08-02)

* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.1 (minor)
* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.1 (minor)
* ember-cli 6.8.0-alpha.1 (patch)

#### :rocket: Enhancement
* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
  * [#10755](https://github.com/ember-cli/ember-cli/pull/10755) Prepare 6.7-beta ([@mansona](https://github.com/mansona))
* Other
  * [#10751](https://github.com/ember-cli/ember-cli/pull/10751) [BETA BACKPORT] Backport drop node 18 ([@mansona](https://github.com/mansona))

#### :house: Internal
* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
  * [#10763](https://github.com/ember-cli/ember-cli/pull/10763) Prepare 6.8-alpha ([@mansona](https://github.com/mansona))
  * [#10754](https://github.com/ember-cli/ember-cli/pull/10754) Prepare Beta Release ([@github-actions[bot]](https://github.com/apps/github-actions))
* Other
  * [#10761](https://github.com/ember-cli/ember-cli/pull/10761) update release-plan ([@mansona](https://github.com/mansona))

#### Committers: 2
- Chris Manson ([@mansona](https://github.com/mansona))
- [@github-actions[bot]](https://github.com/apps/github-actions)