### PR TITLE
BUGFIX ignore .gitkeep-only addon trees

### DIFF
--- a/lib/models/addon.js
+++ b/lib/models/addon.js
@@ -1240,6 +1240,24 @@ let addonProto = {
     @return {Tree} Processed javascript file tree
   */
   processedAddonJsFiles(inputTree) {
+    let files = this._getAddonTreeFiles();
+    let addonTreePath = this._treePathFor('addon');
+    let addonTemplatesTreePath = this._treePathFor('addon-templates');
+    let addonTemplatesTreeInAddonTree =
+      addonTemplatesTreePath === addonTreePath || addonTemplatesTreePath.indexOf(`${addonTreePath}/`) === 0;
+
+    if (!addonTemplatesTreeInAddonTree) {
+      files = files.concat(this._getAddonTemplatesTreeFiles());
+    }
+
+    let addonFiles = files.filter((file) => !file.endsWith('/'));
+    let containsOnlyGitkeepFiles =
+      addonFiles.length > 0 && addonFiles.every((file) => path.basename(file) === '.gitkeep');
+
+    if (containsOnlyGitkeepFiles) {
+      return inputTree;
+    }
+
     let preprocessedAddonJS = this._addonPreprocessTree('js', inputTree);
 
     let processedAddonJS = this.preprocessJs(preprocessedAddonJS, '/', this.name, {

--- a/tests/unit/models/addon-test.js
+++ b/tests/unit/models/addon-test.js
@@ -555,6 +555,38 @@ describe('models/addon.js', function () {
     });
   });
 
+  describe('compileAddon', function () {
+    beforeEach(function () {
+      projectPath = path.resolve(fixturePath, 'simple');
+      const packageContents = require(path.join(projectPath, 'package.json'));
+      let cli = new MockCLI();
+
+      project = new Project(projectPath, packageContents, cli.ui, cli);
+
+      project.initializeAddons();
+
+      addon = project.addons.find((addon) => addon.name === 'ember-generated-with-export-addon');
+    });
+
+    it('does not require a JavaScript preprocessor for an addon tree containing only .gitkeep files', async function () {
+      const { path: addonRoot } = await tmp.dir({ unsafeCleanup: true });
+      let addonPath = path.join(addonRoot, 'addon');
+
+      fs.outputFileSync(path.join(addonPath, '.gitkeep'), '');
+      fs.outputFileSync(path.join(addonPath, 'templates', '.gitkeep'), '');
+
+      addon.root = addonRoot;
+      let addonTree = addon.treeGenerator(addonPath);
+
+      expect(() => addon.treeForAddon(addonTree)).not.to.throw();
+
+      fs.outputFileSync(path.join(addonPath, 'index.js'), '');
+      delete addon._cachedFileSystemInfo;
+
+      expect(() => addon.treeForAddon(addonTree)).to.throw(/no JavaScript preprocessor/);
+    });
+  });
+
   describe('_fileSystemInfo', function () {
     beforeEach(function () {
       projectPath = path.resolve(fixturePath, 'simple');


### PR DESCRIPTION
## Summary

Ignore .gitkeep placeholders when deciding whether addon trees require JavaScript preprocessing.

## Change

- `lib/models/addon.js`
- `tests/unit/models/addon-test.js`

### Checks
- `node node_modules/mocha/bin/mocha.js --require ./tests/bootstrap.js tests/unit/models/addon-test.js --fgrep 'does not require a JavaScript preprocessor for an addon tree containing only .gitkeep files'` — passed in a network-isolated container.

Fixes #7154

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-168:start -->
### Verification

[Northset proof-of-pass receipt M-168](https://northset-oss.github.io/verification-pilot/receipts/M-168/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-168:end -->
