### PR TITLE
move resolution of @ember/app-blueprint to prevent loading latest

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -12,8 +12,6 @@ const { isPnpmProject, isYarnProject } = require('../utilities/package-managers'
 const getLangArg = require('../../lib/utilities/get-lang-arg');
 const { deprecate, DEPRECATIONS } = require('../debug');
 
-const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
-
 module.exports = Command.extend({
   name: 'init',
   description: 'Reinitializes a new ember-cli project in the current folder.',
@@ -125,10 +123,6 @@ module.exports = Command.extend({
 
     let blueprintOpts = clone(commandOptions);
     let blueprint = normalizeBlueprint(blueprintOpts.blueprint || this._defaultBlueprint());
-
-    if (isExperimentEnabled('VITE') && blueprint === 'app') {
-      blueprint = '@ember/app-blueprint';
-    }
 
     merge(blueprintOpts, {
       rawName: packageName,

--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -13,6 +13,7 @@ const npa = require('npm-package-arg');
 const lintFix = require('../utilities/lint-fix');
 
 const logger = require('heimdalljs-logger')('ember-cli:tasks:install-blueprint');
+const { isExperimentEnabled } = require('@ember-tooling/blueprint-model/utilities/experiments');
 
 const NOT_FOUND_REGEXP = /npm ERR! 404 {2}'(\S+)' is not in the npm registry/;
 
@@ -60,6 +61,10 @@ class InstallBlueprintTask extends Task {
   async _resolveBlueprint(name) {
     name = name || 'app';
     logger.info(`Resolving blueprint "${name}" ...`);
+
+    if (isExperimentEnabled('VITE') && name === 'app') {
+      return Blueprint.load(path.dirname(require.resolve('@ember/app-blueprint')));
+    }
 
     let blueprint;
     try {

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -162,32 +162,9 @@ describe('init command', function () {
   });
 
   it('Uses the "app" blueprint by default', function () {
-    if (isExperimentEnabled('VITE')) {
-      this.skip();
-    }
-
     tasks.InstallBlueprint = class extends Task {
       run(blueprintOpts) {
         expect(blueprintOpts.blueprint).to.equal('app');
-        return Promise.reject('Called run');
-      }
-    };
-
-    buildCommand();
-
-    return command.validateAndRun(['--name=provided-name']).catch(function (reason) {
-      expect(reason).to.equal('Called run');
-    });
-  });
-
-  it('Experiment(VITE): Uses @ember/app-blueprint by default', function () {
-    if (!isExperimentEnabled('VITE')) {
-      this.skip();
-    }
-
-    tasks.InstallBlueprint = class extends Task {
-      run(blueprintOpts) {
-        expect(blueprintOpts.blueprint).to.equal('@ember/app-blueprint');
         return Promise.reject('Called run');
       }
     };


### PR DESCRIPTION
this makes sure that we change what the `app` blueprint means at a point where we can resolve a true path and return a real blueprint module. This means that we're now resolving the blueprint in the context of ember-cli's dependencies and not always getting latest