### PR TITLE
Reorganize tests for `new` and `addon` commands

### DIFF
--- a/tests/acceptance/addon-dummy-generate-test.js
+++ b/tests/acceptance/addon-dummy-generate-test.js
@@ -82,41 +82,41 @@ describe('Acceptance: ember generate in-addon-dummy', function () {
     expect(file('server/index.js')).to.exist;
   });
 
-  // ember addon foo --lang
-  // -------------------------------
-  // Good: Correct Usage
-  it('ember addon foo --lang=(valid code): no message + set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=en-US']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html lang="en-US">');
-  });
+  describe('--lang', function () {
+    // Good: Correct Usage
+    it('ember addon foo --lang=(valid code): no message + set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=en-US']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html lang="en-US">');
+    });
 
-  // Edge Case: both valid code AND programming language abbreviation, possible misuse
-  it('ember addon foo --lang=(valid code + programming language abbreviation): emit warning + set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=css']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html lang="css">');
-  });
+    // Edge Case: both valid code AND programming language abbreviation, possible misuse
+    it('ember addon foo --lang=(valid code + programming language abbreviation): emit warning + set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=css']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html lang="css">');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember addon foo --lang=(programming language): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=JavaScript']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember addon foo --lang=(programming language): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=JavaScript']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember addon foo --lang=(programming language abbreviation): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=JS']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember addon foo --lang=(programming language abbreviation): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=JS']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember addon foo --lang=(programming language file extension): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=.js']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember addon foo --lang=(programming language file extension): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=.js']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: Invalid Country Code
-  it('ember addon foo --lang=(invalid code): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=en-UK']);
-    expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+    // Misuse: Invalid Country Code
+    it('ember addon foo --lang=(invalid code): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--lang=en-UK']);
+      expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+    });
   });
 });

