### PR TITLE
bump node on publish.yml and stop updating npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,10 +32,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
         # pass --github-prerelease when we are only branch other than release


### PR DESCRIPTION
This is forward-porting https://github.com/ember-cli/ember-cli/pull/10989 so that it can make it to all the other branches during the normal release workflow 👍 