### PR TITLE
[bugfix release] fix app-blueprint being considered a blueprint

### DIFF
--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -6,6 +6,9 @@
     "url": "https://github.com/ember-cli/ember-cli.git",
     "directory": "packages/app-blueprint"
   },
+  "keywords": [
+    "ember-blueprint"
+  ],
   "dependencies": {
     "@ember-tooling/blueprint-model": "^0.0.2",
     "chalk": "^4.1.2",


### PR DESCRIPTION
This is needed for the recommendations in https://github.com/ember-cli/ember-cli-update/pull/1280 to be true 👍 