### PR TITLE
update nopt to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "markdown-it-terminal": "^0.4.0",
     "minimatch": "^10.1.1",
     "morgan": "^1.10.1",
-    "nopt": "^3.0.6",
+    "nopt": "^9.0.0",
     "npm-package-arg": "^13.0.2",
     "os-locale": "^6.0.2",
     "p-defer": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: ^1.10.1
         version: 1.10.1
       nopt:
-        specifier: ^3.0.6
-        version: 3.0.6
+        specifier: ^9.0.0
+        version: 9.0.0
       npm-package-arg:
         specifier: ^13.0.2
         version: 13.0.2
@@ -981,8 +981,9 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3900,8 +3901,9 @@ packages:
     deprecated: Use uuid module instead
     hasBin: true
 
-  nopt@3.0.6:
-    resolution: {integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-path@2.1.1:
@@ -6148,7 +6150,7 @@ snapshots:
 
   abab@2.0.6: {}
 
-  abbrev@1.1.1: {}
+  abbrev@4.0.0: {}
 
   accepts@1.3.8:
     dependencies:
@@ -9541,9 +9543,9 @@ snapshots:
 
   node-uuid@1.4.8: {}
 
-  nopt@3.0.6:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 4.0.0
 
   normalize-path@2.1.1:
     dependencies:


### PR DESCRIPTION
I have been updating dependencies recently to see which ones will be easy to change. It looks like this one had a change in behaviour so it's not an easy upgrade. 

I don't have the time to be looking at this right now so if anyone wants to take over and take a look please feel free 👍 