### PR TITLE
Prepare Alpha Release

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -1,14 +1,18 @@
 {
   "solution": {
     "ember-cli": {
-      "impact": "minor",
-      "oldVersion": "7.2.0-alpha.0",
-      "newVersion": "7.2.0-alpha.1",
+      "impact": "patch",
+      "oldVersion": "7.2.0-alpha.1",
+      "newVersion": "7.2.0-alpha.2",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
+          "impact": "patch",
+          "reason": "Appears in changelog section :bug: Bug Fix"
+        },
+        {
+          "impact": "patch",
+          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
         },
         {
           "impact": "patch",
@@ -20,57 +24,33 @@
         },
         {
           "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
           "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./package.json"
     },
     "@ember-tooling/classic-build-addon-blueprint": {
-      "impact": "minor",
-      "oldVersion": "7.2.0-alpha.0",
-      "newVersion": "7.2.0-alpha.1",
+      "impact": "patch",
+      "oldVersion": "7.2.0-alpha.1",
+      "newVersion": "7.2.0-alpha.2",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
-        },
-        {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/addon-blueprint/package.json"
     },
     "@ember-tooling/classic-build-app-blueprint": {
-      "impact": "minor",
-      "oldVersion": "7.2.0-alpha.0",
-      "newVersion": "7.2.0-alpha.1",
+      "impact": "patch",
+      "oldVersion": "7.2.0-alpha.1",
+      "newVersion": "7.2.0-alpha.2",
       "tagName": "alpha",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
-        },
-        {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @ember-tooling/blueprint-model"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/app-blueprint/package.json"
@@ -79,18 +59,18 @@
       "oldVersion": "0.3.0"
     },
     "@ember-tooling/blueprint-model": {
-      "impact": "minor",
-      "oldVersion": "0.6.3",
-      "newVersion": "0.7.0",
+      "impact": "patch",
+      "oldVersion": "0.7.0",
+      "newVersion": "0.7.1",
       "tagName": "latest",
       "constraints": [
         {
-          "impact": "minor",
-          "reason": "Appears in changelog section :rocket: Enhancement"
+          "impact": "patch",
+          "reason": "Appears in changelog section :bug: Bug Fix"
         }
       ],
       "pkgJSONPath": "./packages/blueprint-model/package.json"
     }
   },
-  "description": "## Release (2026-06-30)\n\n* ember-cli 7.2.0-alpha.1 (minor)\n* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.1 (minor)\n* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.1 (minor)\n* @ember-tooling/blueprint-model 0.7.0 (minor)\n\n#### :rocket: Enhancement\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`, `@ember-tooling/blueprint-model`\n  * [#11032](https://github.com/ember-cli/ember-cli/pull/11032) Prepare 7.2 alpha ([@mansona](https://github.com/mansona))\n* `@ember-tooling/classic-build-addon-blueprint`\n  * [#11035](https://github.com/ember-cli/ember-cli/pull/11035) Add placeholder for documenting exports from an addon ([@kategengler](https://github.com/kategengler))\n* `ember-cli`, `@ember-tooling/blueprint-model`\n  * [#10672](https://github.com/ember-cli/ember-cli/pull/10672) Separate blueprint model so it can be used outside of ember-cli ([@mansona](https://github.com/mansona))\n\n#### :bug: Bug Fix\n* `ember-cli`\n  * [#11027](https://github.com/ember-cli/ember-cli/pull/11027) Fix error when blueprint is missing keyword ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n  * [#11028](https://github.com/ember-cli/ember-cli/pull/11028) [BUGFIX release] fix require(esm) of blueprint indexes ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :house: Internal\n* `ember-cli`\n  * [#11037](https://github.com/ember-cli/ember-cli/pull/11037) bring test fixtures in line with updates from addon readme ([@void-mAlex](https://github.com/void-mAlex))\n  * [#11038](https://github.com/ember-cli/ember-cli/pull/11038) fix running tests on blueprint markdown changes ([@mansona](https://github.com/mansona))\n  * [#10880](https://github.com/ember-cli/ember-cli/pull/10880) stop using internal package cache in the addon smoke test and rely on pnpm caching ([@mansona](https://github.com/mansona))\n  * [#11033](https://github.com/ember-cli/ember-cli/pull/11033) Merge release into beta ([@mansona](https://github.com/mansona))\n* `ember-cli`, `@ember-tooling/classic-build-addon-blueprint`, `@ember-tooling/classic-build-app-blueprint`\n  * [#11029](https://github.com/ember-cli/ember-cli/pull/11029) Prepare Beta Release ([@mansona](https://github.com/mansona))\n\n#### Committers: 4\n- Alex ([@void-mAlex](https://github.com/void-mAlex))\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Katie Gengler ([@kategengler](https://github.com/kategengler))\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
+  "description": "## Release (2026-08-14)\n\n* ember-cli 7.2.0-alpha.2 (patch)\n* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.2 (patch)\n* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.2 (patch)\n* @ember-tooling/blueprint-model 0.7.1 (patch)\n\n#### :bug: Bug Fix\n* `ember-cli`, `@ember-tooling/blueprint-model`\n  * [#11050](https://github.com/ember-cli/ember-cli/pull/11050) fix default blueprint lookup ([@mansona](https://github.com/mansona))\n\n#### :house: Internal\n* `ember-cli`\n  * [#11051](https://github.com/ember-cli/ember-cli/pull/11051) fix release-plan ([@mansona](https://github.com/mansona))\n  * [#11052](https://github.com/ember-cli/ember-cli/pull/11052) speed up windows CI ([@mansona](https://github.com/mansona))\n  * [#11049](https://github.com/ember-cli/ember-cli/pull/11049) fix help tests to stop relying on private APIs ([@mansona](https://github.com/mansona))\n  * [#11048](https://github.com/ember-cli/ember-cli/pull/11048) update fixturify-project from v2 to v7 ([@mansona](https://github.com/mansona))\n  * [#11044](https://github.com/ember-cli/ember-cli/pull/11044) add a notify discord webhook action for CI ([@mansona](https://github.com/mansona))\n  * [#11023](https://github.com/ember-cli/ember-cli/pull/11023) Update RELEASE.md ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # ember-cli Changelog
 
+## Release (2026-08-14)
+
+* ember-cli 7.2.0-alpha.2 (patch)
+* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.2 (patch)
+* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.2 (patch)
+* @ember-tooling/blueprint-model 0.7.1 (patch)
+
+#### :bug: Bug Fix
+* `ember-cli`, `@ember-tooling/blueprint-model`
+  * [#11050](https://github.com/ember-cli/ember-cli/pull/11050) fix default blueprint lookup ([@mansona](https://github.com/mansona))
+
+#### :house: Internal
+* `ember-cli`
+  * [#11051](https://github.com/ember-cli/ember-cli/pull/11051) fix release-plan ([@mansona](https://github.com/mansona))
+  * [#11052](https://github.com/ember-cli/ember-cli/pull/11052) speed up windows CI ([@mansona](https://github.com/mansona))
+  * [#11049](https://github.com/ember-cli/ember-cli/pull/11049) fix help tests to stop relying on private APIs ([@mansona](https://github.com/mansona))
+  * [#11048](https://github.com/ember-cli/ember-cli/pull/11048) update fixturify-project from v2 to v7 ([@mansona](https://github.com/mansona))
+  * [#11044](https://github.com/ember-cli/ember-cli/pull/11044) add a notify discord webhook action for CI ([@mansona](https://github.com/mansona))
+  * [#11023](https://github.com/ember-cli/ember-cli/pull/11023) Update RELEASE.md ([@mansona](https://github.com/mansona))
+
+#### Committers: 1
+- Chris Manson ([@mansona](https://github.com/mansona))
+
 ## Release (2026-06-30)
 
 * ember-cli 7.2.0-alpha.1 (minor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli",
-  "version": "7.2.0-alpha.1",
+  "version": "7.2.0-alpha.2",
   "description": "Command line tool for developing ambitious ember.js apps",
   "keywords": [
     "app",

--- a/packages/addon-blueprint/package.json
+++ b/packages/addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-addon-blueprint",
-  "version": "7.2.0-alpha.1",
+  "version": "7.2.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/app-blueprint/files/package.json
+++ b/packages/app-blueprint/files/package.json
@@ -63,7 +63,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-auto-import": "^2.13.1",
-    "ember-cli": "~7.2.0-alpha.1",
+    "ember-cli": "~7.2.0-alpha.2",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.3.1",
     "ember-cli-clean-css": "^3.0.0",

--- a/packages/app-blueprint/package.json
+++ b/packages/app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/classic-build-app-blueprint",
-  "version": "7.2.0-alpha.1",
+  "version": "7.2.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/packages/blueprint-model/package.json
+++ b/packages/blueprint-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-tooling/blueprint-model",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ember-cli/ember-cli.git",

--- a/release-plan-stderr.txt
+++ b/release-plan-stderr.txt
@@ -1,0 +1,7 @@
+# Unlabeled Changes
+
+* `ember-cli`
+  * [#11044](https://github.com/ember-cli/ember-cli/pull/11044) add a notify discord webhook action for CI ([@mansona](https://github.com/mansona))
+
+
+*Cannot plan release until the above changes are labeled*.


### PR DESCRIPTION
This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍

-----------------------------------------

## Release (2026-08-14)

* ember-cli 7.2.0-alpha.2 (patch)
* @ember-tooling/classic-build-addon-blueprint 7.2.0-alpha.2 (patch)
* @ember-tooling/classic-build-app-blueprint 7.2.0-alpha.2 (patch)
* @ember-tooling/blueprint-model 0.7.1 (patch)

#### :bug: Bug Fix
* `ember-cli`, `@ember-tooling/blueprint-model`
  * [#11050](https://github.com/ember-cli/ember-cli/pull/11050) fix default blueprint lookup ([@mansona](https://github.com/mansona))

#### :house: Internal
* `ember-cli`
  * [#11051](https://github.com/ember-cli/ember-cli/pull/11051) fix release-plan ([@mansona](https://github.com/mansona))
  * [#11052](https://github.com/ember-cli/ember-cli/pull/11052) speed up windows CI ([@mansona](https://github.com/mansona))
  * [#11049](https://github.com/ember-cli/ember-cli/pull/11049) fix help tests to stop relying on private APIs ([@mansona](https://github.com/mansona))
  * [#11048](https://github.com/ember-cli/ember-cli/pull/11048) update fixturify-project from v2 to v7 ([@mansona](https://github.com/mansona))
  * [#11044](https://github.com/ember-cli/ember-cli/pull/11044) add a notify discord webhook action for CI ([@mansona](https://github.com/mansona))
  * [#11023](https://github.com/ember-cli/ember-cli/pull/11023) Update RELEASE.md ([@mansona](https://github.com/mansona))

#### Committers: 1
- Chris Manson ([@mansona](https://github.com/mansona))