--- a/tests/acceptance/addon-test-slow.js
+++ b/tests/acceptance/addon-test-slow.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const tmp = require('tmp-promise');
+const execa = require('execa');
+const { join, resolve } = require('node:path');
+const ember = require('../helpers/ember');
+
+const emberCliRoot = resolve(join(__dirname, '../..'));
+const root = process.cwd();
+let tmpDir;
+
+describe('Acceptance: ember new | ember addon', function () {
+  this.timeout(500000);
+
+  beforeEach(async function () {
+    const { path } = await tmp.dir();
+    tmpDir = path;
+    process.chdir(path);
+  });
+
+  afterEach(function () {
+    process.chdir(root);
+  });
+
+  describe('ember addon', function () {
+    it('generates a new addon with no linting errors', async function () {
+      await ember(['addon', 'foo-addon', '--pnpm', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
+      await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
+    });
+
+    it('generates a new TS addon with no linting errors', async function () {
+      await ember(['addon', 'foo-addon', '--pnpm', '--typescript', '--skip-npm']);
+      // link current version of ember-cli in the newly generated app
+      await execa('pnpm', ['link', emberCliRoot]);
+      await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
+    });
+  });
+});

--- a/tests/acceptance/addon-test.js
+++ b/tests/acceptance/addon-test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+const tmp = require('tmp-promise');
+
+const { expect } = require('chai');
+const { dir, file } = require('chai-files');
+
+const ember = require('../helpers/ember');
+
+const { checkFile } = require('../helpers-internal/file-utils');
+const {
+  currentVersion,
+  checkEslintConfig,
+  checkFileWithJSONReplacement,
+  checkEmberCLIBuild,
+} = require('../helpers-internal/fixtures');
+
+let root = process.cwd();
+
+describe('Acceptance: ember addon', function () {
+  this.timeout(300000);
+
+  let ORIGINAL_PROCESS_ENV_CI;
+
+  beforeEach(async function () {
+    const { path } = await tmp.dir();
+
+    process.chdir(path);
+
+    ORIGINAL_PROCESS_ENV_CI = process.env.CI;
+  });
+
+  afterEach(function () {
+    if (ORIGINAL_PROCESS_ENV_CI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = ORIGINAL_PROCESS_ENV_CI;
+    }
+
+    process.chdir(root);
+  });
+
+  it('ember addon with --directory uses given directory name and has correct package name', async function () {
+    let workdir = process.cwd();
+
+    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--directory=bar']);
+
+    expect(dir(path.join(workdir, 'foo'))).to.not.exist;
+    expect(dir(path.join(workdir, 'bar'))).to.exist;
+
+    let cwd = process.cwd();
+    expect(cwd).to.not.match(/foo/, 'does not use addon name for directory name');
+    expect(cwd).to.match(/bar/, 'uses given directory name');
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
+  });
+
+  it('ember addon @foo/bar when parent directory does not contain `foo`', async function () {
+    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
+
+    let directoryName = path.basename(process.cwd());
+
+    expect(directoryName).to.equal('foo-bar');
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('@foo/bar', 'uses addon name for package name');
+  });
+
+  it('ember addon @foo/bar when parent directory contains `foo`', async function () {
+    let scopedDirectoryPath = path.join(process.cwd(), 'foo');
+    fs.mkdirsSync(scopedDirectoryPath);
+    process.chdir(scopedDirectoryPath);
+
+    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
+
+    let directoryName = path.basename(process.cwd());
+
+    expect(directoryName).to.equal('bar');
+
+    let pkgJson = fs.readJsonSync('package.json');
+    expect(pkgJson.name).to.equal('@foo/bar', 'uses addon name for package name');
+  });
+
+  it('ember addon generates the correct directory name in `CONTRIBUTING.md` for scoped package names', async function () {
+    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
+
+    expect(file('CONTRIBUTING.md')).to.match(/- `cd foo-bar`/);
+  });
+
+  it('addon defaults', async function () {
+    await ember(['addon', 'foo', '--skip-npm', '--skip-git']);
+
+    let namespace = 'addon';
+    let fixturePath = `${namespace}/defaults`;
+
+    [
+      'tests/dummy/config/ember-try.js',
+      'tests/dummy/app/templates/application.hbs',
+      '.github/workflows/ci.yml',
+      'README.md',
+      'CONTRIBUTING.md',
+      '.ember-cli',
+    ].forEach((filePath) => {
+      checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
+    });
+
+    checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
+    checkFileWithJSONReplacement(
+      fixturePath,
+      'tests/dummy/config/ember-cli-update.json',
+      'packages[0].version',
+      currentVersion
+    );
+
+    // option independent, but piggy-backing on an existing generate for speed
+    checkEslintConfig(namespace);
+
+    // ember addon without --lang flag (default) has no lang attribute in dummy index.html
+    expect(file('tests/dummy/app/index.html')).to.contain('<html>');
+
+    // no TypeScript files
+    [
+      'tsconfig.json',
+      'tsconfig.declarations.json',
+      'tests/dummy/app/config/environment.d.ts',
+      'types/global.d.ts',
+    ].forEach((filePath) => {
+      expect(file(filePath)).to.not.exist;
+    });
+  });
+
+  it('addon + yarn + welcome', async function () {
+    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--yarn', '--welcome']);
+
+    let fixturePath = 'addon/yarn';
+
+    [
+      'tests/dummy/config/ember-try.js',
+      'tests/dummy/app/templates/application.hbs',
+      '.github/workflows/ci.yml',
+      'README.md',
+      'CONTRIBUTING.md',
+    ].forEach((filePath) => {
+      checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
+    });
+
+    checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
+    checkFileWithJSONReplacement(
+      fixturePath,
+      'tests/dummy/config/ember-cli-update.json',
+      'packages[0].version',
+      currentVersion
+    );
+  });
+
+  it('addon + pnpm + welcome', async function () {
+    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--pnpm', '--welcome']);
+
+    let fixturePath = 'addon/pnpm';
+
+    [
+      'tests/dummy/config/ember-try.js',
+      'tests/dummy/app/templates/application.hbs',
+      '.github/workflows/ci.yml',
+      'README.md',
+      'CONTRIBUTING.md',
+      '.npmrc',
+    ].forEach((filePath) => {
+      checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
+    });
+
+    checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
+    checkFileWithJSONReplacement(
+      fixturePath,
+      'tests/dummy/config/ember-cli-update.json',
+      'packages[0].version',
+      currentVersion
+    );
+  });
+
+  it('addon - no CI provider', async function () {
+    await ember(['addon', 'foo', '--ci-provider=none', '--skip-install', '--skip-git']);
+
+    expect(file('.github/workflows/ci.yml')).to.not.exist;
+    expect(file('tests/dummy/config/ember-cli-update.json')).to.include('--ci-provider=none');
+  });
+
+  it('addon + typescript', async function () {
+    await ember(['addon', 'foo', '--typescript', '--skip-npm', '--skip-git', '--yarn']);
+
+    let fixturePath = 'addon/typescript';
+
+    // check fixtures
+    [
+      '.ember-cli',
+      'index.js',
+      'tests/helpers/index.ts',
+      'tsconfig.json',
+      'tsconfig.declarations.json',
+      'tests/dummy/app/config/environment.d.ts',
+      'types/global.d.ts',
+    ].forEach((filePath) => {
+      checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
+    });
+    checkFileWithJSONReplacement(
+      fixturePath,
+      'tests/dummy/config/ember-cli-update.json',
+      'packages[0].version',
+      currentVersion
+    );
+    checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
+    checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
+    checkEslintConfig(fixturePath);
+  });
+});

--- a/tests/acceptance/new-test-slow.js
+++ b/tests/acceptance/new-test-slow.js
@@ -51,20 +51,4 @@ describe('Acceptance: ember new | ember addon', function () {
       await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-app') });
     });
   });
-
-  describe('ember addon', function () {
-    it('generates a new addon with no linting errors', async function () {
-      await ember(['addon', 'foo-addon', '--pnpm', '--skip-npm']);
-      // link current version of ember-cli in the newly generated app
-      await execa('pnpm', ['link', emberCliRoot]);
-      await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
-    });
-
-    it('generates a new TS addon with no linting errors', async function () {
-      await ember(['addon', 'foo-addon', '--pnpm', '--typescript', '--skip-npm']);
-      // link current version of ember-cli in the newly generated app
-      await execa('pnpm', ['link', emberCliRoot]);
-      await execa('pnpm', ['lint'], { cwd: join(tmpDir, 'foo-addon') });
-    });
-  });
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -170,12 +170,6 @@ describe('Acceptance: ember new', function () {
     });
   });
 
