### PR TITLE
[backport 6.10] Remove tracked-built-ins

### DIFF
--- a/packages/addon-blueprint/index.js
+++ b/packages/addon-blueprint/index.js
@@ -90,10 +90,6 @@ module.exports = {
     // @see https://github.com/emberjs/rfcs/blob/master/text/0811-element-modifiers.md#detailed-design
     delete contents.devDependencies['ember-modifier'];
 
-    // Per RFC #812, addons should not have this dependency.
-    // @see https://github.com/emberjs/rfcs/blob/master/text/0812-tracked-built-ins.md#detailed-design
-    delete contents.devDependencies['tracked-built-ins'];
-
     // 100% of addons don't need ember-cli-app-version, make it opt-in instead
     delete contents.devDependencies['ember-cli-app-version'];
 

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -92,8 +92,7 @@
     "qunit": "^2.25.0",
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
-    "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0<% if (typescript) { %>",
+    "stylelint-config-standard": "^36.0.1<% if (typescript) { %>",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1<% } %>",
     "webpack": "^5.104.1"

--- a/tests/fixtures/app/defaults/package.json
+++ b/tests/fixtures/app/defaults/package.json
@@ -72,7 +72,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/embroider-no-ember-data/package.json
@@ -72,7 +72,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-no-welcome/package.json
+++ b/tests/fixtures/app/embroider-no-welcome/package.json
@@ -72,7 +72,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-pnpm/package.json
+++ b/tests/fixtures/app/embroider-pnpm/package.json
@@ -73,7 +73,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/embroider-yarn/package.json
+++ b/tests/fixtures/app/embroider-yarn/package.json
@@ -73,7 +73,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/embroider/package.json
+++ b/tests/fixtures/app/embroider/package.json
@@ -73,7 +73,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/no-ember-data/package.json
+++ b/tests/fixtures/app/no-ember-data/package.json
@@ -71,7 +71,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/npm/package.json
+++ b/tests/fixtures/app/npm/package.json
@@ -71,7 +71,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/pnpm/package.json
+++ b/tests/fixtures/app/pnpm/package.json
@@ -72,7 +72,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-embroider-no-ember-data/package.json
@@ -79,7 +79,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "webpack": "^5.104.1"

--- a/tests/fixtures/app/typescript-embroider/package.json
+++ b/tests/fixtures/app/typescript-embroider/package.json
@@ -91,7 +91,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "webpack": "^5.104.1"

--- a/tests/fixtures/app/typescript-no-ember-data/package.json
+++ b/tests/fixtures/app/typescript-no-ember-data/package.json
@@ -78,7 +78,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "webpack": "^5.104.1"

--- a/tests/fixtures/app/typescript/package.json
+++ b/tests/fixtures/app/typescript/package.json
@@ -90,7 +90,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "webpack": "^5.104.1"

--- a/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
+++ b/tests/fixtures/app/with-blueprint-override-lint-fail/package.json
@@ -66,8 +66,7 @@
     "qunit-dom": "^1.6.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard": "^36.0.1",
-    "stylelint-prettier": "^5.0.2",
-    "tracked-built-ins": "^3.1.0"
+    "stylelint-prettier": "^5.0.2"
   },
   "engines": {
     "node": ">= 20.19"

--- a/tests/fixtures/app/yarn/package.json
+++ b/tests/fixtures/app/yarn/package.json
@@ -72,7 +72,6 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
-    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.104.1"
   },
   "engines": {


### PR DESCRIPTION
This is a backport of https://github.com/ember-cli/ember-cli/pull/10932 which is part of a fix for the `use-ember-modules` deprecation

This was a clean cherry-pick, I had to make no changes 👍 