### PR TITLE
[BUGFIX] ensure CSS instructions work out the box

### DIFF
--- a/packages/app-blueprint/files/app/app.ts
+++ b/packages/app-blueprint/files/app/app.ts
@@ -4,6 +4,7 @@ import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from '<%= modulePrefix %>/config/environment';
 import { importSync, isDevelopingApp, macroCondition } from '@embroider/macros';
+import './styles/app.css';
 
 if (macroCondition(isDevelopingApp())) {
   importSync('./deprecation-workflow');


### PR DESCRIPTION
Since Vite became the default, if you follow the instructions for plain CSS and create multiple CSS files they will not be compiled properly

this is because according to embroider spec the CSS file should have an import statement in order for the compilation to occur properly

https://embroider-build.github.io/embroider/docs/spec.html see under CSS header

Initial research done here https://github.com/embroider-build/embroider/issues/2657