### PR TITLE
update the format of the ember-cli-update.json

### DIFF
--- a/packages/addon-blueprint/index.js
+++ b/packages/addon-blueprint/index.js
@@ -243,7 +243,7 @@ module.exports = {
       npm: options.packageManager !== 'yarn' && options.packageManager !== 'pnpm',
       invokeScriptPrefix,
       welcome: options.welcome,
-      blueprint: 'addon',
+      blueprint: '@ember-tooling/classic-build-addon-blueprint',
       blueprintOptions,
       embroider: false,
       lang: options.lang,

--- a/packages/app-blueprint/files/config/ember-cli-update.json
+++ b/packages/app-blueprint/files/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
+      "name": "<%= blueprint %>",
       "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
           "name": "<%= blueprint %>",
-          "outputRepo": "https://github.com/ember-cli/ember-<%= blueprint === 'app' ? 'new' : 'addon' %>-output",
-          "codemodsSource": "ember-<%= blueprint %>-codemods-manifest@1",
           "isBaseBlueprint": true,
           "options": [<%= blueprintOptions %>]
         }

--- a/packages/app-blueprint/index.js
+++ b/packages/app-blueprint/index.js
@@ -75,7 +75,7 @@ module.exports = {
       invokeScriptPrefix,
       execBinPrefix,
       welcome: options.welcome,
-      blueprint: 'app',
+      blueprint: '@ember-tooling/classic-build-app-blueprint',
       blueprintOptions,
       embroider,
       lang: options.lang,

--- a/tests/acceptance/addon-test.js
+++ b/tests/acceptance/addon-test.js
@@ -12,6 +12,7 @@ const ember = require('../helpers/ember');
 const { checkFile } = require('../helpers-internal/file-utils');
 const {
   currentVersion,
+  currentAddonBlueprintVersion,
   checkEslintConfig,
   checkFileWithJSONReplacement,
   checkEmberCLIBuild,
@@ -177,7 +178,7 @@ describe('Acceptance: ember addon', function () {
       fixturePath,
       'tests/dummy/config/ember-cli-update.json',
       'packages[0].version',
-      currentVersion
+      currentAddonBlueprintVersion
     );
   });
 
@@ -209,7 +210,7 @@ describe('Acceptance: ember addon', function () {
       fixturePath,
       'tests/dummy/config/ember-cli-update.json',
       'packages[0].version',
-      currentVersion
+      currentAddonBlueprintVersion
     );
     checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
     checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');

--- a/tests/acceptance/new-test.js
+++ b/tests/acceptance/new-test.js
@@ -22,6 +22,7 @@ const { dir, file } = require('chai-files');
 const { checkFile } = require('../helpers-internal/file-utils');
 const {
   currentVersion,
+  currentAppBlueprintVersion,
   checkEslintConfig,
   checkFileWithJSONReplacement,
   checkEmberCLIBuild,
@@ -268,7 +269,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = `${namespace}/embroider`;
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
 
@@ -304,7 +310,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = 'app/embroider-no-welcome';
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       // option independent, but piggy-backing on an existing generate for speed
       checkEslintConfig(namespace);
@@ -323,7 +334,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = 'app/embroider-yarn';
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
     });
 
@@ -340,7 +356,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = 'app/embroider-pnpm';
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
     });
 
@@ -400,7 +421,12 @@ describe('Acceptance: ember new', function () {
       ].forEach((filePath) => {
         checkFile(filePath, path.join(__dirname, '../fixtures', fixturePath, filePath));
       });
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
       checkEslintConfig(fixturePath);
@@ -418,7 +444,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = 'app/no-ember-data';
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
     });
@@ -433,7 +464,12 @@ describe('Acceptance: ember new', function () {
         fixturePath = 'app/typescript-no-ember-data';
       }
 
-      checkFileWithJSONReplacement(fixturePath, 'config/ember-cli-update.json', 'packages[0].version', currentVersion);
+      checkFileWithJSONReplacement(
+        fixturePath,
+        'config/ember-cli-update.json',
+        'packages[0].version',
+        currentAppBlueprintVersion
+      );
       checkFileWithJSONReplacement(fixturePath, 'package.json', 'devDependencies.ember-cli', `~${currentVersion}`);
       checkEmberCLIBuild(fixturePath, 'ember-cli-build.js');
     });

--- a/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
@@ -2,11 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "@ember-tooling/classic-build-app-blueprint",
+      "name": "@ember-tooling/classic-build-addon-blueprint",
       "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "@ember-tooling/classic-build-app-blueprint",
+          "name": "@ember-tooling/classic-build-addon-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--ci-provider=github"

--- a/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/defaults/tests/dummy/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "addon",
-          "outputRepo": "https://github.com/ember-cli/ember-addon-output",
-          "codemodsSource": "ember-addon-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--ci-provider=github"

--- a/tests/fixtures/addon/pnpm/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/pnpm/tests/dummy/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "addon",
-          "outputRepo": "https://github.com/ember-cli/ember-addon-output",
-          "codemodsSource": "ember-addon-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--welcome",

--- a/tests/fixtures/addon/pnpm/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/pnpm/tests/dummy/config/ember-cli-update.json
@@ -2,11 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "@ember-tooling/classic-build-app-blueprint",
+      "name": "@ember-tooling/classic-build-addon-blueprint",
       "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "@ember-tooling/classic-build-app-blueprint",
+          "name": "@ember-tooling/classic-build-addon-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--welcome",

