### PR TITLE
Fix string option parsing with nopt v9

### DIFF
--- a/lib/models/command.js
+++ b/lib/models/command.js
@@ -569,17 +569,80 @@ let Command = CoreObject.extend({
       }
     };
 
+    let stringOptions = new Set();
+
     this.availableOptions.forEach((option) => {
-      if (typeof option.type !== 'string') {
-        knownOpts[option.name] = option.type;
-      } else if (option.type === 'Path') {
+      let type = option.type;
+
+      if (typeof type !== 'string' && type !== undefined) {
+        knownOpts[option.name] = type;
+      } else if (type === 'Path') {
         knownOpts[option.name] = path;
+      } else if (typeof type === 'string' && type.toLowerCase() === 'boolean') {
+        knownOpts[option.name] = Boolean;
       } else {
-        knownOpts[option.name] = String;
+        knownOpts[option.name] = [String, null];
+      }
+
+      if (
+        knownOpts[option.name] === String ||
+        (Array.isArray(knownOpts[option.name]) &&
+          knownOpts[option.name].includes(String))
+      ) {
+        stringOptions.add(`--${option.name}`);
       }
     });
 
-    parsedOptions = nopt(knownOpts, this.optionsAliases, commandArgs, 0);
+    if (this.optionsAliases) {
+      for (let key of Object.keys(this.optionsAliases)) {
+        let value = this.optionsAliases[key];
+
+        if (stringOptions.has(value[0]) && value.length === 1) {
+          stringOptions.add(`-${key}`);
+          stringOptions.add(`--${key}`);
+        }
+      }
+    }
+
+    const MASK = '__EMBER_STRING_OPTION__';
+
+    let maskedArgs = commandArgs.slice(0);
+
+    for (let i = 0; i < maskedArgs.length; i++) {
+      let arg = maskedArgs[i];
+
+      if (stringOptions.has(arg) && i + 1 < maskedArgs.length) {
+        if (
+          typeof maskedArgs[i + 1] === 'string' &&
+          maskedArgs[i + 1].startsWith('--')
+        ) {
+          maskedArgs[i + 1] = `${MASK}${maskedArgs[i + 1]}`;
+        }
+      } else if (typeof arg === 'string' && arg.includes('=')) {
+        let parts = arg.split('=');
+        let option = parts[0];
+        let value = parts.slice(1).join('=');
+
+        if (stringOptions.has(option) && value.startsWith('--')) {
+          maskedArgs[i] = `${option}=${MASK}${value}`;
+        }
+      }
+    }
+
+    parsedOptions = nopt(knownOpts, this.optionsAliases, maskedArgs, 0);
+
+    let unmask = (value) =>
+      typeof value === 'string' && value.startsWith(MASK)
+        ? value.replace(MASK, '')
+        : value;
+
+    for (let key of Object.keys(parsedOptions)) {
+      if (key !== 'argv') {
+        parsedOptions[key] = unmask(parsedOptions[key]);
+      }
+    }
+
+    parsedOptions.argv.remain = parsedOptions.argv.remain.map(unmask);
 
     if (!this.availableOptions.every(assembleAndValidateOption.bind(this))) {
       return null;


### PR DESCRIPTION
I investigated the `nopt@9` regression and narrowed the issue down to parsing string option values that begin with `--`.

`nopt@9` interprets those values as additional flags instead of string values, which breaks cases like:

`--options "--split 2 --random"`

The fix adds a small compatibility layer in `parseArgs()` that temporarily masks string option values beginning with `--` during parsing and restores them afterward.

Verified locally with:

* `tests/unit/models/command-test.js`
* relevant acceptance tests (`ember new uses yarn when blueprint has yarn.lock`)

Current local result:

* 173 passing
* 0 failing
