### PR TITLE
bump minimum node version to 20.19

### DIFF
--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -99,7 +99,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/defaults/package.json
+++ b/tests/fixtures/addon/defaults/package.json
@@ -82,7 +82,7 @@
     "ember-source": ">= 4.0.0"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/pnpm/package.json
+++ b/tests/fixtures/addon/pnpm/package.json
@@ -83,7 +83,7 @@
     "ember-source": ">= 4.0.0"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/typescript/package.json
+++ b/tests/fixtures/addon/typescript/package.json
@@ -109,7 +109,7 @@
     "ember-source": ">= 4.0.0"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/addon/yarn/package.json
+++ b/tests/fixtures/addon/yarn/package.json
@@ -83,7 +83,7 @@
     "ember-source": ">= 4.0.0"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/embroider-no-ember-data/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/nested-project/actual-project/package.json
+++ b/tests/fixtures/app/nested-project/actual-project/package.json
@@ -68,7 +68,7 @@
     "stylelint-prettier": "^5.0.2"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/no-ember-data/package.json
+++ b/tests/fixtures/app/no-ember-data/package.json
@@ -75,7 +75,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -75,7 +75,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/pnpm/package.json
+++ b/tests/fixtures/app/pnpm/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
@@ -85,7 +85,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -97,7 +97,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/typescript-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-no-ember-data/package.json
@@ -84,7 +84,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -96,7 +96,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -70,7 +70,7 @@
     "tracked-built-ins": "^3.1.0"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": ">= 20.11"
+    "node": ">= 20.19"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
The thing that seems to be blocking me on https://github.com/ember-cli/ember-cli/pull/10873 is that warp-drive now **requires** you to be on a version of node that supports require(esm). This means that we have a new minimum minor version of node that we can support with the current dependencies as defined in the blueprints. 

I don't know if we need to update anything in our node support documentation for this 🤔 