### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -1,31 +1,27 @@
 {
   "solution": {
     "@ember-tooling/classic-build-addon-blueprint": {
-      "impact": "minor",
-      "oldVersion": "6.8.0-alpha.1",
-      "newVersion": "6.8.0-alpha.2",
+      "impact": "patch",
+      "oldVersion": "6.8.0-alpha.2",
+      "newVersion": "6.8.0-alpha.3",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
-      "impact": "minor",
-      "oldVersion": "6.8.0-alpha.1",
-      "newVersion": "6.8.0-alpha.2",
+      "impact": "patch",
+      "oldVersion": "6.8.0-alpha.2",
+      "newVersion": "6.8.0-alpha.3",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
-        },
-        {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./packages/app-blueprint/package.json"
@@ -34,12 +30,22 @@
       "oldVersion": "0.0.2"
     },
     "@ember-tooling/blueprint-model": {
-      "oldVersion": "0.0.2"
+      "impact": "minor",
+      "oldVersion": "0.0.2",
+      "newVersion": "0.1.0",
+      "tagName": "latest",
+      "constraints": [
+        {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        }
+      ],
+      "pkgJSONPath": "./packages/blueprint-model/package.json"
     },
     "ember-cli": {
       "impact": "patch",
-      "oldVersion": "6.8.0-alpha.1",
-      "newVersion": "6.8.0-alpha.2",
+      "oldVersion": "6.8.0-alpha.2",
+      "newVersion": "6.8.0-alpha.3",
       "tagName": "alpha",
       "constraints": [
         {
@@ -49,10 +55,14 @@
         {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-app-blueprint"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./package.json"
     }
   },
-  "description": "## Release (2025-09-01)\n\n* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.2 (minor)\n* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.2 (minor)\n* ember-cli 6.8.0-alpha.2 (patch)\n\n#### :rocket: Enhancement\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10791](https://github.com/ember-cli/ember-cli/pull/10791) update the format of the ember-cli-update.json ([@mansona](https://github.com/mansona))\n* Other\n  * [#10785](https://github.com/ember-cli/ember-cli/pull/10785) Depracate passing filenames and globs to `init` ([@pichfl](https://github.com/pichfl))\n  * [#10776](https://github.com/ember-cli/ember-cli/pull/10776) Add deprecation warning for the `--embroider` argument ([@pichfl](https://github.com/pichfl))\n\n#### :bug: Bug Fix\n* Other\n  * [#10782](https://github.com/ember-cli/ember-cli/pull/10782) update heimdall-fs-monitor ([@mansona](https://github.com/mansona))\n* `@ember-tooling/classic-build-app-blueprint`\n  * [#10707](https://github.com/ember-cli/ember-cli/pull/10707) Enabled recommended configs from eslint-plugin-n and eslint-plugin-qunit ([@ijlee2](https://github.com/ijlee2))\n\n#### :house: Internal\n* [#10790](https://github.com/ember-cli/ember-cli/pull/10790) Reorganize tests for `new` and `addon` commands ([@pichfl](https://github.com/pichfl))\n* [#10783](https://github.com/ember-cli/ember-cli/pull/10783) remove unused changelog script ([@mansona](https://github.com/mansona))\n* [#10764](https://github.com/ember-cli/ember-cli/pull/10764) fix double CI run on release-plan PR ([@mansona](https://github.com/mansona))\n* [#10750](https://github.com/ember-cli/ember-cli/pull/10750) Add more notes to the Release.md ([@mansona](https://github.com/mansona))\n\n#### Committers: 3\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Florian Pichler ([@pichfl](https://github.com/pichfl))\n- Isaac Lee ([@ijlee2](https://github.com/ijlee2))\n"
+  "description": "## Release (2025-09-05)\n\n* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.3 (patch)\n* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.3 (patch)\n* @ember-tooling/blueprint-model 0.1.0 (minor)\n* ember-cli 6.8.0-alpha.3 (patch)\n\n#### :rocket: Enhancement\n* `@ember-tooling/blueprint-model`\n  * [#10781](https://github.com/ember-cli/ember-cli/pull/10781) Add new `VITE` experiment to generate app with new Vite blueprint ([@pichfl](https://github.com/pichfl))\n\n#### Committers: 1\n- Florian Pichler ([@pichfl](https://github.com/pichfl))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ember-cli Changelog
 
+## Release (2025-09-05)
+
+* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.3 (patch)
+* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.3 (patch)
+* @ember-tooling/blueprint-model 0.1.0 (minor)
+* ember-cli 6.8.0-alpha.3 (patch)
+
+#### :rocket: Enhancement
+* `@ember-tooling/blueprint-model`
+  * [#10781](https://github.com/ember-cli/ember-cli/pull/10781) Add new `VITE` experiment to generate app with new Vite blueprint ([@pichfl](https://github.com/pichfl))
+
+#### Committers: 1
+- Florian Pichler ([@pichfl](https://github.com/pichfl))
+
 ## Release (2025-09-01)
 
 * @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.2 (minor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.8.0-alpha.2",
+  "version": "6.8.0-alpha.3",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.8.0-alpha.2",
+  "version": "6.8.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.0",
     "ember-auto-import": "^2.10.0",
-    "ember-cli": "~6.8.0-alpha.2",
+    "ember-cli": "~6.8.0-alpha.3",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.8.0-alpha.2",
+  "version": "6.8.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/blueprint-model",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2025-09-05)

* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.3 (patch)
* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.3 (patch)
* @ember-tooling/blueprint-model 0.1.0 (minor)
* ember-cli 6.8.0-alpha.3 (patch)

#### :rocket: Enhancement
* `@ember-tooling/blueprint-model`
  * [#10781](https://github.com/ember-cli/ember-cli/pull/10781) Add new `VITE` experiment to generate app with new Vite blueprint ([@pichfl](https://github.com/pichfl))

#### Committers: 1
- Florian Pichler ([@pichfl](https://github.com/pichfl))