### PR TITLE
[backport release] remove unused isbinaryfile from ember-cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "inquirer": "^13.1.0",
     "is-git-url": "^1.0.0",
     "is-language-code": "^5.1.0",
-    "isbinaryfile": "^6.0.0",
     "lodash": "^4.17.21",
     "markdown-it": "^14.1.0",
     "markdown-it-terminal": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       is-language-code:
         specifier: ^5.1.0
         version: 5.1.0
-      isbinaryfile:
-        specifier: ^6.0.0
-        version: 6.0.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3322,10 +3319,6 @@ packages:
   isbinaryfile@5.0.4:
     resolution: {integrity: sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==}
     engines: {node: '>= 18.0.0'}
-
-  isbinaryfile@6.0.0:
-    resolution: {integrity: sha512-2FN2B8MAqKv6d5TaKsLvMrwMcghxwHTpcKy0L5mhNbRqjNqo2++SpCqN6eG1lCC1GmTQgvrYJYXv2+Chvyevag==}
-    engines: {node: '>= 24.0.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -8912,8 +8905,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isbinaryfile@5.0.4: {}
-
-  isbinaryfile@6.0.0: {}
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
This is backporting a commit from https://github.com/ember-cli/ember-cli/pull/10941 

isbinaryfile is not used directly by ember-cli so it shouldn't be a direct dependency 👍 