### PR TITLE
add correct --publish-branch to pnpm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,9 @@ jobs:
         # pass --github-prerelease when we are only branch other than release
         run: |
           if [ ${{ github.ref }} = "refs/heads/release" ]; then
-            pnpm release-plan publish
+            pnpm release-plan publish --publish-branch=release
+          elif [ ${{ github.ref }} = "refs/heads/beta" ]; then
+            pnpm release-plan publish --github-prerelease --publish-branch=beta
           else
             pnpm release-plan publish --github-prerelease
           fi


### PR DESCRIPTION
This should **hopefully** be the last PR required to fix deployment with OIDC 🙏 😭 🫠 

Essentially we missed a bunch of subtleties in the deleted files in https://github.com/ember-cli/ember-cli/pull/10950

1. anything not main/master needs to have `--publish-branch=<branch-name>`
2. only release should be called without `--github-prerelease` 

That means that we need an if/elif block that has a different behaviour for all 3 branches that we deploy from 🙈 But this should do it 👍 