### PR TITLE
update @ember/app-blueprint beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ember-tooling/blueprint-model": "workspace:*",
     "@ember-tooling/classic-build-addon-blueprint": "workspace:*",
     "@ember-tooling/classic-build-app-blueprint": "workspace:*",
-    "@ember/app-blueprint": "~6.8.0-beta.1",
+    "@ember/app-blueprint": "~6.8.0-beta.2",
     "@pnpm/find-workspace-dir": "^1000.1.0",
     "babel-remove-types": "^1.0.1",
     "broccoli": "^3.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/app-blueprint
       '@ember/app-blueprint':
-        specifier: ~6.8.0-beta.1
-        version: 6.8.0-beta.1
+        specifier: ~6.8.0-beta.2
+        version: 6.8.0-beta.2
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.0
         version: 1000.1.0
@@ -560,8 +560,8 @@ packages:
     engines: {node: '>=0.1.95'}
     hasBin: true
 
-  '@ember/app-blueprint@6.8.0-beta.1':
-    resolution: {integrity: sha512-numsThY0m1gXrOSpe4B8luGds0vPi0Jlh4BHltE0nOxX5LwfXGDadeNh1uezfjimuRJmRtPE0EXyX5BOOEpcew==}
+  '@ember/app-blueprint@6.8.0-beta.2':
+    resolution: {integrity: sha512-dcIUAHJhRaGYh0kistsJboeW0xKMGvjAimSuRx1X7XtWfOGWr5r/6DA5L3EByq0NOdpwzdOQzI9BfR5hBVo0OA==}
 
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
@@ -5490,7 +5490,7 @@ snapshots:
       exec-sh: 0.3.6
       minimist: 1.2.8
 
-  '@ember/app-blueprint@6.8.0-beta.1':
+  '@ember/app-blueprint@6.8.0-beta.2':
     dependencies:
       chalk: 4.1.2
       ember-cli-string-utils: 1.1.0


### PR DESCRIPTION
I'm trying to make sure that https://github.com/ember-learn/super-rentals-tutorial/pull/272 uses the latest ember-source beta, I don't know why it's not updating correctly but the best way is just update it all the way down? 🤷 