### PR TITLE
[ENHANCEMENT] Warn when ember destroy finds no files to remove

### DIFF
--- a/lib/models/blueprint.js
+++ b/lib/models/blueprint.js
@@ -961,7 +961,18 @@ let Blueprint = CoreObject.extend({
       return acc;
     }, []);
 
-    return finishProcessingForUninstall(fileInfos);
+    let validInfos = finishProcessingForUninstall(fileInfos);
+
+    if (fileInfos.length > 0 && validInfos.length === 0) {
+      this.ui.writeLine(
+        chalk.yellow(
+          `No files found to remove for blueprint \`${this.name}\` and entity \`${templateVariables.dasherizedModuleName}\`. ` +
+            `Verify that the blueprint name and the entity name are correct.`
+        )
+      );
+    }
+
+    return validInfos;
   },
 
   /**

--- a/tests/acceptance/destroy-test.js
+++ b/tests/acceptance/destroy-test.js
@@ -188,4 +188,15 @@ describe('Acceptance: ember destroy', function () {
 
     expect(file('server/index.js')).to.exist;
   });
+
+  it('warns when no matching files exist to remove', async function () {
+    await initApp();
+
+    let result = await destroy(['blueprint', 'does-not-exist']);
+    let output = result.outputStream.join('\n');
+
+    expect(output).to.include('No files found to remove');
+    expect(output).to.include('blueprint');
+    expect(output).to.include('does-not-exist');
+  });
 });


### PR DESCRIPTION
Closes #8499.

## Why

`ember destroy` previously gave no feedback when it failed to remove files because the blueprint or entity didn't match anything on disk. The CLI would print "uninstalling <name>" and other progress lines as if everything succeeded, leaving users wondering whether the command actually worked.

## What changed

`processFilesForUninstall` now emits a yellow warning when the blueprint has files defined but none of them exist on disk. The warning names the blueprint and entity so users can see exactly what didn't match.

## Why per-blueprint instead of per-file

The TypeScript-undecided code path in `processFilesForUninstall` pushes both the `.ts` and `.js` variants of each expected output into the candidate list, since only one of them will actually exist on disk. A per-file "not-found" warning would always print a false positive for whichever variant didn't match. Aggregating to "did this blueprint find anything to remove?" sidesteps that cleanly without needing TS-pair tracking.

## Test plan

- [x] New acceptance test in `tests/acceptance/destroy-test.js` covers `ember destroy blueprint does-not-exist` against a fresh app and asserts the warning lands in the output.
- [x] Existing `Acceptance: ember destroy` suite still passes.