### PR TITLE
[BUGFIX release] Re-add the --watcher flag to build, so that when using vite, we don't run out of watchers on macOS, and allow watchman usage

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -6,7 +6,7 @@ const SilentError = require('silent-error');
 
 const ClassicOptions = [
   { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
-  { name: 'watcher', type: String, default: 'events' },
+  { name: 'watcher', type: String },
 ];
 
 module.exports = Command.extend({
@@ -33,7 +33,7 @@ module.exports = Command.extend({
       this.availableOptions = this.availableOptions.concat(ClassicOptions);
     } else if (process.env.EMBROIDER_PREBUILD) {
       // having the --watch option available surpresses a warning that you get in Vite prebuild
-      this.availableOptions = this.availableOptions.concat(ClassicOptions);
+      this.availableOptions = this.availableOptions.concat(ClassicOptions[0]);
     }
   },
 

--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -312,7 +312,7 @@ let Command = CoreObject.extend({
 
     let options = commandOptions.options;
 
-    if (this.hasOption('watcher')) {
+    if (this.hasOption('watcher') || process.env.EMBROIDER_PREBUILD) {
       // Do stuff to try and provide a good experience when it comes to file watching:
       let watchPreference = detector.findBestWatcherOption(options);
 


### PR DESCRIPTION
Exploration in Discord: https://discord.com/channels/480462759797063690/568935504288940056/1432791167799656469


The problem is here: 
- https://github.com/ember-cli/ember-cli/blob/01a68b9b3641cc6acaa8dc1e4a101d660e70f29f/lib/models/command.js#L315
  We never enter this block unless a `watcher` option is present. when doing `ember s`, `watcher` has a default value of `"events"`, specified here: https://github.com/ember-cli/ember-cli/blob/01a68b9b3641cc6acaa8dc1e4a101d660e70f29f/lib/commands/serve.js#L57 -- but in the build command (edited in this PR) -- we were omitting that in the `availableOptions` during `$EMBROIDER_PREBUILD` -- which opts the `build --watch` that `compatPrebuild` is doing out of using `watchman` (which is a requirement to do anything on macOS with watched files).


NOTE: `availableOptions` was found as being relevant while debugging `parseArgs`
- https://github.com/ember-cli/ember-cli/blob/01a68b9b3641cc6acaa8dc1e4a101d660e70f29f/lib/models/command.js#L554 -- where you find if you break in that function, you _never_ see `watcher` -- which is required to use watchman.
  - from here: https://github.com/ember-cli/ember-cli/blob/01a68b9b3641cc6acaa8dc1e4a101d660e70f29f/lib/models/command.js#L584
  
  
  
An alternate implementation of this PR is to always use watchman if process.env.EMBROIDER_PREBUILD is present (or rather, assume we "have a watcher" -- and let our call to WatchDetector figure it out -- (Linux, for example, doesn't need watchman))