### PR TITLE
Fix error when blueprint is missing keyword

### DIFF
--- a/lib/tasks/install-blueprint.js
+++ b/lib/tasks/install-blueprint.js
@@ -186,7 +186,9 @@ class InstallBlueprintTask extends Task {
     logger.info(`Checking for "ember-blueprint" keyword in "${packageName}" module ...`);
     let pkg = require(this._resolvePackageJSON(modulePath));
     if (!pkg || !pkg.keywords || pkg.keywords.indexOf('ember-blueprint') === -1) {
-      throw new SilentError(`The package '${packageName}' is not a valid Ember CLI blueprint.`);
+      throw new SilentError(
+        `The package '${packageName}' is not a valid Ember CLI blueprint. The package.json keywords list must include "ember-blueprint".`
+      );
     }
   }
 


### PR DESCRIPTION
If an error can provide actionable context, it should