### PR TITLE
fix incorrect ember-cli-update version in tests

### DIFF
--- a/tests/acceptance/addon-test.js
+++ b/tests/acceptance/addon-test.js
@@ -113,7 +113,7 @@ describe('Acceptance: ember addon', function () {
       fixturePath,
       'tests/dummy/config/ember-cli-update.json',
       'packages[0].version',
-      currentVersion
+      currentAddonBlueprintVersion
     );
 
     // option independent, but piggy-backing on an existing generate for speed
@@ -153,7 +153,7 @@ describe('Acceptance: ember addon', function () {
       fixturePath,
       'tests/dummy/config/ember-cli-update.json',
       'packages[0].version',
-      currentVersion
+      currentAddonBlueprintVersion
     );
   });
 


### PR DESCRIPTION
This fixes a case where the addon blueprint could have a different version compared to ember-cli and cause tests to fail.

This fixes the tests in https://github.com/ember-cli/ember-cli/pull/10820