### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,10 +2,22 @@
   "solution": {
     "ember-cli": {
       "impact": "patch",
-      "oldVersion": "6.12.0-alpha.2",
-      "newVersion": "6.12.0-alpha.3",
+      "oldVersion": "6.12.0-alpha.3",
+      "newVersion": "6.12.0-alpha.4",
       "tagName": "alpha",
       "constraints": [
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-addon-blueprint"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-app-blueprint"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        },
         {
           "impact": "patch",
           "reason": "Appears in changelog section :house: Internal"
@@ -14,17 +26,55 @@
       "pkgJSONPath": "./package.json"
     },
     "@ember-tooling/classic-build-addon-blueprint": {
-      "oldVersion": "6.12.0-alpha.2"
+      "impact": "patch",
+      "oldVersion": "6.12.0-alpha.2",
+      "newVersion": "6.12.0-alpha.3",
+      "tagName": "alpha",
+      "constraints": [
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        }
+      ],
+      "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
-      "oldVersion": "6.12.0-alpha.2"
+      "impact": "patch",
+      "oldVersion": "6.12.0-alpha.2",
+      "newVersion": "6.12.0-alpha.3",
+      "tagName": "alpha",
+      "constraints": [
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        }
+      ],
+      "pkgJSONPath": "./packages/app-blueprint/package.json"
     },
     "@ember-tooling/blueprint-blueprint": {
       "oldVersion": "0.3.0"
     },
     "@ember-tooling/blueprint-model": {
-      "oldVersion": "0.6.1"
+      "impact": "patch",
+      "oldVersion": "0.6.1",
+      "newVersion": "0.6.2",
+      "tagName": "latest",
+      "constraints": [
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
+        }
+      ],
+      "pkgJSONPath": "./packages/blueprint-model/package.json"
     }
   },
-  "description": "## Release (2026-02-07)\n\n* ember-cli 6.12.0-alpha.3 (patch)\n\n#### :house: Internal\n* `ember-cli`\n  * [#10945](https://github.com/ember-cli/ember-cli/pull/10945) update release-plan for OIDC ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
+  "description": "## Release (2026-02-07)\n\n* ember-cli 6.12.0-alpha.4 (patch)\n* @ember-tooling/classic-build-addon-blueprint 6.12.0-alpha.3 (patch)\n* @ember-tooling/classic-build-app-blueprint 6.12.0-alpha.3 (patch)\n* @ember-tooling/blueprint-model 0.6.2 (patch)\n\n#### :house: Internal\n* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`, `ember-cli`\n  * [#10947](https://github.com/ember-cli/ember-cli/pull/10947) bump in-range versions ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Release (2026-02-07)
 
+* ember-cli 6.12.0-alpha.4 (patch)
+* @ember-tooling/classic-build-addon-blueprint 6.12.0-alpha.3 (patch)
+* @ember-tooling/classic-build-app-blueprint 6.12.0-alpha.3 (patch)
+* @ember-tooling/blueprint-model 0.6.2 (patch)
+
+#### :house: Internal
+* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`, `ember-cli`
+  * [#10947](https://github.com/ember-cli/ember-cli/pull/10947) bump in-range versions ([@mansona](https://github.com/mansona))
+
+#### Committers: 1
+- Chris Manson ([@mansona](https://github.com/mansona))
+
+## Release (2026-02-07)
+
 * ember-cli 6.12.0-alpha.3 (patch)
 
 #### :house: Internal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.12.0-alpha.3",
+  "version": "6.12.0-alpha.4",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.12.0-alpha.2",
+  "version": "6.12.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.12.0",
-    "ember-cli": "~6.12.0-alpha.3",
+    "ember-cli": "~6.12.0-alpha.4",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.3.1",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.12.0-alpha.2",
+  "version": "6.12.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/blueprint-model",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2026-02-07)

* ember-cli 6.12.0-alpha.4 (patch)
* @ember-tooling/classic-build-addon-blueprint 6.12.0-alpha.3 (patch)
* @ember-tooling/classic-build-app-blueprint 6.12.0-alpha.3 (patch)
* @ember-tooling/blueprint-model 0.6.2 (patch)

#### :house: Internal
* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`, `ember-cli`
  * [#10947](https://github.com/ember-cli/ember-cli/pull/10947) bump in-range versions ([@mansona](https://github.com/mansona))

#### Committers: 1
- Chris Manson ([@mansona](https://github.com/mansona))