### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,50 +2,50 @@
   "solution": {
     "@ember-tooling/classic-build-addon-blueprint": {
       "impact": "patch",
-      "oldVersion": "6.8.0-alpha.3",
-      "newVersion": "6.8.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.4",
+      "newVersion": "6.8.0-alpha.5",
       "tagName": "alpha",
       "constraints": [
         {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
       "impact": "patch",
-      "oldVersion": "6.8.0-alpha.3",
-      "newVersion": "6.8.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.4",
+      "newVersion": "6.8.0-alpha.5",
       "tagName": "alpha",
       "constraints": [
         {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./packages/app-blueprint/package.json"
     },
     "@ember-tooling/blueprint-blueprint": {
-      "impact": "patch",
-      "oldVersion": "0.0.2",
-      "newVersion": "0.0.3",
+      "oldVersion": "0.0.3"
+    },
+    "@ember-tooling/blueprint-model": {
+      "impact": "minor",
+      "oldVersion": "0.1.0",
+      "newVersion": "0.2.0",
       "tagName": "latest",
       "constraints": [
         {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
         }
       ],
-      "pkgJSONPath": "./packages/blueprint-blueprint/package.json"
-    },
-    "@ember-tooling/blueprint-model": {
-      "oldVersion": "0.1.0"
+      "pkgJSONPath": "./packages/blueprint-model/package.json"
     },
     "ember-cli": {
       "impact": "patch",
-      "oldVersion": "6.8.0-alpha.3",
-      "newVersion": "6.8.0-alpha.4",
+      "oldVersion": "6.8.0-alpha.4",
+      "newVersion": "6.8.0-alpha.5",
       "tagName": "alpha",
       "constraints": [
         {
@@ -58,11 +58,11 @@
         },
         {
           "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-blueprint"
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         }
       ],
       "pkgJSONPath": "./package.json"
     }
   },
-  "description": "## Release (2025-09-09)\n\n* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.4 (patch)\n* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.4 (patch)\n* @ember-tooling/blueprint-blueprint 0.0.3 (patch)\n* ember-cli 6.8.0-alpha.4 (patch)\n\n#### :bug: Bug Fix\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-blueprint`\n  * [#10803](https://github.com/ember-cli/ember-cli/pull/10803) Add \"ember-blueprint\" to keywords in `package.json` for the classic blueprints ([@pichfl](https://github.com/pichfl))\n* `@ember-tooling/classic-build-app-blueprint`\n  * [#10798](https://github.com/ember-cli/ember-cli/pull/10798) Add import from ember-data breakage/deprecation ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### Committers: 2\n- Florian Pichler ([@pichfl](https://github.com/pichfl))\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
+  "description": "## Release (2025-09-10)\n\n* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.5 (patch)\n* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.5 (patch)\n* @ember-tooling/blueprint-model 0.2.0 (minor)\n* ember-cli 6.8.0-alpha.5 (patch)\n\n#### :rocket: Enhancement\n* `@ember-tooling/blueprint-model`\n  * [#10802](https://github.com/ember-cli/ember-cli/pull/10802) enable Vite by default ([@mansona](https://github.com/mansona))\n* Other\n  * [#10804](https://github.com/ember-cli/ember-cli/pull/10804) Support a `--ts` alias for the `addon`, `init` and `new` commands ([@bertdeblock](https://github.com/bertdeblock))\n\n#### :house: Internal\n* [#10806](https://github.com/ember-cli/ember-cli/pull/10806) skip build watch tests when vite is enabled ([@mansona](https://github.com/mansona))\n\n#### Committers: 2\n- Bert De Block ([@bertdeblock](https://github.com/bertdeblock))\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # ember-cli Changelog
 
+## Release (2025-09-10)
+
+* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.5 (patch)
+* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.5 (patch)
+* @ember-tooling/blueprint-model 0.2.0 (minor)
+* ember-cli 6.8.0-alpha.5 (patch)
+
+#### :rocket: Enhancement
+* `@ember-tooling/blueprint-model`
+  * [#10802](https://github.com/ember-cli/ember-cli/pull/10802) enable Vite by default ([@mansona](https://github.com/mansona))
+* Other
+  * [#10804](https://github.com/ember-cli/ember-cli/pull/10804) Support a `--ts` alias for the `addon`, `init` and `new` commands ([@bertdeblock](https://github.com/bertdeblock))
+
+#### :house: Internal
+* [#10806](https://github.com/ember-cli/ember-cli/pull/10806) skip build watch tests when vite is enabled ([@mansona](https://github.com/mansona))
+
+#### Committers: 2
+- Bert De Block ([@bertdeblock](https://github.com/bertdeblock))
+- Chris Manson ([@mansona](https://github.com/mansona))
+
 ## Release (2025-09-09)
 
 * @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.4 (patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.8.0-alpha.4",
+  "version": "6.8.0-alpha.5",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.8.0-alpha.4",
+  "version": "6.8.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.0",
     "ember-auto-import": "^2.10.0",
-    "ember-cli": "~6.8.0-alpha.4",
+    "ember-cli": "~6.8.0-alpha.5",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.8.0-alpha.4",
+  "version": "6.8.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/blueprint-model",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2025-09-10)

* @ember-tooling/classic-build-addon-blueprint 6.8.0-alpha.5 (patch)
* @ember-tooling/classic-build-app-blueprint 6.8.0-alpha.5 (patch)
* @ember-tooling/blueprint-model 0.2.0 (minor)
* ember-cli 6.8.0-alpha.5 (patch)

#### :rocket: Enhancement
* `@ember-tooling/blueprint-model`
  * [#10802](https://github.com/ember-cli/ember-cli/pull/10802) enable Vite by default ([@mansona](https://github.com/mansona))
* Other
  * [#10804](https://github.com/ember-cli/ember-cli/pull/10804) Support a `--ts` alias for the `addon`, `init` and `new` commands ([@bertdeblock](https://github.com/bertdeblock))

#### :house: Internal
* [#10806](https://github.com/ember-cli/ember-cli/pull/10806) skip build watch tests when vite is enabled ([@mansona](https://github.com/mansona))

#### Committers: 2
- Bert De Block ([@bertdeblock](https://github.com/bertdeblock))
- Chris Manson ([@mansona](https://github.com/mansona))