### PR TITLE
Make strict app blueprints show gjs/gts extensions in the WelcomePage

### DIFF
--- a/packages/app-blueprint/files/app/templates/_js_application.gjs
+++ b/packages/app-blueprint/files/app/templates/_js_application.gjs
@@ -7,7 +7,7 @@ import WelcomePage from 'ember-welcome-page/components/welcome-page';<% } %>
   {{outlet}}
 
   {{! The following component displays Ember's default welcome message. }}
-  <WelcomePage />
+  <WelcomePage @extension="gjs" />
   {{! Feel free to remove this! }}<% } else { %>
   <h2 id="title">Welcome to Ember</h2>
 

--- a/packages/app-blueprint/files/app/templates/_ts_application.gts
+++ b/packages/app-blueprint/files/app/templates/_ts_application.gts
@@ -7,7 +7,7 @@ import WelcomePage from 'ember-welcome-page/components/welcome-page';<% } %>
   {{outlet}}
 
   {{! The following component displays Ember's default welcome message. }}
-  <WelcomePage />
+  <WelcomePage @extension="gts" />
   {{! Feel free to remove this! }}<% } else { %>
   <h2 id="title">Welcome to Ember</h2>
 

--- a/tests/fixtures/app/strict-typescript/app/templates/application.gts
+++ b/tests/fixtures/app/strict-typescript/app/templates/application.gts
@@ -7,6 +7,6 @@ import WelcomePage from 'ember-welcome-page/components/welcome-page';
   {{outlet}}
 
   {{! The following component displays Ember's default welcome message. }}
-  <WelcomePage />
+  <WelcomePage @extension="gts" />
   {{! Feel free to remove this! }}
 </template>

--- a/tests/fixtures/app/strict/app/templates/application.gjs
+++ b/tests/fixtures/app/strict/app/templates/application.gjs
@@ -7,6 +7,6 @@ import WelcomePage from 'ember-welcome-page/components/welcome-page';
   {{outlet}}
 
   {{! The following component displays Ember's default welcome message. }}
-  <WelcomePage />
+  <WelcomePage @extension="gjs" />
   {{! Feel free to remove this! }}
 </template>


### PR DESCRIPTION
This change would allow the freshly generated app to guide a user to the correct file in its welcome message

<img width="984" height="210" alt="Screenshot 2025-08-20 at 00 39 50" src="https://github.com/user-attachments/assets/df22ba1d-a208-4414-8eeb-63c8f91186d2" />

Depends on ember-cli/ember-welcome-page#405