### PR TITLE
Backport: Enable use-ember-modules in blueprint optional-features.json

### DIFF
--- a/packages/addon-blueprint/files/config/optional-features.json
+++ b/packages/addon-blueprint/files/config/optional-features.json
@@ -2,5 +2,6 @@
   "application-template-wrapper": false,
   "default-async-observers": true,
   "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "template-only-glimmer-components": true,
+  "use-ember-modules": true
 }

--- a/packages/app-blueprint/files/config/optional-features.json
+++ b/packages/app-blueprint/files/config/optional-features.json
@@ -3,5 +3,6 @@
   "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true,
-  "no-implicit-route-model": true
+  "no-implicit-route-model": true,
+  "use-ember-modules": true
 }


### PR DESCRIPTION
## Summary

Backport of #10976 to the `release` branch.

- Enables `use-ember-modules: true` in the blueprint `optional-features.json`

Related: #10970