-  it('ember new npm blueprint with old version', async function () {
-    await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm']);
-
-    expect(dir('src')).to.exist;
-  });
-
   it('ember new foo, where foo does not yet exist, works', async function () {
     await ember(['new', 'foo', '--skip-npm']);
 
@@ -225,112 +219,120 @@ describe('Acceptance: ember new', function () {
     confirmBlueprintedForDir(path.dirname(require.resolve('@ember-tooling/classic-build-app-blueprint')), 'bar');
   });
 
-  it('ember new with blueprint uses the specified blueprint directory with a relative path', async function () {
-    fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync('my_blueprint/files/gitignore', '');
+  describe('--blueprint', function () {
+    it('ember new npm blueprint with old version', async function () {
+      await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm']);
 
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=./my_blueprint']);
+      expect(dir('src')).to.exist;
+    });
 
-    confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-  });
+    it('ember new with blueprint uses the specified blueprint directory with a relative path', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/files/gitignore', '');
 
-  it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function () {
-    fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync('my_blueprint/files/gitignore', '');
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=./my_blueprint']);
 
-    await ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-git',
-      `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
-    ]);
+      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+    });
 
-    confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-  });
+    it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/files/gitignore', '');
 
-  it('ember new with git blueprint checks out the blueprint and uses it', async function () {
-    this.timeout(20000); // relies on GH network stuff
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
+      ]);
 
-    await ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-git',
-      '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
-    ]);
+      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+    });
 
-    expect(file('.ember-cli')).to.exist;
-  });
+    it('ember new with git blueprint checks out the blueprint and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
 
-  it('ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
-    this.timeout(20000); // relies on GH network stuff
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
+      ]);
 
-    await ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-git',
-      '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
-    ]);
+      expect(file('.ember-cli')).to.exist;
+    });
 
-    expect(file('.named-ref')).to.exist;
-  });
+    it('ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
 
-  it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
-    this.timeout(20000); // relies on GH network stuff
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
+      ]);
 
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=ember-cli/app-blueprint-test#named-ref']);
+      expect(file('.named-ref')).to.exist;
+    });
 
-    expect(file('.named-ref')).to.exist;
-  });
+    it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
 
-  it('ember new passes blueprint options through to blueprint', async function () {
-    fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync(
-      'my_blueprint/index.js',
-      [
-        'module.exports = {',
-        "  availableOptions: [ { name: 'custom-option' } ],",
-        '  locals(options) {',
-        '    return {',
-        '      customOption: options.customOption',
-        '    };',
-        '  }',
-        '};',
-      ].join('\n')
-    );
-    fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=ember-cli/app-blueprint-test#named-ref']);
 
-    await ember([
-      'new',
-      'foo',
-      '--skip-npm',
-      '--skip-git',
-      '--blueprint=./my_blueprint',
-      '--custom-option=customValue',
-    ]);
+      expect(file('.named-ref')).to.exist;
+    });
 
-    expect(file('.gitignore')).to.contain('customValue');
-  });
+    it('ember new passes blueprint options through to blueprint', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync(
+        'my_blueprint/index.js',
+        [
+          'module.exports = {',
+          "  availableOptions: [ { name: 'custom-option' } ],",
+          '  locals(options) {',
+          '    return {',
+          '      customOption: options.customOption',
+          '    };',
+          '  }',
+          '};',
+        ].join('\n')
+      );
+      fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
 
-  it('ember new uses yarn when blueprint has yarn.lock', async function () {
-    if (!hasGlobalYarn) {
-      this.skip();
-    }
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=./my_blueprint',
+        '--custom-option=customValue',
+      ]);
 
-    fs.mkdirsSync('my_blueprint/files');
-    fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
-    fs.writeFileSync(
-      'my_blueprint/files/package.json',
-      '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}'
-    );
-    fs.writeFileSync('my_blueprint/files/yarn.lock', '');
+      expect(file('.gitignore')).to.contain('customValue');
+    });
 
-    await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
+    it('ember new uses yarn when blueprint has yarn.lock', async function () {
+      if (!hasGlobalYarn) {
+        this.skip();
+      }
 
-    expect(file('yarn.lock')).to.not.be.empty;
-    expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
+      fs.writeFileSync(
+        'my_blueprint/files/package.json',
+        '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}'
+      );
+      fs.writeFileSync('my_blueprint/files/yarn.lock', '');
+
+      await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
+
+      expect(file('yarn.lock')).to.not.be.empty;
+      expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
+    });
   });
 
   it('ember new without skip-git flag creates .git dir', async function () {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -439,6 +439,40 @@ describe('Acceptance: ember new', function () {
     });
   });
 
+  describe('Experiment: Embroider', function () {
+    if (!isExperimentEnabled('CLASSIC')) {
+      it('embroider experiment creates the correct files', async function () {
+        let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
+        process.env['EMBER_CLI_EMBROIDER'] = 'true';
+        await ember(['new', 'foo', '--skip-npm', '--skip-git']);
+
+        if (ORIGINAL_PROCESS_ENV === undefined) {
+          delete process.env['EMBER_CLI_EMBROIDER'];
+        } else {
+          process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
+        }
+
+        let pkgJson = fs.readJsonSync('package.json');
+        expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+      });
+    }
+
+    it('embroider enabled with --embroider', async function () {
+      if (DEPRECATIONS.EMBROIDER.isRemoved) {
+        this.skip();
+      }
+
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
+
+      let pkgJson = fs.readJsonSync('package.json');
+      expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+    });
+  });
+
   describe('--blueprint', function () {
     it('ember new npm blueprint with old version', async function () {
       await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm']);
@@ -552,40 +586,6 @@ describe('Acceptance: ember new', function () {
 
       expect(file('yarn.lock')).to.not.be.empty;
       expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
-    });
-  });
-
-  describe('Experiment: Embroider', function () {
-    if (!isExperimentEnabled('CLASSIC')) {
-      it('embroider experiment creates the correct files', async function () {
-        let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
-        process.env['EMBER_CLI_EMBROIDER'] = 'true';
-        await ember(['new', 'foo', '--skip-npm', '--skip-git']);
-
-        if (ORIGINAL_PROCESS_ENV === undefined) {
-          delete process.env['EMBER_CLI_EMBROIDER'];
-        } else {
-          process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
-        }
-
-        let pkgJson = fs.readJsonSync('package.json');
-        expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-        expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-        expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
-      });
-    }
-
-    it('embroider enabled with --embroider', async function () {
-      if (DEPRECATIONS.EMBROIDER.isRemoved) {
-        this.skip();
-      }
-
-      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
-
-      let pkgJson = fs.readJsonSync('package.json');
-      expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-      expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-      expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
     });
   });
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -1,22 +1,31 @@
 'use strict';
 
 const fs = require('fs-extra');
-const ember = require('../helpers/ember');
 const walkSync = require('walk-sync');
-const Blueprint = require('../../lib/models/blueprint');
 const path = require('path');
 const tmp = require('tmp-promise');
 let root = process.cwd();
 const util = require('util');
+
 const EOL = require('os').EOL;
+
+const Blueprint = require('../../lib/models/blueprint');
+const ember = require('../helpers/ember');
 const hasGlobalYarn = require('../helpers/has-global-yarn');
-const { set, get, cloneDeep } = require('lodash');
 const { DEPRECATIONS } = require('../../lib/debug');
 
 const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 const { expect } = require('chai');
 const { dir, file } = require('chai-files');
+
+const { checkFile } = require('../helpers-internal/file-utils');
+const {
+  currentVersion,
+  checkEslintConfig,
+  checkFileWithJSONReplacement,
+  checkEmberCLIBuild,
+} = require('../helpers-internal/fixtures');
 
 let tmpDir;
 
@@ -356,54 +365,6 @@ describe('Acceptance: ember new', function () {
     expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
   });
 
-  it('ember addon with --directory uses given directory name and has correct package name', async function () {
-    let workdir = process.cwd();
-
-    await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--directory=bar']);
-
-    expect(dir(path.join(workdir, 'foo'))).to.not.exist;
-    expect(dir(path.join(workdir, 'bar'))).to.exist;
-
-    let cwd = process.cwd();
-    expect(cwd).to.not.match(/foo/, 'does not use addon name for directory name');
-    expect(cwd).to.match(/bar/, 'uses given directory name');
-
-    let pkgJson = fs.readJsonSync('package.json');
-    expect(pkgJson.name).to.equal('foo', 'uses addon name for package name');
-  });
-
-  it('ember addon @foo/bar when parent directory does not contain `foo`', async function () {
-    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
-
-    let directoryName = path.basename(process.cwd());
-
-    expect(directoryName).to.equal('foo-bar');
-
-    let pkgJson = fs.readJsonSync('package.json');
-    expect(pkgJson.name).to.equal('@foo/bar', 'uses addon name for package name');
-  });
-
-  it('ember addon @foo/bar when parent directory contains `foo`', async function () {
-    let scopedDirectoryPath = path.join(process.cwd(), 'foo');
-    fs.mkdirsSync(scopedDirectoryPath);
-    process.chdir(scopedDirectoryPath);
-
-    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
-
-    let directoryName = path.basename(process.cwd());
-
-    expect(directoryName).to.equal('bar');
-
-    let pkgJson = fs.readJsonSync('package.json');
-    expect(pkgJson.name).to.equal('@foo/bar', 'uses addon name for package name');
-  });
-
-  it('ember addon generates the correct directory name in `CONTRIBUTING.md` for scoped package names', async function () {
-    await ember(['addon', '@foo/bar', '--skip-npm', '--skip-git']);
-
-    expect(file('CONTRIBUTING.md')).to.match(/- `cd foo-bar`/);
-  });
-
   if (!isExperimentEnabled('CLASSIC')) {
     it('embroider experiment creates the correct files', async function () {
       let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
@@ -437,40 +398,6 @@ describe('Acceptance: ember new', function () {
   });
 
   describe('verify fixtures', function () {
-    function checkEslintConfig(fixturePath) {
-      expect(file('eslint.config.mjs')).to.equal(
-        file(path.join(__dirname, '../fixtures', fixturePath, 'eslint.config.mjs'))
-      );
-    }
-
-    const currentVersion = require('../../package').version;
-
-    function checkFileWithJSONReplacement(fixtureName, fileName, targetPath, value) {
-      let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
-      let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' });
-      let fixtureData = JSON.parse(fixtureContents);
-
-      let candidateContents = fs.readFileSync(fileName, 'utf8');
-      let candidateData = JSON.parse(candidateContents);
-
-      if (process.env.WRITE_FIXTURES) {
-        let newFixtureData = cloneDeep(candidateData);
-        set(newFixtureData, targetPath, get(fixtureData, targetPath));
-        fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
-        fs.writeFileSync(fixturePath, `${JSON.stringify(newFixtureData, null, 2)}\n`, { encoding: 'utf-8' });
-      }
-
-      set(fixtureData, targetPath, value);
-
-      expect(JSON.stringify(candidateData, null, 2)).to.equal(JSON.stringify(fixtureData, null, 2));
-    }
-
-    function checkEmberCLIBuild(fixtureName, fileName) {
-      let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
-      let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' });
-      expect(file(fileName)).to.equal(fixtureContents);
-    }
-
     it('app defaults', async function () {
       await ember(['new', 'foo', '--skip-npm', '--skip-git']);
 
@@ -502,48 +429,6 @@ describe('Acceptance: ember new', function () {
         'app/config/environment.d.ts',
         'types/global.d.ts',
         'types/foo/index.d.ts',
-      ].forEach((filePath) => {
-        expect(file(filePath)).to.not.exist;
-      });
-    });
-
-    it('addon defaults', async function () {
-      await ember(['addon', 'foo', '--skip-npm', '--skip-git']);
-
-      let namespace = 'addon';
-      let fixturePath = `${namespace}/defaults`;
-
-      [
-        'tests/dummy/config/ember-try.js',
-        'tests/dummy/app/templates/application.hbs',
-        '.github/workflows/ci.yml',
-        'README.md',
-        'CONTRIBUTING.md',
-        '.ember-cli',
-      ].forEach((filePath) => {
-        checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
-      });
-
-      checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
-      checkFileWithJSONReplacement(
-        fixturePath,
-        'tests/dummy/config/ember-cli-update.json',
-        'packages[0].version',
-        currentVersion
-      );
-
-      // option independent, but piggy-backing on an existing generate for speed
-      checkEslintConfig(namespace);
-
-      // ember addon without --lang flag (default) has no lang attribute in dummy index.html
-      expect(file('tests/dummy/app/index.html')).to.contain('<html>');
-
-      // no TypeScript files
-      [
-        'tsconfig.json',
-        'tsconfig.declarations.json',
-        'tests/dummy/app/config/environment.d.ts',
-        'types/global.d.ts',
       ].forEach((filePath) => {
         expect(file(filePath)).to.not.exist;
       });
@@ -603,67 +488,11 @@ describe('Acceptance: ember new', function () {
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
     });
 
-    it('addon + yarn + welcome', async function () {
-      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--yarn', '--welcome']);
-
-      let fixturePath = 'addon/yarn';
-
-      [
-        'tests/dummy/config/ember-try.js',
-        'tests/dummy/app/templates/application.hbs',
-        '.github/workflows/ci.yml',
-        'README.md',
-        'CONTRIBUTING.md',
-      ].forEach((filePath) => {
-        checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
-      });
-
-      checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
-      checkFileWithJSONReplacement(
-        fixturePath,
-        'tests/dummy/config/ember-cli-update.json',
-        'packages[0].version',
-        currentVersion
-      );
-    });
-
-    it('addon + pnpm + welcome', async function () {
-      await ember(['addon', 'foo', '--skip-npm', '--skip-git', '--pnpm', '--welcome']);
-
-      let fixturePath = 'addon/pnpm';
-
-      [
-        'tests/dummy/config/ember-try.js',
-        'tests/dummy/app/templates/application.hbs',
-        '.github/workflows/ci.yml',
-        'README.md',
-        'CONTRIBUTING.md',
-        '.npmrc',
-      ].forEach((filePath) => {
-        checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
-      });
-
-      checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
-      checkFileWithJSONReplacement(
-        fixturePath,
-        'tests/dummy/config/ember-cli-update.json',
-        'packages[0].version',
-        currentVersion
-      );
-    });
-
     it('new - no CI provider', async function () {
       await ember(['new', 'foo', '--ci-provider=none', '--skip-install', '--skip-git']);
 
       expect(file('.github/workflows/ci.yml')).to.not.exist;
       expect(file('config/ember-cli-update.json')).to.include('--ci-provider=none');
-    });
-
-    it('addon - no CI provider', async function () {
-      await ember(['addon', 'foo', '--ci-provider=none', '--skip-install', '--skip-git']);
-
-      expect(file('.github/workflows/ci.yml')).to.not.exist;
-      expect(file('tests/dummy/config/ember-cli-update.json')).to.include('--ci-provider=none');
     });
 
     it('app + strict', async function () {
@@ -723,34 +552,6 @@ describe('Acceptance: ember new', function () {
       expect(file('tsconfig.declarations.json')).to.not.exist;
     });
 
-    it('addon + typescript', async function () {
-      await ember(['addon', 'foo', '--typescript', '--skip-npm', '--skip-git', '--yarn']);
-
-      let fixturePath = 'addon/typescript';
-
-      // check fixtures
-      [
-        '.ember-cli',
-        'index.js',
-        'tests/helpers/index.ts',
-        'tsconfig.json',
-        'tsconfig.declarations.json',
-        'tests/dummy/app/config/environment.d.ts',
-        'types/global.d.ts',
-      ].forEach((filePath) => {
-        checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
-      });
-      checkFileWithJSONReplacement(
-        fixturePath,
-        'tests/dummy/config/ember-cli-update.json',
-        'packages[0].version',
-        currentVersion
-      );
-      checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
-      checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
-      checkEslintConfig(fixturePath);
-    });
-
     it('app + no-ember-data', async function () {
       await ember(['new', 'foo', '--no-ember-data', '--skip-npm', '--skip-git']);
 
@@ -782,13 +583,3 @@ describe('Acceptance: ember new', function () {
     });
   });
 });
-
-function checkFile(inputPath, outputPath) {
-  if (process.env.WRITE_FIXTURES) {
-    let content = fs.readFileSync(inputPath, { encoding: 'utf-8' });
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    fs.writeFileSync(outputPath, content, { encoding: 'utf-8' });
-  }
-
-  expect(file(inputPath)).to.equal(file(outputPath));
-}

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -365,36 +365,38 @@ describe('Acceptance: ember new', function () {
     expect(pkgJson.name).to.equal('foo', 'uses app name for package name');
   });
 
-  if (!isExperimentEnabled('CLASSIC')) {
-    it('embroider experiment creates the correct files', async function () {
-      let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
-      process.env['EMBER_CLI_EMBROIDER'] = 'true';
-      await ember(['new', 'foo', '--skip-npm', '--skip-git']);
+  describe('Experiment: Embroider', function () {
+    if (!isExperimentEnabled('CLASSIC')) {
+      it('embroider experiment creates the correct files', async function () {
+        let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
+        process.env['EMBER_CLI_EMBROIDER'] = 'true';
+        await ember(['new', 'foo', '--skip-npm', '--skip-git']);
 
-      if (ORIGINAL_PROCESS_ENV === undefined) {
-        delete process.env['EMBER_CLI_EMBROIDER'];
-      } else {
-        process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
+        if (ORIGINAL_PROCESS_ENV === undefined) {
+          delete process.env['EMBER_CLI_EMBROIDER'];
+        } else {
+          process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
+        }
+
+        let pkgJson = fs.readJsonSync('package.json');
+        expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+      });
+    }
+
+    it('embroider enabled with --embroider', async function () {
+      if (DEPRECATIONS.EMBROIDER.isRemoved) {
+        this.skip();
       }
+
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
 
       let pkgJson = fs.readJsonSync('package.json');
       expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
       expect(pkgJson.devDependencies['@embroider/core']).to.exist;
       expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
     });
-  }
-
-  it('embroider enabled with --embroider', async function () {
-    if (DEPRECATIONS.EMBROIDER.isRemoved) {
-      this.skip();
-    }
-
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
-
-    let pkgJson = fs.readJsonSync('package.json');
-    expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-    expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-    expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
   });
 
   describe('verify fixtures', function () {

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -253,156 +253,6 @@ describe('Acceptance: ember new', function () {
     });
   });
 
-  describe('--blueprint', function () {
-    it('ember new npm blueprint with old version', async function () {
-      await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm']);
-
-      expect(dir('src')).to.exist;
-    });
-
-    it('ember new with blueprint uses the specified blueprint directory with a relative path', async function () {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/files/gitignore', '');
-
-      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=./my_blueprint']);
-
-      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-    });
-
-    it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function () {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/files/gitignore', '');
-
-      await ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-git',
-        `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
-      ]);
-
-      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
-    });
-
-    it('ember new with git blueprint checks out the blueprint and uses it', async function () {
-      this.timeout(20000); // relies on GH network stuff
-
-      await ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-git',
-        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
-      ]);
-
-      expect(file('.ember-cli')).to.exist;
-    });
-
-    it('ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
-      this.timeout(20000); // relies on GH network stuff
-
-      await ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-git',
-        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
-      ]);
-
-      expect(file('.named-ref')).to.exist;
-    });
-
-    it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
-      this.timeout(20000); // relies on GH network stuff
-
-      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=ember-cli/app-blueprint-test#named-ref']);
-
-      expect(file('.named-ref')).to.exist;
-    });
-
-    it('ember new passes blueprint options through to blueprint', async function () {
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync(
-        'my_blueprint/index.js',
-        [
-          'module.exports = {',
-          "  availableOptions: [ { name: 'custom-option' } ],",
-          '  locals(options) {',
-          '    return {',
-          '      customOption: options.customOption',
-          '    };',
-          '  }',
-          '};',
-        ].join('\n')
-      );
-      fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
-
-      await ember([
-        'new',
-        'foo',
-        '--skip-npm',
-        '--skip-git',
-        '--blueprint=./my_blueprint',
-        '--custom-option=customValue',
-      ]);
-
-      expect(file('.gitignore')).to.contain('customValue');
-    });
-
-    it('ember new uses yarn when blueprint has yarn.lock', async function () {
-      if (!hasGlobalYarn) {
-        this.skip();
-      }
-
-      fs.mkdirsSync('my_blueprint/files');
-      fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
-      fs.writeFileSync(
-        'my_blueprint/files/package.json',
-        '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}'
-      );
-      fs.writeFileSync('my_blueprint/files/yarn.lock', '');
-
-      await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
-
-      expect(file('yarn.lock')).to.not.be.empty;
-      expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
-    });
-  });
-
-  describe('Experiment: Embroider', function () {
-    if (!isExperimentEnabled('CLASSIC')) {
-      it('embroider experiment creates the correct files', async function () {
-        let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
-        process.env['EMBER_CLI_EMBROIDER'] = 'true';
-        await ember(['new', 'foo', '--skip-npm', '--skip-git']);
-
-        if (ORIGINAL_PROCESS_ENV === undefined) {
-          delete process.env['EMBER_CLI_EMBROIDER'];
-        } else {
-          process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
-        }
-
-        let pkgJson = fs.readJsonSync('package.json');
-        expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-        expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-        expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
-      });
-    }
-
-    it('embroider enabled with --embroider', async function () {
-      if (DEPRECATIONS.EMBROIDER.isRemoved) {
-        this.skip();
-      }
-
-      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
-
-      let pkgJson = fs.readJsonSync('package.json');
-      expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
-      expect(pkgJson.devDependencies['@embroider/core']).to.exist;
-      expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
-    });
-  });
-
   describe('verify fixtures', function () {
     it('app defaults', async function () {
       await ember(['new', 'foo', '--skip-npm', '--skip-git']);
@@ -586,6 +436,156 @@ describe('Acceptance: ember new', function () {
       checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
+    });
+  });
+
+  describe('--blueprint', function () {
+    it('ember new npm blueprint with old version', async function () {
+      await ember(['new', 'foo', '--blueprint', '@glimmer/blueprint@0.6.4', '--skip-npm']);
+
+      expect(dir('src')).to.exist;
+    });
+
+    it('ember new with blueprint uses the specified blueprint directory with a relative path', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/files/gitignore', '');
+
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=./my_blueprint']);
+
+      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+    });
+
+    it('ember new with blueprint uses the specified blueprint directory with an absolute path', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/files/gitignore', '');
+
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        `--blueprint=${path.resolve(process.cwd(), 'my_blueprint')}`,
+      ]);
+
+      confirmBlueprintedForDir(path.join(tmpDir, 'my_blueprint'));
+    });
+
+    it('ember new with git blueprint checks out the blueprint and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
+
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git',
+      ]);
+
+      expect(file('.ember-cli')).to.exist;
+    });
+
+    it('ember new with git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
+
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=https://github.com/ember-cli/app-blueprint-test.git#named-ref',
+      ]);
+
+      expect(file('.named-ref')).to.exist;
+    });
+
+    it('ember new with shorthand git blueprint and ref checks out the blueprint with the correct ref and uses it', async function () {
+      this.timeout(20000); // relies on GH network stuff
+
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--blueprint=ember-cli/app-blueprint-test#named-ref']);
+
+      expect(file('.named-ref')).to.exist;
+    });
+
+    it('ember new passes blueprint options through to blueprint', async function () {
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync(
+        'my_blueprint/index.js',
+        [
+          'module.exports = {',
+          "  availableOptions: [ { name: 'custom-option' } ],",
+          '  locals(options) {',
+          '    return {',
+          '      customOption: options.customOption',
+          '    };',
+          '  }',
+          '};',
+        ].join('\n')
+      );
+      fs.writeFileSync('my_blueprint/files/gitignore', '<%= customOption %>');
+
+      await ember([
+        'new',
+        'foo',
+        '--skip-npm',
+        '--skip-git',
+        '--blueprint=./my_blueprint',
+        '--custom-option=customValue',
+      ]);
+
+      expect(file('.gitignore')).to.contain('customValue');
+    });
+
+    it('ember new uses yarn when blueprint has yarn.lock', async function () {
+      if (!hasGlobalYarn) {
+        this.skip();
+      }
+
+      fs.mkdirsSync('my_blueprint/files');
+      fs.writeFileSync('my_blueprint/index.js', 'module.exports = {};');
+      fs.writeFileSync(
+        'my_blueprint/files/package.json',
+        '{ "name": "foo", "dependencies": { "ember-try-test-suite-helper": "*" }}'
+      );
+      fs.writeFileSync('my_blueprint/files/yarn.lock', '');
+
+      await ember(['new', 'foo', '--skip-git', '--blueprint=./my_blueprint']);
+
+      expect(file('yarn.lock')).to.not.be.empty;
+      expect(dir('node_modules/ember-try-test-suite-helper')).to.not.be.empty;
+    });
+  });
+
+  describe('Experiment: Embroider', function () {
+    if (!isExperimentEnabled('CLASSIC')) {
+      it('embroider experiment creates the correct files', async function () {
+        let ORIGINAL_PROCESS_ENV = process.env.EMBER_CLI_EMBROIDER;
+        process.env['EMBER_CLI_EMBROIDER'] = 'true';
+        await ember(['new', 'foo', '--skip-npm', '--skip-git']);
+
+        if (ORIGINAL_PROCESS_ENV === undefined) {
+          delete process.env['EMBER_CLI_EMBROIDER'];
+        } else {
+          process.env['EMBER_CLI_EMBROIDER'] = ORIGINAL_PROCESS_ENV;
+        }
+
+        let pkgJson = fs.readJsonSync('package.json');
+        expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+        expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
+      });
+    }
+
+    it('embroider enabled with --embroider', async function () {
+      if (DEPRECATIONS.EMBROIDER.isRemoved) {
+        this.skip();
+      }
+
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--embroider']);
+
+      let pkgJson = fs.readJsonSync('package.json');
+      expect(pkgJson.devDependencies['@embroider/compat']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/core']).to.exist;
+      expect(pkgJson.devDependencies['@embroider/webpack']).to.exist;
     });
   });
 });

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -132,42 +132,42 @@ describe('Acceptance: ember new', function () {
     expect(file('README.md')).to.match(/- `cd foo-bar`/);
   });
 
