### PR TITLE
Revert "Prepare v6.10.x Release  using 'release-plan'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,5 @@
 # ember-cli Changelog
 
-## Release (2026-04-03)
-
-* ember-cli 6.10.3 (patch)
-* @ember-tooling/classic-build-addon-blueprint 6.10.1 (patch)
-* @ember-tooling/classic-build-app-blueprint 6.10.1 (patch)
-
-#### :bug: Bug Fix
-* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
-  * [#10986](https://github.com/ember-cli/ember-cli/pull/10986) [backport 6.10] Add use-ember-modules: true to blueprint optional-features.json ([@mansona](https://github.com/mansona))
-* `@ember-tooling/classic-build-app-blueprint`, `ember-cli`
-  * [#10985](https://github.com/ember-cli/ember-cli/pull/10985) [backport 6.10] Update ember-cli-htmlbars to ^7.0.0 in blueprints ([@mansona](https://github.com/mansona))
-* `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `ember-cli`
-  * [#10984](https://github.com/ember-cli/ember-cli/pull/10984) [backport 6.10] Remove tracked-built-ins ([@mansona](https://github.com/mansona))
-
-#### :house: Internal
-* `ember-cli`
-  * [#10981](https://github.com/ember-cli/ember-cli/pull/10981) Update publish.yml to use RELEASE_PLAN_GH_PAT ([@kategengler](https://github.com/kategengler))
-  * [#10979](https://github.com/ember-cli/ember-cli/pull/10979) enable releasing packports to 6.10 ([@mansona](https://github.com/mansona))
-
-#### Committers: 2
-- Chris Manson ([@mansona](https://github.com/mansona))
-- Katie Gengler ([@kategengler](https://github.com/kategengler))
-
 ## Release (2026-02-09)
 
 * ember-cli 6.10.2 (patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "6.10.3",
+  "version": "6.10.2",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "6.10.1",
+  "version": "6.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -60,7 +60,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.12.0",
-    "ember-cli": "~6.10.3",
+    "ember-cli": "~6.10.2",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "6.10.1",
+  "version": "6.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This reverts commit 71d931b36751a37647820571bbd1d857b4502daa.

There is an npm bug that is preventing us from doing a release 🫠 I'm reverting the last release to fix it on this brancy before attempting to release again

https://github.com/npm/cli/issues/9151