### PR TITLE
fix release-plan

### DIFF
--- a/.github/workflows/plan-alpha-release.yml
+++ b/.github/workflows/plan-alpha-release.yml
@@ -61,9 +61,6 @@ jobs:
           sign-commits: true
           branch: releaseplan-preview
           title: Prepare Alpha Release ${{ steps.explanation.outputs.new-version }}
-          # this doesn't use secrets.GITHUB_TOKEN because we want CI to run on the PR that it opens.
-          # See: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_PLAN_GH_PAT }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/plan-beta-release.yml
+++ b/.github/workflows/plan-beta-release.yml
@@ -60,9 +60,6 @@ jobs:
           sign-commits: true
           branch: release-preview-beta
           title: Prepare Beta Release ${{ steps.explanation.outputs.new-version }}
-          # this doesn't use secrets.GITHUB_TOKEN because we want CI to run on the PR that it opens.
-          # See: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_PLAN_GH_PAT }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/plan-stable-release.yml
+++ b/.github/workflows/plan-stable-release.yml
@@ -60,9 +60,6 @@ jobs:
           sign-commits: true
           branch: release-preview-stable
           title: Prepare Stable Release ${{ steps.explanation.outputs.new-version }}
-          # this doesn't use secrets.GITHUB_TOKEN because we want CI to run on the PR that it opens.
-          # See: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_PLAN_GH_PAT }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 


### PR DESCRIPTION
now that we can approve PRs that are generated with the github bot we don't need to use a Personal Access Token any more 🎉 This means that the release plan PR won't look like it's coming from me any more 😂 