### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,42 +2,28 @@
   "solution": {
     "ember-cli": {
       "impact": "minor",
-      "oldVersion": "7.1.0-alpha.0",
-      "newVersion": "7.1.0-alpha.1",
+      "oldVersion": "7.1.0-alpha.1",
+      "newVersion": "7.1.0-alpha.2",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-addon-blueprint"
-        },
-        {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/classic-build-app-blueprint"
+        },
+        {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
         }
       ],
       "pkgJSONPath": "./package.json"
     },
     "@ember-tooling/classic-build-addon-blueprint": {
-      "impact": "minor",
-      "oldVersion": "7.1.0-alpha.0",
-      "newVersion": "7.1.0-alpha.1",
-      "tagName": "alpha",
-      "constraints": [
-        {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
-        }
-      ],
-      "pkgJSONPath": "./packages/addon-blueprint/package.json"
+      "oldVersion": "7.1.0-alpha.1"
     },
     "@ember-tooling/classic-build-app-blueprint": {
       "impact": "minor",
-      "oldVersion": "7.1.0-alpha.0",
-      "newVersion": "7.1.0-alpha.1",
+      "oldVersion": "7.1.0-alpha.1",
+      "newVersion": "7.1.0-alpha.2",
       "tagName": "alpha",
       "constraints": [
         {
@@ -54,5 +40,5 @@
       "oldVersion": "0.6.2"
     }
   },
-  "description": "## Release (2026-04-24)\n\n* ember-cli 7.1.0-alpha.1 (minor)\n* @ember-tooling/classic-build-addon-blueprint 7.1.0-alpha.1 (minor)\n* @ember-tooling/classic-build-app-blueprint 7.1.0-alpha.1 (minor)\n\n#### :rocket: Enhancement\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#11001](https://github.com/ember-cli/ember-cli/pull/11001) Prepare 7.1 Alpha ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
+  "description": "## Release (2026-04-26)\n\n* ember-cli 7.1.0-alpha.2 (minor)\n* @ember-tooling/classic-build-app-blueprint 7.1.0-alpha.2 (minor)\n\n#### :rocket: Enhancement\n* `@ember-tooling/classic-build-app-blueprint`, `ember-cli`\n  * [#11006](https://github.com/ember-cli/ember-cli/pull/11006) update ember-welcome-page to v8 in app blueprint ([@mansona](https://github.com/mansona))\n  * [#11005](https://github.com/ember-cli/ember-cli/pull/11005) update ember-cli-deprecation-workflow to v4 ([@mansona](https://github.com/mansona))\n  * [#11003](https://github.com/ember-cli/ember-cli/pull/11003) update @ember/optional-features to v3 ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ember-cli Changelog
 
+## Release (2026-04-26)
+
+* ember-cli 7.1.0-alpha.2 (minor)
+* @ember-tooling/classic-build-app-blueprint 7.1.0-alpha.2 (minor)
+
+#### :rocket: Enhancement
+* `@ember-tooling/classic-build-app-blueprint`, `ember-cli`
+  * [#11006](https://github.com/ember-cli/ember-cli/pull/11006) update ember-welcome-page to v8 in app blueprint ([@mansona](https://github.com/mansona))
+  * [#11005](https://github.com/ember-cli/ember-cli/pull/11005) update ember-cli-deprecation-workflow to v4 ([@mansona](https://github.com/mansona))
+  * [#11003](https://github.com/ember-cli/ember-cli/pull/11003) update @ember/optional-features to v3 ([@mansona](https://github.com/mansona))
+
+#### Committers: 1
+- Chris Manson ([@mansona](https://github.com/mansona))
+
 ## Release (2026-04-24)
 
 * ember-cli 7.1.0-alpha.1 (minor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "7.1.0-alpha.1",
+  "version": "7.1.0-alpha.2",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -63,7 +63,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.13.1",
-    "ember-cli": "~7.1.0-alpha.1",
+    "ember-cli": "~7.1.0-alpha.2",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.3.1",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "7.1.0-alpha.1",
+  "version": "7.1.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2026-04-26)

* ember-cli 7.1.0-alpha.2 (minor)
* @ember-tooling/classic-build-app-blueprint 7.1.0-alpha.2 (minor)

#### :rocket: Enhancement
* `@ember-tooling/classic-build-app-blueprint`, `ember-cli`
  * [#11006](https://github.com/ember-cli/ember-cli/pull/11006) update ember-welcome-page to v8 in app blueprint ([@mansona](https://github.com/mansona))
  * [#11005](https://github.com/ember-cli/ember-cli/pull/11005) update ember-cli-deprecation-workflow to v4 ([@mansona](https://github.com/mansona))
  * [#11003](https://github.com/ember-cli/ember-cli/pull/11003) update @ember/optional-features to v3 ([@mansona](https://github.com/mansona))

#### Committers: 1
- Chris Manson ([@mansona](https://github.com/mansona))