### PR TITLE
FEATURE: instrument add-on discovery and instantiation. Close #9373

### DIFF
--- a/lib/models/instantiate-addons.js
+++ b/lib/models/instantiate-addons.js
@@ -24,6 +24,9 @@ const SilentError = require('silent-error');
  */
 function instantiateAddons(parent, project, addonPackages) {
   // depending on whether this is really a project or an addon, the 'name' property may be a getter.
+  let addonInstantiationNode= heimdall.start({
+    name:'ember-cli:addon-instantiation',
+  })
   let parentName = typeof parent.name === 'function' ? parent.name() : parent.name;
 
   logger.info('instantiateAddons for: ', parentName);
@@ -32,6 +35,7 @@ function instantiateAddons(parent, project, addonPackages) {
 
   if (addonNames.length === 0) {
     logger.info('    no addons');
+    addonInstantiationNode.stop();
     return [];
   } else {
     logger.info('    addon names are:', addonNames);
@@ -90,7 +94,7 @@ function instantiateAddons(parent, project, addonPackages) {
   );
 
   initializeAddonsToken.stop();
-
+  addonInstantiationNode.stop();
   return addons;
 }
 

--- a/lib/models/package-info-cache/index.js
+++ b/lib/models/package-info-cache/index.js
@@ -13,6 +13,8 @@ const PackageInfo = require('./package-info');
 const NodeModulesList = require('./node-modules-list');
 const logger = require('heimdalljs-logger')('ember-cli:package-info-cache');
 const resolvePackagePath = require('resolve-package-path');
+const heimdall = require('heimdalljs');
+
 
 const getRealFilePath = resolvePackagePath.getRealFilePath;
 const getRealDirectoryPath = resolvePackagePath.getRealDirectoryPath;
@@ -163,6 +165,7 @@ class PackageInfoCache {
    * No copy is made.
    */
   loadProject(projectInstance) {
+    let node = heimdall.start('ember-cli:addon-discovery:load-project');
     logger.info('Loading project at %o...', projectInstance.root);
 
     let pkgInfo = this._readPackage(projectInstance.root, projectInstance.pkg, true);
@@ -196,7 +199,7 @@ class PackageInfoCache {
 
       this._resolveDependencies();
     }
-
+    node.stop();
     return pkgInfo;
   }
 


### PR DESCRIPTION
This PR adds Heimdall instrumentation nodes for addon discovery and instantiation as requested in #9373.

Technical Details:

=> Added ember-cli:addon-instantiation node in lib/models/instantiate-addons.js.

=> Added ember-cli:addon-discovery node in lib/models/package-info-cache/index.js.

Followed the two-space indentation syntax and ensured all nodes are stopped, including early return paths.

Testing:

=> Ran the test suite via pnpm test.