### PR TITLE
chore: upgrade nopt to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "markdown-it-terminal": "^0.4.0",
     "minimatch": "^10.1.1",
     "morgan": "^1.10.1",
-    "nopt": "^3.0.6",
+    "nopt": "^9.0.0",
     "npm-package-arg": "^13.0.2",
     "os-locale": "^6.0.2",
     "p-defer": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: ^1.10.1
         version: 1.10.1
       nopt:
-        specifier: ^3.0.6
-        version: 3.0.6
+        specifier: ^9.0.0
+        version: 9.0.0
       npm-package-arg:
         specifier: ^13.0.2
         version: 13.0.2
@@ -1050,6 +1050,7 @@ packages:
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -1060,8 +1061,9 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3983,8 +3985,9 @@ packages:
     deprecated: Use uuid module instead
     hasBin: true
 
-  nopt@3.0.6:
-    resolution: {integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-path@2.1.1:
@@ -6354,7 +6357,7 @@ snapshots:
 
   abab@2.0.6: {}
 
-  abbrev@1.1.1: {}
+  abbrev@4.0.0: {}
 
   accepts@1.3.8:
     dependencies:
@@ -9750,9 +9753,9 @@ snapshots:
 
   node-uuid@1.4.8: {}
 
-  nopt@3.0.6:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 4.0.0
 
   normalize-path@2.1.1:
     dependencies:

--- a/tests/unit/models/command-test.js
+++ b/tests/unit/models/command-test.js
@@ -182,8 +182,8 @@ describe('models/command.js', function () {
         return options;
       },
     });
-    const command = new CustomAliasCommand(options).parseArgs(['1', '--options', '--split 2 --random']);
-    expect(command).to.have.nested.property('options.options', '--split 2 --random');
+    const command = new CustomAliasCommand(options).parseArgs(['1', '--options', 'split-2-random']);
+expect(command).to.have.nested.property('options.options', 'split-2-random');
   });
 
   describe('#validateAndRun', function () {


### PR DESCRIPTION
### Description
This PR upgrades the nopt dependency from v3.0.6 directly to v9.0.0.

### Context & Motivation
Upgrading nopt has previously been a challenge due to a breaking change introduced in nopt v8 regarding how strings starting with dashes (e.g., --options "--split 2") are parsed. Previous attempts to fix this involved complex "masking" logic to preserve legacy behavior.

However, modern nopt versions have moved toward stricter, more standard CLI parsing for better predictability. This PR takes a "surgical" approach: instead of adding complexity to the source code, it updates the test suite to use standard string formats. This allows us to benefit from the latest nopt features and security updates while keeping the ember-cli codebase clean.

### Changes
- Dependency Update: Upgraded nopt to ^9.0.0 in package.json.

- Test Refactor: Updated tests/unit/models/command-test.js to use a standard string ('split-2-random') for the parseArgs string-parsing test.

- Lockfile: Updated pnpm-lock.yaml to reflect the new dependency tree.

### Verification Results
I have verified this change against the core unit test suites on a Windows environment:

- **tests/unit/models/command-test.js**: 43 passing
- **tests/unit/cli/cli-test.js**: 84 passing

<details>
<summary><b>View Test Verification Screenshots</b></summary>

### Command Model Tests (43 Passing)
<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/c5ac927d-715d-40fe-94ae-76dd1f44b899" />


### CLI Unit Tests (84 Passing)
<img width="1919" height="1017" alt="image" src="https://github.com/user-attachments/assets/78d50a83-d3c6-4253-9c89-c972f858e231" />
<img width="1919" height="1002" alt="image" src="https://github.com/user-attachments/assets/3db9ec30-b448-4c8e-876c-4e739ccf7809" />


</details>

### Related Issues
- Alternative to #11012 and #10907.
- This PR follows the suggestion by @mansona and @bertdeblock to avoid "overkill" masking logic and instead addresses the outdated test case that was blocking the upgrade.