### PR TITLE
Update diff to latest v8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "content-tag": "^4.0.0",
     "core-object": "^3.1.5",
     "dag-map": "^2.0.2",
-    "diff": "^8.0.2",
+    "diff": "^8.0.4",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^5.0.1",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^5.6.2",
-    "diff": "^7.0.0",
+    "diff": "^8.0.4",
     "isbinaryfile": "^5.0.7",
     "lodash": "^4.17.23",
     "promise.hash.helper": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       diff:
-        specifier: ^8.0.2
-        version: 8.0.2
+        specifier: ^8.0.4
+        version: 8.0.4
       ember-cli-is-package-missing:
         specifier: ^1.0.0
         version: 1.0.0
@@ -411,8 +411,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       diff:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^8.0.4
+        version: 8.0.4
       isbinaryfile:
         specifier: ^5.0.7
         version: 5.0.7
@@ -2144,8 +2144,8 @@ packages:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
-  diff@8.0.2:
-    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   doctrine@3.0.0:
@@ -7479,7 +7479,7 @@ snapshots:
 
   diff@7.0.0: {}
 
-  diff@8.0.2: {}
+  diff@8.0.4: {}
 
   doctrine@3.0.0:
     dependencies:


### PR DESCRIPTION
This PR is fixing a low security issue in `@ember-tooling/blueprint-model` package (see https://github.com/advisories/GHSA-73rr-hh4g-fpgx)

The latest version of diff is v9, but it doesn't support anymore ES5... not sure if we can upgrade already to v9, but updating to latest v8 helps already to remove this security issue.

v8.x was already installed in `ember-cli` package, but i think there is no usage in `ember-cli` package (only in blueprint-model package there is use).

<img width="358" height="435" alt="grafik" src="https://github.com/user-attachments/assets/86f751c2-16f7-49c6-ab34-bad66891a249" />

Let me know, if you want remove this i `ember-cli`