### PR TITLE
Update `diff` in `@ember-tooling/blueprint-model`

### DIFF
--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^5.6.2",
-    "diff": "^7.0.0",
+    "diff": "^8.0.3",
     "isbinaryfile": "^5.0.4",
     "lodash": "^4.17.21",
     "promise.hash.helper": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,8 +414,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       diff:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^8.0.3
+        version: 8.0.3
       isbinaryfile:
         specifier: ^5.0.4
         version: 5.0.4
@@ -2076,6 +2076,10 @@ packages:
 
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   doctrine@3.0.0:
@@ -4976,6 +4980,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -7303,6 +7308,8 @@ snapshots:
   diff@7.0.0: {}
 
   diff@8.0.2: {}
+
+  diff@8.0.3: {}
 
   doctrine@3.0.0:
     dependencies:


### PR DESCRIPTION
Updating to address https://github.com/advisories/GHSA-73rr-hh4g-fpgx

If this change were accepted, I would love to update the `@ember-tooling/blueprint-model` dependency in `ember-cli` on the release branch. Let me know if that is not possible.