### PR TITLE
fix default blueprint lookup

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -523,13 +523,21 @@ class Project {
    */
   blueprintLookupPaths() {
     if (this.isEmberCLIProject()) {
-      let lookupPaths = [this.localBlueprintLookupPath()];
-      let addonLookupPaths = this.addonBlueprintLookupPaths();
-
-      return lookupPaths.concat(addonLookupPaths);
+      return [this.localBlueprintLookupPath(), ...this.addonBlueprintLookupPaths(), this.builtInLookupPath()];
     } else {
-      return this.addonBlueprintLookupPaths();
+      return [...this.addonBlueprintLookupPaths(), this.builtInLookupPath()];
     }
+  }
+
+  /**
+   * Returns the built-in ember-cli path for looking up blueprints
+   *
+   * @private
+   * @method builtInLookupPath
+   * @return {string} path to the ember-cli built-in blueprints
+   */
+  builtInLookupPath() {
+    return path.resolve(__dirname, '..', '..', 'blueprints');
   }
 
   /**

--- a/packages/blueprint-model/index.js
+++ b/packages/blueprint-model/index.js
@@ -20,7 +20,6 @@ const zipObject = require('lodash/zipObject');
 const intersection = require('lodash/intersection');
 const cloneDeep = require('lodash/cloneDeep');
 const compact = require('lodash/compact');
-const uniq = require('lodash/uniq');
 const sortBy = require('lodash/sortBy');
 const walkSync = require('walk-sync');
 const SilentError = require('silent-error');
@@ -1425,10 +1424,13 @@ const builtInBlueprints = new Map([
 Blueprint.lookup = function (name, options) {
   options = options || {};
 
-  let lookupPaths = generateLookupPaths(options.paths);
+  let lookupPaths = new Set(options.paths);
 
-  let lookupPath;
-  for (let i = 0; (lookupPath = lookupPaths[i]); i++) {
+  for (let path of options?.project?.blueprintLookupPaths() ?? []) {
+    lookupPaths.add(path);
+  }
+
+  for (let lookupPath of lookupPaths) {
     let blueprintPath = path.resolve(lookupPath, name);
 
     if (Blueprint._existsSync(blueprintPath)) {
@@ -1502,10 +1504,15 @@ Blueprint.load = function (blueprintPath, blueprintOptions) {
 Blueprint.list = function (options) {
   options = options || {};
 
-  let lookupPaths = generateLookupPaths(options.paths);
+  let lookupPaths = new Set(options.paths);
+
+  for (let path of options?.project?.blueprintLookupPaths() ?? []) {
+    lookupPaths.add(path);
+  }
+
   let seen = [];
 
-  return lookupPaths.map((lookupPath) => {
+  return Array.from(lookupPaths).map((lookupPath) => {
     let source;
     let packagePath = path.join(lookupPath, '../package.json');
     if (Blueprint._existsSync(packagePath)) {
@@ -1583,14 +1590,6 @@ Blueprint.ignoredFiles = initialIgnoredFiles;
 Blueprint.ignoredUpdateFiles = ['.gitkeep', 'app.css', 'LICENSE.md'];
 
 /**
-  @static
-  @property defaultLookupPaths
-*/
-Blueprint.defaultLookupPaths = function () {
-  return [path.resolve(__dirname, '..', '..', 'blueprints')];
-};
-
-/**
   @private
   @method prepareConfirm
   @param {FileInfo} info
@@ -1647,21 +1646,6 @@ function isIgnored(info) {
   let fn = info.inputPath;
 
   return Blueprint.ignoredFiles.some((ignoredFile) => minimatch(fn, ignoredFile, { matchBase: true }));
-}
-
-/**
-  Combines provided lookup paths with defaults and removes
-  duplicates.
-
-  @private
-  @method generateLookupPaths
-  @param {Array} lookupPaths
-  @return {Array}
-*/
-function generateLookupPaths(lookupPaths) {
-  lookupPaths = lookupPaths || [];
-  lookupPaths = lookupPaths.concat(Blueprint.defaultLookupPaths());
-  return uniq(lookupPaths);
 }
 
 /**

--- a/tests/unit/models/blueprint-test.js
+++ b/tests/unit/models/blueprint-test.js
@@ -142,9 +142,6 @@ const bar = 'bar';
         return path.indexOf('package.json') === -1;
       });
 
-      td.replace(Blueprint, 'defaultLookupPaths');
-      td.when(Blueprint.defaultLookupPaths()).thenReturn([]);
-
       td.replace(Blueprint, 'load', function (blueprintPath) {
         return {
           name: path.basename(blueprintPath),

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -414,6 +414,7 @@ describe('models/project.js', function () {
         project.root + path.normalize('/node_modules/ember-after-blueprint-addon/blueprints'),
         project.root + path.normalize('/node_modules/ember-random-addon/blueprints'),
         project.root + path.normalize('/node_modules/ember-before-blueprint-addon/blueprints'),
+        path.normalize(path.resolve(__dirname, '..', '..', '..', 'blueprints')),
       ];
 
       expect(project.blueprintLookupPaths()).to.deep.equal(expected);
@@ -424,7 +425,10 @@ describe('models/project.js', function () {
         return false;
       };
 
-      expect(project.blueprintLookupPaths()).to.deep.equal(project.addonBlueprintLookupPaths());
+      expect(project.blueprintLookupPaths()).to.deep.equal([
+        ...project.addonBlueprintLookupPaths(),
+        project.builtInLookupPath(),
+      ]);
     });
 
     it('returns an instance of an addon with an object export', function () {


### PR DESCRIPTION
When I extracted the blueprint model in https://github.com/ember-cli/ember-cli/pull/10672 I missed one place where the system was looking up a relative path which is not possible any more. 

This was caught in https://github.com/ember-cli/ember-cli/pull/11042 because the blueprint model package only exists on the main branch of the monorepo 👍 

This unblocks the 7.2 release 