--- a/tests/fixtures/addon/typescript/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/typescript/tests/dummy/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "addon",
-          "outputRepo": "https://github.com/ember-cli/ember-addon-output",
-          "codemodsSource": "ember-addon-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/fixtures/addon/typescript/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/typescript/tests/dummy/config/ember-cli-update.json
@@ -2,11 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "@ember-tooling/classic-build-app-blueprint",
+      "name": "@ember-tooling/classic-build-addon-blueprint",
       "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "@ember-tooling/classic-build-app-blueprint",
+          "name": "@ember-tooling/classic-build-addon-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "addon",
-          "outputRepo": "https://github.com/ember-cli/ember-addon-output",
-          "codemodsSource": "ember-addon-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--welcome",

--- a/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
+++ b/tests/fixtures/addon/yarn/tests/dummy/config/ember-cli-update.json
@@ -2,11 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "@ember-tooling/classic-build-app-blueprint",
+      "name": "@ember-tooling/classic-build-addon-blueprint",
       "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "@ember-tooling/classic-build-app-blueprint",
+          "name": "@ember-tooling/classic-build-addon-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--welcome",

--- a/tests/fixtures/app/defaults/config/ember-cli-update.json
+++ b/tests/fixtures/app/defaults/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--ci-provider=github"

--- a/tests/fixtures/app/embroider-no-ember-data/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-no-ember-data/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--embroider",

--- a/tests/fixtures/app/embroider-no-welcome/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-no-welcome/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--no-welcome",

--- a/tests/fixtures/app/embroider-pnpm/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-pnpm/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--pnpm",

--- a/tests/fixtures/app/embroider-yarn/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider-yarn/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/fixtures/app/embroider/config/ember-cli-update.json
+++ b/tests/fixtures/app/embroider/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--embroider",

--- a/tests/fixtures/app/no-ember-data/config/ember-cli-update.json
+++ b/tests/fixtures/app/no-ember-data/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--ci-provider=github",

--- a/tests/fixtures/app/npm/config/ember-cli-update.json
+++ b/tests/fixtures/app/npm/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--no-welcome",

--- a/tests/fixtures/app/pnpm/config/ember-cli-update.json
+++ b/tests/fixtures/app/pnpm/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--pnpm",

--- a/tests/fixtures/app/typescript-embroider-no-ember-data/config/ember-cli-update.json
+++ b/tests/fixtures/app/typescript-embroider-no-ember-data/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--embroider",

--- a/tests/fixtures/app/typescript-embroider/config/ember-cli-update.json
+++ b/tests/fixtures/app/typescript-embroider/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/fixtures/app/typescript-no-ember-data/config/ember-cli-update.json
+++ b/tests/fixtures/app/typescript-no-ember-data/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--ci-provider=github",

--- a/tests/fixtures/app/typescript/config/ember-cli-update.json
+++ b/tests/fixtures/app/typescript/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/config/ember-cli-update.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": []
         }

--- a/tests/fixtures/app/yarn/config/ember-cli-update.json
+++ b/tests/fixtures/app/yarn/config/ember-cli-update.json
@@ -2,13 +2,11 @@
   "schemaVersion": "1.0.0",
   "packages": [
     {
-      "name": "ember-cli",
-      "version": "<%= emberCLIVersion %>",
+      "name": "@ember-tooling/classic-build-app-blueprint",
+      "version": "<%= blueprintVersion %>",
       "blueprints": [
         {
-          "name": "app",
-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
-          "codemodsSource": "ember-app-codemods-manifest@1",
+          "name": "@ember-tooling/classic-build-app-blueprint",
           "isBaseBlueprint": true,
           "options": [
             "--yarn",

--- a/tests/helpers-internal/fixtures.js
+++ b/tests/helpers-internal/fixtures.js
@@ -9,6 +9,7 @@ const { set, get, cloneDeep } = require('lodash');
 
 const currentVersion = require('../../package').version;
 const currentAppBlueprintVersion = require('@ember-tooling/classic-build-app-blueprint/package').version;
+const currentAddonBlueprintVersion = require('@ember-tooling/classic-build-addon-blueprint/package').version;
 
 function checkEslintConfig(fixturePath) {
   expect(file('eslint.config.mjs')).to.equal(
@@ -45,6 +46,7 @@ function checkEmberCLIBuild(fixtureName, fileName) {
 module.exports = {
   currentVersion,
   currentAppBlueprintVersion,
+  currentAddonBlueprintVersion,
   checkEslintConfig,
   checkFileWithJSONReplacement,
   checkEmberCLIBuild,

--- a/tests/helpers-internal/fixtures.js
+++ b/tests/helpers-internal/fixtures.js
@@ -8,6 +8,7 @@ const { file } = require('chai-files');
 const { set, get, cloneDeep } = require('lodash');
 
 const currentVersion = require('../../package').version;
+const currentAppBlueprintVersion = require('@ember-tooling/classic-build-app-blueprint/package').version;
 
 function checkEslintConfig(fixturePath) {
   expect(file('eslint.config.mjs')).to.equal(
@@ -43,6 +44,7 @@ function checkEmberCLIBuild(fixtureName, fileName) {
 
 module.exports = {
   currentVersion,
+  currentAppBlueprintVersion,
   checkEslintConfig,
   checkFileWithJSONReplacement,
   checkEmberCLIBuild,


### PR DESCRIPTION
Fundamentally this PR fixes a problem that has been surfaced by https://github.com/ember-cli/ember-cli/pull/10766

We can now have a difference in versions between `ember-cli` and the two app and addon blueprint packages. This means that expecting the app and addon blueprints to have a version the same as ember-cli is no longer valid.

This also sets us up to correctly update people across the vite boundary to the "old blueprints" without to much trouble 👍 