### PR TITLE
Add "ember-blueprint" to keywords in `package.json` for the classic blueprints

### DIFF
--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -6,6 +6,9 @@
     "url": "https://github.com/ember-cli/ember-cli.git",
     "directory": "packages/addon-blueprint"
   },
+  "keywords": [
+    "ember-blueprint"
+  ],
   "dependencies": {
     "@ember-tooling/blueprint-model": "workspace:*",
     "chalk": "^4.1.2",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -6,6 +6,9 @@
     "url": "https://github.com/ember-cli/ember-cli.git",
     "directory": "packages/app-blueprint"
   },
+  "keywords": [
+    "ember-blueprint"
+  ],
   "dependencies": {
     "@ember-tooling/blueprint-model": "workspace:*",
     "chalk": "^4.1.2",

--- a/packages/blueprint-blueprint/package.json
+++ b/packages/blueprint-blueprint/package.json
@@ -5,5 +5,8 @@
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",
     "directory": "packages/blueprint-blueprint"
-  }
+  },
+  "keywords": [
+    "ember-blueprint"
+  ]
 }


### PR DESCRIPTION
Using them with `-b` wouldn't work otherwise, which breaks `ember-cli-update`.

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).