### PR TITLE
speed up windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - uses: ./.github/actions/setup-environment
         with:
           node-version: ${{ matrix.node-version }}
+      - if: runner.os == 'Windows'
+        run: new-item D:\temp -ItemType Directory; echo "TEMP=D:\temp" >> $env:GITHUB_ENV
       - run: pnpm test
 
   slow-tests:


### PR DESCRIPTION
now that we're using fixturify-project for basic tests we're hitting timeouts on windows 😭 

This PR improves the performance of windows tests by setting temp to the `D:` drive

Edit: it looks like this drops 1 minute off what was previously taking 4 minutes 🎉 that's a good improvement 💪 