### PR TITLE
Prepare Stable Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -1,24 +1,56 @@
 {
   "solution": {
     "ember-cli": {
-      "impact": "patch",
-      "oldVersion": "6.8.0",
-      "newVersion": "6.8.1",
+      "impact": "minor",
+      "oldVersion": "6.8.1",
+      "newVersion": "6.9.0",
       "tagName": "latest",
       "constraints": [
         {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        },
+        {
           "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-app-blueprint"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-addon-blueprint"
+        },
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./package.json"
     },
     "@ember-tooling/classic-build-addon-blueprint": {
-      "oldVersion": "6.8.0"
+      "impact": "minor",
+      "oldVersion": "6.8.0",
+      "newVersion": "6.9.0",
+      "tagName": "latest",
+      "constraints": [
+        {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        }
+      ],
+      "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
-      "oldVersion": "6.8.0"
+      "impact": "minor",
+      "oldVersion": "6.8.0",
+      "newVersion": "6.9.0",
+      "tagName": "latest",
+      "constraints": [
+        {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        }
+      ],
+      "pkgJSONPath": "./packages/app-blueprint/package.json"
     }
   },
-  "description": "## Release (2025-11-29)\n\n* ember-cli 6.8.1 (patch)\n\n#### :bug: Bug Fix\n* `ember-cli`\n  * [#10860](https://github.com/ember-cli/ember-cli/pull/10860) [BUGFIX release]: Enter the WatchDetector branch of the build command when EMBROIDER_PREBUILD is present ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### Committers: 1\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
+  "description": "## Release (2025-12-10)\n\n* ember-cli 6.9.0 (minor)\n* @ember-tooling/classic-build-addon-blueprint 6.9.0 (minor)\n* @ember-tooling/classic-build-app-blueprint 6.9.0 (minor)\n\n#### :rocket: Enhancement\n* `ember-cli`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10885](https://github.com/ember-cli/ember-cli/pull/10885) Promote Beta and update all dependencies for 6.9 release ([@mansona](https://github.com/mansona))\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#10854](https://github.com/ember-cli/ember-cli/pull/10854) Prepare Beta Release ([@mansona](https://github.com/mansona))\n\n#### :house: Internal\n* `ember-cli`\n  * [#10809](https://github.com/ember-cli/ember-cli/pull/10809) Update RELEASE ([@mansona](https://github.com/mansona))\n  * [#10813](https://github.com/ember-cli/ember-cli/pull/10813) Document need for future vite experiment test cleanup ([@ef4](https://github.com/ef4))\n\n#### Committers: 2\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Edward Faulkner ([@ef4](https://github.com/ef4))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # ember-cli Changelog
 
+## Release (2025-12-10)
+
+* ember-cli 6.9.0 (minor)
+* @ember-tooling/classic-build-addon-blueprint 6.9.0 (minor)
+* @ember-tooling/classic-build-app-blueprint 6.9.0 (minor)
+
+#### :rocket: Enhancement
+* `ember-cli`, `@ember-tooling/classic-build-app-blueprint`
+  * [#10885](https://github.com/ember-cli/ember-cli/pull/10885) Promote Beta and update all dependencies for 6.9 release ([@mansona](https://github.com/mansona))
+* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
+  * [#10854](https://github.com/ember-cli/ember-cli/pull/10854) Prepare Beta Release ([@mansona](https://github.com/mansona))
+
+#### :house: Internal
+* `ember-cli`
+  * [#10809](https://github.com/ember-cli/ember-cli/pull/10809) Update RELEASE ([@mansona](https://github.com/mansona))
+  * [#10813](https://github.com/ember-cli/ember-cli/pull/10813) Document need for future vite experiment test cleanup ([@ef4](https://github.com/ef4))
+
+#### Committers: 2
+- Chris Manson ([@mansona](https://github.com/mansona))
+- Edward Faulkner ([@ef4](https://github.com/ef4))
+
 ## Release (2025-11-29)
 
 * ember-cli 6.8.1 (patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.8.1",
+  "version": "6.9.0",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.12.0",
-    "ember-cli": "~6.8.1",
+    "ember-cli": "~6.9.0",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2025-12-10)

* ember-cli 6.9.0 (minor)
* @ember-tooling/classic-build-addon-blueprint 6.9.0 (minor)
* @ember-tooling/classic-build-app-blueprint 6.9.0 (minor)

#### :rocket: Enhancement
* `ember-cli`, `@ember-tooling/classic-build-app-blueprint`
  * [#10885](https://github.com/ember-cli/ember-cli/pull/10885) Promote Beta and update all dependencies for 6.9 release ([@mansona](https://github.com/mansona))
* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
  * [#10854](https://github.com/ember-cli/ember-cli/pull/10854) Prepare Beta Release ([@mansona](https://github.com/mansona))

#### :house: Internal
* `ember-cli`
  * [#10809](https://github.com/ember-cli/ember-cli/pull/10809) Update RELEASE ([@mansona](https://github.com/mansona))
  * [#10813](https://github.com/ember-cli/ember-cli/pull/10813) Document need for future vite experiment test cleanup ([@ef4](https://github.com/ef4))

#### Committers: 2
- Chris Manson ([@mansona](https://github.com/mansona))
- Edward Faulkner ([@ef4](https://github.com/ef4))