### PR TITLE
`VITE` experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           - ENABLE_ALL_EXPERIMENTS
           - EMBROIDER
           - CLASSIC
+          - VITE
 
     steps:
       - uses: actions/checkout@v4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,9 +45,9 @@ You can use [this saved search](https://github.com/ember-cli/ember-cli/pulls?q=i
   - make sure to not add the `release-plan` config section to the package.json during this step. We are releasing a real release so we don't want to configure release-plan to do a pre-release.
 - Update blueprint dependencies to latest
 
-```
-node ./dev/update-blueprint-dependencies.js --ember-source=latest --ember-data=latest
-```
+  ```
+  node ./dev/update-blueprint-dependencies.js --ember-source=latest --ember-data=latest
+  ```
 
 - commit this update `git commit -am "update blueprint dependencies to latest"`
 - push and open a PR targeting `release` with a PR title like `Update all dependencies for 6.4 release`
@@ -78,11 +78,12 @@ node ./dev/update-blueprint-dependencies.js --ember-source=latest --ember-data=l
   - update the `ember-cli` reference in `packages/app-blueprint/files/package.json` to be the same as the version you just put in the top level package.json
 - Update blueprint dependencies to beta
 
-```
-node ./dev/update-blueprint-dependencies.js --ember-source=beta --ember-data=beta
-```
+  ```
+  node ./dev/update-blueprint-dependencies.js --ember-source=beta --ember-data=beta
+  ```
 
 - commit this update `git commit -am "update blueprint dependencies to beta"`
+- **TODO**: document how to update @ember/app-blueprint dependency
 - push and open a PR targeting `beta` with a PR title like `Prepare 6.5-beta`
 - mark this PR as an `enchancement` if the next beta is a minor release
 - check that everything is ok i.e. CI passes
@@ -110,11 +111,12 @@ node ./dev/update-blueprint-dependencies.js --ember-source=beta --ember-data=bet
 - commit this change to the version in package.json: `git commit -am "update to the next alpha version"`
 - Update blueprint dependencies to alpha
 
-```
-node ./dev/update-blueprint-dependencies.js --ember-source=alpha --ember-data=canary
-```
+  ```
+  node ./dev/update-blueprint-dependencies.js --ember-source=alpha --ember-data=canary
+  ```
 
 - commit this update `git commit -am "update blueprint dependencies to alpha"`
+- **TODO**: document how to update @ember/app-blueprint dependency
 - push and open a PR targeting `master` with a PR title like `Prepare 6.6-alpha`
 - mark this PR as an `enchancement` if the next alpha is a minor release
 - check that everything is ok i.e. CI passes

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2,7 +2,7 @@
 
 "Experiments" are what Ember CLI calls [Feature Toggle](https://en.wikipedia.org/wiki/Feature_toggle).
 
-They are defined in `lib/experiments/index.js`. For example:
+They are defined in `packages/blueprint-model/utilities/experiments.js`. For example:
 
 ```javascript
 const availableExperiments = [
@@ -14,7 +14,7 @@ When a new feature is added, all supporting code and tests **must** be guarded
 to ensure all tests pass when the feature is enabled _or_ disabled:
 
 ```javascript
-const { isExperimentEnabled } = require('../experiments');
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 // ...snip...
 if (isExperimentEnabled('SOME_EXPERIMENT')) {
@@ -43,11 +43,11 @@ EMBER_CLI_CONFIG_CACHING=true pnpm test
 
 The Ember CLI core team will evaluate each experiment before betas get released.
 If the experiment is not ready, the entry for the experiment is deleted from
-`lib/experiments/index.js` (and therefore disabled).
+`packages/blueprint-model/utilities/experiments.js` (and therefore disabled).
 
 ## Supported
 
 Once an experiment has gone through the different stages of beta, and we can
 confidently say a specific feature from an experiment will be supported, we
-delete the entry in `lib/experiments/index.js` and remove the experiment guards
-(e.g. if (experiments.FOO_BAR) {) from the codebase.
+delete the entry in `packages/blueprint-model/utilities/experiments.js` and
+remove the experiment guards (e.g. if (experiments.FOO_BAR) {) from the codebase.

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -12,6 +12,8 @@ const { isPnpmProject, isYarnProject } = require('../utilities/package-managers'
 const getLangArg = require('../../lib/utilities/get-lang-arg');
 const { deprecate, DEPRECATIONS } = require('../debug');
 
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
+
 module.exports = Command.extend({
   name: 'init',
   description: 'Reinitializes a new ember-cli project in the current folder.',
@@ -116,12 +118,17 @@ module.exports = Command.extend({
     }
 
     let blueprintOpts = clone(commandOptions);
+    let blueprint = normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint());
+
+    if (isExperimentEnabled('VITE') && blueprint === 'app') {
+      blueprint = '@ember/app-blueprint';
+    }
 
     merge(blueprintOpts, {
       rawName: packageName,
       targetFiles: rawArgs || [],
       rawArgs: rawArgs.toString(),
-      blueprint: normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint()),
+      blueprint,
       ciProvider,
     });
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ember-tooling/blueprint-model": "workspace:*",
     "@ember-tooling/classic-build-addon-blueprint": "workspace:*",
     "@ember-tooling/classic-build-app-blueprint": "workspace:*",
+    "@ember/app-blueprint": "^0.8.1",
     "@pnpm/find-workspace-dir": "^1000.1.0",
     "babel-remove-types": "^1.0.1",
     "broccoli": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ember-tooling/blueprint-model": "workspace:*",
     "@ember-tooling/classic-build-addon-blueprint": "workspace:*",
     "@ember-tooling/classic-build-app-blueprint": "workspace:*",
-    "@ember/app-blueprint": "^0.8.1",
+    "@ember/app-blueprint": "^0.8.2",
     "@pnpm/find-workspace-dir": "^1000.1.0",
     "babel-remove-types": "^1.0.1",
     "broccoli": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ember-tooling/blueprint-model": "workspace:*",
     "@ember-tooling/classic-build-addon-blueprint": "workspace:*",
     "@ember-tooling/classic-build-app-blueprint": "workspace:*",
-    "@ember/app-blueprint": "^0.8.2",
+    "@ember/app-blueprint": "^6.8.0-beta.1",
     "@pnpm/find-workspace-dir": "^1000.1.0",
     "babel-remove-types": "^1.0.1",
     "broccoli": "^3.5.2",

--- a/packages/blueprint-model/utilities/experiments.js
+++ b/packages/blueprint-model/utilities/experiments.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const availableExperiments = Object.freeze(['EMBROIDER', 'CLASSIC']);
+const availableExperiments = Object.freeze(['EMBROIDER', 'CLASSIC', 'VITE']);
 
 const deprecatedExperiments = Object.freeze([]);
 const enabledExperiments = Object.freeze([]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/app-blueprint
       '@ember/app-blueprint':
-        specifier: ^0.8.1
-        version: 0.8.1
+        specifier: ^0.8.2
+        version: 0.8.2
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.0
         version: 1000.1.0
@@ -560,8 +560,8 @@ packages:
     engines: {node: '>=0.1.95'}
     hasBin: true
 
-  '@ember/app-blueprint@0.8.1':
-    resolution: {integrity: sha512-eKf622lVo+IEnf2STZYCezaY4GfrzxL/0kg9BK050G+2bPN9I7XIcbL+1/MJMSqsNp3u6qhir9W3r3IdZ6PWiw==}
+  '@ember/app-blueprint@0.8.2':
+    resolution: {integrity: sha512-BxTCHP7mT52+6unymDs21Z/gYrXe760V6dUewQ/BNEuwap7fO+50CeYs9PZY0GuqK3wSp+4Q8ylL4gpWkTjq8g==}
 
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
@@ -4718,6 +4718,7 @@ packages:
   superagent@10.2.1:
     resolution: {integrity: sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@7.1.1:
     resolution: {integrity: sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==}
@@ -5489,7 +5490,7 @@ snapshots:
       exec-sh: 0.3.6
       minimist: 1.2.8
 
-  '@ember/app-blueprint@0.8.1':
+  '@ember/app-blueprint@0.8.2':
     dependencies:
       chalk: 4.1.2
       ember-cli-string-utils: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@ember-tooling/classic-build-app-blueprint':
         specifier: workspace:*
         version: link:packages/app-blueprint
+      '@ember/app-blueprint':
+        specifier: ^0.8.1
+        version: 0.8.1
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.0
         version: 1000.1.0
@@ -556,6 +559,9 @@ packages:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
     engines: {node: '>=0.1.95'}
     hasBin: true
+
+  '@ember/app-blueprint@0.8.1':
+    resolution: {integrity: sha512-eKf622lVo+IEnf2STZYCezaY4GfrzxL/0kg9BK050G+2bPN9I7XIcbL+1/MJMSqsNp3u6qhir9W3r3IdZ6PWiw==}
 
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
@@ -5482,6 +5488,13 @@ snapshots:
     dependencies:
       exec-sh: 0.3.6
       minimist: 1.2.8
+
+  '@ember/app-blueprint@0.8.1':
+    dependencies:
+      chalk: 4.1.2
+      ember-cli-string-utils: 1.1.0
+      lodash: 4.17.21
+      walk-sync: 3.0.0
 
   '@eslint-community/eslint-utils@4.4.1(eslint@8.57.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/app-blueprint
       '@ember/app-blueprint':
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^6.8.0-beta.1
+        version: 6.8.0-beta.1
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.0
         version: 1000.1.0
@@ -560,8 +560,8 @@ packages:
     engines: {node: '>=0.1.95'}
     hasBin: true
 
-  '@ember/app-blueprint@0.8.2':
-    resolution: {integrity: sha512-BxTCHP7mT52+6unymDs21Z/gYrXe760V6dUewQ/BNEuwap7fO+50CeYs9PZY0GuqK3wSp+4Q8ylL4gpWkTjq8g==}
+  '@ember/app-blueprint@6.8.0-beta.1':
+    resolution: {integrity: sha512-numsThY0m1gXrOSpe4B8luGds0vPi0Jlh4BHltE0nOxX5LwfXGDadeNh1uezfjimuRJmRtPE0EXyX5BOOEpcew==}
 
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
@@ -5490,7 +5490,7 @@ snapshots:
       exec-sh: 0.3.6
       minimist: 1.2.8
 
-  '@ember/app-blueprint@0.8.2':
+  '@ember/app-blueprint@6.8.0-beta.1':
     dependencies:
       chalk: 4.1.2
       ember-cli-string-utils: 1.1.0

--- a/tests/acceptance/addon-test-slow.js
+++ b/tests/acceptance/addon-test-slow.js
@@ -9,7 +9,7 @@ const emberCliRoot = resolve(join(__dirname, '../..'));
 const root = process.cwd();
 let tmpDir;
 
-describe('Acceptance: ember new | ember addon', function () {
+describe('Acceptance: ember addon (slow)', function () {
   this.timeout(500000);
 
   beforeEach(async function () {

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -55,11 +55,19 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('a custom environment config can be used in Brocfile.js', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/custom-environment-config');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('builds with an ES modules ember-cli-build.js', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await fs.writeFile(
       'ember-cli-build.js',
       `
@@ -88,6 +96,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('without app/templates', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await fs.remove(path.join(process.cwd(), 'app/templates'));
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
@@ -113,6 +125,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using autoRun: true', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/auto-run-true');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -125,6 +141,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using autoRun: false', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/auto-run-false');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -137,7 +157,7 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   // we dont run postprocessTree in embroider
-  if (!isExperimentEnabled('EMBROIDER')) {
+  if (!isExperimentEnabled('EMBROIDER') && !isExperimentEnabled('VITE')) {
     it('app.import works properly with test tree files', async function () {
       await copyFixtureFiles('brocfile-tests/app-test-import');
 
@@ -201,11 +221,19 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using pods based templates with a podModulePrefix', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/pods-with-prefix-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 
   it('addon trees are not jshinted', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/jshint-addon');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -223,6 +251,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('multiple css files in styles/ are output when a preprocessor is not used', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/multiple-css-files');
 
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
@@ -249,6 +281,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn anonymous AMD into named AMD', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/app-import-anonymous-amd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -273,6 +309,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn named UMD into named AMD', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/app-import-named-umd');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
 
@@ -297,6 +337,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can do amd transform from addon', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -327,6 +371,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('can use transformation to turn library into custom transformation', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/app-import-custom-transform');
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -347,12 +395,20 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('app.css is output to <app name>.css by default', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'build');
     expect(file(`dist/assets/${appName}.css`)).to.exist;
   });
 
   // for backwards compat.
   it('app.scss is output to <app name>.css by default', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/multiple-sass-files');
 
     let brocfilePath = path.join(appRoot, 'ember-cli-build.js');

--- a/tests/acceptance/brocfile-smoke-test-slow.js
+++ b/tests/acceptance/brocfile-smoke-test-slow.js
@@ -216,6 +216,10 @@ describe('Acceptance: brocfile-smoke-test', function () {
   });
 
   it('using pods based templates', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('brocfile-tests/pods-templates');
     await runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -16,7 +16,10 @@ const EOL = require('os').EOL;
 const td = require('testdouble');
 const lintFix = require('../../lib/utilities/lint-fix');
 
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
+
 const { DEPRECATIONS } = require('../../lib/debug');
+const { confirmViteBlueprint } = require('../helpers-internal/blueprint');
 
 const { expect } = require('chai');
 const { dir, file } = require('chai-files');
@@ -49,6 +52,11 @@ describe('Acceptance: ember init', function () {
   });
 
   function confirmBlueprinted(typescript = false) {
+    if (isExperimentEnabled('VITE')) {
+      confirmViteBlueprint();
+      return;
+    }
+
     let blueprintPath = path.join(path.dirname(require.resolve('@ember-tooling/classic-build-app-blueprint')), 'files');
     // ignore TypeScript files
     let expected = walkSync(blueprintPath, {
@@ -144,7 +152,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init a single file', async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 
@@ -154,7 +162,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it("init a single file on already init'd folder", async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 
@@ -166,7 +174,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init multiple files by glob pattern', async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 
@@ -176,7 +184,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it("init multiple files by glob pattern on already init'd folder", async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 
@@ -188,7 +196,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init multiple files by glob patterns', async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 
@@ -198,7 +206,7 @@ describe('Acceptance: ember init', function () {
   });
 
   it("init multiple files by glob patterns on already init'd folder", async function () {
-    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved || isExperimentEnabled('VITE')) {
       this.skip();
     }
 

--- a/tests/acceptance/new-test-slow.js
+++ b/tests/acceptance/new-test-slow.js
@@ -4,12 +4,13 @@ const tmp = require('tmp-promise');
 const execa = require('execa');
 const { join, resolve } = require('node:path');
 const ember = require('../helpers/ember');
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 const emberCliRoot = resolve(join(__dirname, '../..'));
 const root = process.cwd();
 let tmpDir;
 
-describe('Acceptance: ember new | ember addon', function () {
+describe('Acceptance: ember new (slow)', function () {
   this.timeout(500000);
 
   beforeEach(async function () {
@@ -23,6 +24,12 @@ describe('Acceptance: ember new | ember addon', function () {
   });
 
   describe('ember new', function () {
+    if (isExperimentEnabled('VITE')) {
+      before(function () {
+        this.skip();
+      });
+    }
+
     it('generates a new app with no linting errors', async function () {
       await ember(['new', 'foo-app', '--pnpm', '--skip-npm']);
       // link current version of ember-cli in the newly generated app

--- a/tests/acceptance/new-test-slow.js
+++ b/tests/acceptance/new-test-slow.js
@@ -4,7 +4,6 @@ const tmp = require('tmp-promise');
 const execa = require('execa');
 const { join, resolve } = require('node:path');
 const ember = require('../helpers/ember');
-const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 const emberCliRoot = resolve(join(__dirname, '../..'));
 const root = process.cwd();
@@ -24,12 +23,6 @@ describe('Acceptance: ember new (slow)', function () {
   });
 
   describe('ember new', function () {
-    if (isExperimentEnabled('VITE')) {
-      before(function () {
-        this.skip();
-      });
-    }
-
     it('generates a new app with no linting errors', async function () {
       await ember(['new', 'foo-app', '--pnpm', '--skip-npm']);
       // link current version of ember-cli in the newly generated app

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -20,6 +20,7 @@ const { expect } = require('chai');
 const { dir, file } = require('chai-files');
 
 const { checkFile } = require('../helpers-internal/file-utils');
+const { confirmViteBlueprint } = require('../helpers-internal/blueprint');
 const {
   currentVersion,
   currentAppBlueprintVersion,
@@ -86,6 +87,12 @@ describe('Acceptance: ember new', function () {
   });
 
   describe('built-in app blueprint', function () {
+    before(function () {
+      if (isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+    });
+
     it('ember new adds ember-welcome-page by default', async function () {
       await ember(['new', 'foo', '--skip-npm', '--skip-git']);
 
@@ -217,6 +224,12 @@ describe('Acceptance: ember new', function () {
   });
 
   describe('--lang', function () {
+    before(function () {
+      if (isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+    });
+
     // Good: Correct Usage
     it('ember new foo --lang=(valid code): no message + set `lang` in index.html', async function () {
       await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=en-US']);
@@ -255,6 +268,12 @@ describe('Acceptance: ember new', function () {
   });
 
   describe('verify fixtures', function () {
+    before(function () {
+      if (isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+    });
+
     it('app defaults', async function () {
       await ember(['new', 'foo', '--skip-npm', '--skip-git']);
 
@@ -475,7 +494,13 @@ describe('Acceptance: ember new', function () {
     });
   });
 
-  describe('Experiment: Embroider', function () {
+  describe('Experiment(EMBROIDER)', function () {
+    before(function () {
+      if (isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+    });
+
     if (!isExperimentEnabled('CLASSIC')) {
       it('embroider experiment creates the correct files', async function () {
         let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
@@ -506,6 +531,20 @@ describe('Acceptance: ember new', function () {
       expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
       expect(pkgJson.devDependencies['@embroider/core']).to.exist;
       expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+    });
+  });
+
+  describe('Experiment(VITE)', function () {
+    before(function () {
+      if (!isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+    });
+
+    it('uses the correct blueprint', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git']);
+
+      confirmViteBlueprint();
     });
   });
 

--- a/tests/acceptance/preprocessor-smoke-test-slow.js
+++ b/tests/acceptance/preprocessor-smoke-test-slow.js
@@ -11,6 +11,7 @@ let createTestTargets = acceptance.createTestTargets;
 let teardownTestTargets = acceptance.teardownTestTargets;
 let linkDependencies = acceptance.linkDependencies;
 let cleanupRun = acceptance.cleanupRun;
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 const { expect } = require('chai');
 const { dir } = require('chai-files');
@@ -55,6 +56,10 @@ describe('Acceptance: preprocessor-smoke-test', function () {
   });
 
   it('addon registry entries are added in the proper order', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles(`preprocessor-tests/app-registry-ordering`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -82,6 +87,10 @@ describe('Acceptance: preprocessor-smoke-test', function () {
       |-- preprocessor should not apply to this
   */
   it('addons depending on preprocessor addon preprocesses addon but not app', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-2`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');
@@ -122,6 +131,10 @@ describe('Acceptance: preprocessor-smoke-test', function () {
       |-- preprocessor should not apply to this
   */
   it('addon N levels deep depending on preprocessor preprocesses that parent addon only', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles(`preprocessor-tests/app-with-addon-with-preprocessors-3`);
 
     let packageJsonPath = path.join(appRoot, 'package.json');

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -126,6 +126,10 @@ describe('Acceptance: smoke-test', function () {
   }
 
   it('ember test --environment=production', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('smoke-tests/passing-test');
 
     let result = await runCommand(
@@ -143,6 +147,10 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test --path with previous build', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     let originalWrite = process.stdout.write;
     let output = [];
 
@@ -174,6 +182,10 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember test wasm', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     let originalWrite = process.stdout.write;
     let output = [];
 
@@ -365,6 +377,10 @@ module.exports = function() {
   });
 
   it('ember new foo, server, SIGINT clears tmp/', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     let result = await runCommand(
       path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'),
       'server',
@@ -393,6 +409,10 @@ module.exports = function() {
   });
 
   it('ember new foo, test, SIGINT exits with error and clears tmp/', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     let result = await expect(
       runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test', '--test-port=25522', {
         onOutput(string, child) {
@@ -462,6 +482,10 @@ module.exports = function() {
   });
 
   it('template linting works properly for pods and classic structured templates', async function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     await copyFixtureFiles('smoke-tests/with-template-failing-linting');
 
     let packageJsonPath = 'package.json';
@@ -498,6 +522,10 @@ module.exports = function() {
     });
 
     it('does fix lint errors with --lint-fix', async function () {
+      if (isExperimentEnabled('VITE')) {
+        this.skip();
+      }
+
       await ember(['generate', 'component', componentName, '--component-class=@ember/component', '--lint-fix']);
 
       await expect(execa('eslint', ['.'], { cwd: appRoot, preferLocal: true })).to.eventually.be.ok;

--- a/tests/acceptance/smoke-test-slow.js
+++ b/tests/acceptance/smoke-test-slow.js
@@ -45,6 +45,10 @@ describe('Acceptance: smoke-test', function () {
   });
 
   it('ember new foo, clean from scratch', function () {
+    if (isExperimentEnabled('VITE')) {
+      this.skip();
+    }
+
     return runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'), 'test');
   });
 

--- a/tests/helpers-internal/blueprint.js
+++ b/tests/helpers-internal/blueprint.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const fs = require('fs-extra');
+
+const { sync: globSync } = require('glob');
+const { expect } = require('chai');
+
+function confirmViteBlueprint() {
+  let pkgJson = fs.readJsonSync('package.json');
+  let viteConfig = globSync('vite.config.{js,cjs,mjs}');
+  let emberCliUpdate = fs.readJsonSync('config/ember-cli-update.json');
+
+  expect(pkgJson.devDependencies['vite'], 'Installs vite in "devDependencies"').to.exist;
+  expect(pkgJson.scripts['start']).to.contain('vite');
+  expect(viteConfig.length, 'creates a vite configuration').to.equal(1);
+  expect(emberCliUpdate.packages[0].name).to.equal('@ember/app-blueprint');
+}
+
+module.exports = {
+  confirmViteBlueprint,
+};


### PR DESCRIPTION
I can and will split this into separate PRs if sensible, but I wanted to make sure everything is in place before I do.

- Update `experiments.md`
- Reorganize tests for `ember new` to make them easier to read (and refactor / remove later)
- Add new experiment `VITE` which defaults `ember new` to the new `@ember/app-blueprint` blueprint
- Skip irrelevant tests when the experiment is active: Since the new blueprint is an external package, what it does should be tested within that package to prevent step-locking `ember-cli` and `@ember/app-blueprint`
- Add _very_ basic test to validate the command did what it should 

Closes #10771 

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).