### PR TITLE
fix double CI run on release-plan PR

### DIFF
--- a/.github/workflows/plan-alpha-release.yml
+++ b/.github/workflows/plan-alpha-release.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           commit-message: "Prepare Alpha Release ${{ steps.explanation.outputs.new_version}} using 'release-plan'"
           labels: "internal"
-          branch: release-preview
+          branch: releaseplan-preview
           title: Prepare Alpha Release ${{ steps.explanation.outputs.new_version }}
           # this doesn't use secrets.GITHUB_TOKEN because we want CI to run on the PR that it opens.
           # See: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow


### PR DESCRIPTION
Now that we're running CI on the release-plan PR I noticed that we are getting a double CI run on it. It turns out that we run on commits for any branch prefixed with `release-` 🤦 so I changed the release-preview PR to `releaseplan-preview`