-  // ember new foo --lang
-  // -------------------------------
-  // Good: Correct Usage
-  it('ember new foo --lang=(valid code): no message + set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=en-US']);
-    expect(file('app/index.html')).to.contain('<html lang="en-US">');
-  });
+  describe('--lang', function () {
+    // Good: Correct Usage
+    it('ember new foo --lang=(valid code): no message + set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=en-US']);
+      expect(file('app/index.html')).to.contain('<html lang="en-US">');
+    });
 
-  // Edge Case: both valid code AND programming language abbreviation, possible misuse
-  it('ember new foo --lang=(valid code + programming language abbreviation): emit warning + set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=css']);
-    expect(file('app/index.html')).to.contain('<html lang="css">');
-  });
+    // Edge Case: both valid code AND programming language abbreviation, possible misuse
+    it('ember new foo --lang=(valid code + programming language abbreviation): emit warning + set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=css']);
+      expect(file('app/index.html')).to.contain('<html lang="css">');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember new foo --lang=(programming language): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=JavaScript']);
-    expect(file('app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember new foo --lang=(programming language): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=JavaScript']);
+      expect(file('app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember new foo --lang=(programming language abbreviation): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=JS']);
-    expect(file('app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember new foo --lang=(programming language abbreviation): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=JS']);
+      expect(file('app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: possibly an attempt to set app programming language
-  it('ember new foo --lang=(programming language file extension): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=.js']);
-    expect(file('app/index.html')).to.contain('<html>');
-  });
+    // Misuse: possibly an attempt to set app programming language
+    it('ember new foo --lang=(programming language file extension): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=.js']);
+      expect(file('app/index.html')).to.contain('<html>');
+    });
 
