### PR TITLE
Ensure new projects do not start with a deprecation warning.

### DIFF
--- a/packages/addon-blueprint/files/config/optional-features.json
+++ b/packages/addon-blueprint/files/config/optional-features.json
@@ -2,5 +2,6 @@
   "application-template-wrapper": false,
   "default-async-observers": true,
   "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "template-only-glimmer-components": true,
+  "use-ember-modules": true
 }

--- a/packages/app-blueprint/files/config/optional-features.json
+++ b/packages/app-blueprint/files/config/optional-features.json
@@ -3,5 +3,6 @@
   "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true,
-  "no-implicit-route-model": true
+  "no-implicit-route-model": true,
+  "use-ember-modules": true
 }


### PR DESCRIPTION

See https://deprecations.emberjs.com/v6.x#toc_using-amd-bundles

Not sure if we should do this because it will also change the default for upgraders and they won't know to check if it is safe to toggle.