### PR TITLE
Support a `--ts` alias for the `addon`, `init` and `new` commands

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -31,7 +31,13 @@ module.exports = NewCommand.extend({
       default: 'github',
       description: 'Installs the optional default CI blueprint. Only Github Actions is supported at the moment.',
     },
-    { name: 'typescript', type: Boolean, default: false, description: 'Set up the addon to use TypeScript' },
+    {
+      name: 'typescript',
+      type: Boolean,
+      default: false,
+      description: 'Set up the addon to use TypeScript',
+      aliases: ['ts'],
+    },
     {
       name: 'strict',
       type: Boolean,

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -60,7 +60,13 @@ module.exports = Command.extend({
       default: true,
       description: 'Include ember-data dependencies and configuration',
     },
-    { name: 'typescript', type: Boolean, default: false, description: 'Set up the app to use TypeScript' },
+    {
+      name: 'typescript',
+      type: Boolean,
+      default: false,
+      description: 'Set up the app to use TypeScript',
+      aliases: ['ts'],
+    },
     {
       name: 'strict',
       type: Boolean,

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -62,7 +62,13 @@ module.exports = Command.extend({
       aliases: ['i'],
       description: 'Create a new Ember app/addon in an interactive way.',
     },
-    { name: 'typescript', type: Boolean, default: false, description: 'Set up the app to use TypeScript' },
+    {
+      name: 'typescript',
+      type: Boolean,
+      default: false,
+      description: 'Set up the app to use TypeScript',
+      aliases: ['ts'],
+    },
     {
       name: 'strict',
       type: Boolean,

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -22,6 +22,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the addon to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember asset-sizes [36m<options...>[39m
@@ -109,6 +110,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
@@ -148,6 +150,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember serve [36m<options...>[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -86,6 +86,7 @@ module.exports = {
           required: false
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -488,6 +489,7 @@ module.exports = {
           default: true
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -646,6 +648,7 @@ module.exports = {
           required: false,
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -22,6 +22,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--lint-fix[39m [36m(Boolean)[39m [36m(Default: true)[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the addon to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember asset-sizes [36m<options...>[39m
@@ -109,6 +110,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
@@ -148,6 +150,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
   [36m--interactive[39m [36m(Boolean)[39m [36m(Default: false)[39m Create a new Ember app/addon in an interactive way.
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
+    [90maliases: -ts[39m
   [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember serve [36m<options...>[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -86,6 +86,7 @@ module.exports = {
           required: false
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -520,6 +521,7 @@ module.exports = {
           default: true
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -678,6 +680,7 @@ module.exports = {
           required: false,
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -86,6 +86,7 @@ module.exports = {
           required: false
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -488,6 +489,7 @@ module.exports = {
           default: true
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',
@@ -646,6 +648,7 @@ module.exports = {
           required: false,
         },
         {
+          aliases: ['ts'],
           default: false,
           key: 'typescript',
           name: 'typescript',


### PR DESCRIPTION
We do the same for the `generate` and `destroy` commands.

---

This work is supported by the [Bert De Block Initiative](https://www.youtube.com/watch?v=xvFZjo5PgG0&list=RDxvFZjo5PgG0).