-  // Misuse: Invalid Country Code
-  it('ember new foo --lang=(invalid code): emit warning + do not set `lang` in index.html', async function () {
-    await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=en-UK']);
-    expect(file('app/index.html')).to.contain('<html>');
+    // Misuse: Invalid Country Code
+    it('ember new foo --lang=(invalid code): emit warning + do not set `lang` in index.html', async function () {
+      await ember(['new', 'foo', '--skip-npm', '--skip-git', '--lang=en-UK']);
+      expect(file('app/index.html')).to.contain('<html>');
+    });
   });
 
   it('ember new npm blueprint with old version', async function () {

--- a/tests/helpers-internal/file-utils.js
+++ b/tests/helpers-internal/file-utils.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const { expect } = require('chai');
+const { file } = require('chai-files');
+
+function checkFile(inputPath, outputPath) {
+  if (process.env.WRITE_FIXTURES) {
+    let content = fs.readFileSync(inputPath, { encoding: 'utf-8' });
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, content, { encoding: 'utf-8' });
+  }
+
+  expect(file(inputPath)).to.equal(file(outputPath));
+}
+
+module.exports = {
+  checkFile,
+};

--- a/tests/helpers-internal/fixtures.js
+++ b/tests/helpers-internal/fixtures.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const { expect } = require('chai');
+const { file } = require('chai-files');
+const { set, get, cloneDeep } = require('lodash');
+
+const currentVersion = require('../../package').version;
+
+function checkEslintConfig(fixturePath) {
+  expect(file('eslint.config.mjs')).to.equal(
+    file(path.join(__dirname, '../fixtures', fixturePath, 'eslint.config.mjs'))
+  );
+}
+
+function checkFileWithJSONReplacement(fixtureName, fileName, targetPath, value) {
+  let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
+  let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' });
+  let fixtureData = JSON.parse(fixtureContents);
+
+  let candidateContents = fs.readFileSync(fileName, 'utf8');
+  let candidateData = JSON.parse(candidateContents);
+
+  if (process.env.WRITE_FIXTURES) {
+    let newFixtureData = cloneDeep(candidateData);
+    set(newFixtureData, targetPath, get(fixtureData, targetPath));
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(fixturePath, `${JSON.stringify(newFixtureData, null, 2)}\n`, { encoding: 'utf-8' });
+  }
+
+  set(fixtureData, targetPath, value);
+
+  expect(JSON.stringify(candidateData, null, 2)).to.equal(JSON.stringify(fixtureData, null, 2));
+}
+
+function checkEmberCLIBuild(fixtureName, fileName) {
+  let fixturePath = path.join(__dirname, '../fixtures', fixtureName, fileName);
+  let fixtureContents = fs.readFileSync(fixturePath, { encoding: 'utf-8' });
+  expect(file(fileName)).to.equal(fixtureContents);
+}
+
+module.exports = {
+  currentVersion,
+  checkEslintConfig,
+  checkFileWithJSONReplacement,
+  checkEmberCLIBuild,
+};


### PR DESCRIPTION
- no functional changes
- logical groups will make it easier to disable specific block in upcoming experiments
- replace code comments with visible describe groups

I recommend going commit by commit for this one. I tried to keep the steps small.