### PR TITLE
Depracate passing filenames and globs to `init`

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -119,11 +119,19 @@ module.exports = Command.extend({
 
     merge(blueprintOpts, {
       rawName: packageName,
-      targetFiles: rawArgs || '',
+      targetFiles: rawArgs || [],
       rawArgs: rawArgs.toString(),
       blueprint: normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint()),
       ciProvider,
     });
+
+    let { targetFiles } = blueprintOpts;
+
+    deprecate(
+      `Do not pass file names or globs to \`init\`. Passed: "${targetFiles.join(' ')}"`,
+      targetFiles.length === 0,
+      DEPRECATIONS.INIT_TARGET_FILES.options
+    );
 
     if (!isValidProjectName(packageName)) {
       return Promise.reject(new SilentError(`We currently do not support a name of \`${packageName}\`.`));

--- a/lib/debug/deprecations.js
+++ b/lib/debug/deprecations.js
@@ -32,6 +32,16 @@ const DEPRECATIONS = {
     until: '7.0.0',
     url: 'https://deprecations.emberjs.com/id/dont-use-embroider-option',
   }),
+
+  INIT_TARGET_FILES: deprecation({
+    for: 'ember-cli',
+    id: 'ember-cli.init-target-files',
+    since: {
+      available: '6.8.0',
+    },
+    until: '7.0.0',
+    url: 'https://deprecations.emberjs.com/id/init-no-file-names',
+  }),
 };
 
 module.exports = DEPRECATIONS;

--- a/tests/acceptance/init-test.js
+++ b/tests/acceptance/init-test.js
@@ -16,6 +16,8 @@ const EOL = require('os').EOL;
 const td = require('testdouble');
 const lintFix = require('../../lib/utilities/lint-fix');
 
+const { DEPRECATIONS } = require('../../lib/debug');
+
 const { expect } = require('chai');
 const { dir, file } = require('chai-files');
 
@@ -142,12 +144,20 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init a single file', async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', 'app.js', '--skip-npm']);
 
     confirmGlobBlueprinted('app.js');
   });
 
   it("init a single file on already init'd folder", async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', '--skip-npm']);
 
     await ember(['init', 'app.js', '--skip-npm']);
@@ -156,12 +166,20 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init multiple files by glob pattern', async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', 'app/**', '--skip-npm']);
 
     confirmGlobBlueprinted('app/**');
   });
 
   it("init multiple files by glob pattern on already init'd folder", async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', '--skip-npm']);
 
     await ember(['init', 'app/**', '--skip-npm']);
@@ -170,12 +188,20 @@ describe('Acceptance: ember init', function () {
   });
 
   it('init multiple files by glob patterns', async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', 'app/**', 'package.json', 'resolver.js', '--skip-npm']);
 
     confirmGlobBlueprinted('{app/**,package.json,resolver.js}');
   });
 
   it("init multiple files by glob patterns on already init'd folder", async function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     await ember(['init', '--skip-npm']);
 
     await ember(['init', 'app/**', 'package.json', 'resolver.js', '--skip-npm']);

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -12,6 +12,8 @@ const InitCommand = require('../../../lib/commands/init');
 const MockCLI = require('../../helpers/mock-cli');
 const td = require('testdouble');
 
+const { DEPRECATIONS } = require('../../../lib/debug');
+
 describe('init command', function () {
   let ui, tasks, command, workingDir;
 
@@ -135,10 +137,18 @@ describe('init command', function () {
     });
   });
 
+  // FIXME: This test is wrong.
+  // This behavior only works because "." is passed as a target file
+  // to the app blueprint, which in turn fails to create files
   it("doesn't use . as the name", function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     tasks.InstallBlueprint = class extends Task {
       run(blueprintOpts) {
         expect(blueprintOpts.rawName).to.equal('some-random-name');
+        expect(blueprintOpts.rawArgs).to.equal('.'); // <-- this is wrong
         return Promise.reject('Called run');
       }
     };
@@ -166,6 +176,10 @@ describe('init command', function () {
   });
 
   it('Uses arguments to select files to init', function () {
+    if (DEPRECATIONS.INIT_TARGET_FILES.isRemoved) {
+      this.skip();
+    }
+
     tasks.InstallBlueprint = class extends Task {
       run(blueprintOpts) {
         expect(blueprintOpts.blueprint).to.equal('app');


### PR DESCRIPTION
Continuing my streak of finding and one day eliminating unexpected behavior in my quest to implement something completely different.

- does not work as intended
- does not work as tested
- bad tests mask the broken behavior
- completely undocumented

Deprecation guide: https://github.com/ember-learn/deprecation-app/pull/1416

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).