### PR TITLE
Fix instrumentation tests by properly resetting fs.statSync

### DIFF
--- a/tests/unit/models/instrumentation-test.js
+++ b/tests/unit/models/instrumentation-test.js
@@ -40,6 +40,10 @@ describe('models/instrumentation.js', function () {
 
     afterEach(function () {
       td.reset();
+      // Manually reset statSync as node@24.6 returns [Function: statSync],
+      // which doesn't match with what `heimdalljs-fs-monitor` does to this
+      // It's likely that this was never correct and just masked by lose types in node<24.6
+      fs.statSync = originalStatSync;
     });
 
     it('if VIZ is NOT enabled, do not monitor', function () {


### PR DESCRIPTION
Fixes the following error that popped up with `node@24.6`:

```
 1) models/instrumentation.js
       ._enableFSMonitorIfInstrumentationEnabled
         "before each" hook for "if instrumentation is enabled, monitor":

      AssertionError: expected [Function] to equal [Function statSync]
      + expected - actual

      -{
      -  "__restore": [Function]
      -}
      +[Function]

      at Context.<anonymous> (tests/unit/models/instrumentation-test.js:38:30)
      at process.processImmediate (node:internal/timers:505:21)
```