### PR TITLE
bump node on publish.yml and stop updating npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
         # pass --github-prerelease when we are only branch other than release


### PR DESCRIPTION
As far as I can tell node 24 has a new enough npm to support OIDC so we don't need to worry about updating npm. 

This sidesteps the problem we're seeing with https://github.com/npm/cli/issues/9151