### PR TITLE
blueprints(testem): `--disable-background-networking` for Chrome

### DIFF
--- a/packages/app-blueprint/files/testem.js
+++ b/packages/app-blueprint/files/testem.js
@@ -12,6 +12,7 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        '--disable-background-networking',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
I don't have the exact scientific evidence for why it's needed, but it fixed focus-based tests in my CI yesterday. Hopefully, this change will save someone else's day in the future.

I suspect that in rare scenarios, `--disable-background-networking` might cause focus to be stolen from browser elements or affect timings. Either way, it seems like an undesirable side effect in isolated environments like CI.

This flag is also a default in [Puppeteer](https://github.com/puppeteer/puppeteer/blob/87be90674742650fd0bcb138922ff61d2bf2ca98/packages/puppeteer-core/src/node/ChromeLauncher.ts#L223), [Playwright](https://github.com/microsoft/playwright/blob/3d38b1d3a38ba378f522554b063be070747b5a26/packages/playwright-core/src/server/chromium/chromiumSwitches.ts#L55), and likely others.

I’ve left this as a draft to gather initial feedback. Let me know if I can help move it forward.