### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,21 +2,13 @@
   "solution": {
     "ember-cli": {
       "impact": "minor",
-      "oldVersion": "7.1.0-alpha.2",
-      "newVersion": "7.1.0-alpha.3",
+      "oldVersion": "7.2.0-alpha.0",
+      "newVersion": "7.2.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
           "impact": "minor",
           "reason": "Appears in changelog section :rocket: Enhancement"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         },
         {
           "impact": "patch",
@@ -28,33 +20,57 @@
         },
         {
           "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        },
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :bug: Bug Fix"
+        },
+        {
+          "impact": "patch",
           "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./package.json"
     },
     "@ember-tooling/classic-build-addon-blueprint": {
-      "impact": "patch",
-      "oldVersion": "7.1.0-alpha.1",
-      "newVersion": "7.1.0-alpha.2",
+      "impact": "minor",
+      "oldVersion": "7.2.0-alpha.0",
+      "newVersion": "7.2.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        },
+        {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        },
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
-      "impact": "patch",
-      "oldVersion": "7.1.0-alpha.2",
-      "newVersion": "7.1.0-alpha.3",
+      "impact": "minor",
+      "oldVersion": "7.2.0-alpha.0",
+      "newVersion": "7.2.0-alpha.1",
       "tagName": "alpha",
       "constraints": [
         {
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
+        },
+        {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
+        },
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/app-blueprint/package.json"
@@ -63,18 +79,18 @@
       "oldVersion": "0.3.0"
     },
     "@ember-tooling/blueprint-model": {
-      "impact": "patch",
-      "oldVersion": "0.6.2",
-      "newVersion": "0.6.3",
+      "impact": "minor",
+      "oldVersion": "0.6.3",
+      "newVersion": "0.7.0",
       "tagName": "latest",
       "constraints": [
         {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
+          "impact": "minor",
+          "reason": "Appears in changelog section :rocket: Enhancement"
         }
       ],
       "pkgJSONPath": "./packages/blueprint-model/package.json"
     }
   },
-  "description": "## Release (2026-05-13)\n\n* ember-cli 7.1.0-alpha.3 (minor)\n* @ember-tooling/classic-build-addon-blueprint 7.1.0-alpha.2 (patch)\n* @ember-tooling/classic-build-app-blueprint 7.1.0-alpha.3 (patch)\n* @ember-tooling/blueprint-model 0.6.3 (patch)\n\n#### :rocket: Enhancement\n* `ember-cli`\n  * [#10610](https://github.com/ember-cli/ember-cli/pull/10610) use semver-deprecate instead of internal code ([@mansona](https://github.com/mansona))\n  * [#11008](https://github.com/ember-cli/ember-cli/pull/11008) update babel-remove-types to v2 ([@mansona](https://github.com/mansona))\n  * [#11009](https://github.com/ember-cli/ember-cli/pull/11009) update configstore to v8 ([@mansona](https://github.com/mansona))\n\n#### :bug: Bug Fix\n* `ember-cli`, `@ember-tooling/blueprint-model`\n  * [#11020](https://github.com/ember-cli/ember-cli/pull/11020) Update diff to latest v8.x ([@mkszepp](https://github.com/mkszepp))\n\n#### :house: Internal\n* `ember-cli`\n  * [#11017](https://github.com/ember-cli/ember-cli/pull/11017) Add Sync Output Repos check to release instructions ([@kategengler](https://github.com/kategengler))\n  * [#11016](https://github.com/ember-cli/ember-cli/pull/11016) fix: sync-output-repos workflow failing on tag pushes ([@Copilot](https://github.com/apps/copilot-swe-agent))\n  * [#10999](https://github.com/ember-cli/ember-cli/pull/10999) update RELEASE with update-blueprint-deps commands ([@mansona](https://github.com/mansona))\n\n#### Committers: 4\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Copilot [Bot] ([@copilot-swe-agent](https://github.com/apps/copilot-swe-agent))\n- Katie Gengler ([@kategengler](https://github.com/kategengler))\n- Markus Sanin ([@mkszepp](https://github.com/mkszepp))\n"
+  "description": "## Release (2026-06-30)\n\n* ember-cli 7.2.0-alpha.1 (minor)\n* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.1 (minor)\n* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.1 (minor)\n* @ember-tooling/blueprint-model 0.7.0 (minor)\n\n#### :rocket: Enhancement\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`\n  * [#11032](https://github.com/ember-cli/ember-cli/pull/11032) Prepare 7.2 alpha ([@mansona](https://github.com/mansona))\n* `@ember-tooling/classic-build-addon-blueprint`\n  * [#11035](https://github.com/ember-cli/ember-cli/pull/11035) Add placeholder for documenting exports from an addon ([@kategengler](https://github.com/kategengler))\n* `ember-cli`, `@ember-tooling/blueprint-model`\n  * [#10672](https://github.com/ember-cli/ember-cli/pull/10672) Separate blueprint model so it can be used outside of ember-cli ([@mansona](https://github.com/mansona))\n\n#### :bug: Bug Fix\n* `ember-cli`\n  * [#11027](https://github.com/ember-cli/ember-cli/pull/11027) Fix error when blueprint is missing keyword ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n  * [#11028](https://github.com/ember-cli/ember-cli/pull/11028) [BUGFIX release] fix require(esm) of blueprint indexes ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :house: Internal\n* `ember-cli`\n  * [#11037](https://github.com/ember-cli/ember-cli/pull/11037) bring test fixtures in line with updates from addon readme ([@void-mAlex](https://github.com/void-mAlex))\n  * [#11038](https://github.com/ember-cli/ember-cli/pull/11038) fix running tests on blueprint markdown changes ([@mansona](https://github.com/mansona))\n  * [#10880](https://github.com/ember-cli/ember-cli/pull/10880) stop using internal package cache in the addon smoke test and rely on pnpm caching ([@mansona](https://github.com/mansona))\n  * [#11033](https://github.com/ember-cli/ember-cli/pull/11033) Merge release into beta ([@mansona](https://github.com/mansona))\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#11029](https://github.com/ember-cli/ember-cli/pull/11029) Prepare Beta Release ([@mansona](https://github.com/mansona))\n\n#### Committers: 4\n- Alex ([@void-mAlex](https://github.com/void-mAlex))\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Katie Gengler ([@kategengler](https://github.com/kategengler))\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # ember-cli Changelog
 
+## Release (2026-06-30)
+
+* ember-cli 7.2.0-alpha.1 (minor)
+* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.1 (minor)
+* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.1 (minor)
+* @ember-tooling/blueprint-model 0.7.0 (minor)
+
+#### :rocket: Enhancement
+* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`
+  * [#11032](https://github.com/ember-cli/ember-cli/pull/11032) Prepare 7.2 alpha ([@mansona](https://github.com/mansona))
+* `@ember-tooling/classic-build-addon-blueprint`
+  * [#11035](https://github.com/ember-cli/ember-cli/pull/11035) Add placeholder for documenting exports from an addon ([@kategengler](https://github.com/kategengler))
+* `ember-cli`, `@ember-tooling/blueprint-model`
+  * [#10672](https://github.com/ember-cli/ember-cli/pull/10672) Separate blueprint model so it can be used outside of ember-cli ([@mansona](https://github.com/mansona))
+
+#### :bug: Bug Fix
+* `ember-cli`
+  * [#11027](https://github.com/ember-cli/ember-cli/pull/11027) Fix error when blueprint is missing keyword ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+  * [#11028](https://github.com/ember-cli/ember-cli/pull/11028) [BUGFIX release] fix require(esm) of blueprint indexes ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+
+#### :house: Internal
+* `ember-cli`
+  * [#11037](https://github.com/ember-cli/ember-cli/pull/11037) bring test fixtures in line with updates from addon readme ([@void-mAlex](https://github.com/void-mAlex))
+  * [#11038](https://github.com/ember-cli/ember-cli/pull/11038) fix running tests on blueprint markdown changes ([@mansona](https://github.com/mansona))
+  * [#10880](https://github.com/ember-cli/ember-cli/pull/10880) stop using internal package cache in the addon smoke test and rely on pnpm caching ([@mansona](https://github.com/mansona))
+  * [#11033](https://github.com/ember-cli/ember-cli/pull/11033) Merge release into beta ([@mansona](https://github.com/mansona))
+* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
+  * [#11029](https://github.com/ember-cli/ember-cli/pull/11029) Prepare Beta Release ([@mansona](https://github.com/mansona))
+
+#### Committers: 4
+- Alex ([@void-mAlex](https://github.com/void-mAlex))
+- Chris Manson ([@mansona](https://github.com/mansona))
+- Katie Gengler ([@kategengler](https://github.com/kategengler))
+- [@NullVoxPopuli](https://github.com/NullVoxPopuli)
+
 ## Release (2026-05-13)
 
 * ember-cli 7.1.0-alpha.3 (minor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "7.2.0-alpha.0",
+  "version": "7.2.0-alpha.1",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "7.2.0-alpha.0",
+  "version": "7.2.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -63,7 +63,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.13.1",
-    "ember-cli": "~7.2.0-alpha.0",
+    "ember-cli": "~7.2.0-alpha.1",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.3.1",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "7.2.0-alpha.0",
+  "version": "7.2.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/blueprint-model",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2026-06-30)

* ember-cli 7.2.0-alpha.1 (minor)
* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.1 (minor)
* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.1 (minor)
* @ember-tooling/blueprint-model 0.7.0 (minor)

#### :rocket: Enhancement
* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`
  * [#11032](https://github.com/ember-cli/ember-cli/pull/11032) Prepare 7.2 alpha ([@mansona](https://github.com/mansona))
* `@ember-tooling/classic-build-addon-blueprint`
  * [#11035](https://github.com/ember-cli/ember-cli/pull/11035) Add placeholder for documenting exports from an addon ([@kategengler](https://github.com/kategengler))
* `ember-cli`, `@ember-tooling/blueprint-model`
  * [#10672](https://github.com/ember-cli/ember-cli/pull/10672) Separate blueprint model so it can be used outside of ember-cli ([@mansona](https://github.com/mansona))

#### :bug: Bug Fix
* `ember-cli`
  * [#11027](https://github.com/ember-cli/ember-cli/pull/11027) Fix error when blueprint is missing keyword ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
  * [#11028](https://github.com/ember-cli/ember-cli/pull/11028) [BUGFIX release] fix require(esm) of blueprint indexes ([@NullVoxPopuli](https://github.com/NullVoxPopuli))

#### :house: Internal
* `ember-cli`
  * [#11037](https://github.com/ember-cli/ember-cli/pull/11037) bring test fixtures in line with updates from addon readme ([@void-mAlex](https://github.com/void-mAlex))
  * [#11038](https://github.com/ember-cli/ember-cli/pull/11038) fix running tests on blueprint markdown changes ([@mansona](https://github.com/mansona))
  * [#10880](https://github.com/ember-cli/ember-cli/pull/10880) stop using internal package cache in the addon smoke test and rely on pnpm caching ([@mansona](https://github.com/mansona))
  * [#11033](https://github.com/ember-cli/ember-cli/pull/11033) Merge release into beta ([@mansona](https://github.com/mansona))
* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`
  * [#11029](https://github.com/ember-cli/ember-cli/pull/11029) Prepare Beta Release ([@mansona](https://github.com/mansona))

#### Committers: 4
- Alex ([@void-mAlex](https://github.com/void-mAlex))
- Chris Manson ([@mansona](https://github.com/mansona))
- Katie Gengler ([@kategengler](https://github.com/kategengler))
- [@NullVoxPopuli](https://github.com/NullVoxPopuli)