### PR TITLE
WIP: fix output workflow and script

### DIFF
--- a/.github/workflows/sync-output-repos.yml
+++ b/.github/workflows/sync-output-repos.yml
@@ -24,7 +24,7 @@ on:
   push:
     # for addon and new output
     tags:
-      - 'v*'
+      - "v*"
 
 # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
 # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
@@ -34,8 +34,8 @@ on:
 #  GITHUB_REF_TYPE - github.ref_type - branch or tag
 
 env:
-  GIT_NAME: 'github-actions[bot]'
-  GIT_EMAIL: 'github-actions+bot@users.noreply.github.com'
+  GIT_NAME: "github-actions[bot]"
+  GIT_EMAIL: "github-actions+bot@users.noreply.github.com"
 
 jobs:
   verify-inputs:
@@ -70,8 +70,10 @@ jobs:
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-
+      - run: |
+          echo "Version: '${{ steps.determine.outputs.version }}'"
+      - run: |
+          echo "Tag: '${{ steps.determine.outputs.tag }}'"
 
   push-addon-app:
     name: "Push to ${{ matrix.blueprint }} output repo"
@@ -102,7 +104,6 @@ jobs:
       fail-fast: false
       matrix:
         variant: ["javascript", "typescript"]
-
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Tests

### via workflow-dispatch

- default branch (we don't want to use workflows from old brancehs)
  - running with tag: `6.6.0-alpha.1-ember-cli`
    core issue: https://github.com/NullVoxPopuli/ember-cli/actions/runs/18412556294/job/52468445423#step:5:19
    ```bash
    Running npx ember-cli@v6.6.0-alpha.1-ember-cli new my-app
    /home/runner/work/ember-cli/ember-cli/node_modules/.pnpm/execa@5.1.1/node_modules/execa/lib/error.js:60
		    error = new Error(message);
		            ^
    
    Error: Command failed with exit code 1: npx ember-cli@v6.6.0-alpha.1-ember-cli new my-app --skip-npm --skip-git
    npm error code ETARGET
    npm error notarget No matching version found for ember-cli@v6.6.0-alpha.1-ember-cli.
    ```
    we need to either:
    - strip the `-ember-cli` suffix from the tag when running this workflow
    - or checkout the code at this tag and grab the version from package.json (preferred, because it's less prone breaking due to tag changes in the future)