### PR TITLE
Update fixturify-project to ^7.1.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,6 +52,7 @@ You can use [this saved search](https://github.com/ember-cli/ember-cli/pulls?q=i
   pnpm dlx update-blueprint-deps --filter '@ember-tooling/.*' --tag latest ./package.json ./packages/*-blueprint/**/*ackage.json
   pnpm dlx update-blueprint-deps --filter '.*' ./package.json ./packages/*-blueprint/**/*ackage.json ./tests/fixtures/*/package.json ./tests/fixtures/*/*/package.json
   ```
+
 - run `pnpm install` to update your pacakge.lock and download any new dependencies
 - run `pnpm lint:fix`
 - update the @ember/app-blueprint dependency `pnpm i -w @ember/app-blueprint@latest`

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-n": "^17.24.0",
     "fixturify": "^3.0.0",
-    "fixturify-project": "^2.1.1",
+    "fixturify-project": "^7.1.3",
     "jsdom": "^21.1.2",
     "latest-version": "^9.0.0",
     "mocha": "^11.7.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       fixturify-project:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^7.1.3
+        version: 7.1.3
       jsdom:
         specifier: ^21.1.2
         version: 21.1.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -664,6 +664,10 @@ packages:
   '@ember/app-blueprint@7.2.0-alpha.1':
     resolution: {integrity: sha512-nF/4LKTl5t6rmdyJ4hQKBSbZU2AMnlNUowYuSDay+fw19EUsAqUxdclrIZX6TjvhTXZICHULwornpdbpFCXN2A==}
 
+  '@embroider/shared-internals@2.9.2':
+    resolution: {integrity: sha512-d96ub/WkS1Gx6dRDxZ0mCRPwFAHIMlMr2iti6uTYxTFzC85Wgt6j7bYr6ppkEuwEwKQVyzKRT0kTsJz6P74caQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -684,6 +688,10 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@gwhitney/detect-indent@7.0.1':
+    resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
+    engines: {node: '>=12.20'}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -997,29 +1005,200 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pnpm/cli-meta@6.0.1':
+    resolution: {integrity: sha512-r1mAyn8wCD5Ow89sF/5IfdwaXyzWI0bI2SVHA8/dR/+ykylCA7L05PKkvV6LSEQ28eKEawNq/0OwnxRSjVx9BQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/cli-utils@3.1.1':
+    resolution: {integrity: sha512-IDUGWShAOCBl71lXx7/o3t1/iC7n71hQdIMnT5ql0blXWYJl6UHzrqIhjyxcNC7fLJtzS2JAhV5aVlazjy339w==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
+
+  '@pnpm/config.env-replace@3.0.0':
+    resolution: {integrity: sha512-tV71wOtu8ULW4Fv5c7MWph3Sfle1wkT2q83qF2Cx/0J5E2dpUsClO9evAouL4fbdmPonkXJbRYL5cGHKuqxr4w==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/config@21.4.0':
+    resolution: {integrity: sha512-SrER4w4eICWd/LdjRkLjleu0aeMVo1exB2AOl5XcFS5yTxWwnkWNGq9ngL8+q7RS/HJA0+A8FJnZkatW2WbK4A==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/constants@10.0.0':
+    resolution: {integrity: sha512-dxIXcW1F1dxIGfye2JXE7Q8WVwYB0axVzdBOkvE1WKIVR4xjB8e6k/Dkjo7DpbyfW5Vu2k21p6dyM32YLSAWoQ==}
+    engines: {node: '>=18.12'}
 
   '@pnpm/constants@1001.3.1':
     resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/constants@8.0.0':
+    resolution: {integrity: sha512-yQosGUvYPpAjb1jOFcdbwekRjZRVxN6C0hHzfRCZrMKbxGjt/E0g0RcFlEDNVZ95tm4oMMcr7nEPa7H7LX3emw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/core-loggers@10.0.1':
+    resolution: {integrity: sha512-u4fVBKK1scEmcQcZj2T4+N4ugRB6Zlrf1p3vHDLXjoETWDimtFybHsKxjwzwBmoAXk76Ewr2GXPAQ879C5nA7Q==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
+  '@pnpm/crypto.base32-hash@3.0.0':
+    resolution: {integrity: sha512-iGKP6rRKng5Tcad1+S+j3UoY5wVZN+z0ZgemlGp69jNgn6EaM4N0Q3mvnDNJ7UZFmL2ClXZZYLNuCk9pUYV3Xg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/dedupe.issues-renderer@2.0.0':
+    resolution: {integrity: sha512-UFKcCGUtL+2vbjXPCdw5H3Y/xj6iqVS86ChJSZj6GVODNR+gWO9j0HYMYVBFiQVOIm/7p86Rudyrm3cxmIEmWw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/dedupe.types@2.0.0':
+    resolution: {integrity: sha512-iCv/dc5dyXN/egiIu89qQn6yuLsQhiFjn0t1N+UKf4jSdMp59WFHjGh04jSsbxbGG91s6K9SQghOBW8BbZjinw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/default-reporter@13.1.4':
+    resolution: {integrity: sha512-AWmWSmxKqxqbnebCZRvuwBwt+pZUvQjKSA9oGXW+JFM2XV9DT5uOsJ/iUBOesrBuKmmslY3cD1IhqVvUVQqENA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
   '@pnpm/error@1000.1.0':
     resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/error@6.0.1':
+    resolution: {integrity: sha512-7yjO0RgmWYb4OKgcWC33yD4Z2CxE7Tm7vXX1SmS7GDifDT/bgZZhHeS2xq/+W6y9yhwIrRSA+7AlQL1NM2wIvw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/error@6.0.3':
+    resolution: {integrity: sha512-OIYhG7HQh4zUFh2s8/6bp7glVRjNxms7bpzXVOLV7pyRa+rSYFmqJ8zDsBC64k58nuaxS85Ip+SCDjFxsFGeOg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/fetcher-base@16.0.1':
+    resolution: {integrity: sha512-F4yFAqlmoVmzlxZTkEaYWQ454L0PVO4ZzTQgtEdBOOv10p9mEpTOz4z24+XSp6MHIIGH117oKeszXuTNoHA2eg==}
     engines: {node: '>=18.12'}
 
   '@pnpm/find-workspace-dir@1000.1.5':
     resolution: {integrity: sha512-r1WzYXBD8cqlglOi4ilN9BphX74mJmH2hhiogzYbcNCHhtXnG7tw/9Iq54UGZ+cpDkgGHjL0xLwj9QLUoKJxmg==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/find-workspace-dir@7.0.3':
+    resolution: {integrity: sha512-eGjkyHSufkHyZ66WpygWnslcRePB0U1lJg1dF3rgWqTChpregYoDyNGDzK7l9Gk+CHVgGZZS5aWp7uKKVmAAEg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/fs.find-packages@3.0.2':
+    resolution: {integrity: sha512-ee+ArUHSrmOIfX0/NAeItmIRApCGENny68yQFPJXatPcpj04cdtyGn92OEXVKAFgWoATZAPis+JLXX2NBlewHg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/fs.packlist@2.0.0':
+    resolution: {integrity: sha512-oy5ynSgI13FxkwDj/iTSWcdJsoih0Fxr2TZjUfgp1z1oyoust8+OxqCMOrHovJEKToHdPQgFtO09KbH7lAlN0w==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/git-utils@2.0.0':
+    resolution: {integrity: sha512-k1rv4Zvno/5zJAqE/Mh9V0ehlm14NsYwpXTdaGMtyhkoHvlSckRfr23OIOIM7Q/TRX+LhqyJ2kep50SY2TsZ+g==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/graceful-fs@4.0.0':
+    resolution: {integrity: sha512-933nhV2Prp51522poxX6Chvb7kEW3U3kzVWoqDU1+icB+QE7z/2qQ8wYHsBt4jm0Uil/sF67t77ugOr8bR63kg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/hooks.types@2.0.2':
+    resolution: {integrity: sha512-b+7ta7aAVUaSqufL09eC5n3pyWFo/Hwd/5cJaj7L4UkY2xJQSalNStE/4WQouaEmb5ARQuQJciE3XKjV1SKQbQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/lockfile-types@7.1.0':
+    resolution: {integrity: sha512-QO+FlNjDiBt+u5esPhvq1d0uv89KCAmlLBkhj/6cQZa7Uq/a/jfRdNGJCthrrEnerwTKipPTNgyuctQE8vQK+Q==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/logger@5.2.0':
+    resolution: {integrity: sha512-dCdSs2wPCweMkRLdISAKBOKSWeq/9iS9aanWgjoUkFs06KN2o5XGFg53oCXg/KbZhF9AXS3vMHPwTebzCeAEsA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/manifest-utils@6.0.2':
+    resolution: {integrity: sha512-Hdy58A2P35rBDfeTc4SiyWH9eSsr/hxUwLT5fzr5SQow12imDk1hLiw+iJSIFWGxvp9rGW4d3s5IMLIMffVrPQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/matcher@6.0.0':
+    resolution: {integrity: sha512-c2diPZzejRYnL6b00Ko70TnOlbsqydUOvAjOZ7THTs0ptXG/AARcwNp9YO5EXFq775TTmsSUBo99qisYF1ogNA==}
+    engines: {node: '>=18.12'}
+
   '@pnpm/network.ca-file@1.0.2':
     resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
     engines: {node: '>=12.22.0'}
 
+  '@pnpm/npm-conf@2.2.2':
+    resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
+    engines: {node: '>=12'}
+
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@pnpm/package-is-installable@9.0.2':
+    resolution: {integrity: sha512-+OFh/J2OERTXpIIxbg9srvan8c7zv5zoVtdjNH2AZE+G9FdaNeJDZUGtncjJiu3K4SD/FJzpKb13wy3m1P3eww==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
+  '@pnpm/parse-overrides@5.0.1':
+    resolution: {integrity: sha512-KD/cE0ovH2JkH5qeAuAo9TyU23Nqk0smlNf6O1t72zdIAOygvjAh5AzThGbYioBNWQP7h1MA7cAzrrDZRcrxgw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/parse-wanted-dependency@6.0.0':
+    resolution: {integrity: sha512-01hKf1qHKREZDOwa5wRXk01P+xBGOeZf/idg17si8ji7UWpdWEQkrUVmGfv3sT04XoiwIb7kaRiKPQT7ooB4fA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/pnpmfile@6.0.4':
+    resolution: {integrity: sha512-F15UJMpQVc2DFatLOEF9ne/eXkqooc8BGpfPfVkQsk4LnHMyZVfsxqU7U8jwmy3meaBw79XWDh2Oge7S3aTP6g==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
+  '@pnpm/ramda@0.28.1':
+    resolution: {integrity: sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==}
+
+  '@pnpm/read-project-manifest@6.0.2':
+    resolution: {integrity: sha512-KhWxAPbZ0BUeX0nNZnQy2PQE2YMTjEbLBrfOsWIsiT42k9AkHgdrAU0rbVq46lnIehtN4OnaA/tHZdSKqKk/Fg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/render-peer-issues@5.0.2':
+    resolution: {integrity: sha512-/nqcyEczeV+hPibC27zzyqYX34mJp6aOlv+WCR+RDVcUVZ0oVjhLvyAVLgA12fJLhfB1eP9iitRV5WKkT6ac9w==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/resolver-base@12.0.1':
+    resolution: {integrity: sha512-EobGNigWvWSPNIZaA5GZFzq2ENutyVYmyTobz2vg6KPH2RLvVo3hO2VYTZ8ARPKOfsFLLFei90ncrm7k+Z5U1g==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/store-controller-types@18.1.0':
+    resolution: {integrity: sha512-3FvgGtnWlKlC8CztqMqT5w2VTdOjKCu1ZrH+d5xFuVHyb2weIz9hxQo/3VHT+qdcN8O7q+rpzRgh3YtgO+r+tA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/text.comments-parser@3.0.0':
+    resolution: {integrity: sha512-BSGvYd59kPKVTUk1InekEp+TiPnJ8650/bQyiOUFSvqHi61YipcR+E4H2i3xTnk2e+GHdGbXvEtAZbQmyxb0/g==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/types@10.1.0':
+    resolution: {integrity: sha512-cM2UhtQJs06zWm3wsXoVVi4b1P8rA7xioZCct/Q4sR5GAUq0VUReZMd9TkPEVdNlAiitctTAi9EM8D5hrO937A==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/util.lex-comparator@3.0.0':
+    resolution: {integrity: sha512-ead+l3IiuVXwKDf/QJPX6G93cwhXki3yOVEA/VdAO7AhZ5vUuSBxHe6gQKEbB0QacJ4H5VsYxeM1xUgwjjOO/Q==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/workspace.find-packages@2.1.1':
+    resolution: {integrity: sha512-BRSaRgBNLxEiunTwEXGGglRRwF84Ci6ZI6AUy9j4aviSpDSZ2wtYCCGA0+KM36GLbrg2exyhiG/ls/eI6QHJKQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^5.0.0
+
+  '@pnpm/workspace.read-manifest@2.0.1':
+    resolution: {integrity: sha512-Aqk77F3CFuN/qNeAIIm8MtwowRZvf5Ei9uq7cySLx44Q23XocGddE7r/5LnmVpD0t4e5Qu5j+mbcRqCJcjhMsQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/write-project-manifest@6.0.1':
+    resolution: {integrity: sha512-K94P822XIdQ2YhyHbBL/jzasVo2YKGOnfbMzJIM3xFBFeVpv+hPxM4Xkac4IskRFSJQoTQgjZy8KbXKXnXxfyw==}
+    engines: {node: '>=18.12'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -1045,9 +1224,6 @@ packages:
   '@types/cors@2.8.17':
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
 
-  '@types/fs-extra@8.1.5':
-    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
-
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -1063,11 +1239,11 @@ packages:
   '@types/node@22.10.2':
     resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
 
-  '@types/rimraf@2.0.5':
-    resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
-
   '@types/rimraf@3.0.2':
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
+
+  '@types/ssri@7.1.5':
+    resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
 
   '@types/symlink-or-copy@1.2.2':
     resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
@@ -1082,6 +1258,11 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+
+  '@zkochan/which@2.0.3':
+    resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -1134,6 +1315,12 @@ packages:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
     engines: {node: '>=0.4.2'}
 
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
+  ansi-diff@1.2.0:
+    resolution: {integrity: sha512-BIXwHKpjzghBjcwEV10Y4b17tjHfK4nhEqK3LqyQ3JgcMcjmi3DIevozNgrOpfvBMmrq9dfvrPJSu5/5vNUBQg==}
+
   ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
     engines: {node: '>=4'}
@@ -1162,6 +1349,9 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-split@1.0.1:
+    resolution: {integrity: sha512-RRxQym4DFtDNmHIkW6aeFVvrXURb11lGAEPXNiryjCe8bK8RsANjzJ0M2aGOkvBYwP4Bl/xZ8ijtr6D3j1x/eg==}
 
   ansi-styles@2.2.1:
     resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
@@ -1235,6 +1425,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  as-table@1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -1256,6 +1449,10 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   async-disk-cache@1.3.5:
     resolution: {integrity: sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==}
 
@@ -1274,6 +1471,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
+
   atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
@@ -1288,6 +1489,10 @@ packages:
 
   aws-sign2@0.5.0:
     resolution: {integrity: sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA==}
+
+  babel-import-util@2.1.1:
+    resolution: {integrity: sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==}
+    engines: {node: '>= 12.*'}
 
   babel-remove-types@2.0.0:
     resolution: {integrity: sha512-HHLQOs/c2h//gl7f5VDa/r1Nd2gIk0kgzC1v01BSCEK5IJu1Zc4/fUj5uYCzC8Q0NWiucCgWKr9a43qmHkY6oA==}
@@ -1317,6 +1522,14 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+
+  bin-links@3.0.3:
+    resolution: {integrity: sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   binaryextensions@2.3.0:
     resolution: {integrity: sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==}
     engines: {node: '>=0.8'}
@@ -1335,10 +1548,17 @@ packages:
   body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
 
+  bole@5.0.29:
+    resolution: {integrity: sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==}
+
   boom@0.4.2:
     resolution: {integrity: sha512-OvfN8y1oAxxphzkl2SnCS+ztV/uVKTATtgLjWYg/7KwcNyf3rzpHxNQJZCKtsZd4+MteKczhWbSjtEX4bGgU9g==}
     engines: {node: '>=0.8.0'}
     deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
+
+  boxen@5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1471,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
     engines: {node: '>=6.14.2'}
 
+  builtins@5.1.0:
+    resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
+
   bytes@1.0.0:
     resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
 
@@ -1510,6 +1733,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -1521,6 +1748,10 @@ packages:
   can-symlink@1.0.0:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}
     hasBin: true
+
+  can-write-to-dir@1.1.1:
+    resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
+    engines: {node: '>=10.13'}
 
   caniuse-lite@1.0.30001689:
     resolution: {integrity: sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==}
@@ -1584,6 +1815,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
@@ -1630,6 +1865,14 @@ packages:
   clean-up-path@1.0.0:
     resolution: {integrity: sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw==}
 
+  cli-boxes@2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
+
+  cli-columns@4.0.0:
+    resolution: {integrity: sha512-XW2Vg+w+L9on9wtwKpyzluIPCWXjaBahI7mTcYjx+BVIYD9c3yqcv/yKC7CmdCZat4rq2yiE1UMSJC5ivKfMtQ==}
+    engines: {node: '>= 10'}
+
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
@@ -1646,6 +1889,10 @@ packages:
   cli-table@0.3.11:
     resolution: {integrity: sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==}
     engines: {node: '>= 0.2.0'}
+
+  cli-truncate@2.1.0:
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
 
   cli-width@2.2.1:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
@@ -1667,6 +1914,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  cmd-shim@5.0.0:
+    resolution: {integrity: sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   codsen-utils@1.7.3:
     resolution: {integrity: sha512-YIFQQ1n2NSgwoB3sCe7RpkZzsrPxTMek6jc7wC9fXOm1wwfWAKja9gLOMEjlXOUd3LKV3o6Jci7n9BoHs5Z8Sg==}
@@ -1969,6 +2220,10 @@ packages:
     engines: {node: '>=0.8.0'}
     deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
 
+  crypto-random-string@2.0.0:
+    resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
+    engines: {node: '>=8'}
+
   cssstyle@3.0.0:
     resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
     engines: {node: '>=14'}
@@ -1983,6 +2238,9 @@ packages:
 
   dag-map@2.0.2:
     resolution: {integrity: sha512-xnsprIzYuDeiyu5zSKwilV/ajRHxnoMlAhEREfyfTgTSViMVY2fGP1ZcHJbtwup26oCkofySU/m6oKJ3HrkW7w==}
+
+  data-uri-to-buffer@2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
   data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
@@ -2072,6 +2330,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   default-require-extensions@3.0.1:
     resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
     engines: {node: '>=8'}
@@ -2126,6 +2388,10 @@ packages:
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
@@ -2201,6 +2467,9 @@ packages:
   ember-cli-string-utils@1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
 
+  ember-rfc176-data@0.3.18:
+    resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2245,6 +2514,9 @@ packages:
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error@7.2.1:
     resolution: {integrity: sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==}
@@ -2612,16 +2884,12 @@ packages:
     resolution: {integrity: sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==}
     engines: {node: '>= 10.13.0'}
 
-  fixturify-project@2.1.1:
-    resolution: {integrity: sha512-sP0gGMTr4iQ8Kdq5Ez0CVJOZOGWqzP5dv/veOTdFNywioKjkNWCHBi1q65DMpcNGUGeoOUWehyji274Q2wRgxA==}
-    engines: {node: 10.* || >= 12.*}
+  fixturify-project@7.1.3:
+    resolution: {integrity: sha512-araEoNawWCIV9xT/+kAQ+H3aiFTVVH1nUDuYU7syhbWnlyA6BzuRE7vhdZQ7m+1+T5A3zG2JljGxRkNP1EhvXQ==}
+    engines: {node: '>= 14.*'}
 
   fixturify@0.3.4:
     resolution: {integrity: sha512-Gx+KSB25b6gMc4bf7UFRTA85uE0iZR+RYur0JHh6dg4AGBh0EksOv4FCHyM7XpGmiJO7Bc7oV7vxENQBT+2WEQ==}
-
-  fixturify@2.1.1:
-    resolution: {integrity: sha512-SRgwIMXlxkb6AUgaVjIX+jCEqdhyXu9hah7mcK+lWynjKtX73Ux1TDv71B7XyaQ+LJxkYRHl5yCL8IycAvQRUw==}
-    engines: {node: 10.* || >= 12.*}
 
   fixturify@3.0.0:
     resolution: {integrity: sha512-PFOf/DT9/t2NCiVyiQ5cBMJtGZfWh3aeOV8XVqQQOPBlTv8r6l0k75/hm36JOaiJlrWFk/8aYFyOKAvOkrkjrw==}
@@ -2724,6 +2992,10 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
   fs-merger@3.2.1:
     resolution: {integrity: sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==}
 
@@ -2776,6 +3048,9 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-source@2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
 
   get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
@@ -2852,6 +3127,11 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@1.0.0:
@@ -3085,6 +3365,10 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ignore-walk@5.0.1:
+    resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3100,6 +3384,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  individual@3.0.0:
+    resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
 
   infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
@@ -3120,6 +3407,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@3.0.1:
+    resolution: {integrity: sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   ini@5.0.0:
     resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
@@ -3161,6 +3452,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -3342,6 +3636,10 @@ packages:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-symbol@1.1.1:
     resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
     engines: {node: '>= 0.4'}
@@ -3468,6 +3766,10 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  js-string-escape@1.0.1:
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
+    engines: {node: '>= 0.8'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3502,6 +3804,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-parse-even-better-errors@4.0.0:
     resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
@@ -3571,6 +3876,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   linkify-it@1.2.4:
     resolution: {integrity: sha512-eGHwtlABkp1NOJSiKUNqBf3SYAS5jPHtvRXPAgNaQwTqmkTahjtiLH9NtxdR5IOPhNvwNMN/diswSfZKzUkhGg==}
 
@@ -3583,6 +3891,10 @@ packages:
   livereload-js@3.4.1:
     resolution: {integrity: sha512-5MP0uUeVCec89ZbNOT/i97Mc+q3SxXmiUGhRFOTmhrGPn//uWVQdCvcLJDy64MSBR5MidFdOR7B9viumoavy6g==}
 
+  load-json-file@6.2.0:
+    resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
+    engines: {node: '>=8'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3594,6 +3906,9 @@ packages:
   locate-path@8.0.0:
     resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
     engines: {node: '>=20'}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.flattendeep@4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
@@ -3647,9 +3962,17 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  map-age-cleaner@0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
+
   map-cache@0.2.2:
     resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
     engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   map-visit@1.0.0:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
@@ -3699,6 +4022,10 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  mem@8.1.1:
+    resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
+    engines: {node: '>=10'}
 
   memory-streams@0.1.3:
     resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
@@ -3777,6 +4104,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-fn@3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3839,6 +4170,10 @@ packages:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
 
+  mkdirp-infer-owner@2.0.0:
+    resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
+    engines: {node: '>=10'}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -3892,6 +4227,11 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  ndjson@2.0.0:
+    resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -3952,9 +4292,20 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-registry-url@2.0.0:
+    resolution: {integrity: sha512-3e9FwDyRAhbxXw4slm4Tjv40u78yPwMc/WZkACpqNQOs5sM7wic853AeTLkMFEVhivZkclGYlse8iYsklz0Yvg==}
+
+  npm-bundled@2.0.1:
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   npm-install-checks@7.1.1:
     resolution: {integrity: sha512-u6DCwbow5ynAX5BdiHQ9qvexme4U3qHW3MWe5NqH+NeBm0LbiH6zvGjNNew1fY+AZZUtVHbOPF3j7mJxbUzpXg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-normalize-package-bin@2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-normalize-package-bin@4.0.0:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
@@ -3967,6 +4318,11 @@ packages:
   npm-package-arg@13.0.2:
     resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-packlist@5.1.3:
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
 
   npm-pick-manifest@10.0.0:
     resolution: {integrity: sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==}
@@ -4073,9 +4429,17 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  p-defer@1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
+
   p-defer@4.0.1:
     resolution: {integrity: sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==}
     engines: {node: '>=12'}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -4104,6 +4468,10 @@ packages:
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
 
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
@@ -4135,6 +4503,14 @@ packages:
   parse-github-repo-url@1.4.1:
     resolution: {integrity: sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
@@ -4163,6 +4539,10 @@ packages:
     resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==}
     engines: {node: '>=0.10.0'}
 
+  path-absolute@1.0.1:
+    resolution: {integrity: sha512-gds5iRhSeOcDtj8gfWkRHLtZKTPsFVuh7utbjYtvnclw4XM+ffRzJrwqMhOD1PVqef7nBLmgsu1vIujjvAJrAw==}
+    engines: {node: '>=4'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4182,6 +4562,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-name@1.0.0:
+    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -4209,6 +4592,10 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-temp@2.1.1:
+    resolution: {integrity: sha512-2pIjpQb28baC42ttBsQuRRqZ33a8DnWzfSwEFKJjz7SMiCmBECUOebUNLTmmPCG8F4ZIXG7ZRJ8FAxYXdx0Jiw==}
+    engines: {node: '>=8.15'}
+
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -4232,6 +4619,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-entry-points@1.1.2:
+    resolution: {integrity: sha512-bmmM+SdLXNNetFr4o53QiiZRZicls2apmzj8HRpo4bU+3nJHiPO/omv8TXHIOzTcirua3YBAwTlKE+7zkICh4g==}
+    engines: {node: '>=20.19.5'}
 
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
@@ -4259,12 +4650,23 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+
   pretty-format@21.2.1:
     resolution: {integrity: sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==}
+
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
 
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
     engines: {node: '>=18'}
+
+  printable-characters@1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
   printf@0.6.1:
     resolution: {integrity: sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==}
@@ -4363,6 +4765,10 @@ packages:
     resolution: {integrity: sha512-BrL7hrZcbyyt5ZDfePkGFDc3m82uUtxCPOnpRUrkOdtBnmV9ldQKxXORkKL8eIzToRNaCpIPyKyfdfq/tBlFAA==}
     engines: {node: '>= 0.14.0'}
 
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
   quick-temp@0.1.9:
     resolution: {integrity: sha512-yI0h7tIhKVObn03kD+Ln9JFi4OljD28lfaOsTdfpTR0xzrhGOod+q66CjGafUqYX2juUfT9oHIGrTBBo22mkRA==}
 
@@ -4393,6 +4799,18 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  read-cmd-shim@3.0.1:
+    resolution: {integrity: sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  read-ini-file@4.0.0:
+    resolution: {integrity: sha512-zz4qv/sKETv7nAkATqSJ9YMbKD8NXRPuA8d17VdYCuNYrVstB1S6UAMU6aytf5vRa9MESbZN7jLZdcmrOxz4gg==}
+    engines: {node: '>=14.6'}
+
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
+
   readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
 
@@ -4407,6 +4825,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  realpath-missing@1.1.0:
+    resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
+    engines: {node: '>=10'}
 
   redeyed@1.0.1:
     resolution: {integrity: sha512-8eEWsNCkV2rvwKLS1Cvp5agNjMhwRe2um+y32B2+3LqOzg4C9BBPs6vzAfV16Ivb8B9HPNKIqd8OrdBws8kNlQ==}
@@ -4516,6 +4938,9 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -4588,6 +5013,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-execa@0.1.2:
+    resolution: {integrity: sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==}
+    engines: {node: '>=12'}
 
   safe-json-parse@1.0.1:
     resolution: {integrity: sha512-o0JmTu17WGUaUOHa1l0FPGXKBfijbxK6qoHzlkihsDXxzBHvJcA7zgviKR92Xs841rX9pK16unfphLq0/KqX7A==}
@@ -4726,6 +5155,10 @@ packages:
   silent-error@1.1.1:
     resolution: {integrity: sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==}
 
+  slice-ansi@3.0.0:
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -4765,6 +5198,10 @@ packages:
   socks@2.8.4:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sort-keys@4.2.0:
+    resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
+    engines: {node: '>=8'}
 
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
@@ -4828,6 +5265,9 @@ packages:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
 
+  split2@3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -4837,6 +5277,9 @@ packages:
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
+
+  stacktracey@2.2.0:
+    resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
 
   static-extend@0.1.2:
     resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
@@ -4856,6 +5299,10 @@ packages:
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
 
   string-template@0.2.1:
     resolution: {integrity: sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==}
@@ -4920,6 +5367,9 @@ packages:
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
+
+  strip-comments-strings@1.2.0:
+    resolution: {integrity: sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ==}
 
   strip-eof@1.0.0:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
@@ -5042,6 +5492,9 @@ packages:
   through2@3.0.2:
     resolution: {integrity: sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==}
 
+  through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -5156,17 +5609,21 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
-  type-fest@0.11.0:
-    resolution: {integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==}
-    engines: {node: '>=8'}
-
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -5201,6 +5658,9 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  typescript-memoize@1.1.1:
+    resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5244,6 +5704,10 @@ packages:
 
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+
+  unique-string@2.0.0:
+    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
+    engines: {node: '>=8'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -5309,6 +5773,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@5.0.0:
+    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   validate-npm-package-name@6.0.0:
     resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
@@ -5422,6 +5890,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -5431,6 +5904,10 @@ packages:
     resolution: {integrity: sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
+
+  widest-line@3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -5462,6 +5939,18 @@ packages:
 
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  write-yaml-file@5.0.0:
+    resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
+    engines: {node: '>=16.14'}
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
@@ -5868,6 +6357,23 @@ snapshots:
       sort-package-json: 3.6.1
       walk-sync: 4.0.2
 
+  '@embroider/shared-internals@2.9.2':
+    dependencies:
+      babel-import-util: 2.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.18.1
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.2
+      resolve-package-path: 4.0.3
+      semver: 7.8.1
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -5892,6 +6398,8 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@gwhitney/detect-indent@7.0.1': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -6232,28 +6740,295 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pnpm/cli-meta@6.0.1':
+    dependencies:
+      '@pnpm/types': 10.1.0
+      load-json-file: 6.2.0
+
+  '@pnpm/cli-utils@3.1.1(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/cli-meta': 6.0.1
+      '@pnpm/config': 21.4.0(@pnpm/logger@5.2.0)
+      '@pnpm/default-reporter': 13.1.4(@pnpm/logger@5.2.0)
+      '@pnpm/error': 6.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/manifest-utils': 6.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/package-is-installable': 9.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/read-project-manifest': 6.0.2
+      '@pnpm/types': 10.1.0
+      chalk: 4.1.2
+      load-json-file: 6.2.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
+  '@pnpm/config.env-replace@3.0.0': {}
+
+  '@pnpm/config@21.4.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.env-replace': 3.0.0
+      '@pnpm/constants': 8.0.0
+      '@pnpm/error': 6.0.1
+      '@pnpm/git-utils': 2.0.0
+      '@pnpm/matcher': 6.0.0
+      '@pnpm/npm-conf': 2.2.2
+      '@pnpm/pnpmfile': 6.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/read-project-manifest': 6.0.2
+      '@pnpm/types': 10.1.0
+      better-path-resolve: 1.0.0
+      camelcase: 6.3.0
+      camelcase-keys: 6.2.2
+      can-write-to-dir: 1.1.1
+      is-subdir: 1.2.0
+      is-windows: 1.0.2
+      normalize-registry-url: 2.0.0
+      path-absolute: 1.0.1
+      path-name: 1.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      read-ini-file: 4.0.0
+      realpath-missing: 1.1.0
+      which: 4.0.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/constants@10.0.0': {}
+
   '@pnpm/constants@1001.3.1': {}
+
+  '@pnpm/constants@8.0.0': {}
+
+  '@pnpm/core-loggers@10.0.1(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 10.1.0
+
+  '@pnpm/crypto.base32-hash@3.0.0':
+    dependencies:
+      rfc4648: 1.5.4
+
+  '@pnpm/dedupe.issues-renderer@2.0.0':
+    dependencies:
+      '@pnpm/dedupe.types': 2.0.0
+      archy: 1.0.0
+      chalk: 4.1.2
+
+  '@pnpm/dedupe.types@2.0.0': {}
+
+  '@pnpm/default-reporter@13.1.4(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config': 21.4.0(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 10.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/dedupe.issues-renderer': 2.0.0
+      '@pnpm/dedupe.types': 2.0.0
+      '@pnpm/error': 6.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/render-peer-issues': 5.0.2
+      '@pnpm/types': 10.1.0
+      ansi-diff: 1.2.0
+      boxen: 5.1.2
+      chalk: 4.1.2
+      cli-truncate: 2.1.0
+      normalize-path: 3.0.0
+      pretty-bytes: 5.6.0
+      pretty-ms: 7.0.1
+      ramda: '@pnpm/ramda@0.28.1'
+      rxjs: 7.8.2
+      semver: 7.8.1
+      stacktracey: 2.2.0
+      string-length: 4.0.2
 
   '@pnpm/error@1000.1.0':
     dependencies:
       '@pnpm/constants': 1001.3.1
+
+  '@pnpm/error@6.0.1':
+    dependencies:
+      '@pnpm/constants': 8.0.0
+
+  '@pnpm/error@6.0.3':
+    dependencies:
+      '@pnpm/constants': 10.0.0
+
+  '@pnpm/fetcher-base@16.0.1':
+    dependencies:
+      '@pnpm/resolver-base': 12.0.1
+      '@pnpm/types': 10.1.0
+      '@types/ssri': 7.1.5
 
   '@pnpm/find-workspace-dir@1000.1.5':
     dependencies:
       '@pnpm/error': 1000.1.0
       find-up: 5.0.0
 
+  '@pnpm/find-workspace-dir@7.0.3':
+    dependencies:
+      '@pnpm/error': 6.0.3
+      find-up: 5.0.0
+
+  '@pnpm/fs.find-packages@3.0.2':
+    dependencies:
+      '@pnpm/read-project-manifest': 6.0.2
+      '@pnpm/types': 10.1.0
+      '@pnpm/util.lex-comparator': 3.0.0
+      fast-glob: 3.3.3
+      p-filter: 2.1.0
+
+  '@pnpm/fs.packlist@2.0.0':
+    dependencies:
+      npm-packlist: 5.1.3
+
+  '@pnpm/git-utils@2.0.0':
+    dependencies:
+      execa: safe-execa@0.1.2
+
+  '@pnpm/graceful-fs@4.0.0':
+    dependencies:
+      graceful-fs: 4.2.11
+
+  '@pnpm/hooks.types@2.0.2':
+    dependencies:
+      '@pnpm/lockfile-types': 7.1.0
+      '@pnpm/types': 10.1.0
+
+  '@pnpm/lockfile-types@7.1.0':
+    dependencies:
+      '@pnpm/types': 10.1.0
+
+  '@pnpm/logger@5.2.0':
+    dependencies:
+      bole: 5.0.29
+      ndjson: 2.0.0
+
+  '@pnpm/manifest-utils@6.0.2(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 10.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/error': 6.0.1
+      '@pnpm/types': 10.1.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/matcher@6.0.0':
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   '@pnpm/network.ca-file@1.0.2':
     dependencies:
       graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@2.2.2':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
 
   '@pnpm/npm-conf@2.3.1':
     dependencies:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@pnpm/package-is-installable@9.0.2(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 10.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/error': 6.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 10.1.0
+      detect-libc: 2.1.2
+      execa: safe-execa@0.1.2
+      mem: 8.1.1
+      semver: 7.8.1
+
+  '@pnpm/parse-overrides@5.0.1':
+    dependencies:
+      '@pnpm/error': 6.0.1
+      '@pnpm/parse-wanted-dependency': 6.0.0
+
+  '@pnpm/parse-wanted-dependency@6.0.0':
+    dependencies:
+      validate-npm-package-name: 5.0.0
+
+  '@pnpm/pnpmfile@6.0.4(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 10.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/crypto.base32-hash': 3.0.0
+      '@pnpm/error': 6.0.1
+      '@pnpm/hooks.types': 2.0.2
+      '@pnpm/lockfile-types': 7.1.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store-controller-types': 18.1.0
+      '@pnpm/types': 10.1.0
+      chalk: 4.1.2
+      path-absolute: 1.0.1
+
+  '@pnpm/ramda@0.28.1': {}
+
+  '@pnpm/read-project-manifest@6.0.2':
+    dependencies:
+      '@gwhitney/detect-indent': 7.0.1
+      '@pnpm/error': 6.0.1
+      '@pnpm/graceful-fs': 4.0.0
+      '@pnpm/text.comments-parser': 3.0.0
+      '@pnpm/types': 10.1.0
+      '@pnpm/write-project-manifest': 6.0.1
+      fast-deep-equal: 3.1.3
+      is-windows: 1.0.2
+      json5: 2.2.3
+      lodash.clonedeep: 4.5.0
+      parse-json: 5.2.0
+      read-yaml-file: 2.1.0
+      sort-keys: 4.2.0
+      strip-bom: 4.0.0
+
+  '@pnpm/render-peer-issues@5.0.2':
+    dependencies:
+      '@pnpm/error': 6.0.1
+      '@pnpm/matcher': 6.0.0
+      '@pnpm/parse-overrides': 5.0.1
+      '@pnpm/types': 10.1.0
+      archy: 1.0.0
+      chalk: 4.1.2
+      cli-columns: 4.0.0
+      semver: 7.8.1
+
+  '@pnpm/resolver-base@12.0.1':
+    dependencies:
+      '@pnpm/types': 10.1.0
+
+  '@pnpm/store-controller-types@18.1.0':
+    dependencies:
+      '@pnpm/fetcher-base': 16.0.1
+      '@pnpm/resolver-base': 12.0.1
+      '@pnpm/types': 10.1.0
+
+  '@pnpm/text.comments-parser@3.0.0':
+    dependencies:
+      strip-comments-strings: 1.2.0
+
+  '@pnpm/types@10.1.0': {}
+
+  '@pnpm/util.lex-comparator@3.0.0': {}
+
+  '@pnpm/workspace.find-packages@2.1.1(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/cli-utils': 3.1.1(@pnpm/logger@5.2.0)
+      '@pnpm/fs.find-packages': 3.0.2
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 10.1.0
+      '@pnpm/util.lex-comparator': 3.0.0
+      '@pnpm/workspace.read-manifest': 2.0.1
+
+  '@pnpm/workspace.read-manifest@2.0.1':
+    dependencies:
+      '@pnpm/constants': 8.0.0
+      '@pnpm/error': 6.0.1
+      read-yaml-file: 2.1.0
+
+  '@pnpm/write-project-manifest@6.0.1':
+    dependencies:
+      '@pnpm/text.comments-parser': 3.0.0
+      '@pnpm/types': 10.1.0
+      json5: 2.2.3
+      write-file-atomic: 5.0.1
+      write-yaml-file: 5.0.0
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -6268,10 +7043,6 @@ snapshots:
   '@types/cookie@0.4.1': {}
 
   '@types/cors@2.8.17':
-    dependencies:
-      '@types/node': 22.10.2
-
-  '@types/fs-extra@8.1.5':
     dependencies:
       '@types/node': 22.10.2
 
@@ -6292,14 +7063,13 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/rimraf@2.0.5':
+  '@types/rimraf@3.0.2':
     dependencies:
       '@types/glob': 8.1.0
       '@types/node': 22.10.2
 
-  '@types/rimraf@3.0.2':
+  '@types/ssri@7.1.5':
     dependencies:
-      '@types/glob': 8.1.0
       '@types/node': 22.10.2
 
   '@types/symlink-or-copy@1.2.2': {}
@@ -6309,6 +7079,10 @@ snapshots:
   '@ungap/structured-clone@1.2.1': {}
 
   '@xmldom/xmldom@0.9.10': {}
+
+  '@zkochan/which@2.0.3':
+    dependencies:
+      isexe: 2.0.0
 
   abab@2.0.6: {}
 
@@ -6363,6 +7137,15 @@ snapshots:
 
   amdefine@1.0.1: {}
 
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
+  ansi-diff@1.2.0:
+    dependencies:
+      ansi-split: 1.0.1
+      wcwidth: 1.0.1
+
   ansi-escapes@3.2.0: {}
 
   ansi-html@0.0.9: {}
@@ -6376,6 +7159,10 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
+
+  ansi-split@1.0.1:
+    dependencies:
+      ansi-regex: 3.0.1
 
   ansi-styles@2.2.1: {}
 
@@ -6444,6 +7231,10 @@ snapshots:
       get-intrinsic: 1.2.6
       is-array-buffer: 3.0.5
 
+  as-table@1.0.55:
+    dependencies:
+      printable-characters: 1.0.42
+
   asap@2.0.6: {}
 
   asn1@0.1.11:
@@ -6457,6 +7248,8 @@ snapshots:
   assertion-error@1.1.0: {}
 
   assign-symbols@1.0.0: {}
+
+  astral-regex@2.0.0: {}
 
   async-disk-cache@1.3.5:
     dependencies:
@@ -6488,6 +7281,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  at-least-node@1.0.0: {}
+
   atob@2.1.2: {}
 
   atomically@2.1.0:
@@ -6501,6 +7296,8 @@ snapshots:
 
   aws-sign2@0.5.0:
     optional: true
+
+  babel-import-util@2.1.1: {}
 
   babel-remove-types@2.0.0:
     dependencies:
@@ -6536,6 +7333,19 @@ snapshots:
       safe-buffer: 5.1.2
 
   before-after-hook@3.0.2: {}
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
+
+  bin-links@3.0.3:
+    dependencies:
+      cmd-shim: 5.0.0
+      mkdirp-infer-owner: 2.0.0
+      npm-normalize-package-bin: 2.0.0
+      read-cmd-shim: 3.0.1
+      rimraf: 3.0.2
+      write-file-atomic: 4.0.2
 
   binaryextensions@2.3.0: {}
 
@@ -6579,10 +7389,26 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
+  bole@5.0.29:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      individual: 3.0.0
+
   boom@0.4.2:
     dependencies:
       hoek: 0.9.1
     optional: true
+
+  boxen@5.1.2:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
 
   brace-expansion@1.1.11:
     dependencies:
@@ -6886,6 +7712,10 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
+  builtins@5.1.0:
+    dependencies:
+      semver: 7.8.1
+
   bytes@1.0.0: {}
 
   bytes@3.1.2: {}
@@ -6955,6 +7785,12 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -6962,6 +7798,10 @@ snapshots:
   can-symlink@1.0.0:
     dependencies:
       tmp: 0.0.28
+
+  can-write-to-dir@1.1.1:
+    dependencies:
+      path-temp: 2.1.1
 
   caniuse-lite@1.0.30001689: {}
 
@@ -7038,6 +7878,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  char-regex@1.0.2: {}
+
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
@@ -7077,6 +7919,13 @@ snapshots:
 
   clean-up-path@1.0.0: {}
 
+  cli-boxes@2.2.1: {}
+
+  cli-columns@4.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
@@ -7095,6 +7944,11 @@ snapshots:
   cli-table@0.3.11:
     dependencies:
       colors: 1.0.3
+
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
 
   cli-width@2.2.1: {}
 
@@ -7119,6 +7973,10 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  cmd-shim@5.0.0:
+    dependencies:
+      mkdirp-infer-owner: 2.0.0
 
   codsen-utils@1.7.3:
     dependencies:
@@ -7286,6 +8144,8 @@ snapshots:
       boom: 0.4.2
     optional: true
 
+  crypto-random-string@2.0.0: {}
+
   cssstyle@3.0.0:
     dependencies:
       rrweb-cssom: 0.6.0
@@ -7299,6 +8159,8 @@ snapshots:
       type: 2.7.3
 
   dag-map@2.0.2: {}
+
+  data-uri-to-buffer@2.0.2: {}
 
   data-urls@4.0.0:
     dependencies:
@@ -7366,6 +8228,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   default-require-extensions@3.0.1:
     dependencies:
       strip-bom: 4.0.0
@@ -7413,6 +8277,8 @@ snapshots:
   detect-file@1.0.0: {}
 
   detect-indent@7.0.2: {}
+
+  detect-libc@2.1.2: {}
 
   detect-newline@4.0.1: {}
 
@@ -7504,6 +8370,8 @@ snapshots:
 
   ember-cli-string-utils@1.1.0: {}
 
+  ember-rfc176-data@0.3.18: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -7552,6 +8420,10 @@ snapshots:
   entities@4.5.0: {}
 
   err-code@2.0.3: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error@7.2.1:
     dependencies:
@@ -8153,25 +9025,28 @@ snapshots:
       micromatch: 4.0.8
       resolve-dir: 1.0.1
 
-  fixturify-project@2.1.1:
+  fixturify-project@7.1.3:
     dependencies:
-      fixturify: 2.1.1
+      '@embroider/shared-internals': 2.9.2
+      '@pnpm/find-workspace-dir': 7.0.3
+      '@pnpm/fs.packlist': 2.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/workspace.find-packages': 2.1.1(@pnpm/logger@5.2.0)
+      bin-links: 3.0.3
+      deepmerge: 4.3.1
+      fixturify: 3.0.0
+      fs-extra: 10.1.0
+      resolve-package-path: 4.0.3
       tmp: 0.0.33
-      type-fest: 0.11.0
+      type-fest: 4.41.0
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   fixturify@0.3.4:
     dependencies:
       fs-extra: 0.30.0
       matcher-collection: 1.1.2
-
-  fixturify@2.1.1:
-    dependencies:
-      '@types/fs-extra': 8.1.5
-      '@types/minimatch': 3.0.5
-      '@types/rimraf': 2.0.5
-      fs-extra: 8.1.0
-      matcher-collection: 2.0.1
-      walk-sync: 2.2.0
 
   fixturify@3.0.0:
     dependencies:
@@ -8296,6 +9171,13 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   fs-merger@3.2.1:
     dependencies:
       broccoli-node-api: 1.7.0
@@ -8381,6 +9263,11 @@ snapshots:
       math-intrinsics: 1.0.0
 
   get-package-type@0.1.0: {}
+
+  get-source@2.0.12:
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
 
   get-stdin@9.0.0: {}
 
@@ -8480,6 +9367,14 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
 
   global-modules@1.0.0:
     dependencies:
@@ -8747,6 +9642,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore-walk@5.0.1:
+    dependencies:
+      minimatch: 5.1.6
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.0:
@@ -8757,6 +9656,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  individual@3.0.0: {}
 
   infer-owner@1.0.4: {}
 
@@ -8772,6 +9673,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@3.0.1: {}
 
   ini@5.0.0: {}
 
@@ -8827,6 +9730,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.3
       get-intrinsic: 1.2.6
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.0.0:
     dependencies:
@@ -8973,6 +9878,10 @@ snapshots:
       call-bound: 1.0.3
       has-tostringtag: 1.0.2
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-symbol@1.1.1:
     dependencies:
       call-bound: 1.0.3
@@ -9116,6 +10025,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  js-string-escape@1.0.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -9169,6 +10080,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@4.0.0: {}
 
@@ -9237,6 +10150,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lines-and-columns@1.2.4: {}
+
   linkify-it@1.2.4:
     dependencies:
       uc.micro: 1.0.6
@@ -9251,6 +10166,13 @@ snapshots:
 
   livereload-js@3.4.1: {}
 
+  load-json-file@6.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 5.2.0
+      strip-bom: 4.0.0
+      type-fest: 0.6.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -9262,6 +10184,8 @@ snapshots:
   locate-path@8.0.0:
     dependencies:
       p-locate: 6.0.0
+
+  lodash.clonedeep@4.5.0: {}
 
   lodash.flattendeep@4.4.0: {}
 
@@ -9330,7 +10254,13 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  map-age-cleaner@0.1.3:
+    dependencies:
+      p-defer: 1.0.0
+
   map-cache@0.2.2: {}
+
+  map-obj@4.3.0: {}
 
   map-visit@1.0.0:
     dependencies:
@@ -9389,6 +10319,11 @@ snapshots:
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
+
+  mem@8.1.1:
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 3.1.0
 
   memory-streams@0.1.3:
     dependencies:
@@ -9463,6 +10398,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-fn@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -9524,6 +10461,12 @@ snapshots:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
+
+  mkdirp-infer-owner@2.0.0:
+    dependencies:
+      chownr: 2.0.0
+      infer-owner: 1.0.4
+      mkdirp: 1.0.4
 
   mkdirp@0.5.6:
     dependencies:
@@ -9603,6 +10546,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  ndjson@2.0.0:
+    dependencies:
+      json-stringify-safe: 5.0.1
+      minimist: 1.2.8
+      readable-stream: 3.6.2
+      split2: 3.2.2
+      through2: 4.0.2
+
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
@@ -9652,9 +10603,17 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-registry-url@2.0.0: {}
+
+  npm-bundled@2.0.1:
+    dependencies:
+      npm-normalize-package-bin: 2.0.0
+
   npm-install-checks@7.1.1:
     dependencies:
       semver: 7.8.1
+
+  npm-normalize-package-bin@2.0.0: {}
 
   npm-normalize-package-bin@4.0.0: {}
 
@@ -9671,6 +10630,13 @@ snapshots:
       proc-log: 6.1.0
       semver: 7.8.1
       validate-npm-package-name: 7.0.1
+
+  npm-packlist@5.1.3:
+    dependencies:
+      glob: 8.1.0
+      ignore-walk: 5.0.1
+      npm-bundled: 2.0.1
+      npm-normalize-package-bin: 2.0.0
 
   npm-pick-manifest@10.0.0:
     dependencies:
@@ -9811,7 +10777,13 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-defer@1.0.0: {}
+
   p-defer@4.0.1: {}
+
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
 
   p-finally@1.0.0: {}
 
@@ -9838,6 +10810,8 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-map@2.1.0: {}
 
   p-map@3.0.0:
     dependencies:
@@ -9871,6 +10845,15 @@ snapshots:
 
   parse-github-repo-url@1.4.1: {}
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-ms@2.1.0: {}
+
   parse-ms@4.0.0: {}
 
   parse-passwd@1.0.0: {}
@@ -9891,6 +10874,8 @@ snapshots:
 
   pascalcase@0.1.1: {}
 
+  path-absolute@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -9900,6 +10885,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-name@1.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -9926,6 +10913,10 @@ snapshots:
       lru-cache: 11.2.2
       minipass: 7.1.3
 
+  path-temp@2.1.1:
+    dependencies:
+      unique-string: 2.0.0
+
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@8.3.0: {}
@@ -9941,6 +10932,8 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-entry-points@1.1.2: {}
 
   portfinder@1.0.38:
     dependencies:
@@ -9959,14 +10952,22 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-bytes@5.6.0: {}
+
   pretty-format@21.2.1:
     dependencies:
       ansi-regex: 3.0.1
       ansi-styles: 3.2.1
 
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
+
   pretty-ms@9.2.0:
     dependencies:
       parse-ms: 4.0.0
+
+  printable-characters@1.0.42: {}
 
   printf@0.6.1: {}
 
@@ -10048,6 +11049,8 @@ snapshots:
       lodash: 4.18.1
       resolve: 1.22.12
 
+  quick-lru@4.0.1: {}
+
   quick-temp@0.1.9:
     dependencies:
       mktemp: 2.0.2
@@ -10088,6 +11091,18 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  read-cmd-shim@3.0.1: {}
+
+  read-ini-file@4.0.0:
+    dependencies:
+      ini: 3.0.1
+      strip-bom: 4.0.0
+
+  read-yaml-file@2.1.0:
+    dependencies:
+      js-yaml: 4.1.1
+      strip-bom: 4.0.0
+
   readable-stream@1.0.34:
     dependencies:
       core-util-is: 1.0.3
@@ -10104,6 +11119,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  realpath-missing@1.1.0: {}
 
   redeyed@1.0.1:
     dependencies:
@@ -10238,6 +11255,8 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  rfc4648@1.5.4: {}
+
   rfdc@1.4.1: {}
 
   rimraf@2.7.1:
@@ -10307,6 +11326,12 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-execa@0.1.2:
+    dependencies:
+      '@zkochan/which': 2.0.3
+      execa: 5.1.1
+      path-name: 1.0.0
 
   safe-json-parse@1.0.1: {}
 
@@ -10504,6 +11529,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   smart-buffer@4.2.0: {}
 
   snapdragon-node@2.1.1:
@@ -10576,6 +11607,10 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sort-keys@4.2.0:
+    dependencies:
+      is-plain-obj: 2.1.0
 
   sort-object-keys@1.1.3: {}
 
@@ -10651,6 +11686,10 @@ snapshots:
     dependencies:
       extend-shallow: 3.0.2
 
+  split2@3.2.2:
+    dependencies:
+      readable-stream: 3.6.2
+
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
@@ -10658,6 +11697,11 @@ snapshots:
   ssri@8.0.1:
     dependencies:
       minipass: 3.3.6
+
+  stacktracey@2.2.0:
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
 
   static-extend@0.1.2:
     dependencies:
@@ -10671,6 +11715,11 @@ snapshots:
   statuses@2.0.2: {}
 
   strict-event-emitter@0.5.1: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
 
   string-template@0.2.1: {}
 
@@ -10749,6 +11798,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@4.0.0: {}
+
+  strip-comments-strings@1.2.0: {}
 
   strip-eof@1.0.0: {}
 
@@ -10953,6 +12004,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
+
   through@2.3.8: {}
 
   tiny-lr@2.0.0:
@@ -11086,11 +12141,13 @@ snapshots:
 
   type-detect@4.1.0: {}
 
-  type-fest@0.11.0: {}
-
   type-fest@0.20.2: {}
 
+  type-fest@0.6.0: {}
+
   type-fest@0.8.1: {}
+
+  type-fest@4.41.0: {}
 
   type-fest@5.6.0:
     dependencies:
@@ -11146,6 +12203,8 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
+  typescript-memoize@1.1.1: {}
+
   typescript@5.9.3: {}
 
   uc.micro@1.0.6: {}
@@ -11187,6 +12246,10 @@ snapshots:
   unique-slug@2.0.2:
     dependencies:
       imurmurhash: 0.1.4
+
+  unique-string@2.0.0:
+    dependencies:
+      crypto-random-string: 2.0.0
 
   universal-user-agent@7.0.3: {}
 
@@ -11238,6 +12301,10 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@5.0.0:
+    dependencies:
+      builtins: 5.1.0
 
   validate-npm-package-name@6.0.0: {}
 
@@ -11396,6 +12463,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.1
+
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
@@ -11403,6 +12474,10 @@ snapshots:
   which@6.0.0:
     dependencies:
       isexe: 3.1.1
+
+  widest-line@3.1.0:
+    dependencies:
+      string-width: 4.2.3
 
   word-wrap@1.2.5: {}
 
@@ -11438,6 +12513,21 @@ snapshots:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
+
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  write-yaml-file@5.0.0:
+    dependencies:
+      js-yaml: 4.1.1
+      write-file-atomic: 5.0.1
 
   ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     optionalDependencies:

--- a/tests/helpers/fixturify-project.js
+++ b/tests/helpers/fixturify-project.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs-extra');
 const merge = require('lodash/merge');
 // this is a test-only dependency
 // eslint-disable-next-line n/no-unpublished-require
-const FixturifyProject = require('fixturify-project');
+const { Project: FixturifyProject } = require('fixturify-project');
 const Project = require('../../lib/models/project');
 const MockCLI = require('./mock-cli');
 
@@ -45,22 +46,18 @@ function getOptionsObjectWithCallbackFunction(defaultOptions, optionsOrCallback)
   );
 }
 
-// Essentially a copy of the function in node-fixturify-project, converted from TS to JS.
-// We need this for use during toJSON().
-function parseScoped(name) {
-  let matched = name.match(/(@[^@/]+)\/(.*)/);
-  if (matched) {
-    return {
-      scope: matched[1],
-      name: matched[2],
-    };
-  }
-  return null;
-}
-
 module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
-  writeSync() {
-    super.writeSync(...arguments);
+  async write() {
+    await super.write(...arguments);
+
+    // in-repo addons are not real dependencies (they live in `lib/`, not
+    // `node_modules/`), so they are not written by the upstream `write`;
+    // write each one into `lib/<name>` ourselves
+    for (let inRepoAddon of this._inRepoAddons || []) {
+      inRepoAddon.baseDir = path.join(this.baseDir, 'lib', inRepoAddon.name);
+      await inRepoAddon.write();
+    }
+
     this._hasWritten = true;
   }
 
@@ -68,26 +65,25 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
     merge(this.files, filesObj);
   }
 
-  buildProjectModel(ProjectClass = ProjectWithoutInternalAddons) {
+  async buildProjectModel(ProjectClass = ProjectWithoutInternalAddons) {
     if (!this._hasWritten) {
-      this.writeSync();
+      await this.write();
     }
 
-    let pkg = JSON.parse(this.toJSON('package.json'));
+    let pkg = fs.readJsonSync(path.join(this.baseDir, 'package.json'));
     let cli = new MockCLI();
-    let root = path.join(this.root, this.name);
 
-    return new ProjectClass(root, pkg, cli.ui, cli);
+    return new ProjectClass(this.baseDir, pkg, cli.ui, cli);
   }
 
-  buildProjectModelForInRepoAddon(addonName, ProjectClass = ProjectWithoutInternalAddons) {
+  async buildProjectModelForInRepoAddon(addonName, ProjectClass = ProjectWithoutInternalAddons) {
     if (!this._hasWritten) {
-      this.writeSync();
+      await this.write();
     }
 
-    let pkg = JSON.parse(this.files.lib[addonName]['package.json']);
+    let root = path.join(this.baseDir, 'lib', addonName);
+    let pkg = fs.readJsonSync(path.join(root, 'package.json'));
     let cli = new MockCLI();
-    let root = path.join(this.root, this.name, 'lib', addonName);
 
     return new ProjectClass(root, pkg, cli.ui, cli);
   }
@@ -95,6 +91,10 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
   /**
    * Add an entry for this object's `dependencies` list. When this object is written out, the
    * dependency will also then write out appropriate files in this object's `node_modules' subdirectory.
+   *
+   * The new dependency is created as an instance of this class (upstream would create a plain
+   * fixturify-project `Project`), so that ember-cli-specific helpers (`addAddon`,
+   * `addReferenceDependency`, etc.) are available on nested dependencies.
    *
    * @param {String} name name of the dependency to add
    * @param {String} version version of the dependency to add
@@ -105,7 +105,7 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
    */
   addDependency(name, version, optionsOrCallback) {
     const options = getOptionsObjectWithCallbackFunction(optionsOrCallback);
-    return super.addDependency(name, version, options.callback);
+    return super.addDependency(new this.constructor(name, version), options.callback);
   }
 
   /**
@@ -113,7 +113,8 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
    * an entry in `dependencies` where the caller knows the dependency's source files are being
    * created elsewhere in the project tree, so no source files should be created locally in
    * `node_modules`, which is the standard FixturifyProject (and node-fixturify-project) behavior.
-   * We do this by adding the necessary reference to `dependencies` during `toJSON`.
+   * We do this by adding the necessary reference to `dependencies` when `package.json` is
+   * generated during `write`.
    *
    * This is used when two addons wish to share a single definition on disk for a dependency (various parts of
    * ember-cli optimize processing based on paths on disk.)
@@ -136,6 +137,8 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
    * Add an entry to this object's `devDependencies` list. When this object is written out, the
    * dependency will also then write out appropriate files in this object's `node_modules' subdirectory.
    *
+   * As with `addDependency`, the new dependency is created as an instance of this class.
+   *
    * @param {String} name name of the dev dependency to add
    * @param {String} version version of the dev dependency to add
    * @param {Object|Function} optionsOrCallback options to configure the new FixturifyProject, or a callback function to call after creating
@@ -145,7 +148,7 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
    */
   addDevDependency(name, version, optionsOrCallback) {
     const options = getOptionsObjectWithCallbackFunction(optionsOrCallback);
-    return super.addDevDependency(name, version, options.callback);
+    return super.addDevDependency(new this.constructor(name, version), options.callback);
   }
 
   /**
@@ -153,7 +156,8 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
    * an entry in `devDependencies` where the caller knows the dependency's source files are being
    * created elsewhere in the project tree, so no source files should be created locally in
    * `node_modules`, which is the standard FixturifyProject (and node-fixturify-project) behavior.
-   * We do this by adding the necessary reference to `devDependencies` during `toJSON`.
+   * We do this by adding the necessary reference to `devDependencies` when `package.json` is
+   * generated during `write`.
    *
    * This is used when two addons wish to share a single definition on disk for a devDependency
    * (various parts of ember-cli optimize processing based on paths on disk.)
@@ -287,13 +291,11 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
 
     // configure the current project to have an ember-addon configured at the
     // appropriate path, i.e. under a common root directory (lib).
-    const addonRootDir = 'lib';
+    const addonPath = `lib/${name}`;
 
     // Add to ember-addon.paths list
     let addon = (this.pkg['ember-addon'] = this.pkg['ember-addon'] || {});
     addon.paths = addon.paths || [];
-
-    const addonPath = `${addonRootDir}/${name}`;
 
     if (addon.paths.find((path) => path.toLowerCase() === addonPath.toLowerCase())) {
       throw new Error(`project: ${this.name} already contains the in-repo-addon: ${name}`);
@@ -301,10 +303,9 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
 
     addon.paths.push(addonPath);
 
-    this.files[addonRootDir] = this.files[addonRootDir] || {};
+    this._inRepoAddons = this._inRepoAddons || [];
+    this._inRepoAddons.push(inRepoAddon);
 
-    let addonJSON = inRepoAddon.toJSON();
-    Object.assign(this.files[addonRootDir], addonJSON);
     return inRepoAddon;
   }
 
@@ -343,54 +344,24 @@ module.exports = class EmberCLIFixturifyProject extends FixturifyProject {
   }
 
   /**
-   * Convert the object into a data structure suitable for passing to `fixturify`.
+   * Applies the 'reference' dependencies (see `addReferenceDependency` and
+   * `addReferenceDevDependency`) to the generated `package.json` contents when this
+   * project is written to disk.
    *
-   * @param {String} key optional key. If specified, the object will be run through toJSON, then the given
-   * property extracted and returned.
-   * @returns {Object} the `toJSON` value of the object (wrapped) or the toJSON value of the specified field
-   * (not wrapped.)
+   * This overrides a private fixturify-project method, as there is no public hook for
+   * customizing the generated `package.json`.
    */
-  toJSON(key) {
-    if (key) {
-      return super.toJSON(key);
+  pkgJSONWithDeps(resolvedLinks) {
+    const pkg = super.pkgJSONWithDeps(resolvedLinks);
+
+    if (this._referenceDependencies) {
+      pkg.dependencies = Object.assign({}, pkg.dependencies, this._referenceDependencies);
     }
 
-    let jsonData = super.toJSON();
-
-    let scoped = parseScoped(this.name);
-
-    // Allowing for scoped names, get the object in the JSON structure that corresponds
-    // to this FixturifyProject.
-    let container = scoped ? jsonData[scoped.scope][scoped.name] : jsonData[this.name];
-
-    if (this._referenceDependencies || this._referenceDevDependencies) {
-      let pkg = JSON.parse(container['package.json']);
-
-      if (this._referenceDependencies) {
-        if (!pkg.dependencies) {
-          pkg.dependencies = {};
-        }
-
-        Object.assign(pkg.dependencies, this._referenceDependencies);
-      }
-
-      if (this._referenceDevDependencies) {
-        if (!pkg.devDependencies) {
-          pkg.devDependencies = {};
-        }
-
-        Object.assign(pkg.devDependencies, this._referenceDevDependencies);
-      }
-
-      container['package.json'] = JSON.stringify(pkg, undefined, 2);
+    if (this._referenceDevDependencies) {
+      pkg.devDependencies = Object.assign({}, pkg.devDependencies, this._referenceDevDependencies);
     }
 
-    // an optimization to remove any node_modules declaration that has nothing in it,
-    // to avoid creating extra directories for no reason.
-    if (container['node_modules'] && Object.keys(container['node_modules']).length === 0) {
-      delete container['node_modules'];
-    }
-
-    return jsonData;
+    return pkg;
   }
 };

--- a/tests/helpers/per-bundle-addon-cache.js
+++ b/tests/helpers/per-bundle-addon-cache.js
@@ -113,47 +113,37 @@ function countAddons(projectOrAddon, config = { byName: {}, proxyCount: 0, realA
 function createStandardCacheFixture() {
   let project = new FixturifyProject('test-ember-project', '1.0.0');
 
+  // these two addons are defined in PROJECT/lib but the project doesn't depend
+  // on them directly (their entries in the project's `ember-addon.paths` are
+  // removed below); the addons and engines that follow share these two
+  // definitions on disk by relative path
+  project.addInRepoAddon('test-addon-dep', '1.0.0');
+  project.addInRepoAddon('test-engine-dep', '1.0.0');
+  project.pkg['ember-addon'].paths = [];
+
   project.addInRepoAddon('test-addon-a', '1.0.0', {
     callback: (addonA) => {
-      addonA.addInRepoAddon('test-addon-dep', '1.0.0');
-
-      // At this point, TAD has been run through toJSON inside of TAA.
-      // TAD itself has no issues.
-      // in TAA, we want to store all the inrepo addons, at any level, in
-      // PROJ/lib, so move TAD from TAA and change its path in TAA.
       addonA.pkg['ember-addon'].paths = ['../test-addon-dep'];
-      project.files.lib = project.files.lib || {};
-      project.files.lib['test-addon-dep'] = addonA.files.lib['test-addon-dep'];
-      delete addonA.files.lib;
     },
   });
 
   project.addInRepoEngine('lazy-engine-a', '1.0.0', {
     enableLazyLoading: true,
     callback: (lazyEngineA) => {
-      lazyEngineA.addInRepoAddon('test-engine-dep', '1.0.0');
-
-      // Similar to above
       lazyEngineA.pkg['ember-addon'].paths = ['../test-engine-dep'];
-      project.files.lib['test-engine-dep'] = lazyEngineA.files.lib['test-engine-dep'];
-      delete lazyEngineA.files.lib;
     },
   });
 
   project.addInRepoEngine('lazy-engine-b', '1.0.0', {
     enableLazyLoading: true,
     callback: (lazyEngineB) => {
-      // These two addon definitions have already been moved to project, so just
-      // fix the ember-addon.paths and remove the files.lib entry.
       lazyEngineB.pkg['ember-addon'].paths = ['../test-engine-dep', '../test-addon-dep'];
-      delete lazyEngineB.files.lib;
     },
   });
 
   project.addInRepoEngine('regular-engine-c', '1.0.0', {
     callback: (regularEngineC) => {
       regularEngineC.pkg['ember-addon'].paths = ['../test-engine-dep'];
-      delete regularEngineC.files.lib;
     },
   });
 

--- a/tests/unit/broccoli/ember-app-test.js
+++ b/tests/unit/broccoli/ember-app-test.js
@@ -1001,7 +1001,7 @@ describe('EmberApp', function () {
         fixturifyProject.dispose();
       });
 
-      it('throws an error if an addon `include` is specified', function () {
+      it('throws an error if an addon `include` is specified', async function () {
         fixturifyProject.addInRepoAddon('foo', '1.0.0', { allowCachingPerBundle: true });
         fixturifyProject.addInRepoAddon('foo-bar', '1.0.0', {
           callback: (inRepoAddon) => {
@@ -1009,9 +1009,9 @@ describe('EmberApp', function () {
           },
         });
 
-        fixturifyProject.writeSync();
+        await fixturifyProject.write();
 
-        let projectWithBundleCaching = fixturifyProject.buildProjectModel();
+        let projectWithBundleCaching = await fixturifyProject.buildProjectModel();
         projectWithBundleCaching.initializeAddons();
         projectWithBundleCaching.addons.push(EMBER_SOURCE_ADDON);
 
@@ -1032,7 +1032,7 @@ describe('EmberApp', function () {
         );
       });
 
-      it('throws an error if an addon `exclude` is specified', function () {
+      it('throws an error if an addon `exclude` is specified', async function () {
         fixturifyProject.addInRepoAddon('foo', '1.0.0', { allowCachingPerBundle: true });
         fixturifyProject.addInRepoAddon('foo-bar', '1.0.0', {
           callback: (inRepoAddon) => {
@@ -1040,9 +1040,9 @@ describe('EmberApp', function () {
           },
         });
 
-        fixturifyProject.writeSync();
+        await fixturifyProject.write();
 
-        let projectWithBundleCaching = fixturifyProject.buildProjectModel();
+        let projectWithBundleCaching = await fixturifyProject.buildProjectModel();
         projectWithBundleCaching.initializeAddons();
         projectWithBundleCaching.addons.push(EMBER_SOURCE_ADDON);
 

--- a/tests/unit/models/host-info-cache-test.js
+++ b/tests/unit/models/host-info-cache-test.js
@@ -19,7 +19,7 @@ describe('Unit | host-addons-utils', function () {
     fixturifyProject.dispose();
   });
 
-  it('multiple lazy engines in project, including nested lazy engines', function () {
+  it('multiple lazy engines in project, including nested lazy engines', async function () {
     fixturifyProject.addEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
 
     fixturifyProject.addAddon('addon-a', '1.0.0', {
@@ -35,8 +35,8 @@ describe('Unit | host-addons-utils', function () {
       },
     });
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
@@ -100,7 +100,7 @@ describe('Unit | host-addons-utils', function () {
     );
   });
 
-  it('multiple lazy engines in project, including nested lazy engines; some nested lazy engines have non-lazy deps', function () {
+  it('multiple lazy engines in project, including nested lazy engines; some nested lazy engines have non-lazy deps', async function () {
     fixturifyProject.addEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
 
     fixturifyProject.addAddon('addon-a', '1.0.0', {
@@ -117,8 +117,8 @@ describe('Unit | host-addons-utils', function () {
       },
     });
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
@@ -148,7 +148,7 @@ describe('Unit | host-addons-utils', function () {
     );
   });
 
-  it('multiple lazy engines at same level with a common ancestor host', function () {
+  it('multiple lazy engines at same level with a common ancestor host', async function () {
     fixturifyProject.addInRepoEngine('lazy-engine-a', '1.0.0', { enableLazyLoading: true });
     fixturifyProject.pkg['ember-addon'].paths = [];
 
@@ -166,8 +166,8 @@ describe('Unit | host-addons-utils', function () {
       },
     });
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 

--- a/tests/unit/models/instantiate-addons-test.js
+++ b/tests/unit/models/instantiate-addons-test.js
@@ -15,7 +15,7 @@ describe('models/instatiate-addons.js', function () {
     fixturifyProject.dispose();
   });
 
-  it('ordering without before/after', function () {
+  it('ordering without before/after', async function () {
     // this tests ordering is very important to maintain, it tests some naunced
     // details which must be maintained
     fixturifyProject.addAddon('foo', '1.0.0');
@@ -32,72 +32,75 @@ describe('models/instatiate-addons.js', function () {
     fixturifyProject.addDevAddon('b', '2.0.0');
     fixturifyProject.addDevAddon('c', '2.0.0');
 
-    fixturifyProject.writeSync();
+    await fixturifyProject.write();
 
-    let project = fixturifyProject.buildProjectModel();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
+    // for the duplicated packages, fixturify-project writes `devDependencies` to
+    // `node_modules` after `dependencies`, so the devDependency copy (2.0.0) is
+    // the one that ends up on disk
     expect(project.addons.map((a) => ({ name: a.pkg.name, version: a.pkg.version }))).to.deep.eql([
       { name: 'a', version: '2.0.0' },
       { name: 'b', version: '2.0.0' },
       { name: 'c', version: '2.0.0' },
 
-      { name: 'bar', version: '1.0.0' },
-      { name: 'foo', version: '1.0.0' },
-      { name: 'qux', version: '1.0.0' },
+      { name: 'bar', version: '2.0.0' },
+      { name: 'foo', version: '2.0.0' },
+      { name: 'qux', version: '2.0.0' },
     ]);
   });
 
-  it('ordering with before specified', function () {
+  it('ordering with before specified', async function () {
     fixturifyProject.addAddon('foo', '1.0.0');
     fixturifyProject.addAddon('bar', '1.0.0');
     fixturifyProject.addAddon('qux', '1.0.0', (a) => (a.pkg['ember-addon'].before = 'foo'));
 
-    fixturifyProject.writeSync();
+    await fixturifyProject.write();
 
-    let project = fixturifyProject.buildProjectModel();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(project.addons.map((a) => a.name)).to.deep.eql(['bar', 'qux', 'foo']);
   });
 
-  it('ordering with after specified', function () {
+  it('ordering with after specified', async function () {
     fixturifyProject.addAddon('foo', '1.0.0');
     fixturifyProject.addAddon('bar', '1.0.0');
     fixturifyProject.addAddon('qux', '1.0.0', (a) => (a.pkg['ember-addon'].after = 'foo'));
 
-    fixturifyProject.writeSync();
+    await fixturifyProject.write();
 
-    let project = fixturifyProject.buildProjectModel();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(project.addons.map((a) => a.name)).to.deep.eql(['bar', 'foo', 'qux']);
   });
 
-  it('ordering always matches package.json name (index.js name is ignored)', function () {
+  it('ordering always matches package.json name (index.js name is ignored)', async function () {
     let foo = fixturifyProject.addAddon('lol', '1.0.0');
     foo.files['index.js'] = 'module.exports = { name: "foo" };';
     fixturifyProject.addAddon('qux', '1.0.0', (a) => (a.pkg['ember-addon'].before = 'foo'));
 
-    fixturifyProject.writeSync();
+    await fixturifyProject.write();
 
-    let project = fixturifyProject.buildProjectModel();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(project.addons.map((a) => a.name)).to.deep.eql(['foo', 'qux']);
   });
 
-  it('errors when there is a cycle detected', function () {
+  it('errors when there is a cycle detected', async function () {
     fixturifyProject.addAddon('foo', '1.0.0', (a) => (a.pkg['ember-addon'].after = 'qux'));
     fixturifyProject.addAddon('qux', '1.0.0', (a) => (a.pkg['ember-addon'].after = 'foo'));
 
-    fixturifyProject.writeSync();
+    await fixturifyProject.write();
 
-    let project = fixturifyProject.buildProjectModel();
+    let project = await fixturifyProject.buildProjectModel();
 
     expect(() => project.initializeAddons()).to.throw(/cycle detected/);
   });

--- a/tests/unit/models/package-info-cache/package-info-cache-test.js
+++ b/tests/unit/models/package-info-cache/package-info-cache-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs-extra');
 const { expect } = require('chai');
 const PackageInfo = require('../../../../lib/models/package-info-cache/package-info');
 const Project = require('../../../../lib/models/project');
@@ -237,7 +238,7 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
   describe('packageInfo', function () {
     describe('project with invalid paths', function () {
       let project, fixturifyProject;
-      beforeEach(function () {
+      beforeEach(async function () {
         // create a new ember-app
         fixturifyProject = new FixturifyProject('simple-ember-app', '0.0.0', (project) => {
           project.addAddon('ember-resolver', '^5.0.1');
@@ -252,9 +253,9 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
           project.pkg['ember-addon'].paths.push('lib/no-such-path');
         });
 
-        fixturifyProject.writeSync();
+        await fixturifyProject.write();
 
-        project = fixturifyProject.buildProjectModel(Project);
+        project = await fixturifyProject.buildProjectModel(Project);
       });
 
       afterEach(function () {
@@ -269,19 +270,13 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
     });
     describe('valid project', function () {
       let project, fixturifyProject;
-      before(function () {
+      before(async function () {
         // create a new ember-app
         fixturifyProject = new FixturifyProject('simple-ember-app', '0.0.0', (project) => {
           project.addAddon('ember-resolver', '^5.0.1');
           project.addAddon('ember-random-addon', 'latest', (addon) => {
             addon.addAddon('other-nested-addon', 'latest', (addon) => {
               addon.addAddon('ember-resolver', '*');
-              addon.toJSON = function () {
-                const json = Object.getPrototypeOf(this).toJSON.call(this);
-                // here we introduce an empty folder in our node_modules.
-                json[this.name].node_modules['ember-resolver'] = {};
-                return json;
-              };
             });
           });
 
@@ -293,12 +288,26 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
           project.addDevDependency('non-ember-thingy', 'latest');
         });
 
-        fixturifyProject.writeSync();
+        await fixturifyProject.write();
 
-        project = fixturifyProject.buildProjectModel(Project);
+        // here we introduce an empty folder in our node_modules, by emptying out
+        // the nested ember-resolver that was written above.
+        fs.emptyDirSync(
+          path.join(
+            fixturifyProject.baseDir,
+            'node_modules',
+            'ember-random-addon',
+            'node_modules',
+            'other-nested-addon',
+            'node_modules',
+            'ember-resolver'
+          )
+        );
+
+        project = await fixturifyProject.buildProjectModel(Project);
         project.discoverAddons();
         pic = project.packageInfoCache;
-        projectPackageInfo = pic.getEntry(path.join(fixturifyProject.root, 'simple-ember-app'));
+        projectPackageInfo = pic.getEntry(fixturifyProject.baseDir);
       });
 
       after(function () {
@@ -353,7 +362,7 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
 
         expect(inRepoAddons).to.exist;
         expect(inRepoAddons.length).to.equal(1);
-        expect(inRepoAddons[0].realPath).to.contain(path.join('simple-ember-app', 'lib', 'ember-super-button'));
+        expect(inRepoAddons[0].realPath).to.equal(path.join(fixturifyProject.baseDir, 'lib', 'ember-super-button'));
         expect(inRepoAddons[0].pkg.name).to.equal('ember-super-button');
       });
 
@@ -522,8 +531,8 @@ describe('models/package-info-cache/package-info-cache-test.js', function () {
         });
       });
 
-      it('lock down dependency orderings', function () {
-        let project = fixturifyProject.buildProjectModel();
+      it('lock down dependency orderings', async function () {
+        let project = await fixturifyProject.buildProjectModel();
 
         project.discoverAddons();
 

--- a/tests/unit/models/per-bundle-addon-cache/cache-bundle-hosts-test.js
+++ b/tests/unit/models/per-bundle-addon-cache/cache-bundle-hosts-test.js
@@ -12,9 +12,9 @@ const { createStandardCacheFixture } = require('../../../../tests/helpers/per-bu
 describe('Unit | per-bundle-addon-cache bundle host', function () {
   let project;
 
-  before('setup fixture', function setup() {
+  before('setup fixture', async function setup() {
     let fixture = createStandardCacheFixture();
-    project = fixture.buildProjectModel(Project);
+    project = await fixture.buildProjectModel(Project);
     project.initializeAddons();
   });
 

--- a/tests/unit/models/per-bundle-addon-cache/enable-cache-test.js
+++ b/tests/unit/models/per-bundle-addon-cache/enable-cache-test.js
@@ -20,9 +20,9 @@ function disablePerBundleAddonCache() {
   process.env.EMBER_CLI_ADDON_INSTANCE_CACHING = false;
 }
 
-function createProject() {
+async function createProject() {
   let fixture = createStandardCacheFixture();
-  let project = fixture.buildProjectModel(Project);
+  let project = await fixture.buildProjectModel(Project);
   return project;
 }
 
@@ -31,19 +31,19 @@ describe('Unit | per-bundle-addon-cache enable caching', function () {
     enablePerBundleAddonCache();
   });
 
-  it('perBundleAddonCache should be set in Project if EMBER_CLI_ADDON_INSTANCE_CACHING is not false', function () {
+  it('perBundleAddonCache should be set in Project if EMBER_CLI_ADDON_INSTANCE_CACHING is not false', async function () {
     enablePerBundleAddonCache('foo');
-    let project = createProject();
+    let project = await createProject();
     expect(project.perBundleAddonCache).to.exist;
 
     enablePerBundleAddonCache();
-    project = createProject();
+    project = await createProject();
     expect(project.perBundleAddonCache).to.exist;
   });
 
-  it('perBundleAddonCache should not be set in Project if EMBER_CLI_ADDON_INSTANCE_CACHING is false', function () {
+  it('perBundleAddonCache should not be set in Project if EMBER_CLI_ADDON_INSTANCE_CACHING is false', async function () {
     disablePerBundleAddonCache();
-    let project = createProject();
+    let project = await createProject();
     expect(project.perBundleAddonCache).not.to.exist;
   });
 });

--- a/tests/unit/models/per-bundle-addon-cache/proxy-test.js
+++ b/tests/unit/models/per-bundle-addon-cache/proxy-test.js
@@ -31,7 +31,7 @@ describe('models/per-bundle-addon-cache', function () {
     fixturifyProject.dispose();
   });
 
-  it('simple case: bundle addon caching within a single project host', function () {
+  it('simple case: bundle addon caching within a single project host', async function () {
     fixturifyProject.addInRepoAddon('foo', '1.0.0', { allowCachingPerBundle: true });
     fixturifyProject.addInRepoAddon('foo-bar', '1.0.0', {
       callback: (inRepoAddon) => {
@@ -39,15 +39,15 @@ describe('models/per-bundle-addon-cache', function () {
       },
     });
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(areAllInstancesEqualWithinHost(project, 'foo')).to.be.true;
   });
 
-  it('it should create multiple proxies within a project host', function () {
+  it('it should create multiple proxies within a project host', async function () {
     fixturifyProject.addInRepoAddon('foo', '1.0.0', { allowCachingPerBundle: true });
 
     for (let i = 0; i < 10; i++) {
@@ -58,15 +58,15 @@ describe('models/per-bundle-addon-cache', function () {
       });
     }
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(areAllInstancesEqualWithinHost(project, 'foo')).to.be.true;
   });
 
-  it('it should create a proxy for a regular addon when added as a dependency to an in-repo addon', function () {
+  it('it should create a proxy for a regular addon when added as a dependency to an in-repo addon', async function () {
     fixturifyProject.addAddon('foo', '1.0.0', { allowCachingPerBundle: true });
 
     for (let i = 0; i < 10; i++) {
@@ -77,15 +77,15 @@ describe('models/per-bundle-addon-cache', function () {
       });
     }
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(areAllInstancesEqualWithinHost(project, 'foo')).to.be.true;
   });
 
-  it('it should create a proxy for a regular addon when added as a dependency to a regular addon', function () {
+  it('it should create a proxy for a regular addon when added as a dependency to a regular addon', async function () {
     fixturifyProject.addAddon('foo', '1.0.0', { allowCachingPerBundle: true });
 
     for (let i = 0; i < 10; i++) {
@@ -96,15 +96,15 @@ describe('models/per-bundle-addon-cache', function () {
       });
     }
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
     expect(areAllInstancesEqualWithinHost(project, 'foo')).to.be.true;
   });
 
-  it('it should create a proxy to a target "real addon" per host', function () {
+  it('it should create a proxy to a target "real addon" per host', async function () {
     fixturifyProject.addAddon('foo', '1.0.0', { allowCachingPerBundle: true });
 
     fixturifyProject.addInRepoEngine('in-repo-lazy-engine', '1.0.0', {
@@ -121,8 +121,8 @@ describe('models/per-bundle-addon-cache', function () {
       },
     });
 
-    fixturifyProject.writeSync();
-    let project = fixturifyProject.buildProjectModel();
+    await fixturifyProject.write();
+    let project = await fixturifyProject.buildProjectModel();
 
     project.initializeAddons();
 
@@ -146,7 +146,7 @@ describe('models/per-bundle-addon-cache', function () {
       delete process.env.EMBER_ENGINES_ADDON_DEDUPE;
     });
 
-    it('it should create a proxy to a target "real addon" using the project host', function () {
+    it('it should create a proxy to a target "real addon" using the project host', async function () {
       fixturifyProject.addAddon('foo', '1.0.0', { allowCachingPerBundle: true });
 
       fixturifyProject.addInRepoEngine('in-repo-lazy-engine', '1.0.0', {
@@ -163,8 +163,8 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      fixturifyProject.writeSync();
-      let project = fixturifyProject.buildProjectModel();
+      await fixturifyProject.write();
+      let project = await fixturifyProject.buildProjectModel();
 
       project.initializeAddons();
 
@@ -185,7 +185,7 @@ describe('models/per-bundle-addon-cache', function () {
       ).to.be.true;
     });
 
-    it('addon with `allowCachingPerBundle`, 1 in each of 2 lazy engines; project also depends on this addon', function () {
+    it('addon with `allowCachingPerBundle`, 1 in each of 2 lazy engines; project also depends on this addon', async function () {
       fixturifyProject.addAddon('test-addon-a', '1.0.0', { allowCachingPerBundle: true });
 
       fixturifyProject.addEngine('lazy-engine-a', '1.0.0', {
@@ -202,7 +202,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -229,7 +229,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries).to.not.exist;
     });
 
-    it('2 lazy engines; each depend on two addons; project also depends on these addons, ensure project cache is used', function () {
+    it('2 lazy engines; each depend on two addons; project also depends on these addons, ensure project cache is used', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
         callback: (addon) => {
@@ -255,7 +255,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -306,7 +306,7 @@ describe('models/per-bundle-addon-cache', function () {
       );
     });
 
-    it('should work for a common ancestor host that is not the project; i.e., another a lazy engine', function () {
+    it('should work for a common ancestor host that is not the project; i.e., another a lazy engine', async function () {
       fixturifyProject.addEngine('lazy-engine-a', '1.0.0', {
         enableLazyLoading: true,
         allowCachingPerBundle: true,
@@ -332,7 +332,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -372,7 +372,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries).to.be.equal(null, 'should not exist; lazy-engine C has not opted-in to bundle caching');
     });
 
-    it('should work for a common ancestor host that is not the project where multiple hosts bundle the same addon', function () {
+    it('should work for a common ancestor host that is not the project where multiple hosts bundle the same addon', async function () {
       fixturifyProject.addInRepoEngine('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
       });
@@ -411,7 +411,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -436,7 +436,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1, 'should exist; lazy-engine B depends on a non-project addon');
     });
 
-    it('should work for a common ancestor host that is not the project with an addon bundled by a different host', function () {
+    it('should work for a common ancestor host that is not the project with an addon bundled by a different host', async function () {
       fixturifyProject.addAddon('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
       });
@@ -468,7 +468,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -511,7 +511,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries).to.be.equal(null, 'should not exist; lazy-engine C has not opted-in to bundle caching');
     });
 
-    it('should work for a common ancestor host that is not the project with an addon bundled by a different host when building a lazy engine independently', function () {
+    it('should work for a common ancestor host that is not the project with an addon bundled by a different host when building a lazy engine independently', async function () {
       fixturifyProject.addAddon('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
       });
@@ -553,7 +553,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModelForInRepoAddon('lazy-engine-a-project');
+      let project = await fixturifyProject.buildProjectModelForInRepoAddon('lazy-engine-a-project');
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -605,9 +605,9 @@ describe('models/per-bundle-addon-cache', function () {
   });
 
   describe('proxy checks with addon counts', function () {
-    it('no `allowCachingPerBundle` set, no proxies, verify instance counts', function () {
+    it('no `allowCachingPerBundle` set, no proxies, verify instance counts', async function () {
       let fixture = createStandardCacheFixture();
-      let project = fixture.buildProjectModel(Project);
+      let project = await fixture.buildProjectModel(Project);
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -625,7 +625,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(project.perBundleAddonCache.numProxies).to.equal(0);
     });
 
-    it('addon with allowCachingPerBundle, 1 instance, the rest proxies', function () {
+    it('addon with allowCachingPerBundle, 1 instance, the rest proxies', async function () {
       // PROJ to TAA, TAB, TAC and TAD. TAB, TAC and TAD have TAA underneath.
       fixturifyProject.addAddon('test-addon-a', '1.0.0', { allowCachingPerBundle: true });
       fixturifyProject.addAddon('test-addon-b', '1.0.0', {
@@ -646,7 +646,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -661,7 +661,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(counts.byName['test-addon-c'].addons.length).to.equal(1);
     });
 
-    it('addon with `allowCachingPerBundle`, 1 in lazy engine, one in regular', function () {
+    it('addon with `allowCachingPerBundle`, 1 in lazy engine, one in regular', async function () {
       // PROJ to LEA, REB, LEA and REB both depend on TAA
       // Neither instance of test-addon-a is declared in the project, but the one in engine B
       // will be 'owned' by Project as far as PerBundleAddonCache is concerned.
@@ -680,7 +680,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -704,7 +704,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('addon with allowCachingPerBundle, 1 in each of 2 lazy engines', function () {
+    it('addon with allowCachingPerBundle, 1 in each of 2 lazy engines', async function () {
       // Same as above, but regular-engine-b is now lazy-engine-b
       // Should have 2 instances, 1 in LEA, 1 in LEB, separate paths.
       fixturifyProject.addEngine('lazy-engine-a', '1.0.0', {
@@ -721,7 +721,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -746,7 +746,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('addon with `allowCachingPerBundle`, 1 in each of 2 lazy engines; project also depends on this addon', function () {
+    it('addon with `allowCachingPerBundle`, 1 in each of 2 lazy engines; project also depends on this addon', async function () {
       fixturifyProject.addAddon('test-addon-a', '1.0.0', { allowCachingPerBundle: true });
 
       fixturifyProject.addEngine('lazy-engine-a', '1.0.0', {
@@ -763,7 +763,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let counts = countAddons(project);
@@ -788,7 +788,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('addon with allowCachingPerBundle, 2 regular engines - cache entries in project but not declared there', function () {
+    it('addon with allowCachingPerBundle, 2 regular engines - cache entries in project but not declared there', async function () {
       // Project declares an in-repo addon TAA. Then remove the ember-addon.paths entry so the project
       // "doesn't know" about it but it's available for engines. Declare 2 non-lazy in-repo engines.
       // Then have them add a shared in-repo dependency to TAA, with the path pointing to the one in
@@ -813,9 +813,9 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      fixturifyProject.writeSync();
+      await fixturifyProject.write();
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { proxyCount, byName } = countAddons(project);
@@ -834,7 +834,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('addon with allowCachingPerBundle, 2 regular engines - cache entries in project (also declared there)', function () {
+    it('addon with allowCachingPerBundle, 2 regular engines - cache entries in project (also declared there)', async function () {
       // Same as above, now both are regular engines.
       // Should have 1 instance, 2 proxies, both in project.
       fixturifyProject.addAddon('test-addon-a', '1.0.0', { allowCachingPerBundle: true });
@@ -851,9 +851,9 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      fixturifyProject.writeSync();
+      await fixturifyProject.write();
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { proxyCount, byName } = countAddons(project);
@@ -872,7 +872,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('2 lazy engines; each depend on two addons; ensure that each lazy engine has proxy for subsequent instantiations of duplicate addons', function () {
+    it('2 lazy engines; each depend on two addons; ensure that each lazy engine has proxy for subsequent instantiations of duplicate addons', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
         callback: (addon) => {
@@ -899,7 +899,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -935,7 +935,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(cacheEntries.length).to.equal(1);
     });
 
-    it('2 regular engines; each depend on two addons; ensure that project cache is used', function () {
+    it('2 regular engines; each depend on two addons; ensure that project cache is used', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0', {
         allowCachingPerBundle: true,
         callback: (addon) => {
@@ -960,7 +960,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -978,7 +978,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(byName['test-addon-b'].proxyCount).to.equal(2);
     });
 
-    it('multiple references to a single lazy engine that has opted-in to `allowCachingPerBundle`', function () {
+    it('multiple references to a single lazy engine that has opted-in to `allowCachingPerBundle`', async function () {
       fixturifyProject.addInRepoEngine('lazy-engine-a', '1.0.0', {
         allowCachingPerBundle: true,
         enableLazyLoading: true,
@@ -1002,7 +1002,7 @@ describe('models/per-bundle-addon-cache', function () {
         },
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -1013,7 +1013,7 @@ describe('models/per-bundle-addon-cache', function () {
       expect(areAllInstancesEqualWithinHost(project, 'lazy-engine-a')).to.be.true;
     });
 
-    it('uses the custom `per-bundle-addon-cache.js` util if it exists', function () {
+    it('uses the custom `per-bundle-addon-cache.js` util if it exists', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0');
 
       fixturifyProject.addInRepoAddon('test-addon-b', '1.0.0', (addon) => {
@@ -1038,7 +1038,7 @@ module.exports = {
 };
       `;
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -1047,7 +1047,7 @@ module.exports = {
       expect(byName['test-addon-a'].proxyCount).to.equal(1);
     });
 
-    it('throws an error if the provided `perBundleAddonCacheUtil` does not exist', function () {
+    it('throws an error if the provided `perBundleAddonCacheUtil` does not exist', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0');
 
       fixturifyProject.addInRepoAddon('test-addon-b', '1.0.0', (addon) => {
@@ -1056,14 +1056,12 @@ module.exports = {
 
       fixturifyProject.pkg['ember-addon'].perBundleAddonCacheUtil = './per-bundle-addon-cache.js';
 
-      expect(() => {
-        fixturifyProject.buildProjectModel();
-      }).to.throw(
+      await expect(fixturifyProject.buildProjectModel()).to.be.rejectedWith(
         '[ember-cli] the provided `./per-bundle-addon-cache.js` for `ember-addon.perBundleAddonCacheUtil` does not exist'
       );
     });
 
-    it('bundle caching works for addons that opt-in via `prototype.allowCachingPerBundle`', function () {
+    it('bundle caching works for addons that opt-in via `prototype.allowCachingPerBundle`', async function () {
       fixturifyProject.addInRepoAddon('test-addon-a', '1.0.0', {
         addonEntryPoint: `
           function Addon() {}
@@ -1078,7 +1076,7 @@ module.exports = {
         addon.pkg['ember-addon'].paths = ['../test-addon-a'];
       });
 
-      let project = fixturifyProject.buildProjectModel();
+      let project = await fixturifyProject.buildProjectModel();
       project.initializeAddons();
 
       let { byName } = countAddons(project);
@@ -1101,7 +1099,7 @@ module.exports = {
       return _foundAddons;
     }
 
-    it('does not throw if the addon returns a stable cache key', function () {
+    it('does not throw if the addon returns a stable cache key', async function () {
       fixturifyProject.addInRepoAddon('foo', '1.0.0', {
         allowCachingPerBundle: true,
       });
@@ -1112,8 +1110,8 @@ module.exports = {
         },
       });
 
-      fixturifyProject.writeSync();
-      let project = fixturifyProject.buildProjectModel();
+      await fixturifyProject.write();
+      let project = await fixturifyProject.buildProjectModel();
 
       project.initializeAddons();
 
@@ -1126,7 +1124,7 @@ module.exports = {
       });
     });
 
-    it('throws an error for addons that do not have stable cache keys', function () {
+    it('throws an error for addons that do not have stable cache keys', async function () {
       fixturifyProject.addInRepoAddon('foo', '1.0.0', {
         allowCachingPerBundle: true,
         additionalContent: `init() {this._super.init.apply(this, arguments); this.current = 0;}, cacheKeyForTree() {return this.current++;},`,
@@ -1138,8 +1136,8 @@ module.exports = {
         },
       });
 
-      fixturifyProject.writeSync();
-      let project = fixturifyProject.buildProjectModel();
+      await fixturifyProject.write();
+      let project = await fixturifyProject.buildProjectModel();
 
       project.initializeAddons();
 

--- a/tests/unit/tasks/server/express-server-test.js
+++ b/tests/unit/tasks/server/express-server-test.js
@@ -24,15 +24,15 @@ function sleep(timeout) {
   return new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
-describe('express-server: processAppMiddlewares', function () {
+describe('express-server: processAppMiddlewares', async function () {
   let subject, fixturifyProject;
 
   nock.enableNetConnect();
 
-  function makeSubject() {
+  async function makeSubject() {
     subject = new ExpressServer({
       ui: new MockUI(),
-      project: fixturifyProject.buildProjectModel(),
+      project: await fixturifyProject.buildProjectModel(),
       watcher: new MockWatcher(),
       serverWatcher: new MockServerWatcher(),
       serverRestartDelayTime: 100,
@@ -53,60 +53,60 @@ describe('express-server: processAppMiddlewares', function () {
     await subject.stopHttpServer().catch(() => {});
   });
 
-  it('has a good error message if a file "server.js" exists, but does not export a function', function () {
+  it('has a good error message if a file "server.js" exists, but does not export a function', async function () {
     fixturifyProject.addFiles({
       'server.js': 'module.exports = { name: "foo" }',
     });
-    let subject = makeSubject();
+    let subject = await makeSubject();
 
     expect(() => {
       subject.processAppMiddlewares();
     }).to.throw(TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
   });
 
-  it('has a good error message if a file "server/index.js" exists, but does not export a function', function () {
+  it('has a good error message if a file "server/index.js" exists, but does not export a function', async function () {
     fixturifyProject.addFiles({
       server: {
         'index.js': 'module.exports = { name: "foo" }',
       },
     });
 
-    let subject = makeSubject();
+    let subject = await makeSubject();
     expect(() => {
       subject.processAppMiddlewares();
     }).to.throw(TypeError, 'ember-cli expected ./server/index.js to be the entry for your mock or proxy server');
   });
 
-  it('returns values returned by server/index.js', function () {
+  it('returns values returned by server/index.js', async function () {
     fixturifyProject.addFiles({
       server: {
         'index.js': 'module.exports = function() {return "foo"}',
       },
     });
-    let subject = makeSubject();
+    let subject = await makeSubject();
     expect(subject.processAppMiddlewares()).to.equal('foo');
   });
 
-  it('returns values returned by server.js', function () {
+  it('returns values returned by server.js', async function () {
     fixturifyProject.addFiles({
       'server.js': 'module.exports = function() {return "foo"}',
     });
-    let subject = makeSubject();
+    let subject = await makeSubject();
     expect(subject.processAppMiddlewares()).to.equal('foo');
   });
 
-  it('returns undefined if middleware files does not exists', function () {
-    let subject = makeSubject();
+  it('returns undefined if middleware files does not exists', async function () {
+    let subject = await makeSubject();
     expect(subject.processAppMiddlewares()).to.equal(undefined);
   });
 
-  it('allow non MODULE_NOT_FOUND errors bubbling if issue happens during module initialization', function () {
+  it('allow non MODULE_NOT_FOUND errors bubbling if issue happens during module initialization', async function () {
     fixturifyProject.addFiles({
       server: {
         'index.js': 'throw new Error("OOPS")',
       },
     });
-    let subject = makeSubject();
+    let subject = await makeSubject();
     expect(() => subject.processAppMiddlewares()).to.throw(Error, 'OOPS');
   });
 });


### PR DESCRIPTION
Updates `fixturify-project` from `^2.1.1` to `^7.1.3` (5 majors). The API changed substantially along the way, so the test helper and its consumers are updated to the new API. Net effect on the helper is a code *reduction* — the new upstream `write()` machinery replaces the helper's hand-rolled serialization.

## Upstream breaking changes handled

- **v3**: the class is now a named export (`const { Project } = require('fixturify-project')`), and `project.root` was removed — `project.baseDir` is now the project directory itself (fixture files are no longer nested under an extra `<name>/` folder inside the tmp dir).
- **v5/v6**: `writeSync()` and `toJSON()` were removed; writing is now the async `write()`.
- **v7**: `files` passed to the constructor are deep-merged (no impact on these tests).

## Changes

### `tests/helpers/fixturify-project.js`

- `writeSync()` → async `write()`; `buildProjectModel()` / `buildProjectModelForInRepoAddon()` are now async and read the generated `package.json` back from disk.
- In-repo addons are no longer serialized into the parent's `files` (that relied on the removed `toJSON()`); the helper now tracks them and writes each one into `lib/<name>` using the regular `write()` machinery during the parent's `write()`. This deleted the old serialization code and, as a bonus, the file-moving workarounds in the per-bundle-addon-cache fixture helper.
- Dependencies created through `addDependency`/`addDevDependency` are constructed as `EmberCLIFixturifyProject` instances and handed to upstream via its public `addDependency(project)` overload (upstream's internal `addDep` hardcodes its own `Project` class since v5). This keeps nested usage like `addon.addAddon(...)` and `engine.addReferenceDependency(...)` working.
- 'Reference' (dev)dependencies — package.json entries whose files intentionally live elsewhere on disk — are injected via a small `pkgJSONWithDeps()` override. This overrides a private upstream method; there is currently no public hook for customizing the generated `package.json`.

### Tests

- All `writeSync()` / `buildProjectModel()` call sites are now `await`ed.
- `tests/helpers/per-bundle-addon-cache.js`: the standard cache fixture now defines the shared `test-addon-dep` / `test-engine-dep` directly in `PROJECT/lib` (and removes them from the project's `ember-addon.paths`) instead of creating them nested and moving their serialized files around — same disk layout, much simpler.
- `package-info-cache-test`: the `toJSON` monkeypatch that left an empty `node_modules/ember-resolver` folder is replaced by explicitly emptying that directory after `write()`. Path assertions using `fixturifyProject.root` now use `baseDir`.
- `proxy-test`: `expect(() => buildProjectModel()).to.throw(...)` became `await expect(...).to.be.rejectedWith(...)` since the model builder is now async.

## Behavioral change worth flagging

Upstream now writes `devDependencies` to `node_modules` **after** `dependencies` (v2's `toJSON` did the opposite), so when the same package name exists in both with different versions, the devDependency copy is what ends up on disk. The duplicated-addon expectations in `instantiate-addons-test` were updated from `1.0.0` to `2.0.0` accordingly (the addon *ordering* that test locks down is unchanged).

## Also included

- A one-line prettier fix to `RELEASE.md` (separate commit) — `prettier --check` has been failing on master because of it, which keeps the linting CI job red.

## Testing

- `node tests/runner tests/unit/**/*-test.js`: 979 passing, 0 failing
- `pnpm lint` (prettier + eslint): passing