### PR TITLE
[backport 6.10] Add use-ember-modules: true to blueprint optional-features.json

### DIFF
--- a/packages/addon-blueprint/files/config/optional-features.json
+++ b/packages/addon-blueprint/files/config/optional-features.json
@@ -2,5 +2,6 @@
   "application-template-wrapper": false,
   "default-async-observers": true,
   "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "template-only-glimmer-components": true,
+  "use-ember-modules": true
 }

--- a/packages/app-blueprint/files/config/optional-features.json
+++ b/packages/app-blueprint/files/config/optional-features.json
@@ -3,5 +3,6 @@
   "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true,
-  "no-implicit-route-model": true
+  "no-implicit-route-model": true,
+  "use-ember-modules": true
 }


### PR DESCRIPTION
This is backporting https://github.com/ember-cli/ember-cli/pull/10976 which is part of a fix for the `use-ember-modules` deprecation

This was a clean cherry-pick, I had to make no changes 👍 