### PR TITLE
[bugfix beta] enable `--strict` by default to match new app blueprint

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -41,7 +41,7 @@ module.exports = NewCommand.extend({
     {
       name: 'strict',
       type: Boolean,
-      default: false,
+      default: true,
       description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
     },
   ],

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -68,7 +68,7 @@ module.exports = Command.extend({
     {
       name: 'strict',
       type: Boolean,
-      default: false,
+      default: true,
       description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
     },
   ],

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -72,7 +72,7 @@ module.exports = Command.extend({
     {
       name: 'strict',
       type: Boolean,
-      default: false,
+      default: true,
       description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
     },
   ],

--- a/packages/addon-blueprint/index.js
+++ b/packages/addon-blueprint/index.js
@@ -134,7 +134,7 @@ module.exports = {
    *     _ts_eslint.config.mjs is renamed to eslint.config.mjs
    */
   buildFileInfo(intoDir, templateVariables, file, commandOptions) {
-    if (file.startsWith('_js_') || file.startsWith('_ts_')) {
+    if (file.includes('_js_') || file.includes('_ts_')) {
       let fileInfo = this._super.buildFileInfo.apply(this, arguments);
 
       if (file.includes('_js_')) {

--- a/packages/app-blueprint/files/.ember-cli
+++ b/packages/app-blueprint/files/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": <%= strict ? '"strict"' : '"loose"' %>,
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": <%= strict ? '"strict"' : '"loose"' %>
 }

--- a/tests/acceptance/addon-test.js
+++ b/tests/acceptance/addon-test.js
@@ -99,7 +99,7 @@ describe('Acceptance: ember addon', function () {
 
     [
       'tests/dummy/config/ember-try.js',
-      'tests/dummy/app/templates/application.hbs',
+      'tests/dummy/app/templates/application.gjs',
       '.github/workflows/ci.yml',
       'README.md',
       'CONTRIBUTING.md',
@@ -140,7 +140,7 @@ describe('Acceptance: ember addon', function () {
 
     [
       'tests/dummy/config/ember-try.js',
-      'tests/dummy/app/templates/application.hbs',
+      'tests/dummy/app/templates/application.gjs',
       '.github/workflows/ci.yml',
       'README.md',
       'CONTRIBUTING.md',
@@ -164,7 +164,7 @@ describe('Acceptance: ember addon', function () {
 
     [
       'tests/dummy/config/ember-try.js',
-      'tests/dummy/app/templates/application.hbs',
+      'tests/dummy/app/templates/application.gjs',
       '.github/workflows/ci.yml',
       'README.md',
       'CONTRIBUTING.md',

--- a/tests/fixtures/addon/defaults/.ember-cli
+++ b/tests/fixtures/addon/defaults/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
-  "componentAuthoringFormat": "loose",
+  "componentAuthoringFormat": "strict",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
-  "routeAuthoringFormat": "loose"
+  "routeAuthoringFormat": "strict"
 }

--- a/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.gjs
+++ b/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.gjs
@@ -1,0 +1,9 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+
+<template>
+  {{pageTitle "Dummy"}}
+
+  <h2 id="title">Welcome to Ember</h2>
+
+  {{outlet}}
+</template>

--- a/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/defaults/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,0 @@
-{{page-title "Dummy"}}
-
-<h2 id="title">Welcome to Ember</h2>
-
-{{outlet}}

--- a/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.gjs
+++ b/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.gjs
@@ -1,0 +1,12 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+import WelcomePage from 'ember-welcome-page/components/welcome-page';
+
+<template>
+  {{pageTitle "Dummy"}}
+
+  {{outlet}}
+
+  {{! The following component displays Ember's default welcome message. }}
+  <WelcomePage />
+  {{! Feel free to remove this! }}
+</template>

--- a/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/pnpm/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,0 @@
-{{page-title "Dummy"}}
-
-{{outlet}}
-
-{{! The following component displays Ember's default welcome message. }}
-<WelcomePage />
-{{! Feel free to remove this! }}

--- a/tests/fixtures/addon/typescript/.ember-cli
+++ b/tests/fixtures/addon/typescript/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
-  "componentAuthoringFormat": "loose",
+  "componentAuthoringFormat": "strict",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
-  "routeAuthoringFormat": "loose"
+  "routeAuthoringFormat": "strict"
 }

--- a/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.gjs
+++ b/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.gjs
@@ -1,0 +1,12 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+import WelcomePage from 'ember-welcome-page/components/welcome-page';
+
+<template>
+  {{pageTitle "Dummy"}}
+
+  {{outlet}}
+
+  {{! The following component displays Ember's default welcome message. }}
+  <WelcomePage />
+  {{! Feel free to remove this! }}
+</template>

--- a/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
+++ b/tests/fixtures/addon/yarn/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,0 @@
-{{page-title "Dummy"}}
-
-{{outlet}}
-
-{{! The following component displays Ember's default welcome message. }}
-<WelcomePage />
-{{! Feel free to remove this! }}

--- a/tests/fixtures/app/defaults/.ember-cli
+++ b/tests/fixtures/app/defaults/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": "loose",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": "loose"
 }

--- a/tests/fixtures/app/strict-typescript/.ember-cli
+++ b/tests/fixtures/app/strict-typescript/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": "strict",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": "strict"
 }

--- a/tests/fixtures/app/strict/.ember-cli
+++ b/tests/fixtures/app/strict/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": "strict",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": "strict"
 }

--- a/tests/fixtures/app/typescript-embroider/.ember-cli
+++ b/tests/fixtures/app/typescript-embroider/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": "loose",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": "loose"
 }

--- a/tests/fixtures/app/typescript/.ember-cli
+++ b/tests/fixtures/app/typescript/.ember-cli
@@ -7,13 +7,13 @@
 
   /**
     Setting `componentAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS files for the component and the component rendering test. "loose" is the default.
+    or GTS files for the component and the component rendering test. "strict" is the default.
   */
   "componentAuthoringFormat": "loose",
 
   /**
     Setting `routeAuthoringFormat` to "strict" will force the blueprint generators to generate GJS
-    or GTS templates for routes. "loose" is the default
+    or GTS templates for routes. "strict" is the default
   */
   "routeAuthoringFormat": "loose"
 }

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -23,7 +23,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the addon to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember asset-sizes [36m<options...>[39m
   Shows the sizes of your asset files.
@@ -111,7 +111,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
   Installs an ember-cli addon from npm.
@@ -151,7 +151,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -94,7 +94,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -497,7 +497,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -656,7 +656,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -23,7 +23,7 @@ ember addon [33m<addon-name>[39m [36m<options...>[39m
   [36m--ci-provider[39m [36m(github, none)[39m [36m(Default: github)[39m Installs the optional default CI blueprint. Only Github Actions is supported at the moment.
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the addon to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember asset-sizes [36m<options...>[39m
   Shows the sizes of your asset files.
@@ -111,7 +111,7 @@ ember init [33m<glob-pattern>[39m [36m<options...>[39m
   [36m--ember-data[39m [36m(Boolean)[39m [36m(Default: true)[39m Include ember-data dependencies and configuration
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember install [33m<addon-name>[39m [36m<options...>[39m
   Installs an ember-cli addon from npm.
@@ -151,7 +151,7 @@ ember new [33m<app-name>[39m [36m<options...>[39m
     [90maliases: -i[39m
   [36m--typescript[39m [36m(Boolean)[39m [36m(Default: false)[39m Set up the app to use TypeScript
     [90maliases: -ts[39m
-  [36m--strict[39m [36m(Boolean)[39m [36m(Default: false)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
+  [36m--strict[39m [36m(Boolean)[39m [36m(Default: true)[39m Use GJS/GTS templates by default for generated components, tests, and route templates
 
 ember serve [36m<options...>[39m
   Builds and serves your app, rebuilding on file changes.

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -94,7 +94,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -529,7 +529,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -688,7 +688,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -94,7 +94,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -497,7 +497,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',
@@ -656,7 +656,7 @@ module.exports = {
           required: false,
         },
         {
-          default: false,
+          default: true,
           description: 'Use GJS/GTS templates by default for generated components, tests, and route templates',
           key: 'strict',
           name: 'strict',


### PR DESCRIPTION
This matches the behaviour of [`@ember/app-blueprint`](https://github.com/ember-cli/ember-app-blueprint) and setting it to `--strict` by default will keep consistency between blueprints