### PR TITLE
Update publish.yml to use RELEASE_PLAN_GH_PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,4 @@ jobs:
           fi
 
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.RELEASE_PLAN_GH_PAT }}


### PR DESCRIPTION
This will enable the Sync Output Repos workflow to run when the tag is pushed.