### PR TITLE
Add deprecation warning for the `--embroider` argument

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,6 +10,7 @@ const normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
 const { isPnpmProject, isYarnProject } = require('../utilities/package-managers');
 const getLangArg = require('../../lib/utilities/get-lang-arg');
+const { deprecate, DEPRECATIONS } = require('../debug');
 
 module.exports = Command.extend({
   name: 'init',
@@ -39,7 +40,12 @@ module.exports = Command.extend({
       type: String,
       description: 'Sets the base human language of the application via index.html',
     },
-    { name: 'embroider', type: Boolean, default: false, description: 'Enables the build system to use Embroider' },
+    {
+      name: 'embroider',
+      type: Boolean,
+      default: false,
+      description: 'Deprecated: Enables the build system to use Embroider',
+    },
     {
       name: 'ci-provider',
       type: ['github', 'none'],
@@ -74,6 +80,12 @@ module.exports = Command.extend({
   beforeRun: mergeBlueprintOptions,
 
   async run(commandOptions, rawArgs) {
+    deprecate(
+      "Don't use `--embroider` option. Use `-b @ember/app-blueprint` instead.",
+      !commandOptions.embroider,
+      DEPRECATIONS.EMBROIDER.options
+    );
+
     if (commandOptions.dryRun) {
       commandOptions.skipNpm = true;
     }
@@ -142,5 +154,11 @@ module.exports = Command.extend({
     this.ui.writeLine(`  ${chalk.gray('$')} ${chalk.cyan(`${commandOptions.packageManager ?? 'npm'} start`)}`);
     this.ui.writeLine('');
     this.ui.writeLine('Happy coding!');
+
+    deprecate(
+      "Don't use `--embroider` option. Use `-b @ember/app-blueprint` instead.",
+      !commandOptions.embroider,
+      DEPRECATIONS.EMBROIDER.options
+    );
   },
 });

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -7,6 +7,7 @@ const SilentError = require('silent-error');
 const isValidProjectName = require('../utilities/valid-project-name');
 const normalizeBlueprint = require('../utilities/normalize-blueprint-option');
 const mergeBlueprintOptions = require('../utilities/merge-blueprint-options');
+const { deprecate, DEPRECATIONS } = require('../debug');
 
 module.exports = Command.extend({
   name: 'new',
@@ -37,7 +38,12 @@ module.exports = Command.extend({
       description: 'Sets the base human language of the application via index.html',
     },
     { name: 'lint-fix', type: Boolean, default: true },
-    { name: 'embroider', type: Boolean, default: false, description: 'Enables the build system to use Embroider' },
+    {
+      name: 'embroider',
+      type: Boolean,
+      default: false,
+      description: 'Deprecated: Enables the build system to use Embroider',
+    },
     {
       name: 'ci-provider',
       type: ['github', 'none'],
@@ -70,6 +76,12 @@ module.exports = Command.extend({
   beforeRun: mergeBlueprintOptions,
 
   async run(commandOptions, rawArgs) {
+    deprecate(
+      "Don't use `--embroider` option. Use `-b @ember/app-blueprint` instead.",
+      !commandOptions.embroider,
+      DEPRECATIONS.EMBROIDER.options
+    );
+
     let projectName = rawArgs[0],
       message;
 
@@ -140,6 +152,12 @@ module.exports = Command.extend({
     });
 
     initCommand.project.root = process.cwd();
+
+    deprecate(
+      "Don't use `--embroider` option. Use `-b @ember/app-blueprint` instead.",
+      !commandOptions.embroider,
+      DEPRECATIONS.EMBROIDER.options
+    );
 
     return await initCommand.run(commandOptions, rawArgs);
   },

--- a/lib/debug/deprecations.js
+++ b/lib/debug/deprecations.js
@@ -23,6 +23,15 @@ const DEPRECATIONS = {
       types: ['app-prefix', 'app-suffix', 'tests-prefix', 'tests-suffix', 'vendor-prefix', 'vendor-suffix'],
     },
   }),
+  EMBROIDER: deprecation({
+    for: 'ember-cli',
+    id: 'ember-cli.dont-use-embroider-option',
+    since: {
+      available: '6.8.0',
+    },
+    until: '7.0.0',
+    url: 'https://deprecations.emberjs.com/id/dont-use-embroider-option',
+  }),
 };
 
 module.exports = DEPRECATIONS;

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -11,6 +11,7 @@ const util = require('util');
 const EOL = require('os').EOL;
 const hasGlobalYarn = require('../helpers/has-global-yarn');
 const { set, get, cloneDeep } = require('lodash');
+const { DEPRECATIONS } = require('../../lib/debug');
 
 const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
@@ -423,6 +424,10 @@ describe('Acceptance: ember new', function () {
   }
 
   it('embroider enabled with --embroider', async function () {
+    if (DEPRECATIONS.EMBROIDER.isRemoved) {
+      this.skip();
+    }
+
     await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
 
     let pkgJson = fs.readJsonSync('package.json');

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -105,7 +105,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--name[39m [36m(String)[39m [36m(Default: "")[39m
     [90maliases: -n <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
-  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Deprecated: Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
@@ -142,7 +142,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -dir <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
-  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Deprecated: Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -469,7 +469,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false,
         },
         {
@@ -620,7 +620,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false,
         },
         {

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -105,7 +105,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--name[39m [36m(String)[39m [36m(Default: "")[39m
     [90maliases: -n <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
-  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Deprecated: Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
@@ -142,7 +142,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -dir <value>[39m
   [36m--lang[39m [36m(String)[39m Sets the base human language of the application via index.html
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
-  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Enables the build system to use Embroider
+  [36m--embroider[39m [36m(Boolean)[39m [36m(Default: false)[39m Deprecated: Enables the build system to use Embroider
   [36m--ci-provider[39m [36m(github, none)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -501,7 +501,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false
         },
         {
@@ -652,7 +652,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false
         },
         {

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -469,7 +469,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false
         },
         {
@@ -620,7 +620,7 @@ module.exports = {
           default: false,
           key: 'embroider',
           name: 'embroider',
-          description: 'Enables the build system to use Embroider',
+          description: 'Deprecated: Enables the build system to use Embroider',
           required: false
         },
         {


### PR DESCRIPTION
- for both `new` and `init`
- at the top and at the bottom of the printout to make sure people don't miss it

This doesn't deprecate or remove the `EMBROIDER` experiment. It only affects the command line option.

Requires https://github.com/ember-learn/deprecation-app/pull/1413 to be merged for the explainer link to work

Closes #10775 